### PR TITLE
Allow multiple optional parameters

### DIFF
--- a/src/completer.ts
+++ b/src/completer.ts
@@ -73,7 +73,7 @@ export class Completer implements vscode.CompletionItemProvider {
         let provider
         switch (type) {
             case 'citation':
-                reg = /(?:\\[a-zA-Z]*cite[a-zA-Z]*(?:\[[^\[\]]*\])?){([^}]*)$/
+                reg = /(?:\\[a-zA-Z]*cite[a-zA-Z]*(?:\[[^\[\]]*\])*){([^}]*)$/
                 provider = this.citation
                 break
             case 'reference':


### PR DESCRIPTION
Hello,

I've changed the autocompletion for citation to allow multiple optional parameter when using a citation function.

For example in German we include something before and after the citation in the footnote, which would look like this in the src:
```tex
\autocite[Vgl.][S.11]{somebook}
```

and would compile to:

```Vgl. Some Book S.11```


The auto completion wouldn't match it as citation because there was only one pair of square brackets allowed :-)