### PR TITLE
Use new tab to display raw log, remove tmp

### DIFF
--- a/package.json
+++ b/package.json
@@ -273,15 +273,13 @@
     "chokidar": "^1.6.1",
     "glob": "^7.1.1",
     "open": "^0.0.5",
-    "tmp": "^0.0.31",
     "ws": "^1.1.1"
   },
   "devDependencies": {
     "@types/chokidar": "^1.6.0",
     "@types/glob": "^5.0.30",
     "@types/node": "^6.0.40",
-    "@types/tmp": "0.0.32",
-    "@types/ws": "0.0.39",
+    "@types/ws": "^0.0.39",
     "tslint": "^5.0.0",
     "typescript": "^2.0.3",
     "vscode": "^1.0.0"

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -79,16 +79,27 @@ export class Commander {
                 return true
             })
             this.commandTitles = commands.map(command => command.title)
+            this.commandTitles.push('Show last LaTeX log')
             this.commands = commands.map(command => command.command)
         }
         vscode.window.showQuickPick(this.commandTitles, {
-            placeHolder: "Please Select LaTeX Workshop Actions"
+            placeHolder: 'Please Select LaTeX Workshop Actions'
         }).then(selected => {
             if (!selected) {
                 return
             }
             const command = this.commands[this.commandTitles.indexOf(selected)]
-            vscode.commands.executeCommand(command)
+            if (command) {
+                vscode.commands.executeCommand(command)
+                return
+            }
+            switch (selected) {
+                case 'Show last LaTeX log':
+                    this.extension.logger.showLog()
+                    break
+                default:
+                    break
+            }
         })
     }
 }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -48,4 +48,38 @@ export class Logger {
             this.statusTimeout = setTimeout(() => this.status.text = `${icon}`, timeout)
         }
     }
+
+    showLog() {
+        if (!this.extension.parser.buildLogRaw) {
+            return
+        }
+        const uri = vscode.Uri.file(this.extension.manager.rootFile).with({scheme: 'latex-workshop-log'})
+        let column = vscode.ViewColumn.Two
+        if (vscode.window.activeTextEditor && vscode.window.activeTextEditor.viewColumn === vscode.ViewColumn.Two) {
+            column = vscode.ViewColumn.Three
+        }
+        vscode.commands.executeCommand("vscode.previewHtml", uri, column, 'Raw LaTeX Log')
+        this.extension.logger.addLogMessage(`Open Log tab`)
+    }
+}
+
+export class LogProvider implements vscode.TextDocumentContentProvider {
+    extension: Extension
+
+    constructor(extension: Extension) {
+        this.extension = extension
+    }
+
+    public provideTextDocumentContent(_uri: vscode.Uri) : string {
+        const dom = this.extension.parser.buildLogRaw.split('\n').map(log => `<span>${log.replace(/&/g, "&amp;")
+                                                                                         .replace(/</g, "&lt;")
+                                                                                         .replace(/>/g, "&gt;")
+                                                                                         .replace(/"/g, "&quot;")
+                                                                                         .replace(/'/g, "&#039;")}</span><br>`)
+        console.log(this.extension.parser.buildLogRaw)
+        return `
+            <!DOCTYPE html style="position:absolute; left: 0; top: 0; width: 100%; height: 100%;"><html><head></head>
+            <body style="position:absolute; left: 0; top: 0; width: 100%; height: 100%; white-space: pre;">${dom.join('')}</body></html>
+        `
+    }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode'
 import * as path from 'path'
 
-import {Logger} from './logger'
+import {Logger, LogProvider} from './logger'
 import {Commander} from './commander'
 import {Manager} from './manager'
 import {Builder} from './builder'
@@ -100,6 +100,7 @@ export async function activate(context: vscode.ExtensionContext) {
     }))
 
     context.subscriptions.push(vscode.workspace.registerTextDocumentContentProvider('latex-workshop-pdf', new PDFProvider(extension)))
+    context.subscriptions.push(vscode.workspace.registerTextDocumentContentProvider('latex-workshop-log', new LogProvider(extension)))
     context.subscriptions.push(vscode.languages.registerCompletionItemProvider('latex', extension.completer, '\\', '{', ','))
     context.subscriptions.push(vscode.languages.registerCodeActionsProvider('latex', extension.codeActions))
     extension.manager.findRoot()


### PR DESCRIPTION
This PR displays LaTeX raw log file in a vscode tab instead of creating temp files.

![image](https://cloud.githubusercontent.com/assets/4210342/24694280/e34b7126-1a13-11e7-8880-d2ffad555aad.png)
