### PR TITLE
check for citekey for references

### DIFF
--- a/src/providers/citation.ts
+++ b/src/providers/citation.ts
@@ -43,7 +43,7 @@ export class Citation {
         if (!fs.existsSync(bib))
             return items
         let content = fs.readFileSync(bib, 'utf-8').replace(/[\r\n]/g, ' ')
-        let itemReg = /@(\w+){/g
+        let itemReg = /@(\w+){\s*\w+\s*,/g
         let result = itemReg.exec(content)
         let prev_result = undefined
         while (result || prev_result) {


### PR DESCRIPTION
Fixes #47. 

It's valid bibtex to create aliases using `@string`. 

For instance we can do:
```bibtex
@string{CVIU="Computer Vision and Image Understanding"}
```
And then later do
```
@article{zafeiriou2015survey,
  title={A survey on face detection in the wild: past, present and future},
  author={Zafeiriou, Stefanos and Zhang, Cha and Zhang, Zhengyou},
  journal=CVIU,
  volume={138},
  pages={1--24},
  year={2015},
  publisher={Elsevier}
}
```
and bibtex will fill in the full name.

This `@string` pattern gets caught by the current regexp for detecting the start of an item:
```re
/@(\w+){/g
```
If we additionally check for a citation key followed by comma (allowing for whitespace) we will no longer match on these @string aliases, which avoids an error when we inevitably fail to parse the string in `splitBibItem`.