### PR TITLE
Fix missing brackets in ipv6 address for macOS

### DIFF
--- a/src/components/server.ts
+++ b/src/components/server.ts
@@ -19,7 +19,12 @@ export class Server {
                 this.extension.logger.addLogMessage(`Error creating LaTeX Workshop http server: ${err}.`)
             } else {
                 const {address, port} = this.httpServer.address()
-                this.address = `[${address}]:${port}`
+                if (address.indexOf(':')>-1) {
+                    // the colon is reserved in URL to separate IPv4 address from port number. IPv6 address needs to be enclosed in square brackets when used in URL
+                    this.address = `[${address}]:${port}`;
+                } else {
+                    this.address = `${address}:${port}`;
+                }
                 this.extension.logger.addLogMessage(`Server created on ${this.address}`)
             }
         })

--- a/src/components/server.ts
+++ b/src/components/server.ts
@@ -19,7 +19,7 @@ export class Server {
                 this.extension.logger.addLogMessage(`Error creating LaTeX Workshop http server: ${err}.`)
             } else {
                 const {address, port} = this.httpServer.address()
-                this.address = `${address}:${port}`
+                this.address = `[${address}]:${port}`
                 this.extension.logger.addLogMessage(`Server created on ${this.address}`)
             }
         })


### PR DESCRIPTION
 I had exactly the same problem as described in #306. Without the brackets, pdf file cannot be displayed on macOS. This commit fixed the problem. But I have not tested it on other platforms.