### PR TITLE
Typing improvements, bibtex missing key detection

### DIFF
--- a/src/codeactions.ts
+++ b/src/codeactions.ts
@@ -23,7 +23,7 @@ const codesToStaticActionStrings = {
     42: "Remove extraneous space"
 }
 
-function replaceWhitespaceOnLineBefore(document: vs.TextDocument, position: vs.Position, replaceWith: string): any {
+function replaceWhitespaceOnLineBefore(document: vs.TextDocument, position: vs.Position, replaceWith: string) {
     const beforePosRange = new vs.Range(new vs.Position(position.line, 0), position)
     const text = document.getText(beforePosRange)
     const regexResult = /\s*$/.exec(text)
@@ -37,13 +37,13 @@ function replaceWhitespaceOnLineBefore(document: vs.TextDocument, position: vs.P
     return vs.workspace.applyEdit(edit)
 }
 
-function replaceRangeWithString(document: vs.TextDocument, range: vs.Range, replacementString: string): any {
+function replaceRangeWithString(document: vs.TextDocument, range: vs.Range, replacementString: string) {
     const edit = new vs.WorkspaceEdit()
     edit.replace(document.uri, range, replacementString)
     return vs.workspace.applyEdit(edit)
 }
 
-function replaceRangeWithRepeatedString(document: vs.TextDocument, range: vs.Range, replacementString: string): any {
+function replaceRangeWithRepeatedString(document: vs.TextDocument, range: vs.Range, replacementString: string) {
     return replaceRangeWithString(document, range, replacementString.repeat(range.end.character - range.start.character))
 }
 
@@ -63,7 +63,7 @@ export class CodeActions {
     }
 
     // Leading underscore to avoid tslint complaint
-    provideCodeActions(document: vs.TextDocument, _range: vs.Range, context: vs.CodeActionContext, _token: vs.CancellationToken): vs.Command[] {
+    provideCodeActions(document: vs.TextDocument, _range: vs.Range, context: vs.CodeActionContext, _token: vs.CancellationToken) : vs.Command[] {
         const actions: vs.Command[] = []
         context.diagnostics.filter(d => d.source === 'ChkTeX').forEach(d => {
             const label = codesToStaticActionStrings[d.code]
@@ -79,7 +79,7 @@ export class CodeActions {
         return actions
     }
 
-    runCodeAction(document: vs.TextDocument, range: vs.Range, code: number, message: string): any {
+    runCodeAction(document: vs.TextDocument, range: vs.Range, code: number, message: string) {
         let fixString
         let regexResult
         switch (code) {

--- a/src/completer.ts
+++ b/src/completer.ts
@@ -21,8 +21,7 @@ export class Completer implements vscode.CompletionItemProvider {
         this.reference = new Reference(extension)
     }
 
-    provideCompletionItems(document: vscode.TextDocument, position: vscode.Position, _token: vscode.CancellationToken):
-        Thenable<vscode.CompletionItem[]> {
+    provideCompletionItems(document: vscode.TextDocument, position: vscode.Position, _token: vscode.CancellationToken) : Promise<vscode.CompletionItem[]> {
         return new Promise((resolve, _reject) => {
             const line = document.lineAt(position.line).text.substr(0, position.character)
             for (const type of ['citation', 'reference', 'environment', 'command']) {
@@ -55,6 +54,10 @@ export class Completer implements vscode.CompletionItemProvider {
                 reg = /\\([a-zA-Z]*)$/
                 provider = this.command
                 break
+            default:
+                // This shouldn't be possible, so mark as error case in log.
+                this.extension.logger.addLogMessage(`Error - trying to complete unknown type ${type}`)
+                return []
         }
         const result = line.match(reg)
         let suggestions = []

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -70,7 +70,7 @@ export class Parser {
         return lines.slice(finalLine).join('\n')
     }
 
-    latexmkSkipped(log: string): boolean {
+    latexmkSkipped(log: string) : boolean {
         const lines = log.replace(/(\r\n)|\r/g, '\n').split('\n')
         if (lines[0].match(latexmkUpToDate)) {
             this.showCompilerDiagnostics()
@@ -123,8 +123,8 @@ export class Parser {
     parseLinter(log: string, singleFileOriginalPath?: string) {
         const re = /^(.*?):(\d+):(\d+):(\d+):(.*?):(\d+):(.*?)$/gm
         const linterLog: LinterLogEntry[] = []
-        let match
-        while (match = re.exec(log)) {
+        let match = re.exec(log)
+        while (match) {
             // this log may be for a single file in memory, in which case we override the
             // path with what is provided
             const filePath = singleFileOriginalPath ? singleFileOriginalPath : match[1]
@@ -137,6 +137,7 @@ export class Parser {
                 code: parseInt(match[6]),
                 text: `${match[6]}: ${match[7]}`
             })
+            match = re.exec(log)
         }
         this.extension.logger.addLogMessage(`Linter log parsed with ${linterLog.length} messages.`)
         if (singleFileOriginalPath === undefined) {

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -4,6 +4,7 @@ import * as path from 'path'
 import * as open from 'open'
 
 import {Extension} from './main'
+import {SyncTeXRecord} from './locator'
 
 export class Viewer {
     extension: Extension
@@ -14,7 +15,7 @@ export class Viewer {
         this.extension = extension
     }
 
-    refreshExistingViewer(sourceFile: string, type: string | undefined = undefined) : boolean {
+    refreshExistingViewer(sourceFile: string, type?: string) : boolean {
         const pdfFile = this.extension.manager.tex2pdf(sourceFile)
         if (pdfFile in this.clients &&
             (type === undefined || this.clients[pdfFile].type === type) &&
@@ -27,7 +28,7 @@ export class Viewer {
         return false
     }
 
-    checkViewer(sourceFile: string, type: string) : string |undefined {
+    checkViewer(sourceFile: string, type: string) : string | undefined {
         if (this.refreshExistingViewer(sourceFile, type)) {
             return
         }
@@ -116,7 +117,7 @@ export class Viewer {
         }
     }
 
-    syncTeX(pdfFile: string, record: object) {
+    syncTeX(pdfFile: string, record: SyncTeXRecord | undefined) {
         if (!(pdfFile in this.clients)) {
             this.extension.logger.addLogMessage(`PDF is not viewed: ${pdfFile}`)
             return
@@ -133,7 +134,7 @@ export class PDFProvider implements vscode.TextDocumentContentProvider {
         this.extension = extension
     }
 
-    public provideTextDocumentContent(uri: vscode.Uri): string {
+    public provideTextDocumentContent(uri: vscode.Uri) : string {
         const url = `http://${this.extension.server.address}/viewer.html?file=\\pdf:${encodeURIComponent(uri.fsPath)}`
         return `
             <!DOCTYPE html style="position:absolute; left: 0; top: 0; width: 100%; height: 100%;"><html><head></head>

--- a/tslint.json
+++ b/tslint.json
@@ -32,11 +32,29 @@
       "check-whitespace"
     ],
     "one-variable-per-declaration": [true, "ignore-for-loop"],
+    "only-arrow-functions": [true, "allow-declarations"],
     "prefer-const": true,
     "quotemark": [true, "avoid-escape", "single"],
     "semicolon": [true, "never"],
     "switch-default": true,
     "triple-equals": true,
+    "typedef-whitespace": [
+      true,
+      {
+        "call-signature": "onespace",
+        "index-signature": "nospace",
+        "parameter": "nospace",
+        "property-declaration": "nospace",
+        "variable-declaration": "nospace"
+      },
+      {
+        "call-signature": "onespace",
+        "index-signature": "onespace",
+        "parameter": "onespace",
+        "property-declaration": "onespace",
+        "variable-declaration": "onespace"
+      }
+    ],
     "variable-name": [
       true,
       "allow-leading-underscore",


### PR DESCRIPTION
1. Adds a `tslint` rule about spacing for return type of function and enforces it throughout
2. Removes some unneeded `any` type declarations (in general we want to avoid adding any where possible as it weakens the ability of TS to let us catch errors)
3. Add a default case to a switch (even though it should be impossible to hit)
4. Tighten typing of `SyncTeX` and citation parsing.
5. Log an error if we find bibtex entries with no cite key