### PR TITLE
[WIP] Clean auxillary files and retry once on build errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -282,6 +282,11 @@
           "default": false,
           "description": "Build LaTeX after a LaTeX source file has changed in the workspace.\nThis property defines whether LaTeX Workshop will execute the LaTeX toolchain command(s) to build the project after any LaTeX file in the workspace is saved on the disk which is not open in the active editor window."
         },
+        "latex-workshop.latex.autoBuild.cleanAndRetry.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Delete LaTeX auxillary files when errors occur during build and retry.\nThis property defines whether LaTeX Workshop will try to clean and build the project once again after errors happen in the build toolchain."
+        },
         "latex-workshop.latex.clean.enabled": {
           "type": "boolean",
           "default": false,

--- a/package.json
+++ b/package.json
@@ -498,7 +498,6 @@
     "workspaceSymbolProvider": "true"
   },
   "dependencies": {
-    "@types/fs-extra": "^5.0.0",
     "chokidar": "^1.6.1",
     "fs-extra": "^5.0.0",
     "glob": "^7.1.1",
@@ -508,6 +507,7 @@
   },
   "devDependencies": {
     "@types/chokidar": "^1.6.0",
+    "@types/fs-extra": "^5.0.0",
     "@types/glob": "^5.0.30",
     "@types/node": "^6.0.40",
     "@types/ws": "^0.0.39",

--- a/package.json
+++ b/package.json
@@ -498,7 +498,9 @@
     "workspaceSymbolProvider": "true"
   },
   "dependencies": {
+    "@types/fs-extra": "^5.0.0",
     "chokidar": "^1.6.1",
+    "fs-extra": "^5.0.0",
     "glob": "^7.1.1",
     "opn": "^5.1.0",
     "pdfjs-dist": "^1.8.609",

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -118,10 +118,10 @@ export class Commander {
         this.extension.locator.syncTeX()
     }
 
-    clean() {
+    clean() : Promise<void> {
         this.extension.logger.addLogMessage(`CLEAN command invoked.`)
         this.extension.manager.findRoot()
-        this.extension.cleaner.clean()
+        return this.extension.cleaner.clean()
     }
 
     citation() {

--- a/src/components/builder.ts
+++ b/src/components/builder.ts
@@ -84,13 +84,14 @@ export class Builder {
             if (exitCode !== 0) {
                 this.extension.logger.addLogMessage(`Toolchain returns with error: ${exitCode}/${signal}.`)
                 this.extension.logger.displayStatus('x', 'errorForeground', `LaTeX toolchain terminated with error.`)
-                
+
                 const configuration = vscode.workspace.getConfiguration('latex-workshop')
                 if (!this.disableCleanAndRetry && configuration.get('latex.autoBuild.cleanAndRetry.enabled') && !configuration.get('latex.clean.enabled')) {
                     this.extension.logger.addLogMessage(`Cleaning auxillary files and retrying build after toolchain error.`)
                     this.disableCleanAndRetry = true
-                    this.extension.commander.clean()
-                    this.buildStep(rootFile, toolchain, 0)
+                    this.extension.commander.clean().then(() => {
+                        this.buildStep(rootFile, toolchain, 0)
+                    })
                 }
             } else {
                 this.buildStep(rootFile, toolchain, index + 1)

--- a/src/components/builder.ts
+++ b/src/components/builder.ts
@@ -86,7 +86,7 @@ export class Builder {
                 this.extension.logger.displayStatus('x', 'errorForeground', `LaTeX toolchain terminated with error.`)
                 
                 const configuration = vscode.workspace.getConfiguration('latex-workshop')
-                if (!this.disableCleanAndRetry && configuration.get('latex.autoBuild.cleanAndRetry.enabled')) {
+                if (!this.disableCleanAndRetry && configuration.get('latex.autoBuild.cleanAndRetry.enabled') && !configuration.get('latex.clean.enabled')) {
                     this.extension.logger.addLogMessage(`Cleaning auxillary files and retrying build after toolchain error.`)
                     this.disableCleanAndRetry = true
                     this.extension.commander.clean()

--- a/src/components/builder.ts
+++ b/src/components/builder.ts
@@ -10,6 +10,7 @@ export class Builder {
     currentProcess: cp.ChildProcess | undefined
     disableBuildAfterSave: boolean = false
     nextBuildRootFile: string | undefined
+    disableCleanAndRetry: boolean = false
 
     constructor(extension: Extension) {
         this.extension = extension
@@ -41,6 +42,7 @@ export class Builder {
     }
 
     build(rootFile: string) {
+        this.disableCleanAndRetry = false
         this.preprocess(rootFile)
         if (this.nextBuildRootFile === undefined) {
             this.buildInitiater(rootFile)
@@ -82,6 +84,14 @@ export class Builder {
             if (exitCode !== 0) {
                 this.extension.logger.addLogMessage(`Toolchain returns with error: ${exitCode}/${signal}.`)
                 this.extension.logger.displayStatus('x', 'errorForeground', `LaTeX toolchain terminated with error.`)
+                
+                const configuration = vscode.workspace.getConfiguration('latex-workshop')
+                if (!this.disableCleanAndRetry && configuration.get('latex.autoBuild.cleanAndRetry.enabled')) {
+                    this.extension.logger.addLogMessage(`Cleaning auxillary files and retrying build after toolchain error.`)
+                    this.disableCleanAndRetry = true
+                    this.extension.commander.clean()
+                    this.buildStep(rootFile, toolchain, 0)
+                }
             } else {
                 this.buildStep(rootFile, toolchain, index + 1)
             }

--- a/src/components/cleaner.ts
+++ b/src/components/cleaner.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode'
 import * as path from 'path'
-import * as fs from 'fs'
+import * as fs from 'fs-extra'
 import * as glob from 'glob'
 
 import {Extension} from '../main'
@@ -12,43 +12,56 @@ export class Cleaner {
         this.extension = extension
     }
 
-    clean() {
+    clean() : Promise<void> {
         if (this.extension.manager.rootFile !== undefined) {
             this.extension.manager.findRoot()
         }
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
-        const globs = configuration.get('latex.clean.fileTypes') as string[]
+        let globs = configuration.get('latex.clean.fileTypes') as string[]
         let outdir = configuration.get('latex.outputDir') as string
         if (!outdir.endsWith('/') && !outdir.endsWith('\\')) {
             outdir += path.sep
         }
-        const globOutDir: string[] = []
         if (outdir !== './') {
-            globs.forEach(globType => globOutDir.push(outdir + globType))
+            globs = globs.concat(globs.map(globType => outdir + globType))
         }
-        for (const globType of globs.concat(globOutDir)) {
-            glob(globType, {cwd: this.extension.manager.rootDir}, (err, files) => {
+
+        return Promise.all(
+            // Get an array of arrays containing all the files found by the globs
+            globs.map(g => this.globP(g, {cwd: this.extension.manager.rootDir}))
+        ).then(files => files
+            // Reduce the array of arrays to a single array containing all the files that should be delted
+            .reduce((all, curr) => all.concat(curr), [])
+            // Resolve the absoulte filepath for every file
+            .map(file => path.resolve(this.extension.manager.rootDir, file))
+        ).then(files => Promise.all(
+            // Try to unlink the files, returning a Promise for every file
+            files.map(file => fs.unlink(file).then(() => {
+                this.extension.logger.addLogMessage(`File cleaned: ${file}`)
+                // If unlinking fails, replace it with an rmdir Promise
+            }, () => fs.rmdir(file).then(() => {
+                this.extension.logger.addLogMessage(`Folder removed: ${file}`)
+            }, () => {
+                this.extension.logger.addLogMessage(`Error removing file: ${file}`)
+            })))
+        )).then(
+            () => {} // Do not pass results to Promise returned by clean()
+        ).catch(err => {
+            this.extension.logger.addLogMessage(`Error during deletion of files: ${err}`)
+        })
+    }
+
+    // This function wraps the glob package into a promise.
+    // It behaves like the original apart from returning a Promise instead of requiring a Callback.
+    globP(pattern: string, options: glob.IOptions) : Promise<string[]> {
+        return new Promise((resolve, reject) => {
+            glob(pattern, options, (err, files) => {
                 if (err) {
-                    this.extension.logger.addLogMessage(`Error identifying files with glob ${globType}: ${files}.`)
-                    return
-                }
-                for (const file of files) {
-                    const fullPath = path.resolve(this.extension.manager.rootDir, file)
-                    fs.unlink(fullPath, unlinkErr => {
-                        if (unlinkErr) {
-                            fs.rmdir(fullPath, rmdirErr => {
-                                if (rmdirErr) {
-                                    this.extension.logger.addLogMessage(`Error removing file: ${fullPath}`)
-                                    return
-                                }
-                                this.extension.logger.addLogMessage(`Folder removed: ${fullPath}`)
-                            })
-                            return
-                        }
-                        this.extension.logger.addLogMessage(`File cleaned: ${fullPath}`)
-                    })
+                    reject(err)
+                } else {
+                    resolve(files)
                 }
             })
-        }
+        })
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13,6 +13,12 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-1.1.0.tgz#93b1be91f63c184450385272c47b6496fd028e02"
 
+"@types/fs-extra@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-5.0.0.tgz#d3e225b35eb5c6d3a5a782c28219df365c781413"
+  dependencies:
+    "@types/node" "*"
+
 "@types/glob@^5.0.30":
   version "5.0.34"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-5.0.34.tgz#ee626c9be3da877d717911c6101eee0a9871bbf4"
@@ -895,6 +901,14 @@ from@~0:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/from/-/from-0.1.7.tgz#83c60afc58b9c56997007ed1a768b3ab303a44fe"
 
+fs-extra@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-5.0.0.tgz#414d0110cdd06705734d055652c5411260c31abd"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -1016,7 +1030,7 @@ glogg@^1.0.0:
   dependencies:
     sparkles "^1.0.0"
 
-graceful-fs@^4.0.0, graceful-fs@^4.1.2:
+graceful-fs@^4.0.0, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
@@ -1471,6 +1485,12 @@ json-stringify-safe@~5.0.1:
 json5@^0.5.0, json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
+
+jsonfile@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
 
 jsonify@~0.0.0:
   version "0.0.0"
@@ -2691,6 +2711,10 @@ unique-stream@^2.0.2:
   dependencies:
     json-stable-stringify "^1.0.0"
     through2-filter "^2.0.0"
+
+universalify@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.1.tgz#fa71badd4437af4c148841e3b3b165f9e9e590b7"
 
 url-parse@^1.1.9:
   version "1.2.0"


### PR DESCRIPTION
This basically works and retries one time when the build fails. The issue I'm having is that the `commander.clean()` method is asynchronous and therefore cleaning and rebuilding starts at the same time. What would be the best approach to implement a callback/promise into that function to continue when the clean is completed?

resolves #414 