### PR TITLE
Customiz-able citation intellisense, citation browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
       },
       {
         "command": "latex-workshop.clean",
-        "title": "Clean up auxillary files of LaTeX project"
+        "title": "Clean up auxillary files"
       },
       {
         "command": "latex-workshop.actions",
@@ -231,6 +231,16 @@
           "type": "number",
           "default": 300,
           "description": "Defines the time interval in milliseconds between invoking LaTeX linter on the active file."
+        },
+        "latex-workshop.citation_intellisense_label": {
+          "type": "string",
+          "enum": [
+            "bibtex key",
+            "title",
+            "authors"
+          ],
+          "default": "bibtex key",
+          "description": "Defines what to show as suggestion labels when intellisense provides citation suggestions."
         },
         "latex-workshop.show_debug_log": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "LaTeX Workshop",
   "description": "Boost LaTeX typesetting efficiency with preview, compile, autocomplete, colorize, and more.",
   "icon": "icon.png",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "publisher": "James-Yu",
   "license": "MIT",
   "homepage": "https://github.com/James-Yu/LaTeX-Workshop",

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -82,6 +82,7 @@ export class Commander {
             this.commands = commands.map(command => command.command)
         }
         const items = JSON.parse(JSON.stringify(this.commandTitles))
+        items.push('Open citation browser')
         if (this.extension.parser.buildLogRaw) {
             items.push('Show last LaTeX log')
         }
@@ -99,6 +100,9 @@ export class Commander {
             switch (selected) {
                 case 'Show last LaTeX log':
                     this.extension.logger.showLog()
+                    break
+                case 'Open citation browser':
+                    this.extension.completer.citation.browser()
                     break
                 default:
                     break

--- a/src/providers/citation.ts
+++ b/src/providers/citation.ts
@@ -81,14 +81,20 @@ export class Citation {
         const pickItems: vscode.QuickPickItem[] = items.map(item => {
             return {
                 label: item.title as string,
-                description: '',
-                detail: `Key: ${item.key}, authors: ${item.author?item.author:'Unknown'}`
+                description: `${item.key}`,
+                detail: `Authors: ${item.author ? item.author : 'Unknown'}, publication: ${item.journal ? item.journal : (item.publisher ? item.publisher : 'Unknown')}`
             }
         })
         vscode.window.showQuickPick(pickItems, {
             placeHolder: 'Press ENTER to insert citation key at cursor'
         }).then(selected => {
-            console.log(selected)
+            if (!selected) {
+                return
+            }
+            if (vscode.window.activeTextEditor) {
+                const editor = vscode.window.activeTextEditor
+                editor.edit(edit => edit.insert(editor.selection.start, selected.description))
+            }
         })
     }
 

--- a/src/providers/citation.ts
+++ b/src/providers/citation.ts
@@ -35,10 +35,32 @@ export class Citation {
             this.citationInBib[bibPath].forEach(item => items.push(item))
         })
 
+        const configuration = vscode.workspace.getConfiguration('latex-workshop')
         this.suggestions = items.map(item => {
             const citation = new vscode.CompletionItem(item.key, vscode.CompletionItemKind.Reference)
             citation.detail = item.title
-            citation.filterText = `${item.author} ${item.title} ${item.journal}`
+            switch (configuration.get('citation_intellisense_label') as string) {
+                case 'bibtex key':
+                default:
+                    citation.label = item.key
+                    break
+                case 'title':
+                    if (item.title) {
+                        citation.label = item.title as string
+                    } else {
+                        citation.label = item.key
+                    }
+                    break
+                case 'authors':
+                    if (item.author) {
+                        citation.label = item.author as string
+                    } else {
+                        citation.label = item.key
+                    }
+                    break
+            }
+
+            citation.filterText = `${item.key} ${item.author} ${item.title} ${item.journal}`
             citation.insertText = item.key
             citation.documentation = Object.keys(item)
                 .filter(key => (key !== 'key' && key !== 'title'))
@@ -48,6 +70,26 @@ export class Citation {
             return citation
         })
         return this.suggestions
+    }
+
+    browser() {
+        this.provide()
+        const items: CitationRecord[] = []
+        Object.keys(this.citationInBib).forEach(bibPath => {
+            this.citationInBib[bibPath].forEach(item => items.push(item))
+        })
+        const pickItems: vscode.QuickPickItem[] = items.map(item => {
+            return {
+                label: item.title as string,
+                description: '',
+                detail: `Key: ${item.key}, authors: ${item.author?item.author:'Unknown'}`
+            }
+        })
+        vscode.window.showQuickPick(pickItems, {
+            placeHolder: 'Press ENTER to insert citation key at cursor'
+        }).then(selected => {
+            console.log(selected)
+        })
     }
 
     parseBibItems(bibPath: string) {

--- a/src/providers/citation.ts
+++ b/src/providers/citation.ts
@@ -47,6 +47,7 @@ export class Citation {
                 case 'title':
                     if (item.title) {
                         citation.label = item.title as string
+                        citation.detail = undefined
                     } else {
                         citation.label = item.key
                     }
@@ -54,6 +55,7 @@ export class Citation {
                 case 'authors':
                     if (item.author) {
                         citation.label = item.author as string
+                        citation.detail = undefined
                     } else {
                         citation.label = item.key
                     }


### PR DESCRIPTION
This PR adds a `latex-workshop.citation_intellisense_label` config item to control what to display in citation intellisense window. Default is `bibtex key` which is identical with what it is now. Below is a demo for `title`:
![image](https://cloud.githubusercontent.com/assets/4210342/24745466/6d4dfb80-1ae8-11e7-8e0d-11839f4c0929.png)

This PR also add a citation browser, accessible from the action dropdown menu:
![image](https://cloud.githubusercontent.com/assets/4210342/24745774/7321608c-1ae9-11e7-91d0-54220c0defc2.png)

Select any items in the menu will insert its key.

#90 