### PR TITLE
Find bar / History improvements

### DIFF
--- a/viewer/viewer.css
+++ b/viewer/viewer.css
@@ -525,6 +525,10 @@ html[dir='rtl'] #viewerContainer {
   box-shadow: inset -1px 0 0 hsla(0,0%,100%,.05);
 }
 
+.notransition {
+  transition: none !important;
+}
+
 .toolbar {
   position: absolute;
   left: 0;

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -154,6 +154,10 @@ See https://github.com/adobe-type-tools/cmap-resources
                 <button id="sidebarToggle" class="toolbarButton" title="Toggle Sidebar" tabindex="11" data-l10n-id="toggle_sidebar">
                   <span data-l10n-id="toggle_sidebar_label">Toggle Sidebar</span>
                 </button>
+                <!-- History back button, useful in the embedded viewer -->
+                <button class="toolbarButton findPrevious" title="Back" id="historyBack">
+                  <span>Back</span>
+                </button>
                 <div class="toolbarButtonSpacer"></div>
                 <button id="viewFind" class="toolbarButton group hiddenSmallView" title="Find in Document" tabindex="12" data-l10n-id="findbar">
                    <span data-l10n-id="findbar_label">Find</span>
@@ -350,6 +354,14 @@ See https://github.com/adobe-type-tools/cmap-resources
     </div> <!-- outerContainer -->
     <div id="printContainer"></div>
     <script>
+      const embedded = window.parent !== window
+
+      // PDFViewerApplication detects whether it's embedded in an iframe (window.parent !== window)
+      // and if so it behaves more "discretely", eg it disables its history mechanism.
+      // We dont want that, so we unset the flag here (to keep viewer.js as vanilla as possible)
+      //
+      pdfjsWebLibs.pdfjsWebApp.PDFViewerApplication.isViewerEmbedded = false;
+
       let query = document.location.search.substring(1)
       let parts = query.split('&')
       let file
@@ -424,7 +436,7 @@ See https://github.com/adobe-type-tools/cmap-resources
       })
 
       // if we're embedded we cannot open external links here. So we intercept clicks and forward them to the extension
-      if (window.parent !== window) {
+      if (embedded) {
         document.addEventListener('click', (e) => {
             if (e.target.nodeName == 'A' && !e.target.href.startsWith(window.location.href)) { // is external link
               socket.send(JSON.stringify({type:"external_link", url:e.target.href}))
@@ -446,12 +458,28 @@ See https://github.com/adobe-type-tools/cmap-resources
           }
       }, true)
 
-      // F opens find bar, cause Ctrl-F is handled by vscode
+      // back button (mostly useful for the embedded viewer)
+      document.getElementById("historyBack").addEventListener("click", function() {
+        history.back()
+      })
+
+      // keyboard bindings
       window.addEventListener('keydown', function(evt) {
+        // F opens find bar, cause Ctrl-F is handled by vscode
         if(evt.keyCode == 70 && evt.target.nodeName != 'INPUT') { // ignore F typed in the search box
           showToolbar(false)
           PDFViewerApplication.findBar.open()
           evt.preventDefault()
+        }
+
+        // Chrome's usual Alt-Left/Right (Command-Left/Right on OSX) for history
+        // Back/Forward don't work in the embedded viewer, so we simulate them.
+        if (embedded && (evt.altKey || evt.metaKey)) {
+          if (evt.keyCode == 37) {
+            history.back();
+          } else if(evt.keyCode == 39) {
+            history.forward();
+          }
         }
       })
 

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -400,10 +400,13 @@ See https://github.com/adobe-type-tools/cmap-resources
                   setTimeout(() => indicator.className = 'hide', 10)
                   break
               case "refresh":
+                  // Note: without showPreviousViewOnLoad = false restoring the position after the refresh will fail if
+                  // the user has clicked on any link in the past (pdf.js will automatically navigate to that link).
                   socket.send(JSON.stringify({type:"position",
                                               scale:PDFViewerApplication.pdfViewer.currentScaleValue,
                                               scrollTop:document.getElementById('viewerContainer').scrollTop,
                                               scrollLeft:document.getElementById('viewerContainer').scrollLeft}))
+                  PDFViewerApplication.viewerPrefs['showPreviousViewOnLoad'] = false
                   PDFViewerApplication.open(`/pdf:${decodeURIComponent(file)}`)
                   break
               case "position":

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -446,17 +446,35 @@ See https://github.com/adobe-type-tools/cmap-resources
           }
       }, true)
 
