### PR TITLE
Linting refinements (avoid tmp file, more robust error reporting)

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,17 +157,22 @@
         "latex-workshop.linter": {
           "type": "boolean",
           "default": false,
-          "description": "Lint LaTeX when no document changes for a defined period of time."
+          "description": "Enable linting LaTeX with ChkTeX.\nThe active document will be linted when no document changes for a defined period of time.\nThe full project will be linted from the root on file save."
         },
-        "latex-workshop.linter_command": {
-          "type": "string",
-          "default": "chktex -q -v0 %DOC%",
-          "description": "Linter command to check LaTeX syntax in real time.\nNow supports chktex.\nPlaceholder %DOC% is used to represent the root LaTeX file name (with extension)."
+        "latex-workshop.linter_command_active_file": {
+          "type": "array",
+          "default": ["chktex", "-q", "-I0", "-f%f:%l:%c:%d:%k:%n:%m\n"],
+          "description": "Linter command to check LaTeX syntax of the current file state in real time with ChkTeX.\nCurrent file contents will be piped to the command through stdin.\nThe format string should be kept as shown in the default as this is the format the parser expects for successful parsing."
+        },
+        "latex-workshop.linter_command_root_file": {
+          "type": "array",
+          "default": ["chktex", "-q", "-f%f:%l:%c:%d:%k:%n:%m\n", "%DOC%"],
+          "description": "Linter command to check LaTeX syntax of the entire project from the root file with ChkTeX.\nPlaceholder %DOC% is used to represent the root LaTeX file name (with extension).\nThe format string should be kept as shown in the default as this is the format the parser expects for successful parsing."
         },
         "latex-workshop.linter_interval": {
           "type": "number",
-          "default": "2000",
-          "description": "Defines the time interval in milliseconds between invoking LaTeX linter"
+          "default": 300,
+          "description": "Defines the time interval in milliseconds between invoking LaTeX linter on the active file."
         },
         "latex-workshop.show_debug_log": {
           "type": "boolean",


### PR DESCRIPTION
This PR does the following:

1. Split the linter command into `linter_command_active_file` and
`linter_command_root_file` to be able to customise independently
2. Moves to have these commands specified as arrays (`[cmd, arg1, arg2]`) to avoid whitespace issues when invoking
3. Directly pipe the content of the active file to `chktex` rather than making a temporary file which needs cleaning up
2. Parse the length of the reported issue and include this in diagnostics
3. Reduce default linting interval to 300ms
4. More robustly handle issues around the linter subprocess call

Here's a little video of the linting experience on a small demo project now:
![demo_chktex_2](https://cloud.githubusercontent.com/assets/1312873/24448389/ec08cc26-146b-11e7-986f-a5f2494be561.gif)
