### PR TITLE
New bibtex parser that handles double quoted strings better

### DIFF
--- a/src/manager.ts
+++ b/src/manager.ts
@@ -218,7 +218,7 @@ export class Manager {
                 this.bibWatcher = chokidar.watch(bibPath)
                 this.bibWatcher.on('change', (path: string) => {
                     this.extension.logger.addLogMessage(`Bib file watcher - responding to change in ${path}`)
-                    this.extension.completer.citation.parseBibItems(path)
+                    this.extension.completer.citation.parseBibFile(path)
                 })
                 this.bibWatcher.on('unlink', (path: string) => {
                     this.extension.logger.addLogMessage(`Bib file watcher: ${path} deleted.`)
@@ -226,12 +226,12 @@ export class Manager {
                     this.bibWatcher.unwatch(path)
                     this.watched.splice(this.watched.indexOf(path), 1)
                 })
-                this.extension.completer.citation.parseBibItems(bibPath)
+                this.extension.completer.citation.parseBibFile(bibPath)
             } else if (this.watched.indexOf(bibPath) < 0) {
                 this.extension.logger.addLogMessage(`Adding .bib file ${bibPath} to bib file watcher.`)
                 this.bibWatcher.add(bibPath)
                 this.watched.push(bibPath)
-                this.extension.completer.citation.parseBibItems(bibPath)
+                this.extension.completer.citation.parseBibFile(bibPath)
             } else {
                 this.extension.logger.addLogMessage(`.bib file ${bibPath} is already being watched.`)
             }

--- a/src/providers/citation.ts
+++ b/src/providers/citation.ts
@@ -102,7 +102,7 @@ export class Citation {
         })
     }
 
-    parseBibItems(bibPath: string) {
+    parseBibFile(bibPath: string) {
         this.extension.logger.addLogMessage(`Parsing .bib entries from ${bibPath}`)
         const items: CitationRecord[] = []
         const content = fs.readFileSync(bibPath, 'utf-8').replace(/[\r\n]/g, ' ')
@@ -112,7 +112,7 @@ export class Citation {
         while (result || prevResult) {
             if (prevResult && bibEntries.indexOf(prevResult[1].toLowerCase()) > -1) {
                 const itemString = content.substring(prevResult.index, result ? result.index : undefined).trim()
-                const item = this.splitBibItem(itemString)
+                const item = this.parseBibString(itemString)
                 if (item !== undefined) {
                     items.push(item)
                 } else {
@@ -134,7 +134,7 @@ export class Citation {
         delete this.citationInBib[bibPath]
     }
 
-    splitBibItem(item: string) {
+    parseBibString(item: string) {
         let unclosed = 0
         let lastSplit = -1
         const segments: string[] = []


### PR DESCRIPTION
As title.

This parser use some regex(s) to better locate the starting position of bib attributes and strings. It yields better result for quoted strings. Curly braces should experience no changes.

Hopefully this parser can fix #132 #173 .