### PR TITLE
move all language ids to lowercase

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,10 +47,9 @@
         "configuration": "./syntax/syntax.json"
       },
       {
-        "id": "LaTeX",
+        "id": "latex",
         "aliases": [
-          "LaTeX",
-          "latex"
+          "LaTeX"
         ],
         "extensions": [
           ".tex"
@@ -58,31 +57,30 @@
         "configuration": "./syntax/syntax.json"
       },
       {
-        "id": "BibTeX",
+        "id": "bibtex",
         "aliases": [
-          "BibTeX",
-          "bibtex"
+          "BibTeX"
         ],
         "extensions": [
           ".bib"
         ]
       },
       {
-        "id": "LaTeX Beamer",
+        "id": "latex-beamer",
         "aliases": [
           "LaTeX Beamer"
         ],
         "configuration": "./syntax/syntax.json"
       },
       {
-        "id": "LaTeX Memoir",
+        "id": "latex-memoir",
         "aliases": [
           "LaTeX Memoir"
         ],
         "configuration": "./syntax/syntax.json"
       },
       {
-        "id": "LaTeX Log",
+        "id": "latex-log",
         "aliases": [
           "LaTeX Log"
         ],
@@ -93,32 +91,32 @@
     ],
     "grammars": [
       {
-        "language": "TeX",
+        "language": "tex",
         "scopeName": "text.tex",
         "path": "./syntax/TeX.plist"
       },
       {
-        "language": "LaTeX",
+        "language": "latex",
         "scopeName": "text.tex.latex",
         "path": "./syntax/LaTeX.plist"
       },
       {
-        "language": "BibTeX",
+        "language": "bibtex",
         "scopeName": "text.bibtex",
         "path": "./syntax/Bibtex.plist"
       },
       {
-        "language": "LaTeX Beamer",
+        "language": "latex-beamer",
         "scopeName": "text.tex.latex.beamer",
         "path": "./syntax/LaTeX Beamer.plist"
       },
       {
-        "language": "LaTeX Memoir",
+        "language": "latex-memoir",
         "scopeName": "text.tex.latex.memoir",
         "path": "./syntax/LaTeX Memoir.plist"
       },
       {
-        "language": "LaTeX Log",
+        "language": "latex-log",
         "scopeName": "text.log.latex",
         "path": "./syntax/LaTeX Log.plist"
       }
@@ -165,22 +163,22 @@
     "menus": {
       "editor/context": [
         {
-          "when": "resourceLangId == LaTeX",
+          "when": "resourceLangId == latex",
           "command": "latex-workshop.build",
           "group": "navigation@100"
         },
         {
-          "when": "resourceLangId == LaTeX",
+          "when": "resourceLangId == latex",
           "command": "latex-workshop.view",
           "group": "navigation@101"
         },
         {
-          "when": "resourceLangId == LaTeX",
+          "when": "resourceLangId == latex",
           "command": "latex-workshop.tab",
           "group": "navigation@102"
         },
         {
-          "when": "resourceLangId == LaTeX",
+          "when": "resourceLangId == latex",
           "command": "latex-workshop.synctex",
           "group": "navigation@103"
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,7 +42,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
 
     context.subscriptions.push(vscode.workspace.registerTextDocumentContentProvider('latex-workshop-pdf', new PDFProvider(extension)))
-    context.subscriptions.push(vscode.languages.registerCompletionItemProvider('LaTeX', extension.completer, '\\', '{', ','));
+    context.subscriptions.push(vscode.languages.registerCompletionItemProvider('latex', extension.completer, '\\', '{', ','));
 }
 
 export class Extension {


### PR DESCRIPTION
1. Fixes up the `registerCompletionItemProvider` call for `latex`
2. Moves all language provider IDs to `lowercase-with-dashes` style (e.g. LaTeX Beamer)