### PR TITLE
typing improvements towards enabling noImplicitAny

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,5 @@
     },
     "typescript.tsdk": "./node_modules/typescript/lib",  // we want to use the TS server from our node_modules folder to control its version
     "vsicons.presets.angular": false,
-    "tslint.exclude": "node_modules/**"
+    "tslint.exclude": "node_modules"
 }

--- a/src/codeactions.ts
+++ b/src/codeactions.ts
@@ -2,7 +2,7 @@ import * as vs from 'vscode'
 
 import { Extension } from './main'
 
-const codesToStaticActionStrings = {
+const CODE_TO_ACTION_STRING: {[key: number]: string} = {
     1: "Terminate command with empty statement",
     2: "Convert to non-breaking space (~)",
     4: "Remove italic correction \\/ (not in italic buffer)",
@@ -66,7 +66,11 @@ export class CodeActions {
     provideCodeActions(document: vs.TextDocument, _range: vs.Range, context: vs.CodeActionContext, _token: vs.CancellationToken) : vs.Command[] {
         const actions: vs.Command[] = []
         context.diagnostics.filter(d => d.source === 'ChkTeX').forEach(d => {
-            const label = codesToStaticActionStrings[d.code]
+            let code  = d.code
+            if (typeof code === 'string') {
+                code = parseInt(code)
+            }
+            const label = CODE_TO_ACTION_STRING[code]
             if (label !== undefined) {
                 actions.push({
                     title: label,

--- a/src/completer.ts
+++ b/src/completer.ts
@@ -60,7 +60,7 @@ export class Completer implements vscode.CompletionItemProvider {
                 return []
         }
         const result = line.match(reg)
-        let suggestions = []
+        let suggestions: vscode.CompletionItem[] = []
         if (result) {
             suggestions = provider.provide()
         }

--- a/src/locator.ts
+++ b/src/locator.ts
@@ -18,7 +18,7 @@ export class Locator {
     }
 
     parseSyncTeX(result: string) {
-        const record = {}
+        const record: {[key: string]: string | number} = {}
         let started = false
         for (const line of result.split('\n')) {
             if (line.indexOf('SyncTeX result begin') > -1) {

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -26,11 +26,11 @@ export class Manager {
         return path.dirname(this.rootFile)
     }
 
-    tex2pdf(texPath) {
+    tex2pdf(texPath: string) {
         return `${texPath.substr(0, texPath.lastIndexOf('.'))}.pdf`
     }
 
-    isTex(filePath) {
+    isTex(filePath: string) {
         return path.extname(filePath) === '.tex'
     }
 
@@ -127,11 +127,11 @@ export class Manager {
         if (prevWatcherClosed || this.fileWatcher === undefined) {
             this.extension.logger.addLogMessage(`Instatiating new file watcher for ${this.rootFile}`)
             this.fileWatcher = chokidar.watch(this.rootFile)
-            this.fileWatcher.on('change', path => {
+            this.fileWatcher.on('change', (path: string) => {
                 this.extension.logger.addLogMessage(`File watcher: responding to change in ${path}`)
                 this.findDependentFiles(path)
             })
-            this.fileWatcher.on('unlink', path => {
+            this.fileWatcher.on('unlink', (path: string) => {
                 this.extension.logger.addLogMessage(`File watcher: ${path} deleted.`)
                 this.fileWatcher.unwatch(path)
                 if (path === this.rootFile) {
@@ -194,11 +194,11 @@ export class Manager {
                     if (this.bibWatcher === undefined) {
                         this.extension.logger.addLogMessage(`Creating file watcher for .bib files.`)
                         this.bibWatcher = chokidar.watch(bibPath)
-                        this.bibWatcher.on('change', path => {
+                        this.bibWatcher.on('change', (path: string) => {
                             this.extension.logger.addLogMessage(`Bib file watcher - responding to change in ${path}`)
                             this.extension.completer.citation.parseBibItems(path)
                         })
-                        this.bibWatcher.on('unlink', path => {
+                        this.bibWatcher.on('unlink', (path: string) => {
                             this.extension.logger.addLogMessage(`Bib file watcher: ${path} deleted.`)
                             this.extension.completer.citation.forgetParsedBibItems(path)
                             this.bibWatcher.unwatch(path)

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -15,7 +15,8 @@ const latexmkPattern = /^Latexmk:\sapplying\srule/gm
 const latexmkPatternNoGM = /^Latexmk:\sapplying\srule/
 const latexmkUpToDate = /^Latexmk: All targets \(.*\) are up-to-date/
 
-const DIAGNOSTIC_SEVERITY = {
+
+const DIAGNOSTIC_SEVERITY: {[key: string]: vscode.DiagnosticSeverity} = {
     'typesetting': vscode.DiagnosticSeverity.Hint,
     'warning': vscode.DiagnosticSeverity.Warning,
     'error': vscode.DiagnosticSeverity.Error,

--- a/src/providers/environment.ts
+++ b/src/providers/environment.ts
@@ -2,6 +2,126 @@ import * as vscode from 'vscode'
 
 import {Extension} from './../main'
 
+const DEFAULT_ENIRONMENTS: {[key: string]: { text: string }} = {
+    figure: {
+        text: 'figure'
+    },
+    table: {
+        text: 'table'
+    },
+    description: {
+        text: 'description'
+    },
+    enumerate: {
+        text: 'enumerate'
+    },
+    itemize: {
+        text: 'itemize'
+    },
+    math: {
+        text: 'math'
+    },
+    displaymath: {
+        text: 'displaymath'
+    },
+    split: {
+        text: 'split'
+    },
+    array: {
+        text: 'array'
+    },
+    eqnarray: {
+        text: 'eqnarray'
+    },
+    equation: {
+        text: 'equation'
+    },
+    equationAst: {
+        text: 'equation*'
+    },
+    subequations: {
+        text: 'subequations'
+    },
+    subequationsAst: {
+        text: 'subequations*'
+    },
+    multiline: {
+        text: 'multiline'
+    },
+    multilineAst: {
+        text: 'multiline*'
+    },
+    gather: {
+        text: 'gather'
+    },
+    gatherAst: {
+        text: 'gather*'
+    },
+    align: {
+        text: 'align'
+    },
+    alignAst: {
+        text: 'align*'
+    },
+    alignat: {
+        text: 'alignat'
+    },
+    alignatAst: {
+        text: 'alignat*'
+    },
+    flalign: {
+        text: 'flalign'
+    },
+    flalignAst: {
+        text: 'flalign*'
+    },
+    theorem: {
+        text: 'theorem'
+    },
+    cases: {
+        text: 'cases'
+    },
+    center: {
+        text: 'center'
+    },
+    flushleft: {
+        text: 'flushleft'
+    },
+    flushright: {
+        text: 'flushright'
+    },
+    minipage: {
+        text: 'minipage'
+    },
+    quotation: {
+        text: 'quotation'
+    },
+    quote: {
+        text: 'quote'
+    },
+    verbatim: {
+        text: 'verbatim'
+    },
+    verse: {
+        text: 'verse'
+    },
+    picture: {
+        text: 'picture'
+    },
+    tabbing: {
+        text: 'tabbing'
+    },
+    tabular: {
+        text: 'tabular'
+    },
+    thebibliography: {
+        text: 'thebibliography'
+    },
+    titlepage: {
+        text: 'titlepage'
+    },
+}
+
 export class Environment {
     extension: Extension
     suggestions: vscode.CompletionItem[]
@@ -10,8 +130,8 @@ export class Environment {
     constructor(extension: Extension) {
         this.extension = extension
         this.suggestions = []
-        Object.keys(this.defaults).map(key => {
-            const item = this.defaults[key]
+        Object.keys(DEFAULT_ENIRONMENTS).forEach(key => {
+            const item = DEFAULT_ENIRONMENTS[key]
             const environment = new vscode.CompletionItem(item.text, vscode.CompletionItemKind.Module)
             this.suggestions.push(environment)
         })
@@ -21,123 +141,4 @@ export class Environment {
         return this.suggestions
     }
 
-    defaults = {
-        figure: {
-            text: 'figure'
-        },
-        table: {
-            text: 'table'
-        },
-        description: {
-            text: 'description'
-        },
-        enumerate: {
-            text: 'enumerate'
-        },
-        itemize: {
-            text: 'itemize'
-        },
-        math: {
-            text: 'math'
-        },
-        displaymath: {
-            text: 'displaymath'
-        },
-        split: {
-            text: 'split'
-        },
-        array: {
-            text: 'array'
-        },
-        eqnarray: {
-            text: 'eqnarray'
-        },
-        equation: {
-            text: 'equation'
-        },
-        equationAst: {
-            text: 'equation*'
-        },
-        subequations: {
-            text: 'subequations'
-        },
-        subequationsAst: {
-            text: 'subequations*'
-        },
-        multiline: {
-            text: 'multiline'
-        },
-        multilineAst: {
-            text: 'multiline*'
-        },
-        gather: {
-            text: 'gather'
-        },
-        gatherAst: {
-            text: 'gather*'
-        },
-        align: {
-            text: 'align'
-        },
-        alignAst: {
-            text: 'align*'
-        },
-        alignat: {
-            text: 'alignat'
-        },
-        alignatAst: {
-            text: 'alignat*'
-        },
-        flalign: {
-            text: 'flalign'
-        },
-        flalignAst: {
-            text: 'flalign*'
-        },
-        theorem: {
-            text: 'theorem'
-        },
-        cases: {
-            text: 'cases'
-        },
-        center: {
-            text: 'center'
-        },
-        flushleft: {
-            text: 'flushleft'
-        },
-        flushright: {
-            text: 'flushright'
-        },
-        minipage: {
-            text: 'minipage'
-        },
-        quotation: {
-            text: 'quotation'
-        },
-        quote: {
-            text: 'quote'
-        },
-        verbatim: {
-            text: 'verbatim'
-        },
-        verse: {
-            text: 'verse'
-        },
-        picture: {
-            text: 'picture'
-        },
-        tabbing: {
-            text: 'tabbing'
-        },
-        tabular: {
-            text: 'tabular'
-        },
-        thebibliography: {
-            text: 'thebibliography'
-        },
-        titlepage: {
-            text: 'titlepage'
-        }
-    }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,7 +15,7 @@ export class Server {
     constructor(extension: Extension) {
         this.extension = extension
         this.httpServer = http.createServer((request, response) => this.handler(request, response))
-        this.httpServer.listen(0, "localhost", undefined, (err) => {
+        this.httpServer.listen(0, "localhost", undefined, (err: Error) => {
             if (err) {
                 this.extension.logger.addLogMessage(`Error creating LaTeX Workshop http server: ${err}.`)
             } else {


### PR DESCRIPTION
I uncommented the following line in `tsconfig.json`:
```
        // "noImplicitAny": true,
```
just to see how far we are from being able to enable TS best practice of avoiding implicit `any` types entirely. We have around 50 errors with this enabled.

This PR fixes most of them, so after this we are down to 19. 😄 

I've still left `"noImplicitAny"` disabled in this PR, and I can do another round in the future to get us down to 0 errors.

The largest change here is in the `viewer` module, where the compiler made us be more careful to check that the websocket we are sending messages through is present.