### PR TITLE
Binary check

### DIFF
--- a/package.json
+++ b/package.json
@@ -207,40 +207,27 @@
         "latex-workshop.synctex_command": {
           "type": "string",
           "default": "synctex",
-          "description": "Define the location of SyncTeX executive file."
+          "description": "Define the location of SyncTeX executive file.\nAdditional arguments, e.g., synctex modes and position of click, will be appended to this command."
         },
         "latex-workshop.linter": {
           "type": "boolean",
           "default": false,
           "description": "Enable linting LaTeX with ChkTeX.\nThe active document will be linted when no document changes for a defined period of time.\nThe full project will be linted from the root on file save."
         },
-        "latex-workshop.linter_command_active_file": {
-          "type": "array",
-          "default": [
-            "chktex",
-            "-wall",
-            "-n22",
-            "-n30",
-            "-e16",
-            "-q",
-            "-I0",
-            "-f%f:%l:%c:%d:%k:%n:%m\n"
-          ],
-          "description": "Linter command to check LaTeX syntax of the current file state in real time with ChkTeX.\nCurrent file contents will be piped to the command through stdin.\nThe format string should be kept as shown in the default as this is the format the parser expects for successful parsing."
+        "latex-workshop.linter_command": {
+          "type": "string",
+          "default": "chktex",
+          "description": "Define the location of ChkTeX executive file.\nThis command will be joint with `latex-workshop.linter_arguments_*` and required arguments to form a complete command of ChkTeX."
         },
-        "latex-workshop.linter_command_root_file": {
-          "type": "array",
-          "default": [
-            "chktex",
-            "-wall",
-            "-n22",
-            "-n30",
-            "-e16",
-            "-q",
-            "-f%f:%l:%c:%d:%k:%n:%m\n",
-            "%DOC%"
-          ],
-          "description": "Linter command to check LaTeX syntax of the entire project from the root file with ChkTeX.\nPlaceholder %DOC% is used to represent the root LaTeX file name (with extension).\nThe format string should be kept as shown in the default as this is the format the parser expects for successful parsing."
+        "latex-workshop.linter_arguments_active": {
+          "type": "string",
+          "default": "-wall -n22 -n30 -e16 -q",
+          "description": "Linter arguments to check LaTeX syntax of the current file state in real time with ChkTeX.\nArguments should be seperated by one space. Additional arguments, i.e., `-I0 -f%f:%l:%c:%d:%k:%n:%m\\n` will be appended when constructing the command. Current file contents will be piped to the command through stdin."
+        },
+        "latex-workshop.linter_arguments_root": {
+          "type": "string",
+          "default": "-wall -n22 -n30 -e16 -q",
+          "description": "Linter arguments to check LaTeX syntax of the entire project from the root file with ChkTeX.\nArguments should be seperated by one space. Additional arguments, i.e., `-f%f:%l:%c:%d:%k:%n:%m\\n %DOC%` will be appended when constructing the command."
         },
         "latex-workshop.linter_interval": {
           "type": "number",

--- a/package.json
+++ b/package.json
@@ -154,6 +154,11 @@
         "category": "LaTeX Workshop"
       },
       {
+        "command": "latex-workshop.binaries",
+        "title": "Check LaTeX binary validity",
+        "category": "LaTeX Workshop"
+      },
+      {
         "command": "latex-workshop.actions",
         "title": "LaTeX Workshop: All actions"
       }
@@ -284,6 +289,7 @@
   "dependencies": {
     "chokidar": "^1.6.1",
     "glob": "^7.1.1",
+    "hasbin": "^1.2.3",
     "open": "^0.0.5",
     "ws": "^1.1.1"
   },

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -72,6 +72,24 @@ export class Commander {
         this.extension.completer.citation.browser()
     }
 
+    binaries() {
+        function windowsPaths(command: string, disks: string[]=['C', 'D'], tlVers: string[]=['2014', '2015', '2016', '2017']) {
+            const paths: string[] = []
+            for (const disk of disks) {
+                for (const tlVer of tlVers) {
+                    paths.push(`${disk}:\\TexLive\\${tlVer}\\bin\\win32\\${command}.exe`)
+                }
+            }
+            return paths
+        }
+        function linuxPaths(command: string) {
+            return `/usr/local/texbin/${command}`
+        }
+        this.extension.logger.addLogMessage(`BINARIES command invoked.`)
+        this.extension.manager.findBinary('synctex_command', windowsPaths('synctex').concat(linuxPaths('synctex')))
+        this.extension.manager.findBinary('linter_command', windowsPaths('chktex').concat(linuxPaths('chktex')))
+    }
+
     actions() {
         this.extension.logger.addLogMessage(`ACTIONS command invoked.`)
         this.extension.logger.displayFullStatus()

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -23,11 +23,13 @@ export class Linter {
         const content = vscode.window.activeTextEditor.document.getText()
 
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
-        const [command, ...args] = configuration.get('linter_command_active_file') as string[]
+        const command = configuration.get('linter_command') as string
+        const args = (configuration.get('linter_arguments_active') as string).split(' ')
+        const requiredArgs = ['-I0', '-f%f:%l:%c:%d:%k:%n:%m\n']
 
         let stdout: string
         try {
-            stdout = await this.processWrapper('active file', command, args, {}, content)
+            stdout = await this.processWrapper('active file', command, args.concat(requiredArgs).filter(arg => arg !== ''), {}, content)
         } catch (err) {
             return
         }
@@ -41,10 +43,13 @@ export class Linter {
         const filePath = this.extension.manager.rootFile
 
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
-        const [command, ...args] = (configuration.get('linter_command_root_file') as string[]).map(s => s.replace('%DOC%', filePath))
+        const command = configuration.get('linter_command') as string
+        const args = (configuration.get('linter_arguments_root') as string).split(' ')
+        const requiredArgs = ['-f%f:%l:%c:%d:%k:%n:%m\n', '%DOC%'.replace('%DOC%', filePath)]
+
         let stdout: string
         try {
-            stdout = await this.processWrapper('root file', command, args, {cwd: path.dirname(this.extension.manager.rootFile)})
+            stdout = await this.processWrapper('root file', command, args.concat(requiredArgs).filter(arg => arg !== ''), {cwd: path.dirname(this.extension.manager.rootFile)})
         } catch (err) {
             return
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -72,6 +72,7 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('latex-workshop.clean', () => extension.commander.clean())
     vscode.commands.registerCommand('latex-workshop.actions', () => extension.commander.actions())
     vscode.commands.registerCommand('latex-workshop.citation', () => extension.commander.citation())
+    vscode.commands.registerCommand('latex-workshop.binaries', () => extension.commander.binaries())
     vscode.commands.registerCommand('latex-workshop.code-action', (d, r, c, m) => extension.codeActions.runCodeAction(d, r, c, m))
 
     context.subscriptions.push(vscode.workspace.onDidSaveTextDocument((e: vscode.TextDocument) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,6 +42,25 @@ function lintActiveFileIfEnabledAfterInterval(extension: Extension) {
     }
 }
 
+function obsoleteConfigCheck() {
+    const configuration = vscode.workspace.getConfiguration('latex-workshop')
+    function messageActions(selected) {
+        if (selected === 'Open Settings Editor') {
+            vscode.commands.executeCommand('workbench.action.openGlobalSettings')
+        }
+    }
+    if (configuration.has('linter_command_active_file')) {
+        vscode.window.showWarningMessage('Config "latex-workshop.linter_command_active_file" as been deprecated. \
+                                          Please use the new "latex-workshop.linter_arguments_active" config item.',
+                                         'Open Settings Editor').then(messageActions)
+    }
+    if (configuration.has('linter_command_root_file')) {
+        vscode.window.showWarningMessage('Config "latex-workshop.linter_command_root_file" as been deprecated. \
+                                          Please use the new "latex-workshop.linter_arguments_root" config item.',
+                                         'Open Settings Editor').then(messageActions)
+    }
+}
+
 export async function activate(context: vscode.ExtensionContext) {
     const extension = new Extension()
     global['latex'] = extension
@@ -70,6 +89,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
     context.subscriptions.push(vscode.workspace.onDidOpenTextDocument((e: vscode.TextDocument) => {
         if (extension.manager.isTex(e.fileName)) {
+            obsoleteConfigCheck()
             extension.manager.findRoot()
         }
     }))
@@ -108,6 +128,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
     // On startup, lint the whole project if enabled.
     lintRootFileIfEnabled(extension)
+    obsoleteConfigCheck()
 }
 
 export class Extension {

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -11,6 +11,7 @@ interface Position {}
 
 interface Client {
     type: 'viewer' | 'tab'
+    prevType?: 'viewer' | 'tab'
     ws?: WebSocket
     position?: Position
 }
@@ -101,12 +102,16 @@ export class Viewer {
                 client = this.clients[decodeURIComponent(data.path)]
                 if (client !== undefined) {
                     client.ws = ws
+                    if (client.type === undefined && client.prevType !== undefined) {
+                        client.type = client.prevType
+                    }
                 }
                 break
             case 'close':
                 for (const key in this.clients) {
                     client = this.clients[key]
                     if (client !== undefined && client.ws === ws) {
+                        client.prevType = client.type
                         delete client.ws
                         delete client.type
                     }


### PR DESCRIPTION
This PR add a new command `latex-workshop.binaries` to check the validity of `synctex` and `chktex`. If anyone is invalid, the extension searches some pre-defined common paths and warns for change. If no alternative binary is found, an error message is popped.

This PR is based on #96 , and should be merged after that.

![image](https://cloud.githubusercontent.com/assets/4210342/24788068/1e191e58-1b9e-11e7-9319-4e43e91d2af3.png)

![image](https://cloud.githubusercontent.com/assets/4210342/24788098/3a7c2806-1b9e-11e7-9d57-8d06ea863f10.png)
