### PR TITLE
refinements to file watcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -283,6 +283,7 @@
     "ws": "^1.1.1"
   },
   "devDependencies": {
+    "@types/chokidar": "^1.6.0",
     "@types/glob": "^5.0.30",
     "@types/node": "^6.0.40",
     "@types/tmp": "0.0.32",


### PR DESCRIPTION
Hey @James-Yu,

Had a good look at #71, have some suggestions for improvements. I've done this as a PR against your `watch-files` branch so if you like what I've done you can accept this to update #71 before merging!

To summarise:

1. Added types for `chokidar`
2. Discovered our test for checking if the file was already being watched wasn't quite correct - added `pathNotWatched()` function that implements this correctly.
3. The citation manager already keeps all the info it needs for bib items, so `bibFileTree` was redundant. Only addition here is I respond to deletion in `.bib` files and I remove these from the `citationInBib` object.
4. If the `rootFile` is deleted (and we detect it) I now trigger a new rootFile search.
5. If the `rootFile` is not in the watcher (i.e. the root has changed) I clear up the old watcher and make a new one.
6. Added more logs
7. Tested a fair amount changing/deleting different parts of my thesis, seems to work correctly after these changes!
