### PR TITLE
Program magic comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,27 @@ To find the root file, LaTeX Workshop will follow the steps below, stopping when
 
 If no root file is found, most of the features in LaTeX Workshop will not work.
 
+### Magic comments?
+LaTeX Workshop supports both `% !TEX root` and `% !TEX program` magic comments. The former is used to define the root file, while the latter helps select compiler program.
+
+All `command` in `toolchain` which are empty will be replaced with the program set by `% !TEX program` magic comment in the root file. Suppose there is a line `% !TEX program = xelatex` in the root file, and the toolchain is set as follows:
+```
+"latex-workshop.latex.toolchain": [
+  {
+    "command": "",
+    "args": [
+      "-synctex=1",
+      "-interaction=nonstopmode",
+      "-file-line-error",
+      "%DOC%"
+    ]
+  }
+]
+```
+Upon building the project, LaTeX Workshop will parse the root file and figure out that `xelatex` should be used. This program will replace the empty `command` in the toolchain. Arguments are untouched.
+
+If the `command` is set empty but no `% !TEX program` magic comment is found, `pdflatex` is used.
+
 ### Spell check?
 [Code Spellchecker](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) did a great job. The following regexps are recommended to be ignored for LaTeX:
 ```

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -87,7 +87,7 @@ export class Builder {
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         // Modify a copy, instead of itself.
         const commands = JSON.parse(JSON.stringify(configuration.get('latex.toolchain'))) as ToolchainCommand[]
-        const program = this.findProgramMagic(rootFile)
+        let program = ''
         for (const command of commands) {
             if (!('command' in command)) {
                 vscode.window.showErrorMessage('LaTeX toolchain is invalid. Each tool in the toolchain must have a "command" string.')
@@ -102,6 +102,9 @@ export class Builder {
                                                           .replace('%DOCFILE%', path.basename(rootFile, '.tex')))
             }
             if (command.command === '') {
+                if (program === '') {
+                    program = this.findProgramMagic(rootFile)
+                }
                 command.command = program
             }
         }

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode'
 import * as path from 'path'
+import * as fs from 'fs'
 import * as cp from 'child_process'
 
 import {Extension} from './main'
@@ -86,6 +87,7 @@ export class Builder {
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         // Modify a copy, instead of itself.
         const commands = JSON.parse(JSON.stringify(configuration.get('latex.toolchain'))) as ToolchainCommand[]
+        const program = this.findProgramMagic(rootFile)
         for (const command of commands) {
             if (!('command' in command)) {
                 vscode.window.showErrorMessage('LaTeX toolchain is invalid. Each tool in the toolchain must have a "command" string.')
@@ -99,8 +101,26 @@ export class Builder {
                 command.args = command.args.map(arg => arg.replace('%DOC%', rootFile.replace(/\.tex$/, ''))
                                                           .replace('%DOCFILE%', path.basename(rootFile, '.tex')))
             }
+            if (command.command === '') {
+                command.command = program
+            }
         }
         return commands
+    }
+
+    findProgramMagic(rootFile: string) : string {
+        const regex = /(?:%\s*!\s*T[Ee]X\s(?:TS-)?program\s*=\s*([^\s]*)$)/m
+        const content = fs.readFileSync(rootFile).toString()
+
+        const result = content.match(regex)
+        let program = ''
+        if (result) {
+            program = result[1]
+            this.extension.logger.addLogMessage(`Found program by magic comment: ${program}`)
+        } else {
+            program = 'pdflatex'
+        }
+        return program
     }
 }
 


### PR DESCRIPTION
Solves #149, concerned in #102.

This PR let LaTeX Workshop read `# !TeX program` magic command and insert the program into any empty commands in the toolchain. `% !TEX program = someprogram` and `% !TEX TS-program = someprogram` are both acceptable.