### PR TITLE
Fix lint on changing editor ignoring setting

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -85,7 +85,9 @@ export async function activate(context: vscode.ExtensionContext) {
             extension.logger.status.show()
         if (vscode.window.activeTextEditor)
             extension.manager.findRoot()
-        if (extension.manager.isTex(e.document.fileName)) {
+        let configuration = vscode.workspace.getConfiguration('latex-workshop')
+        let linter = configuration.get('linter') as boolean
+        if (linter && extension.manager.isTex(e.document.fileName)) {
             extension.linter.lintActiveFile()
         }
     }))


### PR DESCRIPTION
Currently the extension will lint the current active file whenever the active editor is changed regardless of `latex-workshop.linter` configuration. This PR fixes the problem.