-      let hideToolbarTimeout = undefined
-      document.getElementById('outerContainer').onmousemove = (e) => {
-        if (e.clientY > 64) {
-          return
+      // F opens find bar, cause Ctrl-F is handled by vscode
+      window.addEventListener('keydown', function(evt) {
+        if(evt.keyCode == 70 && evt.target.nodeName != 'INPUT') { // ignore F typed in the search box
+          showToolbar(false)
+          PDFViewerApplication.findBar.open()
+          evt.preventDefault()
         }
-        if (hideToolbarTimeout) {
-          clearTimeout(hideToolbarTimeout)
+      })
+
+      let hideToolbarInterval = undefined
+      function showToolbar(animate) {
+        if (hideToolbarInterval) {
+          clearInterval(hideToolbarInterval)
         }
         var d = document.getElementsByClassName('toolbar')[0]
-        d.className = d.className.replace(' hide', '')
-        hideToolbarTimeout = setTimeout(() => {d.className += ' hide'}, 3000)
+        d.className = d.className.replace(' hide', '') + (animate ? '' : ' notransition')
+
+        hideToolbarInterval = setInterval(() => {
+          if(!PDFViewerApplication.findBar.opened) {
+            d.className = d.className.replace(' notransition', '') + ' hide'
+            clearInterval(hideToolbarInterval)
+          }
+        }, 3000)
+      }
+
+      document.getElementById('outerContainer').onmousemove = (e) => {
+        if (e.clientY <= 64) {
+          showToolbar(true)
+        }
       }
     </script>
   </body>

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -1834,7 +1834,7 @@ var pdfjsWebLibs;
     FIND_WRAPPED: 2,
     FIND_PENDING: 3
    };
-   var FIND_SCROLL_OFFSET_TOP = -50;
+   var FIND_SCROLL_OFFSET_TOP = -100;
    var FIND_SCROLL_OFFSET_LEFT = -400;
    var CHARACTERS_TO_NORMALIZE = {
     '\u2018': '\'',


### PR DESCRIPTION
A few improvements for the find bar in the pdf viewer:

1. When searching, the result was being placed right underneath the find bar (so it was invisible), cause pdf.js does not account for the fact that the toolbar is hidden! Chainging the `FIND_SCROLL_OFFSET_TOP` constant fixes this.

2. Vscode shows it's own find interface on `Ctrl-F` (it would be awesome if we can change that) which can't work properly for the pdf, so I made "F" open pdf.js's find bar in the viewer.

3. The toolbar now remains visible while the find bar is open.


**Edit:** I added some improvements for navigating history:

pdf.js has a mechanism for going back/forward in history using the browser's back/forward buttons, which is extremely useful for navigating large latex files (when clicking on references, citations, etc). Unfortunately this didn't work in the embedded viewer so:

1. I added a "back" button in the toolbar, since there's no browser "Back" in the embedded viewer

2. I set `PDFViewerApplication.isViewerEmbedded = false` otherwise pdf.js stupidly disables its history management.

3. Chrome's Alt-Left/Right shortcuts for history back/forward don't work in the embedded viewer, so I simulate them.

Finally a history-related bugfix:

4. If the user has clicked on a link in the pdf anytime in the past, after a refresh pdf.js automatically navigates to that link, failing to restore the exact previous position. This is solved by setting `showPreviousViewOnLoad = false` (note that in the currently released version, this bug only appears in the web viewer, cause history navigation is disabled in the embedded viewer). 


PS. sorry for mixing changes in the same PR, there would be conflicts otherwise.


