### PR TITLE
Add regular types from biblatex

### DIFF
--- a/src/providers/citation.ts
+++ b/src/providers/citation.ts
@@ -3,10 +3,11 @@ import * as fs from 'fs'
 
 import {Extension} from './../main'
 
-const bibEntries = ['article', 'book', 'booklet', 'conference', 'inbook',
-                    'incollection', 'inproceedings', 'manual', 'mastersthesis',
-                    'misc', 'phdthesis', 'proceedings', 'techreport',
-                    'unpublished']
+const bibEntries = ['article', 'book', 'bookinbook', 'booklet', 'collection', 'conference', 'inbook',
+                    'incollection', 'inproceedings', 'inreference', 'manual', 'mastersthesis', 'misc',
+                    'mvbook', 'mvcollection', 'mvproceedings', 'mvreference', 'online', 'patent', 'periodical',
+                    'phdthesis', 'proceedings', 'reference', 'report', 'set', 'suppbook', 'suppcollection',
+                    'suppperiodical', 'techreport', 'thesis', 'unpublished']
 
 interface CitationRecord {
     key: string


### PR DESCRIPTION
Hi,

I've added some regular types for citation completion from biblatex which I was missing :-)

Taken from 2.1.1 Regular Types:
http://tug.ctan.org/macros/latex/exptl/biblatex/doc/biblatex.pdf
