### PR TITLE
Fix undefined intellisense for commands with args

### DIFF
--- a/src/providers/command.ts
+++ b/src/providers/command.ts
@@ -38,10 +38,8 @@ export class Command {
         Object.keys(suggestions).forEach(key => {
             let item = suggestions[key]
             let command = new vscode.CompletionItem(item.command,vscode.CompletionItemKind.Keyword)
-            if (item.snippet){
-                console.log(item.command, item.snippet)
+            if (item.snippet)
                 command.insertText = new vscode.SnippetString(item.snippet)
-            }
             if (item.documentation)
                 command.documentation = item.documentation
             this.suggestions.push(command)

--- a/src/providers/command.ts
+++ b/src/providers/command.ts
@@ -38,8 +38,10 @@ export class Command {
         Object.keys(suggestions).forEach(key => {
             let item = suggestions[key]
             let command = new vscode.CompletionItem(item.command,vscode.CompletionItemKind.Keyword)
-            if (item.snippet)
+            if (item.snippet){
+                console.log(item.command, item.snippet)
                 command.insertText = new vscode.SnippetString(item.snippet)
+            }
             if (item.documentation)
                 command.documentation = item.documentation
             this.suggestions.push(command)
@@ -67,7 +69,7 @@ export class Command {
                 }
                 if (result[2]) {
                     items[result[1]].chain = true
-                    items[result[1]].snippet += `{$\{1:arg}}`
+                    items[result[1]].snippet = `${result[1]}{$\{1:arg}}`
                 }
                 if (result[3])
                     items[result[1]].snippet += `{$\{2:arg}}`


### PR DESCRIPTION
Previous commits on default commands broke the command parsing in the editors. `\somecommand{args}` will have `\undefined{args}` inserted. This PR solves the problem.