### PR TITLE
Small improvements to map/forEach in citation provider

### DIFF
--- a/src/providers/citation.ts
+++ b/src/providers/citation.ts
@@ -15,16 +15,16 @@ export class Citation {
     }
 
     provide() : vscode.CompletionItem[] {
-        if (Date.now() - this.provideRefreshTime < 1000)
+        if (Date.now() - this.provideRefreshTime < 1000) {
             return this.suggestions
+        }
         this.provideRefreshTime = Date.now()
         this.extension.manager.findAllDependentFiles()
         let items = []
-        this.extension.manager.bibFiles.map(bib =>
-            items = items.concat(this.getBibItems(bib)))
-        let suggestions = []
-        items.map(item => {
-            let citation = new vscode.CompletionItem(item.key,vscode.CompletionItemKind.Reference)
+        this.extension.manager.bibFiles.forEach(
+            bib => this.getBibItems(bib).forEach(i => items.push(i)))
+        this.suggestions = items.map(item => {
+            let citation = new vscode.CompletionItem(item.key, vscode.CompletionItemKind.Reference)
             citation.detail = item.title
             citation.filterText = `${item.author} ${item.title} ${item.journal}`
             citation.insertText = item.key
@@ -33,10 +33,9 @@ export class Citation {
                 .sort()
                 .map(key => `${key}: ${item[key]}`)
                 .join('\n');
-            suggestions.push(citation)
+            return citation
         })
-        this.suggestions = suggestions
-        return suggestions
+        return this.suggestions
     }
 
     getBibItems(bib: string) {


### PR DESCRIPTION
in general, `array.map()` should be used when a modified array is being made:
```ts
new_array = old_array.map(x => x * 2)
```
(notice the function passed must return something, here we use the fat arrow implicit return property)

whilst `array.forEach()` should be used when you want to just do a for loop over elements without building a new array.

This just tidies up the citation handler to follow these best practices.

BTW, love that you've moved to semicolonless style, personal fave of mine!