### PR TITLE
minor tidying up of configuration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,8 +4,8 @@
         "out": false // set this to true to hide the "out" folder with the compiled JS files
     },
     "search.exclude": {
-        "out": true // set this to false to include "out" folder in search results
+        "out/**": true // set this to false to include "out" folder in search results
     },
-    "typescript.tsdk": "./node_modules/typescript/lib",
-    "vsicons.presets.angular": false // we want to use the TS server from our node_modules folder to control its version
+    "typescript.tsdk": "./node_modules/typescript/lib",  // we want to use the TS server from our node_modules folder to control its version
+    "vsicons.presets.angular": false
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -23,7 +23,7 @@
     "args": ["run", "compile", "--loglevel", "silent"],
 
     // The tsc compiler is started in watching mode
-    "isWatching": true,
+    "isBackground": true,
 
     // use the standard tsc in watch mode problem matcher to find compile problems in the output.
     "problemMatcher": "$tsc-watch"

--- a/package.json
+++ b/package.json
@@ -237,16 +237,16 @@
   },
   "dependencies": {
     "glob": "^7.1.1",
-    "hasbin": "^1.2.3",
     "open": "^0.0.5",
     "tmp": "^0.0.31",
     "ws": "^1.1.1"
   },
   "devDependencies": {
-    "typescript": "^2.0.3",
-    "vscode": "^1.0.0",
-    "mocha": "^2.3.3",
+    "@types/glob": "^5.0.30",
     "@types/node": "^6.0.40",
-    "@types/mocha": "^2.2.32"
+    "@types/tmp": "0.0.32",
+    "@types/ws": "0.0.39",
+    "typescript": "^2.0.3",
+    "vscode": "^1.0.0"
   }
 }


### PR DESCRIPTION
- The search exclusion of `out` wasn't working without the `'**'` glob
- Updating a renamed key in `tasks.json` (`isWatching` now `isBackground`)
- Removed two unused deps (`hasbin`, `mocha`)
- Add types for `glob`, `tmp`, `ws`