### PR TITLE
Handle external links in the embedded viewer

### DIFF
--- a/src/components/viewer.ts
+++ b/src/components/viewer.ts
@@ -152,6 +152,9 @@ export class Viewer {
             case 'click':
                 this.extension.locator.locate(data, decodeURIComponent(data.path))
                 break
+            case 'external_link':
+                vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(data.url))
+                break
             default:
                 this.extension.logger.addLogMessage(`Unknown websocket message: ${msg}`)
                 break

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -420,6 +420,16 @@ See https://github.com/adobe-type-tools/cmap-resources
           socket.send(JSON.stringify({type:"loaded", path:file}))
       })
 
+      // if we're embedded we cannot open external links here. So we intercept clicks and forward them to the extension
+      if (window.parent !== window) {
+        document.addEventListener('click', (e) => {
+            if (e.target.nodeName == 'A' && !e.target.href.startsWith(window.location.href)) { // is external link
+              socket.send(JSON.stringify({type:"external_link", url:e.target.href}))
+              e.preventDefault();
+            }
+        })
+      }
+
       document.addEventListener('pagerendered', (e) => {
           let page = e.target.dataset.pageNumber
           let target = e.target


### PR DESCRIPTION
When the viewer runs embedded in a tab it cannot open external links, which is annoying. This PR intercepts clicks to external links and forwards them to the extension for opening in a browser.