### PR TITLE
Be robust to .tex filenames with periods in them

### DIFF
--- a/src/manager.ts
+++ b/src/manager.ts
@@ -118,9 +118,10 @@ export class Manager {
             if (!result)
                 break
             let inputFile = result[1];
-            if (path.extname(inputFile) === '')
-                inputFile += '.tex'
             let inputFilePath = path.resolve(path.join(rootDir, inputFile))
+            if (path.extname(inputFilePath) !== '.tex' && !fs.existsSync(inputFilePath)) {
+                inputFilePath += '.tex'
+            }
             if (this.texFiles.indexOf(inputFilePath) < 0) {
                 this.texFiles.push(inputFilePath)
                 this.findDependentFiles(inputFilePath)


### PR DESCRIPTION
In the new logic we have a problem dealing with tex pathnames with a `.` in them.

For instance, the latex project template I am using has the following structure:
```
thesis.tex
thesis.preamble.tex
```
With the following line in `thesis.tex`:
```latex
\include{thesis.preamble}
```
Unfortunately the current logic would find that there is an extension on this name, and therefore would try and load `./thesis.preable` raising an exception.

This PR adds a guard by only appending `.tex` if the extension is not `.tex` and if the file does not exist. This should be robust to this issue, at the annoying cost of a (synchronous) exists check for most linked files.

I have in mind a better solution for this that will be more performant but it's a larger change, thought it would be better to submit the quick fix so users with period-y `.tex` files can get back up and running.

PS there may be an edge case - if the user _additionally_ has a dir with the non-tex extension next to the file:
```
thesis.tex
thesis.preamble.tex
thesis.preamble/
```
the nicer full solution will additionally be robust to this.