### PR TITLE
improved citation autocompletion

### DIFF
--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -27,10 +27,18 @@ export function find_citation_keys() {
                 var BibtexParser = require(latex_workshop.find_path('lib/bibtex-parser'));
                 var parser = new BibtexParser(bib_content);
                 var data = parser.parse();
-                data.map((item) => {
-                    var key = new vscode.CompletionItem(item.citationKey, vscode.CompletionItemKind.Keyword);
+                data.forEach(item => {
+                    if (item.citationKey === undefined) {
+                        return;
+                    }
+                    const key = new vscode.CompletionItem(item.citationKey, vscode.CompletionItemKind.Reference);
                     if (item.entryTags != undefined) {
-                        key.documentation = `${item.entryTags.title}\n\n${item.entryTags.journal}\n\n${item.entryTags.author}`;
+                        key.detail = item.entryTags.title;
+                        key.filterText = `${item.citationKey} ${item.entryTags.title}`;
+                        key.documentation = Object.keys(item.entryTags)
+                                                .filter(k => k !== 'title')  // we already show the title in the detail
+                                                .map(k => `${k}: ${item.entryTags[k]}`)
+                                                .join('\n');
                     }
                     keys.push(key);
                 });


### PR DESCRIPTION
Few small improvements to citation autocompletion:

1. Add guard to check `citationKey` exists before creating a completion item for entry
2. Display the title in the `detail` section (so it's visible for the highlighted completion)
3. Display all information in the detail view
4. Allow completion based on title as well as citation key 

![cite_preview](https://cloud.githubusercontent.com/assets/1312873/24321470/7564231e-1145-11e7-9d35-f05427434587.gif)
