### PR TITLE
(#92) Add LaTeX Workshop prefix in quick menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,6 +149,11 @@
         "category": "LaTeX Workshop"
       },
       {
+        "command": "latex-workshop.citation",
+        "title": "Open citation browser",
+        "category": "LaTeX Workshop"
+      },
+      {
         "command": "latex-workshop.actions",
         "title": "LaTeX Workshop Actions"
       }

--- a/package.json
+++ b/package.json
@@ -125,23 +125,28 @@
     "commands": [
       {
         "command": "latex-workshop.build",
-        "title": "Build LaTeX project"
+        "title": "Build LaTeX project",
+        "category": "LaTeX Workshop"
       },
       {
         "command": "latex-workshop.view",
-        "title": "View PDF file in web page"
+        "title": "View PDF file in web page",
+        "category": "LaTeX Workshop"
       },
       {
         "command": "latex-workshop.tab",
-        "title": "View PDF file in new tab"
+        "title": "View PDF file in new tab",
+        "category": "LaTeX Workshop"
       },
       {
         "command": "latex-workshop.synctex",
-        "title": "SyncTeX from cursor"
+        "title": "SyncTeX from cursor",
+        "category": "LaTeX Workshop"
       },
       {
         "command": "latex-workshop.clean",
-        "title": "Clean up auxillary files"
+        "title": "Clean up auxillary files",
+        "category": "LaTeX Workshop"
       },
       {
         "command": "latex-workshop.actions",

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -67,6 +67,11 @@ export class Commander {
         this.extension.cleaner.clean()
     }
 
+    citation() {
+        this.extension.logger.addLogMessage(`CITATION command invoked.`)
+        this.extension.completer.citation.browser()
+    }
+
     actions() {
         this.extension.logger.addLogMessage(`ACTIONS command invoked.`)
         this.extension.logger.displayFullStatus()
@@ -82,7 +87,6 @@ export class Commander {
             this.commands = commands.map(command => command.command)
         }
         const items = JSON.parse(JSON.stringify(this.commandTitles))
-        items.push('Open citation browser')
         if (this.extension.parser.buildLogRaw) {
             items.push('Show last LaTeX log')
         }
@@ -100,9 +104,6 @@ export class Commander {
             switch (selected) {
                 case 'Show last LaTeX log':
                     this.extension.logger.showLog()
-                    break
-                case 'Open citation browser':
-                    this.extension.completer.citation.browser()
                     break
                 default:
                     break

--- a/src/main.ts
+++ b/src/main.ts
@@ -52,6 +52,7 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('latex-workshop.synctex', () => extension.commander.synctex())
     vscode.commands.registerCommand('latex-workshop.clean', () => extension.commander.clean())
     vscode.commands.registerCommand('latex-workshop.actions', () => extension.commander.actions())
+    vscode.commands.registerCommand('latex-workshop.citation', () => extension.commander.citation())
     vscode.commands.registerCommand('latex-workshop.code-action', (d, r, c, m) => extension.codeActions.runCodeAction(d, r, c, m))
 
     context.subscriptions.push(vscode.workspace.onDidSaveTextDocument((e: vscode.TextDocument) => {


### PR DESCRIPTION
This PR adds a `LaTeX Workshop: ` prefix to commands in quick menu.
![image](https://cloud.githubusercontent.com/assets/4210342/24746924/45c39368-1aed-11e7-92f1-1f804dba024b.png)

Should the citation browser be added as a vscode command or as is?