### PR TITLE
Minor cleanup and overhaul to log-parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,3 +164,7 @@ If the `command` is set empty but no `% !TEX program` magic comment is found, `p
 ## License
 
 [MIT](https://opensource.org/licenses/MIT)
+
+## GitHub
+
+The code for this extension is available on github at: https://github.com/James-Yu/LaTeX-Workshop


### PR DESCRIPTION
While working on a solution to the issue that error messages were not fully included in the log, I also removed some minor repetition from the preprocessing of the logging and added a reference to the repo in the readme of the addin.

The new parser now works by remembering how many empty lines follow a certain kind of entry in the sanitized log and appending lines until so many empty lines were included.