### PR TITLE
Fix activation language (latex not LaTeX)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "hint"
   ],
   "activationEvents": [
-    "onLanguage:latex"
+    "onLanguage:latex",
+    "onLanguage:LaTeX"
   ],
   "main": "./out/src/main",
   "contributes": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "hint"
   ],
   "activationEvents": [
-    "onLanguage:LaTeX"
+    "onLanguage:latex"
   ],
   "main": "./out/src/main",
   "contributes": {


### PR DESCRIPTION
I had to tweak the activation language to `latex` (lower case) to get the new v1.0.0 of the Extension to activate.