### PR TITLE
Initial version of code actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -175,12 +175,12 @@
         },
         "latex-workshop.linter_command_active_file": {
           "type": "array",
-          "default": ["chktex", "-q", "-I0", "-f%f:%l:%c:%d:%k:%n:%m\n"],
+          "default": ["chktex", "-wall", "-n22", "-n30", "-e16", "-q", "-I0", "-f%f:%l:%c:%d:%k:%n:%m\n"],
           "description": "Linter command to check LaTeX syntax of the current file state in real time with ChkTeX.\nCurrent file contents will be piped to the command through stdin.\nThe format string should be kept as shown in the default as this is the format the parser expects for successful parsing."
         },
         "latex-workshop.linter_command_root_file": {
           "type": "array",
-          "default": ["chktex", "-q", "-f%f:%l:%c:%d:%k:%n:%m\n", "%DOC%"],
+          "default": ["chktex", "-wall", "-n22", "-n30", "-e16", "-q", "-f%f:%l:%c:%d:%k:%n:%m\n", "%DOC%"],
           "description": "Linter command to check LaTeX syntax of the entire project from the root file with ChkTeX.\nPlaceholder %DOC% is used to represent the root LaTeX file name (with extension).\nThe format string should be kept as shown in the default as this is the format the parser expects for successful parsing."
         },
         "latex-workshop.linter_interval": {

--- a/src/codeactions.ts
+++ b/src/codeactions.ts
@@ -1,0 +1,134 @@
+import * as vs from 'vscode'
+
+import { Extension } from './main'
+
+const codesToStaticActionStrings = {
+    1: "Terminate command with empty statement",
+    2: "Convert to non-breaking space (~)",
+    4: "Remove italic correction \\/ (not in italic buffer)",
+    5: "Remove extraneous italic correction(s)",
+    6: "Add italic correction (\\/)",
+    11: "Fix ellipsis",
+    13: "Add intersentence space (\\@)",
+    18: "Replace with ` or '",
+    32: "Replace with `",
+    33: "Replace with '",
+    24: "Remove extraneous space",
+    28: "Remove incorrect \\/",
+    26: "Remove extraneous space",
+    34: "Replace with ` or '",
+    35: "Use suggested alternative",
+    39: "Remove extraneous space",
+    42: "Remove extraneous space"
+}
+
+function replaceWhitespaceOnLineBefore(document: vs.TextDocument, position: vs.Position, replaceWith: string): any {
+    const beforePosRange = new vs.Range(new vs.Position(position.line, 0), position)
+    const text = document.getText(beforePosRange)
+    const charactersToRemove = /\s*$/.exec(text)[0].length
+    const wsRange = new vs.Range(new vs.Position(position.line, position.character - charactersToRemove), position)
+    const edit = new vs.WorkspaceEdit()
+    edit.replace(document.uri, wsRange, replaceWith)
+    return vs.workspace.applyEdit(edit)
+}
+
+function replaceRangeWithString(document: vs.TextDocument, range: vs.Range, replacementString: string): any {
+    const edit = new vs.WorkspaceEdit()
+    edit.replace(document.uri, range, replacementString)
+    return vs.workspace.applyEdit(edit)
+}
+
+function replaceRangeWithRepeatedString(document: vs.TextDocument, range: vs.Range, replacementString: string): any {
+    return replaceRangeWithString(document, range, replacementString.repeat(range.end.character - range.start.character))
+}
+
+function characterBeforeRange(document: vs.TextDocument, range: vs.Range) {
+    return document.getText(range.with(range.start.translate(0, -1)))[0]
+}
+
+function isOpeningQuote(document: vs.TextDocument, range: vs.Range) {
+    return range.start.character === 0 || characterBeforeRange(document, range) === ' '
+}
+
+export class CodeActions {
+    extension: Extension
+
+    constructor(extension: Extension) {
+        this.extension = extension
+    }
+
+    provideCodeActions(document: vs.TextDocument, range: vs.Range, context: vs.CodeActionContext, token: vs.CancellationToken): vs.Command[] {
+        const actions = []
+
+        context.diagnostics.filter(d => d.source === 'ChkTeX').forEach(d => {
+            const label = codesToStaticActionStrings[d.code]
+            if (label !== undefined) {
+                actions.push({
+                    title: label,
+                    command: 'latex-workshop.code-action',
+                    arguments: [document, d.range, d.code, d.message]
+                })
+            }
+        })
+
+        return actions
+    }
+
+    runCodeAction(document: vs.TextDocument, range: vs.Range, code: number, message: string): any {
+        let fixString
+        switch (code) {
+            case 24:
+            case 26:
+            case 39:
+            case 42:
+                // In all these cases remove all proceeding whitespace.
+                replaceWhitespaceOnLineBefore(document, range.end, '')
+                break
+            case 4:
+            case 5:
+            case 28:
+                // In all these cases just clear what ChxTeX highlighted.
+                replaceRangeWithString(document, range, "")
+                break
+            case 1:
+                replaceWhitespaceOnLineBefore(document, range.end.translate(0, -1), '{}')
+                break
+            case 2:
+                replaceWhitespaceOnLineBefore(document, range.end, '~')
+                break
+            case 6:
+                replaceWhitespaceOnLineBefore(document, range.end.translate(0, -1), '\\/')
+            case 11:
+                fixString = /\\[cl]dots/.exec(message)[0]
+                replaceRangeWithString(document, range, fixString)
+                break
+            case 13:
+                replaceWhitespaceOnLineBefore(document, range.end.translate(0, -1), '\\@')
+                break
+            case 18:
+                if (isOpeningQuote(document, range)) {
+                    replaceRangeWithRepeatedString(document, range, "``")
+                } else {
+                    replaceRangeWithRepeatedString(document, range, "''")
+                }
+                break
+            case 32:
+                replaceRangeWithRepeatedString(document, range, "`")
+                break
+            case 33:
+                replaceRangeWithRepeatedString(document, range, "'")
+                break
+            case 34:
+                if (isOpeningQuote(document, range)) {
+                    replaceRangeWithRepeatedString(document, range, "`")
+                } else {
+                    replaceRangeWithRepeatedString(document, range, "'")
+                }
+                break
+            case 35:
+                fixString = /`(.+)'/.exec(message)[1]
+                replaceRangeWithString(document, range, fixString)
+                break
+        }
+    }
+}

--- a/src/codeactions.ts
+++ b/src/codeactions.ts
@@ -99,7 +99,8 @@ export class CodeActions {
             case 6:
                 replaceWhitespaceOnLineBefore(document, range.end.translate(0, -1), '\\/')
             case 11:
-                fixString = /\\[cl]dots/.exec(message)[0]
+                // add a space after so we don't accidentally join with the following word.
+                fixString = /\\[cl]?dots/.exec(message)[0] + " "
                 replaceRangeWithString(document, range, fixString)
                 break
             case 13:

--- a/src/main.ts
+++ b/src/main.ts
@@ -95,11 +95,8 @@ export async function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(vscode.languages.registerCodeActionsProvider('latex', extension.codeActions))
     extension.manager.findRoot()
 
-    if (vscode.window.activeTextEditor && 
-        extension.manager.isTex(vscode.window.activeTextEditor.document.fileName)) {
-        lintActiveFileIfEnabled(extension)
-    }
-
+    // On startup, lint the whole project if enabled.
+    lintRootFileIfEnabled(extension)
 }
 
 export class Extension {

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import {Logger} from './logger'
 import {Commander} from './commander'
 import {Manager} from './manager'
 import {Builder} from './builder'
+import {CodeActions} from './codeactions'
 import {Viewer, PDFProvider} from './viewer'
 import {Server} from './server'
 import {Locator} from './locator'
@@ -21,6 +22,7 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('latex-workshop.tab', () => extension.commander.tab())
     vscode.commands.registerCommand('latex-workshop.synctex', () => extension.commander.synctex())
     vscode.commands.registerCommand('latex-workshop.clean', () => extension.commander.clean())
+    vscode.commands.registerCommand('latex-workshop.code-action', (d, r, c, m) => extension.codeActions.runCodeAction(d, r, c, m))
 
     context.subscriptions.push(vscode.workspace.onDidSaveTextDocument((e: vscode.TextDocument) => {
         let configuration = vscode.workspace.getConfiguration('latex-workshop')
@@ -69,7 +71,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
     context.subscriptions.push(vscode.workspace.registerTextDocumentContentProvider('latex-workshop-pdf', new PDFProvider(extension)))
     context.subscriptions.push(vscode.languages.registerCompletionItemProvider('latex', extension.completer, '\\', '{', ','))
-
+    context.subscriptions.push(vscode.languages.registerCodeActionsProvider('latex', extension.codeActions))
     extension.manager.findRoot()
 }
 
@@ -85,6 +87,7 @@ export class Extension {
     completer: Completer
     linter: Linter
     cleaner: Cleaner
+    codeActions: CodeActions
 
     constructor() {
         this.logger = new Logger(this)
@@ -98,6 +101,7 @@ export class Extension {
         this.completer = new Completer(this)
         this.linter = new Linter(this)
         this.cleaner = new Cleaner(this)
+        this.codeActions = new CodeActions(this)
         this.logger.addLogMessage(`LaTeX Workshop initialized.`)
     }
 }

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -25,9 +25,7 @@ export class Manager {
     }
 
     isTex(filePath) {
-        if (path.extname(filePath) == '.tex')
-            return true
-        return false
+        return path.extname(filePath) === '.tex'
     }
 
     findRoot() : string | undefined {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -189,7 +189,11 @@ export class Parser {
             diagsCollection[item.file].push(diag)
         }
         for (const file in diagsCollection) {
-            this.linterDiagnostics.set(vscode.Uri.file(file), diagsCollection[file])
+            if (this.extension.manager.isTex(file)) {
+                // only report ChkTeX errors on TeX files. This is done to avoid
+                // reporting errors in .sty files which for most users is irrelevant.
+                this.linterDiagnostics.set(vscode.Uri.file(file), diagsCollection[file])
+            }
         }
     }
 }


### PR DESCRIPTION
This PR adds a basic set of code actions that can be performed to fix simple errors detected by ChkTeX. 

Hit `cmd` + `.` over a warning to see any relevent code actions, or use the mouse to click the light bulb icon.

Best explained with a demo:

![demo linting](https://cloud.githubusercontent.com/assets/1312873/24458498/0303c3ca-1491-11e7-8685-f743ddb0838c.gif)


For now I've just for common easy to fix errors. It's simple enough to extend this to more complex fixes though.