### PR TITLE
(#125, #126) User configurable citation browser title, intellisense type

### DIFF
--- a/package.json
+++ b/package.json
@@ -307,6 +307,15 @@
           "default": 300,
           "description": "Defines the time interval in milliseconds between invoking LaTeX linter on the active file."
         },
+        "latex-workshop.intellisense.citation.type": {
+          "type": "string",
+          "enum": [
+            "inline",
+            "browser"
+          ],
+          "default": "inline",
+          "description": "Defines which type of hint to show when intellisense provides citation suggestions."
+        },
         "latex-workshop.intellisense.citation.label": {
           "type": "string",
           "enum": [
@@ -316,6 +325,15 @@
           ],
           "default": "bibtex key",
           "description": "Defines what to show as suggestion labels when intellisense provides citation suggestions."
+        },
+        "latex-workshop.intellisense.citation.browser.title": {
+          "type": "string",
+          "enum": [
+            "title",
+            "title and authors"
+          ],
+          "default": "title",
+          "description": "Defines what to show as citation browser titles when intellisense provides citation suggestions.\nOnly title strings are indexable."
         },
         "latex-workshop.debug.showLog": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -326,15 +326,6 @@
           "default": "bibtex key",
           "description": "Defines what to show as suggestion labels when intellisense provides citation suggestions."
         },
-        "latex-workshop.intellisense.citation.browser.title": {
-          "type": "string",
-          "enum": [
-            "title",
-            "title and authors"
-          ],
-          "default": "title",
-          "description": "Defines what to show as citation browser titles when intellisense provides citation suggestions.\nOnly title strings are indexable."
-        },
         "latex-workshop.debug.showLog": {
           "type": "boolean",
           "default": true,

--- a/src/completer.ts
+++ b/src/completer.ts
@@ -52,6 +52,13 @@ export class Completer implements vscode.CompletionItemProvider {
             for (const type of ['citation', 'reference', 'environment', 'command']) {
                 const suggestions = this.completion(type, line)
                 if (suggestions.length > 0) {
+                    if (type === 'citation') {
+                        const configuration = vscode.workspace.getConfiguration('latex-workshop')
+                        if (configuration.get('intellisense.citation.type') as string === 'browser') {
+                            resolve([])
+                            this.extension.completer.citation.browser()
+                        }
+                    }
                     resolve(suggestions)
                 }
             }

--- a/src/completer.ts
+++ b/src/completer.ts
@@ -57,9 +57,11 @@ export class Completer implements vscode.CompletionItemProvider {
                         if (configuration.get('intellisense.citation.type') as string === 'browser') {
                             resolve([])
                             this.extension.completer.citation.browser()
+                            return
                         }
                     }
                     resolve(suggestions)
+                    return
                 }
             }
             resolve([])

--- a/src/providers/citation.ts
+++ b/src/providers/citation.ts
@@ -80,21 +80,17 @@ export class Citation {
         Object.keys(this.citationInBib).forEach(bibPath => {
             this.citationInBib[bibPath].forEach(item => items.push(item))
         })
-        const configuration = vscode.workspace.getConfiguration('latex-workshop')
-        const authors = configuration.get('intellisense.citation.browser.title') as string === 'title and authors'
         const pickItems: vscode.QuickPickItem[] = items.map(item => {
-            let title = item.title as string
-            if (authors && item.author) {
-                title += ` ${item.author}`
-            }
             return {
-                label: title,
+                label: item.title as string,
                 description: `${item.key}`,
                 detail: `Authors: ${item.author ? item.author : 'Unknown'}, publication: ${item.journal ? item.journal : (item.publisher ? item.publisher : 'Unknown')}`
             }
         })
         vscode.window.showQuickPick(pickItems, {
-            placeHolder: 'Press ENTER to insert citation key at cursor'
+            placeHolder: 'Press ENTER to insert citation key at cursor',
+            matchOnDetail: true,
+            matchOnDescription: true
         }).then(selected => {
             if (!selected) {
                 return

--- a/src/providers/citation.ts
+++ b/src/providers/citation.ts
@@ -80,9 +80,15 @@ export class Citation {
         Object.keys(this.citationInBib).forEach(bibPath => {
             this.citationInBib[bibPath].forEach(item => items.push(item))
         })
+        const configuration = vscode.workspace.getConfiguration('latex-workshop')
+        const authors = configuration.get('intellisense.citation.browser.title') as string === 'title and authors'
         const pickItems: vscode.QuickPickItem[] = items.map(item => {
+            let title = item.title as string
+            if (authors && item.author) {
+                title += ` ${item.author}`
+            }
             return {
-                label: item.title as string,
+                label: title,
                 description: `${item.key}`,
                 detail: `Authors: ${item.author ? item.author : 'Unknown'}, publication: ${item.journal ? item.journal : (item.publisher ? item.publisher : 'Unknown')}`
             }


### PR DESCRIPTION
This PR adds two configuration items to better customize citation intellisense behaviors.

`latex-workshop.intellisense.citation.type` determines whether the citation browser or the build-in completionitemprovider is used to provide hints. Default is `inline` which is the normal case. When set to `browser`, the citation browser will show.

`latex-workshop.intellisense.citation.browser.title` determines what to display as the `quickpickitem` label in the citation browser. Only strings in the label are searchable. Default is `title`. When set to `title and authors`, the citation browser looks like this:
![image](https://cloud.githubusercontent.com/assets/4210342/25467394/77af4f12-2b40-11e7-9270-4ce9cdbf7de5.png)

Addresses #125 #126 