### PR TITLE
Add a quickpick menu for all commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,11 +137,15 @@
       },
       {
         "command": "latex-workshop.synctex",
-        "title": "SyncTeX from LaTeX to PDF"
+        "title": "SyncTeX from cursor"
       },
       {
         "command": "latex-workshop.clean",
         "title": "Clean up auxillary files of LaTeX project"
+      },
+      {
+        "command": "latex-workshop.actions",
+        "title": "LaTeX Workshop Actions"
       }
     ],
     "configuration": {
@@ -244,23 +248,13 @@
         },
         {
           "when": "resourceLangId == latex",
-          "command": "latex-workshop.view",
+          "command": "latex-workshop.synctex",
           "group": "navigation@101"
         },
         {
           "when": "resourceLangId == latex",
-          "command": "latex-workshop.tab",
+          "command": "latex-workshop.actions",
           "group": "navigation@102"
-        },
-        {
-          "when": "resourceLangId == latex",
-          "command": "latex-workshop.synctex",
-          "group": "navigation@103"
-        },
-        {
-          "when": "resourceLangId == latex",
-          "command": "latex-workshop.clean",
-          "group": "navigation@104"
         }
       ]
     }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -12,7 +12,8 @@ export class Logger {
         this.extension = extension
         this.logPanel = vscode.window.createOutputChannel('LaTeX Workshop')
         this.addLogMessage('Initializing LaTeX Workshop.')
-        this.status = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 1)
+        this.status = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, -10000)
+        this.status.command = 'latex-workshop.actions'
         this.status.show()
         this.displayStatus('repo', 'white', 'LaTeX Workshop')
     }
@@ -33,6 +34,18 @@ export class Logger {
         this.status.color = color
         if (timeout > 0) {
             this.statusTimeout = setTimeout(() => this.status.text = `$(${icon})`, timeout)
+        }
+    }
+
+    displayFullStatus(timeout: number = 5000) {
+        if (this.statusTimeout) {
+            clearTimeout(this.statusTimeout)
+        }
+        const icon = this.status.text.split(' ')[0]
+        const message = this.status.tooltip
+        this.status.text = `${icon} Previous message: ${message}`
+        if (timeout > 0) {
+            this.statusTimeout = setTimeout(() => this.status.text = `${icon}`, timeout)
         }
     }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -50,6 +50,7 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('latex-workshop.tab', () => extension.commander.tab())
     vscode.commands.registerCommand('latex-workshop.synctex', () => extension.commander.synctex())
     vscode.commands.registerCommand('latex-workshop.clean', () => extension.commander.clean())
+    vscode.commands.registerCommand('latex-workshop.actions', () => extension.commander.actions())
     vscode.commands.registerCommand('latex-workshop.code-action', (d, r, c, m) => extension.codeActions.runCodeAction(d, r, c, m))
 
     context.subscriptions.push(vscode.workspace.onDidSaveTextDocument((e: vscode.TextDocument) => {


### PR DESCRIPTION
This PR add a quickpick menu for all commands. The menu can be invoked by either clicking the status bar item or right click latex files. To make the context menu more compact, many items are removed.

Another small change is that when clicking the status bar item, previous message is displayed again.