### PR TITLE
Initial implementation of real-time as-you-type linting

### DIFF
--- a/src/linter.ts
+++ b/src/linter.ts
@@ -4,63 +4,99 @@ import * as vscode from 'vscode'
 import * as path from 'path'
 import * as fs from 'fs'
 import * as cp from 'child_process'
+import * as tmp from 'tmp'
 
 import {Extension} from './main'
+
+function writeFile(filename: string, data: any) {
+    return new Promise((resolve, reject) => {
+        fs.writeFile(filename, data, (err, result) => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve(result)
+            }
+        })
+    })
+}
 
 export class Linter {
     extension: Extension
     linterFile: string
     linterTimeout: NodeJS.Timer
-    currentProcess: cp.ChildProcess
+    currentProcesses: {[linterId: string]: cp.ChildProcess} = {}
 
     constructor(extension: Extension) {
         this.extension = extension
     }
 
-    lint() {
-        if (!vscode.window.activeTextEditor || !vscode.window.activeTextEditor.document.getText())
+    async lintActiveFile() {
+        if (!vscode.window.activeTextEditor || !vscode.window.activeTextEditor.document.getText()) {
             return
-        if (this.currentProcess)
-            this.currentProcess.kill()
-        this.extension.logger.addLogMessage(`Linter start.`)
-        if (vscode.window.activeTextEditor.document.fileName !== this.extension.manager.rootFile) {
-            let configuration = vscode.workspace.getConfiguration('latex-workshop')
-            let command = (configuration.get('linter_command') as string).replace('%DOC%', `"${this.extension.manager.rootFile}"`)
-            this.lintCommand(command, this.extension.manager.rootFile)
-        } else {
-            let content = vscode.window.activeTextEditor.document.getText()
-            let tmpFile = path.join(path.dirname(this.extension.manager.rootFile), `.chktex.${path.basename(this.extension.manager.rootFile)}`)
-            fs.writeFile(tmpFile, content, err => {
-                if (err) {
-                    this.extension.logger.addLogMessage(`Unable to write file ${tmpFile}`)
-                    return;
-                }
-                let configuration = vscode.workspace.getConfiguration('latex-workshop')
-                let command = (configuration.get('linter_command') as string).replace('%DOC%', `"${tmpFile}"`)
-                this.lintCommand(command, tmpFile)
-            })
         }
+        this.extension.logger.addLogMessage(`Linter for active file state started.`)
+        const content = vscode.window.activeTextEditor.document.getText()
+        const filePath = vscode.window.activeTextEditor.document.fileName
+        const tmpFilePath = tmp.fileSync()
+        try {
+            await writeFile(tmpFilePath.name, content)
+        } catch (err) {
+            this.extension.logger.addLogMessage(`Unable to write file ${tmpFilePath}`)
+            return
+        }
+        // provide the original path to the active file as the second argument.
+        // this will mean: 
+        //   1. we won't follow \input directives (lint this one file only)
+        //   2. we will report this second path in the diagnostics instead of the temporary one.
+        await this.lintFile(tmpFilePath.name, filePath)
+        tmpFilePath.removeCallback()
+        this.extension.logger.addLogMessage(`Temp file removed: ${tmpFilePath}`)
     }
 
-    lintCommand(command: string, fileName: string) {
-        this.extension.logger.addLogMessage(`Linting with command ${command}`)
-        this.currentProcess = this.processWrapper(command, {cwd: path.dirname(this.extension.manager.rootFile)}, (error, stdout, stderr) => {
-            if (!error) {
-                this.extension.parser.parseLinter(stdout.split(fileName).join(this.extension.manager.rootFile))
-                this.extension.logger.addLogMessage(`Linter finished.`)
-                if (fileName !== this.extension.manager.rootFile) {
-                    console.log(fileName)
-                    fs.unlink(fileName)
-                    this.extension.logger.addLogMessage(`Temp file removed: ${fileName}`)
-                }
-                return
+    lintRootFile() {
+        this.extension.logger.addLogMessage(`Linter for root file started.`)
+        return this.lintFile(this.extension.manager.rootFile)
+    }
+    
+    async lintFile(fileName: string, activeFileOriginalPath?: string) {
+        const configuration = vscode.workspace.getConfiguration('latex-workshop')
+        let command = (configuration.get('linter_command') as string).replace('%DOC%', `"${fileName}"`)
+        let linterId = 'rootFile'
+        if (activeFileOriginalPath) {
+            command += ' -I0'  // Don't follow \input directives
+            linterId = 'activeFile'
+        }
+        let stdout: string
+        try {
+            stdout = await this.lintCommand(linterId, command, fileName)
+        } catch (err) {
+            this.extension.logger.addLogMessage(`Linter failed with error ${err.message}.`)
+        }
+        this.extension.parser.parseLinter(stdout, activeFileOriginalPath)
+    }
+
+    async lintCommand(linterId: string, command: string, fileName: string) {
+        this.extension.logger.addLogMessage(`Linter with ID '${linterId}' running with command ${command}`)
+        const stdout = await this.processWrapper(linterId, command, {cwd: path.dirname(this.extension.manager.rootFile)})
+        this.extension.logger.addLogMessage(`Linter with ID '${linterId}' successfully finished.`)
+        return stdout
+    }
+
+    processWrapper(linterId: string, command: string, options: any) : Promise<string> {
+        // linterId allows us to have two linters in flight simultaneously for separate jobs
+        // (i.e. a full project lint and a current working file real-time lint)
+        return new Promise((resolve, reject) => {
+            if (this.currentProcesses[linterId]) {
+                this.currentProcesses[linterId].kill()
             }
-            this.extension.logger.addLogMessage(`Linter failed with error ${error.message}.`)
+            this.currentProcesses[linterId] = cp.exec(command, {maxBuffer: Infinity, ...options}, (err, stdout, stderr) => {
+                if (err) {
+                    reject(err)
+                } else {
+                    resolve(stdout)
+                }
+            })
         })
     }
 
-    processWrapper(command: string, options: any, callback: (error: Error, stdout: string, stderr: string) => void) : cp.ChildProcess {
-        options.maxBuffer = Infinity
-        return cp.exec(command, options, callback)
-    }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,8 +26,13 @@ export async function activate(context: vscode.ExtensionContext) {
         let configuration = vscode.workspace.getConfiguration('latex-workshop')
         if (!configuration.get('build_after_save') || extension.builder.disableBuildAfterSave)
             return
-        if (extension.manager.isTex(e.fileName))
+        if (extension.manager.isTex(e.fileName)) {
+            const linter = configuration.get('linter') as boolean
+            if (linter) {
+                extension.linter.lintRootFile()
+            }
             extension.commander.build()
+        }
     }))
 
     context.subscriptions.push(vscode.workspace.onDidOpenTextDocument((e: vscode.TextDocument) => {
@@ -42,7 +47,7 @@ export async function activate(context: vscode.ExtensionContext) {
                 let interval = configuration.get('linter_interval') as number
                 if (extension.linter.linterTimeout)
                     clearTimeout(extension.linter.linterTimeout)
-                extension.linter.linterTimeout = setTimeout(() => extension.linter.lint(), interval)
+                extension.linter.linterTimeout = setTimeout(() => extension.linter.lintActiveFile(), interval)
             }
         }
     }))


### PR DESCRIPTION
This PR separates linting into two categories:

1. **`activeFile`** - a real-time check of just the current `.tex` file *in it's current (unsaved) state*.
2. **`rootFile`** - a full check of all `.tex` files in the project starting from the root, *only considering saved files*.

This separation is needed if we want to be able to offer real-time linting on unsaved files, as we need to be able to give `chktex` the current unsaved active file, without giving up on the nice security of full-project linting.

`activeFile` linting is now run at the times where all linting was previously performed (i.e. after a timeout on an `onDidChangeTextDocument` event). A temporary copy of the current file is saved and the linting run on that, with the temp file cleaned up afterwards (just as before). A flag is passed to `chktex` to prevent `\input` directives from being followed. This reduces the runtime significantly, allowing for a quick response of issues on the active file.

`rootFile` linting is simply what was always done in the past - a full lint from the root file, with chktex itself following `\input` directives. This linting is now only run on save in parallel to a build if the `latex-workshop.build_after_save` flag is set.

the same `latex-workshop.linter` flag is respected but now for both types of linting.

This seems to work well and fixes a current issue with the linting - that although it fires after a delay, for all files except the root file it does not respond to changes in the editor, which makes the real-time aspect pointless (you have to save to have chktex see the new version).

In doing this I moved the callback-style code in the `linter` module to `async`/`await` with Promises to avoid too many nested callbacks - hope that's a style you don't mind!