### PR TITLE
Log server 'error' events

### DIFF
--- a/src/components/server.ts
+++ b/src/components/server.ts
@@ -28,6 +28,9 @@ export class Server {
                 this.extension.logger.addLogMessage(`Server created on ${this.address}`)
             }
         })
+        this.httpServer.on('error', (err) => {
+            this.extension.logger.addLogMessage(`Error creating LaTeX Workshop http server: ${err}.`)
+        })
         this.wsServer = ws.createServer({server: this.httpServer})
         this.wsServer.on('connection', (websocket) => {
             websocket.on('message', (msg) => this.extension.viewer.handler(websocket, msg))


### PR DESCRIPTION
This came in handy while debugging #401. Without this, vs code was just throwing an error in dev tools without pointing at the source.