### PR TITLE
better solution to make dependent file lookup robust

### DIFF
--- a/src/manager.ts
+++ b/src/manager.ts
@@ -118,7 +118,7 @@ export class Manager {
             let result = inputReg.exec(content)
             if (!result)
                 break
-            const inputFile = result[1];
+            const inputFile = result[1]
             let inputFilePath = path.resolve(path.join(rootDir, inputFile))
             if (path.extname(inputFilePath) === '') {
                 inputFilePath += '.tex'
@@ -147,7 +147,7 @@ export class Manager {
 
         let bibReg = /(?:\\(?:bibliography|addbibresource)(?:\[[^\[\]\{\}]*\])?){(.+?)}/g
         while (true) {
-            let result = bibReg.exec(content);
+            let result = bibReg.exec(content)
             if (!result)
                 break
             let bibs = result[1].split(',').map((bib) => {

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -9,8 +9,8 @@ import {Extension} from './main'
 export class Manager {
     extension: Extension
     rootFile: string
-    texFiles: string[]
-    bibFiles: string[]
+    texFiles: Set<string>
+    bibFiles: Set<string>
 
     findAllDependentFilesTime: number
 
@@ -103,12 +103,13 @@ export class Manager {
             this.findRoot()
         if (this.rootFile === undefined)
             return
-        this.texFiles = [this.rootFile]
-        this.bibFiles = []
+        this.texFiles = new Set<string>()
+        this.texFiles.add(this.rootFile)
+        this.bibFiles = new Set<string>()
         this.findDependentFiles(this.rootFile)
     }
 
-    findDependentFiles(filePath: string) {
+    findDependentFiles(filePath: string, tryAppendTex = true) {
         let content = fs.readFileSync(filePath, 'utf-8')
         let rootDir = path.dirname(this.rootFile)
 
@@ -117,13 +118,30 @@ export class Manager {
             let result = inputReg.exec(content)
             if (!result)
                 break
-            let inputFile = result[1];
-            if (path.extname(inputFile) === '')
-                inputFile += '.tex'
+            const inputFile = result[1];
             let inputFilePath = path.resolve(path.join(rootDir, inputFile))
-            if (this.texFiles.indexOf(inputFilePath) < 0) {
-                this.texFiles.push(inputFilePath)
-                this.findDependentFiles(inputFilePath)
+            if (path.extname(inputFilePath) === '') {
+                inputFilePath += '.tex'
+            }
+            if (!this.texFiles.has(inputFilePath)) {
+                this.texFiles.add(inputFilePath)
+                try {
+                    this.findDependentFiles(inputFilePath)
+                } catch (err) {
+                    if (tryAppendTex && (err.code === 'ENOENT' || err.code === 'EISDIR')) {
+                        // It's possible that the filename was a .tex file with
+                        // a period in it (intro.math.tex)
+
+                        // Remove this filename from the checked list...
+                        this.texFiles.delete(inputFilePath)
+                        // ...add the .tex extension...
+                        inputFilePath += '.tex'
+                        this.texFiles.add(inputFilePath)
+                        // ...and try again. If this fails, don't try appending
+                        // .tex any more.
+                        this.findDependentFiles(inputFilePath, false)
+                    }
+                }
             }
         }
 
@@ -139,8 +157,7 @@ export class Manager {
                 if (path.extname(bib) === '')
                     bib += '.bib'
                 let bibPath = path.resolve(path.join(rootDir, bib))
-                if (this.bibFiles.indexOf(bibPath) < 0)
-                    this.bibFiles.push(bibPath)
+                this.bibFiles.add(bibPath)
             }
         }
     }

--- a/src/providers/command.ts
+++ b/src/providers/command.ts
@@ -20,7 +20,7 @@ export class Command {
         this.provideRefreshTime = Date.now()
         this.extension.manager.findAllDependentFiles()
         let suggestions = JSON.parse(JSON.stringify(this.defaults))
-        this.extension.manager.texFiles.map(filePath => {
+        this.extension.manager.texFiles.forEach(filePath => {
             let items = this.getCommandsTeX(filePath)
             Object.keys(items).map(key => {
                 if (key in suggestions)

--- a/src/providers/reference.ts
+++ b/src/providers/reference.ts
@@ -20,7 +20,7 @@ export class Reference {
         this.provideRefreshTime = Date.now()
         this.extension.manager.findAllDependentFiles()
         let suggestions = {}
-        this.extension.manager.texFiles.map(filePath => {
+        this.extension.manager.texFiles.forEach(filePath => {
             let items = this.getReferencesTeX(filePath)
             Object.keys(items).map(key => {
                 if (!(key in suggestions))


### PR DESCRIPTION
Supersedes #43 as a better solution.

Here we only try appending .tex again if we try and fail to read the file. As in general it is probably rare for most tex files to have periods in the name (and as it's quite common to have includes with `.tex` omitted) this avoids doing `n_files` exists checks unlike #43.

As I now have to remove bad entries from the `.texFiles` property, it made sense to turn this into a `Set`, which has O(1) insert/check exists/remove.