### PR TITLE
use alwaysStrict TS flag

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -1,5 +1,3 @@
-'use strict'
-
 import * as vscode from 'vscode'
 import * as path from 'path'
 import * as cp from 'child_process'

--- a/src/cleaner.ts
+++ b/src/cleaner.ts
@@ -1,5 +1,3 @@
-'use strict'
-
 import * as vscode from 'vscode'
 import * as path from 'path'
 import * as fs from 'fs'

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -1,5 +1,3 @@
-'use strict'
-
 import * as vscode from 'vscode'
 
 import {Extension} from './main'

--- a/src/completer.ts
+++ b/src/completer.ts
@@ -1,5 +1,3 @@
-'use strict'
-
 import * as vscode from 'vscode'
 
 import {Extension} from './main'

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -1,5 +1,3 @@
-'use strict'
-
 import * as vscode from 'vscode'
 import * as path from 'path'
 import {ChildProcess, spawn, SpawnOptions} from 'child_process'

--- a/src/locator.ts
+++ b/src/locator.ts
@@ -1,5 +1,3 @@
-'use strict'
-
 import * as vscode from 'vscode'
 import * as path from 'path'
 import * as cp from 'child_process'

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,5 +1,3 @@
-'use strict'
-
 import * as vscode from 'vscode'
 
 import {Extension} from './main'

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,3 @@
-'use strict'
-
 import * as vscode from 'vscode'
 
 import {Logger} from './logger'

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -1,5 +1,3 @@
-'use strict'
-
 import * as vscode from 'vscode'
 import * as path from 'path'
 import * as fs from 'fs'

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,5 +1,3 @@
-'use strict'
-
 import * as vscode from 'vscode'
 import * as path from 'path'
 import * as tmp from 'tmp'

--- a/src/providers/citation.ts
+++ b/src/providers/citation.ts
@@ -1,5 +1,3 @@
-'use strict'
-
 import * as vscode from 'vscode'
 import * as fs from 'fs'
 

--- a/src/providers/command.ts
+++ b/src/providers/command.ts
@@ -1,5 +1,3 @@
-'use strict'
-
 import * as vscode from 'vscode'
 import * as fs from 'fs'
 

--- a/src/providers/environment.ts
+++ b/src/providers/environment.ts
@@ -1,5 +1,3 @@
-'use strict'
-
 import * as vscode from 'vscode'
 import * as fs from 'fs'
 

--- a/src/providers/reference.ts
+++ b/src/providers/reference.ts
@@ -1,5 +1,3 @@
-'use strict'
-
 import * as vscode from 'vscode'
 import * as fs from 'fs'
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,3 @@
-'use strict'
-
 import * as vscode from 'vscode'
 import * as http from 'http'
 import * as ws from 'ws'

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -1,5 +1,3 @@
-'use strict'
-
 import * as vscode from 'vscode'
 import * as ws from 'ws'
 import * as fs from 'fs'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
         "module": "commonjs",
         "target": "es6",
         "outDir": "out",
+        "alwaysStrict": true,
         "lib": [
             "es6"
         ],


### PR DESCRIPTION
From [the docs](https://www.typescriptlang.org/docs/handbook/compiler-options.html):
> `--alwaysStrict` : Parse in strict mode and emit "use strict" for each source file

Saves having the boilerplate in each file.