### PR TITLE
Support .chktexrc

### DIFF
--- a/src/components/linter.ts
+++ b/src/components/linter.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode'
 import * as path from 'path'
+import * as fs from 'fs'
 import {ChildProcess, spawn, SpawnOptions} from 'child_process'
 import {EOL} from 'os'
 
@@ -25,6 +26,12 @@ export class Linter {
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         const command = configuration.get('chktex.path') as string
         const args = configuration.get('chktex.args.active') as string[]
+        if (this.extension.manager.rootDir) {
+            const rcPath = path.join(this.extension.manager.rootDir, '.chktexrc')
+            if (fs.existsSync(rcPath)) {
+                args.push('-l', rcPath)
+            }
+        }
         const requiredArgs = ['-I0', '-f%f:%l:%c:%d:%k:%n:%m\n']
 
         let stdout: string
@@ -49,6 +56,12 @@ export class Linter {
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         const command = configuration.get('chktex.path') as string
         const args = configuration.get('chktex.args.root') as string[]
+        if (this.extension.manager.rootDir) {
+            const rcPath = path.join(this.extension.manager.rootDir, '.chktexrc')
+            if (fs.existsSync(rcPath)) {
+                args.push('-l', rcPath)
+            }
+        }
         const requiredArgs = ['-f%f:%l:%c:%d:%k:%n:%m\n', '%DOC%'.replace('%DOC%', filePath)]
 
         let stdout: string


### PR DESCRIPTION
Detect `.chktexrc` file in project root folder and use it if exists.
It is useful when you want to disable certain annoying lint errors.
e.g., this,

![lint](https://user-images.githubusercontent.com/9464825/32892417-1f791e60-cb11-11e7-86b0-842e2dee1e69.PNG)

With this pr, you can disable lint no 21 by putting a `.chktexrc` file that contains
```txt
CmdLine
{
-n 21
}
```
