### PR TITLE
chktex fixes, now asynchronous to compiler errors

### DIFF
--- a/src/manager.ts
+++ b/src/manager.ts
@@ -18,6 +18,10 @@ export class Manager {
         this.extension = extension
     }
 
+    get rootDir() {
+        return path.dirname(this.rootFile)
+    }
+
     tex2pdf(texPath) {
         return `${texPath.substr(0, texPath.lastIndexOf('.'))}.pdf`
     }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -156,7 +156,7 @@ export class Parser {
             this.compilerDiagnostics.set(vscode.Uri.file(file), diagsCollection[file])
     }
 
-    showLinterDiagnostics(createBuildLogRaw: boolean = false) {
+    showLinterDiagnostics() {
         this.linterDiagnostics.clear()
         const diagsCollection: {[key:string]:vscode.Diagnostic[]} = {}
         for (const item of this.linterLog) {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -163,6 +163,7 @@ export class Parser {
             const range = new vscode.Range(new vscode.Position(item.line - 1, item.position - 1), 
                                            new vscode.Position(item.line - 1, item.position - 1))
             const diag = new vscode.Diagnostic(range, item.text, diagnostic_severity[item.type])
+            diag.code = item.code
             if (diagsCollection[item.file] === undefined) {
                 diagsCollection[item.file] = []
             }


### PR DESCRIPTION
There we a few issues in the chktex parser, including:

1. Handling messages containing colons
2. Handling the file in the report (sometimes absolute, sometimes relative)

I fixed these by using the regexp mentioned in #39 which I've been testing the last week or so, fairly sure that's solid.

I also changed this so there are two separate diagnostic collections - one for the linter, one for the compiler. As the linter is fired at different times to the compiler, it's important to keep them separate so that we can clear and update them independently without impacting each other. If not, the linter will fire after a short pause in typing, and when it reports back new changes it would also clear any current compiler errors, which doesn't make sense.

I also fixed a typo I introduced yesterday (`diagnostic_severity`) apologies!

With these changes chktex is working great, thanks for the swift feature addition @James-Yu!