### PR TITLE
Make path for latexindent configurable

### DIFF
--- a/package.json
+++ b/package.json
@@ -427,6 +427,11 @@
           "type": "string",
           "default": "",
           "description": "The browser used to view PDF file.\nExample: \"firefox\", \"google chrome\". See https://www.npmjs.com/package/opn.\nLeave it blank to use the default browser."
+        },
+        "latex-workshop.latexindent.path": {
+          "type": "string",
+          "default": "latexindent",
+          "description": "Define the location of the latexindent executable file."
         }
       }
     },

--- a/src/providers/latexformatter.ts
+++ b/src/providers/latexformatter.ts
@@ -33,13 +33,10 @@ export class LaTexFormatter {
     constructor(extension: Extension) {
         this.extension = extension
         this.machineOs = os.platform()
-        this.formatter = 'latexindent'
     }
 
     public formatDocument(document: vscode.TextDocument) : Thenable<vscode.TextEdit[]> {
         return new Promise((resolve, _reject) => {
-            const filename = document.fileName
-
             if (this.machineOs === windows.name) {
                 this.currentOs = windows
             } else if (this.machineOs === linux.name) {
@@ -48,47 +45,57 @@ export class LaTexFormatter {
                 this.currentOs = mac
             }
 
-            this.checkPath(this.currentOs.checker).then((latexindentPresent) => {
-                if (!latexindentPresent) {
-                    this.extension.logger.addLogMessage('Can not find latexindent in PATH!')
-                    vscode.window.showErrorMessage('Can not find latexindent in PATH!')
-                    return resolve()
-                }
-                this.format(filename, document).then((edit) => {
+            const configuration = vscode.workspace.getConfiguration('latex-workshop.latexindent')
+            this.formatter = configuration.get<string>('path') || 'latexindent'
+            const pathMeta = configuration.inspect('path')
+
+            if (pathMeta && pathMeta.defaultValue && pathMeta.defaultValue !== this.formatter) {
+                this.format(document).then((edit) => {
                     return resolve(edit)
                 })
-
-            })
+            } else {
+                this.checkPath(this.currentOs.checker).then((latexindentPresent) => {
+                    if (!latexindentPresent) {
+                        this.extension.logger.addLogMessage('Can not find latexindent in PATH!')
+                        vscode.window.showErrorMessage('Can not find latexindent in PATH!')
+                        return resolve()
+                    }
+                    this.format(document).then((edit) => {
+                        return resolve(edit)
+                    })
+                })
+            }
         })
     }
 
     private checkPath(checker: string) : Thenable<boolean> {
         return new Promise((resolve, _reject) => {
-            cp.exec(checker + ' ' + this.formatter, (_err, stdout, _stderr) => {
-                if (stdout === '') {
+            cp.exec(checker + ' ' + this.formatter, (err, _stdout, _stderr) => {
+                if (err) {
                     this.formatter += this.currentOs.fileExt
-                    this.checkPath(checker).then((res) => {
-                        if (res) {
-                            resolve(true)
-                        } else {
+                    cp.exec(checker + ' ' + this.formatter, (err1, _stdout1, _stderr1) => {
+                        if (err1) {
                             resolve(false)
+                        } else {
+                            resolve(true)
                         }
                     })
+                } else {
+                    resolve(true)
                 }
-                resolve(true)
             })
         })
 
     }
 
-    private format(filename: string, document: vscode.TextDocument) : Thenable<vscode.TextEdit[]> {
+    private format(document: vscode.TextDocument) : Thenable<vscode.TextEdit[]> {
         return new Promise((resolve, _reject) => {
             const configuration = vscode.workspace.getConfiguration('editor', document.uri)
             const useSpaces = configuration.get<boolean>('insertSpaces')
             const tabSize = configuration.get<number>('tabSize') || 4
             const indent = useSpaces ? ' '.repeat(tabSize) : '\\t'
 
-            cp.exec(this.formatter + ' "' + filename + '"' + ' -y="defaultIndent: \'' + indent + '\'"',
+            cp.exec(this.formatter + ' "' + document.fileName + '"' + ' -y="defaultIndent: \'' + indent + '\'"',
              (err, stdout, _stderr) => {
                 if (err) {
                     this.extension.logger.addLogMessage(`Formatting failed: ${err.message}`)
@@ -99,7 +106,7 @@ export class LaTexFormatter {
                 if (stdout !== '') {
                     const edit = [vscode.TextEdit.replace(fullRange(document), stdout)]
                     try {
-                        fs.unlinkSync(path.dirname(filename) + path.sep + 'indent.log')
+                        fs.unlinkSync(path.dirname(document.fileName) + path.sep + 'indent.log')
                     } catch (ignored) {
                     }
 


### PR DESCRIPTION
Make path for latexindent configurable to allow installation without setting up perl and manually installing packages (see #376).