### PR TITLE
Trigger build with .tex file watcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -235,6 +235,11 @@
           "default": true,
           "description": "Build LaTeX after saving LaTeX source file.\nThis property defines whether LaTeX Workshop will execute the LaTeX toolchain command(s) to build the project after new LaTeX contents are saved."
         },
+        "latex-workshop.latex.autoBuildOnTexChange.enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Build LaTeX after a LaTeX source file has changed in the workspace.\nThis property defines whether LaTeX Workshop will execute the LaTeX toolchain command(s) to build the project after any LaTeX file in the workspace is saved on the disk which is not open in the active editor window.\nNote: this requires latex-workshop.latex.autoBuild.enabled setting to be true."
+        },
         "latex-workshop.latex.clean.enabled": {
           "type": "boolean",
           "default": false,

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -14,9 +14,9 @@ export class Commander {
 
     build() {
         this.extension.logger.addLogMessage(`BUILD command invoked.`)
-        if (!vscode.window.activeTextEditor || !this.extension.manager.isTex(vscode.window.activeTextEditor.document.fileName)) {
-            return
-        }
+        // if (!vscode.window.activeTextEditor || !this.extension.manager.isTex(vscode.window.activeTextEditor.document.fileName)) {
+        //     return
+        // }
         const rootFile = this.extension.manager.findRoot()
         if (rootFile !== undefined) {
             this.extension.logger.addLogMessage(`Building root file: ${rootFile}`)

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -14,9 +14,9 @@ export class Commander {
 
     build() {
         this.extension.logger.addLogMessage(`BUILD command invoked.`)
-        // if (!vscode.window.activeTextEditor || !this.extension.manager.isTex(vscode.window.activeTextEditor.document.fileName)) {
-        //     return
-        // }
+        if (!vscode.window.activeTextEditor || !this.extension.manager.isTex(vscode.window.activeTextEditor.document.fileName)) {
+            return
+        }
         const rootFile = this.extension.manager.findRoot()
         if (rootFile !== undefined) {
             this.extension.logger.addLogMessage(`Building root file: ${rootFile}`)

--- a/src/main.ts
+++ b/src/main.ts
@@ -152,6 +152,19 @@ export async function activate(context: vscode.ExtensionContext) {
         }
     }))
 
+    context.subscriptions.push(vscode.workspace.createFileSystemWatcher('**/*.tex', true, false, true).onDidChange((e: vscode.Uri) => {
+        if (vscode.window.activeTextEditor && vscode.window.activeTextEditor.document.fileName === e.fsPath) {
+            return
+        }
+        const configuration = vscode.workspace.getConfiguration('latex-workshop')
+        if (!configuration.get('latex.autoBuild.enabled') || extension.builder.disableBuildAfterSave) {
+            return
+        }
+        if (extension.manager.isTex(e.fsPath)) {
+            extension.commander.build()
+        }
+    }))
+
     context.subscriptions.push(vscode.workspace.registerTextDocumentContentProvider('latex-workshop-pdf', new PDFProvider(extension)))
     context.subscriptions.push(vscode.workspace.registerTextDocumentContentProvider('latex-workshop-log', extension.logProvider))
     context.subscriptions.push(vscode.languages.registerCompletionItemProvider('latex', extension.completer, '\\', '{', ','))

--- a/src/main.ts
+++ b/src/main.ts
@@ -157,11 +157,16 @@ export async function activate(context: vscode.ExtensionContext) {
             return
         }
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
-        if (!configuration.get('latex.autoBuild.enabled') || extension.builder.disableBuildAfterSave) {
+        if (!configuration.get('latex.autoBuild.enabled') || !configuration.get('latex.autoBuildOnTexChange.enabled') || extension.builder.disableBuildAfterSave) {
             return
         }
-        if (extension.manager.isTex(e.fsPath)) {
-            extension.commander.build()
+        extension.logger.addLogMessage(`BUILD command invoked on TeX file change.`)
+        const rootFile = extension.manager.findRoot()
+        if (rootFile !== undefined) {
+            extension.logger.addLogMessage(`Building root file: ${rootFile}`)
+            extension.builder.build(extension.manager.rootFile)
+        } else {
+            extension.logger.addLogMessage(`Cannot find LaTeX root file.`)
         }
     }))
 


### PR DESCRIPTION
Adds a file watcher to trigger builds when external program changes a `.tex` file. Proposal for this feature is in Issue #151 .