### PR TITLE
Integrate nfode/latex-formatter with fix for indent.log

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -22,6 +22,7 @@ import {HoverProvider} from './providers/hover'
 import {DocSymbolProvider} from './providers/docsymbol'
 import {ProjectSymbolProvider} from './providers/projectsymbol'
 import {DefinitionProvider} from './providers/definition'
+import {LatexFormatterProvider} from './providers/latexformatter'
 
 function lintRootFileIfEnabled(extension: Extension) {
     const configuration = vscode.workspace.getConfiguration('latex-workshop')
@@ -141,6 +142,8 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('latex-workshop.log', () => extension.commander.log())
     vscode.commands.registerCommand('latex-workshop.code-action', (d, r, c, m) => extension.codeActions.runCodeAction(d, r, c, m))
     vscode.commands.registerCommand('latex-workshop.goto-section', (filePath, lineNumber) => extension.commander.gotoSection(filePath, lineNumber))
+
+    vscode.languages.registerDocumentFormattingEditProvider('latex', new LatexFormatterProvider(extension))
 
     context.subscriptions.push(vscode.workspace.onDidSaveTextDocument((e: vscode.TextDocument) => {
         if (extension.manager.isTex(e.fileName)) {

--- a/src/providers/latexformatter.ts
+++ b/src/providers/latexformatter.ts
@@ -1,0 +1,119 @@
+import * as vscode from 'vscode'
+import * as cp from 'child_process'
+import * as path from 'path'
+import * as fs from 'fs'
+import * as os from 'os'
+
+import { Extension } from '../main'
+
+const fullRange = doc => doc.validateRange(new vscode.Range(0, 0, Number.MAX_VALUE, Number.MAX_VALUE))
+
+export class OperatingSystem {
+    public name
+    public fileExt
+    public checker
+
+    constructor(name: string, fileExt: string, checker: string) {
+        this.name = name
+        this.fileExt = fileExt
+        this.checker = checker
+    }
+}
+
+const windows: OperatingSystem = new OperatingSystem('win32', '.exe', 'where')
+const linux: OperatingSystem = new OperatingSystem('linux', '.pl', 'which')
+const mac: OperatingSystem = new OperatingSystem('darwin', '.pl', 'which')
+
+export class LaTexFormatter {
+    private extension: Extension
+    private machineOs: string
+    private currentOs: OperatingSystem
+    private formatter: string
+
+    constructor(extension: Extension) {
+        this.extension = extension
+        this.machineOs = os.platform()
+        this.formatter = 'latexindent'
+    }
+
+    public formatDocument(document: vscode.TextDocument) : Thenable<vscode.TextEdit[]> {
+        return new Promise((resolve, reject) => {
+            const formatter = 'latexindent'
+            const filename = document.fileName
+
+            if (this.machineOs === windows.name) {
+                this.currentOs = windows
+            } else if (this.machineOs === linux.name) {
+                this.currentOs = linux
+            }  else if (this.machineOs === mac.name) {
+                this.currentOs = mac
+            }
+
+            this.checkPath(this.currentOs.checker).then((latexindentPresent) => {
+                if (!latexindentPresent) {
+                    this.extension.logger.addLogMessage('Can not find latexindent in PATH!')
+                    vscode.window.showErrorMessage('Can not find latexindent in PATH!')
+                    return resolve()
+                }
+                this.format(filename, document).then((edit) => {
+                    return resolve(edit)
+                })
+
+            })
+        })
+    }
+
+    private checkPath(checker: string) : Thenable<boolean> {
+        return new Promise((resolve, reject) => {
+            cp.exec(checker + ' ' + this.formatter, (err, stdout, stderr) => {
+                if (stdout === '') {
+                    this.formatter += this.currentOs.fileExt
+                    this.checkPath(checker).then((res) => {
+                        if (res) {
+                            resolve(true)
+                        } else {
+                            resolve(false)
+                        }
+                    })
+                }
+                resolve(true)
+            })
+        })
+
+    }
+
+    private format(filename: string, document: vscode.TextDocument) : Thenable<vscode.TextEdit[]> {
+        return new Promise((resolve, reject) => {
+            cp.exec(this.formatter + ' "' + filename + '"', (err, stdout, stderr) => {
+                if (stdout !== '') {
+                    const edit = [vscode.TextEdit.replace(fullRange(document), stdout)]
+                    try {
+                        fs.unlinkSync(path.dirname(filename) + path.sep + 'indent.log')
+                    } catch (ignored) {
+                    }
+                    return resolve(edit)
+                }
+                return resolve()
+            })
+        })
+
+    }
+}
+
+export class LatexFormatterProvider implements vscode.DocumentFormattingEditProvider {
+    private formatter: LaTexFormatter
+    private extension: Extension
+
+    constructor(extension: Extension) {
+        this.extension = extension
+        this.formatter = new LaTexFormatter(extension)
+    }
+
+    public provideDocumentFormattingEdits(document: vscode.TextDocument, options: vscode.FormattingOptions, token: vscode.CancellationToken) :
+        vscode.ProviderResult<vscode.TextEdit[]> {
+            return document.save().then(() => {
+                return this.formatter.formatDocument(document)
+            })
+    }
+
+}


### PR DESCRIPTION
This PR adds formatting support for Latex files by integrating the code from nfode/latex-formatter (with a fix for the creation of indent.log) as discussed in issue #118 .