### PR TITLE
Change some configs, alerts on finding obsolete ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,22 +61,59 @@ Choose the item in the menu to have LaTeX Workshop attempt to fix the issue:
 
 ## FAQ
 ### <a name="toolchain"></a>LaTeX toolchain?
-LaTeX toolchain refers to a sequence/array of commands which LaTeX Workshop will execute sequentially when building LaTeX projects. It is set in `File`>`Preferences`>`Settings`>`latex-workshop.toolchain`. By default [`latexmk`](http://personal.psu.edu/jcc8/software/latexmk/) is used. For non-perl users, the following `texify` toolchain may worth a try:
-```
-[ "texify --synctex --tex-option=\"-interaction=nonstopmode -file-line-error\" --pdf %DOC%.tex" ]
-```
+LaTeX toolchain refers to a sequence/array of commands which LaTeX Workshop will execute sequentially when building LaTeX projects. It is set in `File`>`Preferences`>`Settings`>`latex-workshop.latex.toolchain`. This configuration item is an array of objects, which should have a `command` field and an optional `args` array field. The former defines the command that will be invoked in each step of the toolchain, while the latter defines the arguments that will be passed alongside with the command.
 
-LaTeX toolchain must always be defined as a JSON array, even if there is only one command to execute. For multiple commands, each one is represented by a string in the array.
-
-The placeholder `%DOC%` in all strings will be replaced by the quoted LaTeX root file name without `.tex` extension on-the-fly. Alternatively, you can also set your commands without the placeholder, just like what you may input in a terminal.
-
-As most LaTeX compiler accepts root file name without extension, and `bibtex` requires to do so, `%DOC%` does not include `.tex` extension. Meanwhile, `texify` requires the extension. So in the above toolchain `%DOC%` and `.tex` are concatenated for completeness. For manual toolchains as the following one, this is not a must:
+By default [`latexmk`](http://personal.psu.edu/jcc8/software/latexmk/) is used. This tool is bundled in most LaTeX distributions, and requires perl to execute. For non-perl users, the following `texify` toolchain from MikTeX may worth a try:
 ```
-[
-  "pdflatex -synctex=1 -interaction=nonstopmode -file-line-error %DOC%",
-  "bibtex %DOC%",
-  "pdflatex -synctex=1 -interaction=nonstopmode -file-line-error %DOC%",
-  "pdflatex -synctex=1 -interaction=nonstopmode -file-line-error %DOC%"
+"latex-workshop.latex.toolchain": [
+  {
+    "command": "texify",
+    "args": [
+      "--synctex",
+      "--tex-option=\"-interaction=nonstopmode -file-line-error\"",
+      "--pdf",
+      "%DOC%.tex"
+    ]
+  }
+]
+```
+LaTeX toolchain must always be defined as a JSON array, even if there is only one command to execute. The placeholder `%DOC%` in any of the strings will be replaced by the LaTeX root file name without `.tex` extension on-the-fly (other extensions are preserved). Alternatively, you can also set your commands without the placeholder, just like what you may input in a terminal. For the special commands which has problem to deal with absolute paths (yes, `bibtex`), `%DOCFILE%` can be used as a placeholder for the root file name without `.tex` extension.
+
+As most LaTeX compiler accepts root file name without extension, and `bibtex` requires to do so, `%DOC%` does not include `.tex` extension. Meanwhile, `texify` requires the extension. So in the above toolchain `%DOC%` and `.tex` are concatenated for completeness.
+
+The following is an example of a typical `pdflatex`>`bibtex`>`pdflatex`>`pdflatex` setting.
+```
+"latex-workshop.latex.toolchain": [
+  {
+    "command": "pdflatex",
+    "args": [
+      "--synctex",
+      "-interaction=nonstopmode",
+      "-file-line-error",
+      "%DOC%"
+    ]
+  }, {
+    "command": "bibtex",
+    "args": [
+      "%DOCFILE%"
+    ]
+  }, {
+    "command": "pdflatex",
+    "args": [
+      "--synctex",
+      "-interaction=nonstopmode",
+      "-file-line-error",
+      "%DOC%"
+    ]
+  }, {
+    "command": "pdflatex",
+    "args": [
+      "--synctex",
+      "-interaction=nonstopmode",
+      "-file-line-error",
+      "%DOC%"
+    ]
+  }
 ]
 ```
 

--- a/package.json
+++ b/package.json
@@ -162,24 +162,33 @@
       "type": "object",
       "title": "LaTeX Workshop configuration",
       "properties": {
-        "latex-workshop.toolchain": {
+        "latex-workshop.latex.toolchain": {
           "type": "array",
           "default": [
-            "latexmk -synctex=1 -interaction=nonstopmode -file-line-error -pdf %DOC%"
+            {
+              "command": "latexmk",
+              "args": [
+                "-synctex=1",
+                "-interaction=nonstopmode",
+                "-file-line-error",
+                "-pdf",
+                "%DOC%"
+              ]
+            }
           ],
-          "description": "LaTeX toolchain to build project.\nThis property defines the sequence of commands LaTeX Workshop will execute to build the LaTeX project. By default it tries latexmk to compile to PDF.\nPlaceholder %DOC% is used to represent the root LaTeX file name (without '.tex' extension), and will be replaced when executing."
+          "description": "LaTeX toolchain to build project.\nThis property defines the sequence of commands LaTeX Workshop will execute to build the LaTeX project. By default it tries latexmk to compile to PDF.\nPlaceholder %DOC% is used to represent the root LaTeX file name (without '.tex' extension), and will be replaced when executing.\n For a detailed explanation on how to customize your toolchain, please visit https://github.com/James-Yu/LaTeX-Workshop#toolchain."
         },
-        "latex-workshop.building.autoBuild.enabled": {
+        "latex-workshop.latex.autoBuild.enabled": {
           "type": "boolean",
           "default": true,
           "description": "Build LaTeX after saving LaTeX source file.\nThis property defines whether LaTeX Workshop will execute the LaTeX toolchain command(s) to build the project after new LaTeX contents are saved."
         },
-        "latex-workshop.building.clean.enabled": {
+        "latex-workshop.latex.clean.enabled": {
           "type": "boolean",
           "default": false,
           "description": "Delete LaTeX auxillary files after building project.\nThis property defines whether LaTeX Workshop will clean up all unnecessary files after building the project."
         },
-        "latex-workshop.building.clean.fileTypes": {
+        "latex-workshop.latex.clean.fileTypes": {
           "type": "array",
           "default": [
             "*.aux",
@@ -228,7 +237,7 @@
             "-e16",
             "-q"
           ],
-          "description": "Linter arguments to check LaTeX syntax of the current file state in real time with ChkTeX.\nAdditional arguments, i.e., `-I0 -f%f:%l:%c:%d:%k:%n:%m\\n` will be appended when constructing the command. Current file contents will be piped to the command through stdin."
+          "description": "Linter arguments to check LaTeX syntax of the current file state in real time with ChkTeX.\nArguments must be in separate strings in the array. Additional arguments, i.e., `-I0 -f%f:%l:%c:%d:%k:%n:%m\\n` will be appended when constructing the command. Current file contents will be piped to the command through stdin."
         },
         "latex-workshop.chktex.args.root": {
           "type": "array",
@@ -239,7 +248,7 @@
             "-e16",
             "-q"
           ],
-          "description": "Linter arguments to check LaTeX syntax of the entire project from the root file with ChkTeX.\nAdditional arguments, i.e., `-f%f:%l:%c:%d:%k:%n:%m\\n %DOC%` will be appended when constructing the command."
+          "description": "Linter arguments to check LaTeX syntax of the entire project from the root file with ChkTeX.\nArguments must be in separate strings in the array. Additional arguments, i.e., `-f%f:%l:%c:%d:%k:%n:%m\\n %DOC%` will be appended when constructing the command."
         },
         "latex-workshop.chktex.interval": {
           "type": "number",

--- a/package.json
+++ b/package.json
@@ -207,40 +207,27 @@
         "latex-workshop.synctex_command": {
           "type": "string",
           "default": "synctex",
-          "description": "Define the location of SyncTeX executive file."
+          "description": "Define the location of SyncTeX executive file.\nAdditional arguments, e.g., synctex modes and position of click, will be appended to this command."
         },
         "latex-workshop.linter": {
           "type": "boolean",
           "default": false,
           "description": "Enable linting LaTeX with ChkTeX.\nThe active document will be linted when no document changes for a defined period of time.\nThe full project will be linted from the root on file save."
         },
-        "latex-workshop.linter_command_active_file": {
-          "type": "array",
-          "default": [
-            "chktex",
-            "-wall",
-            "-n22",
-            "-n30",
-            "-e16",
-            "-q",
-            "-I0",
-            "-f%f:%l:%c:%d:%k:%n:%m\n"
-          ],
-          "description": "Linter command to check LaTeX syntax of the current file state in real time with ChkTeX.\nCurrent file contents will be piped to the command through stdin.\nThe format string should be kept as shown in the default as this is the format the parser expects for successful parsing."
+        "latex-workshop.linter_command": {
+          "type": "string",
+          "default": "chktex",
+          "description": "Define the location of ChkTeX executive file.\nThis command will be joint with `latex-workshop.linter_arguments_*` and required arguments to form a complete command of ChkTeX."
         },
-        "latex-workshop.linter_command_root_file": {
-          "type": "array",
-          "default": [
-            "chktex",
-            "-wall",
-            "-n22",
-            "-n30",
-            "-e16",
-            "-q",
-            "-f%f:%l:%c:%d:%k:%n:%m\n",
-            "%DOC%"
-          ],
-          "description": "Linter command to check LaTeX syntax of the entire project from the root file with ChkTeX.\nPlaceholder %DOC% is used to represent the root LaTeX file name (with extension).\nThe format string should be kept as shown in the default as this is the format the parser expects for successful parsing."
+        "latex-workshop.linter_arguments_active": {
+          "type": "string",
+          "default": "-wall -n22 -n30 -e16 -q",
+          "description": "Linter arguments to check LaTeX syntax of the current file state in real time with ChkTeX.\nArguments should be seperated by one space. Additional arguments, i.e., `-I0 -f%f:%l:%c:%d:%k:%n:%m\\n` will be appended when constructing the command. Current file contents will be piped to the command through stdin."
+        },
+        "latex-workshop.linter_arguments_root": {
+          "type": "string",
+          "default": "-wall -n22 -n30 -e16 -q",
+          "description": "Linter arguments to check LaTeX syntax of the entire project from the root file with ChkTeX.\nArguments should be seperated by one space. Additional arguments, i.e., `-f%f:%l:%c:%d:%k:%n:%m\\n %DOC%` will be appended when constructing the command."
         },
         "latex-workshop.linter_interval": {
           "type": "number",

--- a/package.json
+++ b/package.json
@@ -169,17 +169,17 @@
           ],
           "description": "LaTeX toolchain to build project.\nThis property defines the sequence of commands LaTeX Workshop will execute to build the LaTeX project. By default it tries latexmk to compile to PDF.\nPlaceholder %DOC% is used to represent the root LaTeX file name (without '.tex' extension), and will be replaced when executing."
         },
-        "latex-workshop.build_after_save": {
+        "latex-workshop.building.autoBuild.enabled": {
           "type": "boolean",
           "default": true,
           "description": "Build LaTeX after saving LaTeX source file.\nThis property defines whether LaTeX Workshop will execute the LaTeX toolchain command(s) to build the project after new LaTeX contents are saved."
         },
-        "latex-workshop.clean_after_build": {
+        "latex-workshop.building.clean.enabled": {
           "type": "boolean",
           "default": false,
           "description": "Delete LaTeX auxillary files after building project.\nThis property defines whether LaTeX Workshop will clean up all unnecessary files after building the project."
         },
-        "latex-workshop.files_to_clean": {
+        "latex-workshop.building.clean.fileTypes": {
           "type": "array",
           "default": [
             "*.aux",
@@ -204,37 +204,37 @@
           ],
           "description": "Files to clean.\nThis property must be an array of strings. File globs such as *.removeme, something?.aux can be used."
         },
-        "latex-workshop.synctex_command": {
+        "latex-workshop.synctex.path": {
           "type": "string",
           "default": "synctex",
           "description": "Define the location of SyncTeX executive file.\nAdditional arguments, e.g., synctex modes and position of click, will be appended to this command."
         },
-        "latex-workshop.linter": {
+        "latex-workshop.chktex.enabled": {
           "type": "boolean",
           "default": false,
           "description": "Enable linting LaTeX with ChkTeX.\nThe active document will be linted when no document changes for a defined period of time.\nThe full project will be linted from the root on file save."
         },
-        "latex-workshop.linter_command": {
+        "latex-workshop.chktex.path": {
           "type": "string",
           "default": "chktex",
           "description": "Define the location of ChkTeX executive file.\nThis command will be joint with `latex-workshop.linter_arguments_*` and required arguments to form a complete command of ChkTeX."
         },
-        "latex-workshop.linter_arguments_active": {
+        "latex-workshop.chktex.args.active": {
           "type": "string",
           "default": "-wall -n22 -n30 -e16 -q",
           "description": "Linter arguments to check LaTeX syntax of the current file state in real time with ChkTeX.\nArguments should be seperated by one space. Additional arguments, i.e., `-I0 -f%f:%l:%c:%d:%k:%n:%m\\n` will be appended when constructing the command. Current file contents will be piped to the command through stdin."
         },
-        "latex-workshop.linter_arguments_root": {
+        "latex-workshop.chktex.args.root": {
           "type": "string",
           "default": "-wall -n22 -n30 -e16 -q",
           "description": "Linter arguments to check LaTeX syntax of the entire project from the root file with ChkTeX.\nArguments should be seperated by one space. Additional arguments, i.e., `-f%f:%l:%c:%d:%k:%n:%m\\n %DOC%` will be appended when constructing the command."
         },
-        "latex-workshop.linter_interval": {
+        "latex-workshop.chktex.interval": {
           "type": "number",
           "default": 300,
           "description": "Defines the time interval in milliseconds between invoking LaTeX linter on the active file."
         },
-        "latex-workshop.citation_intellisense_label": {
+        "latex-workshop.intellisense.citation.label": {
           "type": "string",
           "enum": [
             "bibtex key",
@@ -244,7 +244,7 @@
           "default": "bibtex key",
           "description": "Defines what to show as suggestion labels when intellisense provides citation suggestions."
         },
-        "latex-workshop.show_debug_log": {
+        "latex-workshop.debug.showLog": {
           "type": "boolean",
           "default": true,
           "description": "Display LaTeX Workshop debug log in output panel.\nThis property defines whether LaTeX Workshop will output its debug log to the log panel."

--- a/package.json
+++ b/package.json
@@ -220,14 +220,26 @@
           "description": "Define the location of ChkTeX executive file.\nThis command will be joint with `latex-workshop.linter_arguments_*` and required arguments to form a complete command of ChkTeX."
         },
         "latex-workshop.chktex.args.active": {
-          "type": "string",
-          "default": "-wall -n22 -n30 -e16 -q",
-          "description": "Linter arguments to check LaTeX syntax of the current file state in real time with ChkTeX.\nArguments should be seperated by one space. Additional arguments, i.e., `-I0 -f%f:%l:%c:%d:%k:%n:%m\\n` will be appended when constructing the command. Current file contents will be piped to the command through stdin."
+          "type": "array",
+          "default": [
+            "-wall",
+            "-n22",
+            "-n30",
+            "-e16",
+            "-q"
+          ],
+          "description": "Linter arguments to check LaTeX syntax of the current file state in real time with ChkTeX.\nAdditional arguments, i.e., `-I0 -f%f:%l:%c:%d:%k:%n:%m\\n` will be appended when constructing the command. Current file contents will be piped to the command through stdin."
         },
         "latex-workshop.chktex.args.root": {
-          "type": "string",
-          "default": "-wall -n22 -n30 -e16 -q",
-          "description": "Linter arguments to check LaTeX syntax of the entire project from the root file with ChkTeX.\nArguments should be seperated by one space. Additional arguments, i.e., `-f%f:%l:%c:%d:%k:%n:%m\\n %DOC%` will be appended when constructing the command."
+          "type": "array",
+          "default": [
+            "-wall",
+            "-n22",
+            "-n30",
+            "-e16",
+            "-q"
+          ],
+          "description": "Linter arguments to check LaTeX syntax of the entire project from the root file with ChkTeX.\nAdditional arguments, i.e., `-f%f:%l:%c:%d:%k:%n:%m\\n %DOC%` will be appended when constructing the command."
         },
         "latex-workshop.chktex.interval": {
           "type": "number",

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -53,7 +53,7 @@ export class Builder {
         this.extension.logger.displayStatus('check', 'white', `LaTeX toolchain succeeded.`)
         this.extension.viewer.refreshExistingViewer(rootFile)
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
-        const clean = configuration.get('clean_after_build') as boolean
+        const clean = configuration.get('building.clean.enabled') as boolean
         if (clean) {
             this.extension.cleaner.clean()
         }

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -22,29 +22,49 @@ export class Builder {
             this.currentProcess.kill()
         }
         const toolchain = this.createToolchain(rootFile)
-        this.extension.logger.addLogMessage(`Created toolchain ${toolchain}`)
+        if (toolchain === undefined) {
+            this.extension.logger.addLogMessage('Invalid toolchain.')
+            return
+        }
         this.buildStep(rootFile, toolchain, 0)
     }
 
-    buildStep(rootFile: string, toolchain: string[], index: number) {
+    buildStep(rootFile: string, toolchain: ToolchainCommand[], index: number) {
         if (toolchain.length === index) {
             this.extension.logger.addLogMessage(`Toolchain of length ${toolchain.length} finished.`)
             this.buildFinished(rootFile)
             return
         }
 
-        this.extension.logger.addLogMessage(`Toolchain step ${index + 1}: ${toolchain[index]}`)
+        this.extension.logger.addLogMessage(`Toolchain step ${index + 1}: ${toolchain[index].command}, ${toolchain[index].args}`)
         this.extension.logger.displayStatus('sync', 'orange', `LaTeX build toolchain step ${index + 1}.`, 0)
-        this.currentProcess = this.processWrapper(toolchain[index], {cwd: path.dirname(rootFile)}, (error, stdout) => {
+        this.currentProcess = cp.spawn(toolchain[index].command, toolchain[index].args, {cwd: path.dirname(rootFile)})
+
+        let stdout = ''
+        this.currentProcess.stdout.on('data', newStdout => {
+            stdout += newStdout
+        })
+
+        let stderr = ''
+        this.currentProcess.stderr.on('data', newStderr => {
+            stderr += newStderr
+        })
+
+        this.currentProcess.on('error', err => {
+            this.extension.logger.addLogMessage(`LaTeX fatal error: ${err.message}, ${stderr}. Does the executable exist?`)
+            this.extension.logger.displayStatus('x', 'red', `Toolchain terminated with fatal error.`)
+        })
+
+        this.currentProcess.on('exit', exitCode => {
             this.extension.parser.parse(stdout)
             const uri = vscode.Uri.file(this.extension.manager.rootFile).with({scheme: 'latex-workshop-log'})
             this.extension.logProvider.update(uri)
-            if (!error) {
+            if (exitCode !== 0) {
+                this.extension.logger.addLogMessage(`Toolchain returns with error. ${stdout}`)
+                this.extension.logger.displayStatus('x', 'red', `LaTeX toolchain terminated with error.`)
+            } else {
                 this.buildStep(rootFile, toolchain, index + 1)
-                return
             }
-            this.extension.logger.addLogMessage(`Toolchain returns with error.`)
-            this.extension.logger.displayStatus('x', 'red', `LaTeX toolchain terminated with error.`)
         })
     }
 
@@ -53,20 +73,34 @@ export class Builder {
         this.extension.logger.displayStatus('check', 'white', `LaTeX toolchain succeeded.`)
         this.extension.viewer.refreshExistingViewer(rootFile)
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
-        const clean = configuration.get('building.clean.enabled') as boolean
+        const clean = configuration.get('latex.clean.enabled') as boolean
         if (clean) {
             this.extension.cleaner.clean()
         }
     }
 
-    processWrapper(command: string, options: any, callback: (error: Error, stdout: string, stderr: string) => void) : cp.ChildProcess {
-        options.maxBuffer = Infinity
-        return cp.exec(command, options, callback)
-    }
-
-    createToolchain(rootFile: string) : string[] {
+    createToolchain(rootFile: string) : ToolchainCommand[] | undefined  {
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
-        const commands = configuration.get('toolchain') as string[]
-        return commands.map(command => command.replace('%DOC%', `"${rootFile.replace(/\.tex$/, '')}"`))
+        const commands = configuration.get('latex.toolchain') as ToolchainCommand[]
+        for (const command of commands) {
+            if (!('command' in command)){
+                vscode.window.showErrorMessage('LaTeX toolchain is invalid. Each tool in the toolchain must have a "command" string.')
+                return undefined
+            }
+            if (!Array.isArray(command.args)) {
+                vscode.window.showErrorMessage('LaTeX toolchain is invalid. "args" must be an array of strings.')
+                return undefined
+            }
+            if (command.args) {
+                command.args = command.args.map(arg => arg.replace('%DOC%', rootFile.replace(/\.tex$/, ''))
+                                                          .replace('%DOCFILE%', path.basename(rootFile, '.tex')))
+            }
+        }
+        return commands
     }
+}
+
+interface ToolchainCommand {
+    command: string,
+    args?: string[]
 }

--- a/src/cleaner.ts
+++ b/src/cleaner.ts
@@ -17,7 +17,7 @@ export class Cleaner {
             this.extension.manager.findRoot()
         }
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
-        const globs = configuration.get('files_to_clean') as string[]
+        const globs = configuration.get('building.clean.fileTypes') as string[]
         for (const globType of globs) {
             glob(globType, {cwd: this.extension.manager.rootDir}, (err, files) => {
                 if (err) {

--- a/src/cleaner.ts
+++ b/src/cleaner.ts
@@ -17,7 +17,7 @@ export class Cleaner {
             this.extension.manager.findRoot()
         }
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
-        const globs = configuration.get('building.clean.fileTypes') as string[]
+        const globs = configuration.get('latex.clean.fileTypes') as string[]
         for (const globType of globs) {
             glob(globType, {cwd: this.extension.manager.rootDir}, (err, files) => {
                 if (err) {

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -23,11 +23,13 @@ export class Linter {
         const content = vscode.window.activeTextEditor.document.getText()
 
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
-        const [command, ...args] = configuration.get('linter_command_active_file') as string[]
+        const command = configuration.get('linter_command') as string
+        const args = (configuration.get('linter_arguments_active') as string).split(' ')
+        const requiredArgs = ['-I0', '-f%f:%l:%c:%d:%k:%n:%m\n']
 
         let stdout: string
         try {
-            stdout = await this.processWrapper('active file', command, args, {}, content)
+            stdout = await this.processWrapper('active file', command, args.concat(requiredArgs).filter(arg => arg !== ''), {}, content)
         } catch (err) {
             return
         }
@@ -41,10 +43,13 @@ export class Linter {
         const filePath = this.extension.manager.rootFile
 
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
-        const [command, ...args] = (configuration.get('linter_command_root_file') as string[]).map(s => s.replace('%DOC%', filePath))
+        const command = configuration.get('linter_command') as string
+        const args = (configuration.get('linter_arguments_root') as string).split(' ')
+        const requiredArgs = ['-f%f:%l:%c:%d:%k:%n:%m\n', '%DOC%'.replace('%DOC%', filePath)]
+
         let stdout: string
         try {
-            stdout = await this.processWrapper('root file', command, args, {cwd: path.dirname(this.extension.manager.rootFile)})
+            stdout = await this.processWrapper('root file', command, args.concat(requiredArgs).filter(arg => arg !== ''), {cwd: path.dirname(this.extension.manager.rootFile)})
         } catch (err) {
             return
         }

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -23,8 +23,8 @@ export class Linter {
         const content = vscode.window.activeTextEditor.document.getText()
 
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
-        const command = configuration.get('linter_command') as string
-        const args = (configuration.get('linter_arguments_active') as string).split(' ')
+        const command = configuration.get('chktex.path') as string
+        const args = (configuration.get('chktex.args.active') as string).split(' ')
         const requiredArgs = ['-I0', '-f%f:%l:%c:%d:%k:%n:%m\n']
 
         let stdout: string
@@ -43,8 +43,8 @@ export class Linter {
         const filePath = this.extension.manager.rootFile
 
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
-        const command = configuration.get('linter_command') as string
-        const args = (configuration.get('linter_arguments_root') as string).split(' ')
+        const command = configuration.get('chktex.path') as string
+        const args = (configuration.get('chktex.args.root') as string).split(' ')
         const requiredArgs = ['-f%f:%l:%c:%d:%k:%n:%m\n', '%DOC%'.replace('%DOC%', filePath)]
 
         let stdout: string

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -24,7 +24,7 @@ export class Linter {
 
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         const command = configuration.get('chktex.path') as string
-        const args = (configuration.get('chktex.args.active') as string).split(' ')
+        const args = configuration.get('chktex.args.active') as string[]
         const requiredArgs = ['-I0', '-f%f:%l:%c:%d:%k:%n:%m\n']
 
         let stdout: string
@@ -44,7 +44,7 @@ export class Linter {
 
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         const command = configuration.get('chktex.path') as string
-        const args = (configuration.get('chktex.args.root') as string).split(' ')
+        const args = configuration.get('chktex.args.root') as string[]
         const requiredArgs = ['-f%f:%l:%c:%d:%k:%n:%m\n', '%DOC%'.replace('%DOC%', filePath)]
 
         let stdout: string

--- a/src/locator.ts
+++ b/src/locator.ts
@@ -64,7 +64,7 @@ export class Locator {
         }
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         const pdfFile = this.extension.manager.tex2pdf(this.extension.manager.rootFile)
-        const cmd = `${configuration.get('synctex_command')} view -i "${position.line + 1}:${position.character + 1}:${filePath}" -o "${pdfFile}"`
+        const cmd = `${configuration.get('synctex.path')} view -i "${position.line + 1}:${position.character + 1}:${filePath}" -o "${pdfFile}"`
         this.extension.logger.addLogMessage(`Executing ${cmd}`)
         cp.exec(cmd, {cwd: path.dirname(pdfFile)}, (err, stdout, stderr) => {
             if (err) {
@@ -77,7 +77,7 @@ export class Locator {
 
     locate(data: any, pdfPath: string) {
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
-        const cmd = `${configuration.get('synctex_command')} edit -o "${data.page}:${data.pos[0]}:${data.pos[1]}:${pdfPath}"`
+        const cmd = `${configuration.get('synctex.path')} edit -o "${data.page}:${data.pos[0]}:${data.pos[1]}:${pdfPath}"`
         this.extension.logger.addLogMessage(`Executing ${cmd}`)
         cp.exec(cmd, {cwd: path.dirname(pdfPath)}, (err, stdout, stderr) => {
             if (err) {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -20,7 +20,7 @@ export class Logger {
 
     addLogMessage(message: string) {
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
-        if (configuration.get('show_debug_log')) {
+        if (configuration.get('debug.showLog')) {
             this.logPanel.append(`[${new Date().toLocaleTimeString('en-US', {hour12: false})}] ${message}\n`)
         }
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -54,14 +54,17 @@ function obsoleteConfigCheck() {
                                           Please use the new "${newConfig}" config item.`,
                                          'Open Settings Editor').then(messageActions)
     }
+    if (configuration.has('toolchain')) {
+        showMessage('latex-workshop.toolchain', 'latex-workshop.latex.toolchain')
+    }
     if (configuration.has('build_after_save')) {
-        showMessage('latex-workshop.build_after_save', 'latex-workshop.building.autoBuild.enabled')
+        showMessage('latex-workshop.build_after_save', 'latex-workshop.latex.autoBuild.enabled')
     }
     if (configuration.has('clean_after_build')) {
-        showMessage('latex-workshop.clean_after_build', 'latex-workshop.building.clean.enabled')
+        showMessage('latex-workshop.clean_after_build', 'latex-workshop.latex.clean.enabled')
     }
     if (configuration.has('files_to_clean')) {
-        showMessage('latex-workshop.files_to_clean', 'latex-workshop.building.clean.fileTypes')
+        showMessage('latex-workshop.files_to_clean', 'latex-workshop.latex.clean.fileTypes')
     }
     if (configuration.has('synctex_command')) {
         showMessage('latex-workshop.synctex_command', 'latex-workshop.synctex.path')
@@ -107,7 +110,7 @@ export async function activate(context: vscode.ExtensionContext) {
             lintRootFileIfEnabled(extension)
         }
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
-        if (!configuration.get('building.autoBuild.enabled') || extension.builder.disableBuildAfterSave) {
+        if (!configuration.get('latex.autoBuild.enabled') || extension.builder.disableBuildAfterSave) {
             return
         }
         if (extension.manager.isTex(e.fileName)) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,6 +42,25 @@ function lintActiveFileIfEnabledAfterInterval(extension: Extension) {
     }
 }
 
+function obsoleteConfigCheck() {
+    const configuration = vscode.workspace.getConfiguration('latex-workshop')
+    function messageActions(selected) {
+        if (selected === 'Open Settings Editor') {
+            vscode.commands.executeCommand('workbench.action.openGlobalSettings')
+        }
+    }
+    if (configuration.has('linter_command_active_file')) {
+        vscode.window.showWarningMessage('Config "latex-workshop.linter_command_active_file" as been deprecated. \
+                                          Please use the new "latex-workshop.linter_arguments_active" config item.',
+                                         'Open Settings Editor').then(messageActions)
+    }
+    if (configuration.has('linter_command_root_file')) {
+        vscode.window.showWarningMessage('Config "latex-workshop.linter_command_root_file" as been deprecated. \
+                                          Please use the new "latex-workshop.linter_arguments_root" config item.',
+                                         'Open Settings Editor').then(messageActions)
+    }
+}
+
 export async function activate(context: vscode.ExtensionContext) {
     const extension = new Extension()
     global['latex'] = extension
@@ -70,6 +89,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
     context.subscriptions.push(vscode.workspace.onDidOpenTextDocument((e: vscode.TextDocument) => {
         if (extension.manager.isTex(e.fileName)) {
+            obsoleteConfigCheck()
             extension.manager.findRoot()
         }
     }))
@@ -108,6 +128,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
     // On startup, lint the whole project if enabled.
     lintRootFileIfEnabled(extension)
+    obsoleteConfigCheck()
 }
 
 export class Extension {

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,7 +16,7 @@ import {Cleaner} from './cleaner'
 
 function lintRootFileIfEnabled(extension: Extension) {
     const configuration = vscode.workspace.getConfiguration('latex-workshop')
-    const linter = configuration.get('linter') as boolean
+    const linter = configuration.get('chktex.enabled') as boolean
     if (linter) {
         extension.linter.lintRootFile()
     }
@@ -24,7 +24,7 @@ function lintRootFileIfEnabled(extension: Extension) {
 
 function lintActiveFileIfEnabled(extension: Extension) {
     const configuration = vscode.workspace.getConfiguration('latex-workshop')
-    const linter = configuration.get('linter') as boolean
+    const linter = configuration.get('chktex.enabled') as boolean
     if (linter) {
         extension.linter.lintActiveFile()
     }
@@ -32,9 +32,9 @@ function lintActiveFileIfEnabled(extension: Extension) {
 
 function lintActiveFileIfEnabledAfterInterval(extension: Extension) {
     const configuration = vscode.workspace.getConfiguration('latex-workshop')
-    const linter = configuration.get('linter') as boolean
+    const linter = configuration.get('chktex.enabled') as boolean
     if (linter) {
-        const interval = configuration.get('linter_interval') as number
+        const interval = configuration.get('chktex.interval') as number
         if (extension.linter.linterTimeout) {
             clearTimeout(extension.linter.linterTimeout)
         }
@@ -49,15 +49,43 @@ function obsoleteConfigCheck() {
             vscode.commands.executeCommand('workbench.action.openGlobalSettings')
         }
     }
-    if (configuration.has('linter_command_active_file')) {
-        vscode.window.showWarningMessage('Config "latex-workshop.linter_command_active_file" as been deprecated. \
-                                          Please use the new "latex-workshop.linter_arguments_active" config item.',
+    function showMessage(originalConfig: string, newConfig: string) {
+        vscode.window.showWarningMessage(`Config "${originalConfig}" as been deprecated. \
+                                          Please use the new "${newConfig}" config item.`,
                                          'Open Settings Editor').then(messageActions)
     }
+    if (configuration.has('build_after_save')) {
+        showMessage('latex-workshop.build_after_save', 'latex-workshop.building.autoBuild.enabled')
+    }
+    if (configuration.has('clean_after_build')) {
+        showMessage('latex-workshop.clean_after_build', 'latex-workshop.building.clean.enabled')
+    }
+    if (configuration.has('files_to_clean')) {
+        showMessage('latex-workshop.files_to_clean', 'latex-workshop.building.clean.fileTypes')
+    }
+    if (configuration.has('synctex_command')) {
+        showMessage('latex-workshop.synctex_command', 'latex-workshop.synctex.path')
+    }
+    if (configuration.has('linter')) {
+        showMessage('latex-workshop.linter', 'latex-workshop.chktex.enabled')
+    }
+    if (configuration.has('linter_command')) {
+        showMessage('latex-workshop.linter_command', 'latex-workshop.chktex.path')
+    }
+    if (configuration.has('linter_command_active_file')) {
+        showMessage('latex-workshop.linter_command_active_file', 'latex-workshop.chktex.args.active')
+    }
     if (configuration.has('linter_command_root_file')) {
-        vscode.window.showWarningMessage('Config "latex-workshop.linter_command_root_file" as been deprecated. \
-                                          Please use the new "latex-workshop.linter_arguments_root" config item.',
-                                         'Open Settings Editor').then(messageActions)
+        showMessage('latex-workshop.linter_command_root_file', 'latex-workshop.chktex.args.root')
+    }
+    if (configuration.has('linter_interval')) {
+        showMessage('latex-workshop.linter_interval', 'latex-workshop.chktex.interval')
+    }
+    if (configuration.has('citation_intellisense_label')) {
+        showMessage('latex-workshop.citation_intellisense_label', 'latex-workshop.intellisense.citation.label')
+    }
+    if (configuration.has('show_debug_log')) {
+        showMessage('latex-workshop.show_debug_log', 'latex-workshop.debug.showLog')
     }
 }
 
@@ -79,7 +107,7 @@ export async function activate(context: vscode.ExtensionContext) {
             lintRootFileIfEnabled(extension)
         }
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
-        if (!configuration.get('build_after_save') || extension.builder.disableBuildAfterSave) {
+        if (!configuration.get('building.autoBuild.enabled') || extension.builder.disableBuildAfterSave) {
             return
         }
         if (extension.manager.isTex(e.fileName)) {

--- a/src/providers/citation.ts
+++ b/src/providers/citation.ts
@@ -39,7 +39,7 @@ export class Citation {
         this.suggestions = items.map(item => {
             const citation = new vscode.CompletionItem(item.key, vscode.CompletionItemKind.Reference)
             citation.detail = item.title
-            switch (configuration.get('citation_intellisense_label') as string) {
+            switch (configuration.get('intellisense.citation.label') as string) {
                 case 'bibtex key':
                 default:
                     citation.label = item.key

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -11,6 +11,7 @@ interface Position {}
 
 interface Client {
     type: 'viewer' | 'tab'
+    prevType?: 'viewer' | 'tab'
     ws?: WebSocket
     position?: Position
 }
@@ -101,12 +102,16 @@ export class Viewer {
                 client = this.clients[decodeURIComponent(data.path)]
                 if (client !== undefined) {
                     client.ws = ws
+                    if (client.type === undefined && client.prevType !== undefined) {
+                        client.type = client.prevType
+                    }
                 }
                 break
             case 'close':
                 for (const key in this.clients) {
                     client = this.clients[key]
                     if (client !== undefined && client.ws === ws) {
+                        client.prevType = client.type
                         delete client.ws
                         delete client.type
                     }


### PR DESCRIPTION
This PR changes `linter_command_active_file` and `linter_command_root_file` configs. ChkTeX commands are separated into `linter_command` `string` + `linter_arguments_` `string` + required arguments (hard-coded, documented in config comments). Seems work well.

In addition, if the extension finds obsolete configs, i.e., `linter_command_active_file` and `linter_command_root_file`, it will show a warning message indicating what is deprecated and what is the replacement. Hope it will not be too painful.

This is a start of the re-work on cleaning up configs. Suggestions welcomed!