### PR TITLE
make arguments for latexindent configurable

### DIFF
--- a/package.json
+++ b/package.json
@@ -442,11 +442,11 @@
           "type": "array",
           "default": [
               "-c",
-              "%DIR%",
+              "%DIR%/",
               "%TMPFILE%",
               "-y=\"defaultIndent: '%INDENT%'\""
           ],
-          "description": "Define the command line arguments for latexindent."
+          "description": "Define the command line arguments for latexindent.\nNote: At this moment -c option requires trailing slash."
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -437,6 +437,11 @@
           "type": "string",
           "default": "latexindent",
           "description": "Define the location of the latexindent executable file."
+        },
+        "latex-workshop.latexindent.args": {
+          "type": "string",
+          "default": "-c \"%DIR%\" \"%TMPFILE%\" -y=\"defaultIndent: '%INDENT%'\"",
+          "description": "Define the command line arguments for latexindent."
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -441,12 +441,12 @@
         "latex-workshop.latexindent.args": {
           "type": "array",
           "default": [
-              "-c",
-              "%DIR%/",
-              "%TMPFILE%",
-              "-y=\"defaultIndent: '%INDENT%'\""
+            "-c",
+            "%DIR%/",
+            "%TMPFILE%",
+            "-y=\"defaultIndent: '%INDENT%'\""
           ],
-          "description": "Define the command line arguments for latexindent.\nNote: At this moment -c option requires trailing slash."
+          "description": "Define the command line arguments for latexindent. Available placeholders:\n- %DOC%, %DOCFILE%, %DIR%: same as latex-workshop.latex.toolchain args.\n- %TMPFILE%: would be replaced with the path of file which contains raw TeX source to be formatted. At this moment you need to use it as an input file of `latexindent`.\n- %INDENT%: would be replaced with the string which represents indent of the target document.\n\nNote: At this moment -c option requires trailing slash."
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -439,8 +439,13 @@
           "description": "Define the location of the latexindent executable file."
         },
         "latex-workshop.latexindent.args": {
-          "type": "string",
-          "default": "-c \"%DIR%\" \"%TMPFILE%\" -y=\"defaultIndent: '%INDENT%'\"",
+          "type": "array",
+          "default": [
+              "-c",
+              "%DIR%",
+              "%TMPFILE%",
+              "-y=\"defaultIndent: '%INDENT%'\""
+          ],
           "description": "Define the command line arguments for latexindent."
         }
       }

--- a/src/providers/latexformatter.ts
+++ b/src/providers/latexformatter.ts
@@ -29,7 +29,7 @@ export class LaTexFormatter {
     private machineOs: string
     private currentOs: OperatingSystem
     private formatter: string
-    private formatterArgs: string
+    private formatterArgs: string[]
 
     constructor(extension: Extension) {
         this.extension = extension
@@ -48,7 +48,8 @@ export class LaTexFormatter {
 
             const configuration = vscode.workspace.getConfiguration('latex-workshop.latexindent')
             this.formatter = configuration.get<string>('path') || 'latexindent'
-            this.formatterArgs = configuration.get<string>('args') || "-c \"%DIR%\" \"%TMPFILE%\" -y=\"defaultIndent: '%INDENT%'\""
+            this.formatterArgs = configuration.get<string[]>('args')
+                || [ "-c", "%DIR%", "%TMPFILE%", "-y=\"defaultIndent: '%INDENT%'\"" ]
             const pathMeta = configuration.inspect('path')
 
             if (pathMeta && pathMeta.defaultValue && pathMeta.defaultValue !== this.formatter) {
@@ -114,23 +115,36 @@ export class LaTexFormatter {
             const temporaryFile = documentDirectory + path.sep + '__latexindent_temp.tex'
             fs.writeFileSync(temporaryFile, textToFormat)
 
-            // generate command line
-            const args = this.formatterArgs
+            // generate command line arguments
+            const args = this.formatterArgs.map(arg => arg
                 // taken from ../components/builder.ts
                 .replace('%DOC%', document.fileName.replace(/\.tex$/, '').split(path.sep).join('/'))
                 .replace('%DOCFILE%', path.basename(document.fileName, '.tex').split(path.sep).join('/'))
                 .replace('%DIR%', path.dirname(document.fileName).split(path.sep).join('/'))
                 // latexformatter.ts specific tokens
                 .replace('%TMPFILE%', temporaryFile)
-                .replace('%INDENT%', indent)
+                .replace('%INDENT%', indent))
 
-            cp.exec(`${this.formatter} ${args}`, (err, stdout, _stderr) => {
-                if (err) {
-                    this.extension.logger.addLogMessage(`Formatting failed: ${err.message}`)
+            const worker = cp.spawn(this.formatter, args, { stdio: 'pipe', shell: true })
+            // handle stdout/stderr
+            const stdoutBuffer = [] as string[]
+            const stderrBuffer = [] as string[]
+            worker.stdout.on('data', chunk => stdoutBuffer.push(chunk.toString()))
+            worker.stderr.on('data', chunk => stderrBuffer.push(chunk.toString()))
+            worker.on('error', err => {
+                vscode.window.showErrorMessage('Formatting failed. Please refer to LaTeX Workshop Output for details.')
+                this.extension.logger.addLogMessage(`Formatting failed: ${err.message}`)
+                this.extension.logger.addLogMessage(`stderr: ${stderrBuffer.join('')}`)
+                resolve()
+            })
+            worker.on('close', code => {
+                if (code !== 0) {
                     vscode.window.showErrorMessage('Formatting failed. Please refer to LaTeX Workshop Output for details.')
+                    this.extension.logger.addLogMessage(`Formatting failed with exit code ${code}`)
+                    this.extension.logger.addLogMessage(`stderr: ${stderrBuffer.join('')}`)
                     return resolve()
                 }
-
+                const stdout = stdoutBuffer.join('')
                 if (stdout !== '') {
                     const edit = [vscode.TextEdit.replace(range ? range : fullRange(document), stdout)]
                     try {

--- a/src/providers/latexformatter.ts
+++ b/src/providers/latexformatter.ts
@@ -49,7 +49,7 @@ export class LaTexFormatter {
             const configuration = vscode.workspace.getConfiguration('latex-workshop.latexindent')
             this.formatter = configuration.get<string>('path') || 'latexindent'
             this.formatterArgs = configuration.get<string[]>('args')
-                || [ "-c", "%DIR%", "%TMPFILE%", "-y=\"defaultIndent: '%INDENT%'\"" ]
+                || [ '-c', '%DIR%', '%TMPFILE%', '-y="defaultIndent: \'%INDENT%\'"' ]
             const pathMeta = configuration.inspect('path')
 
             if (pathMeta && pathMeta.defaultValue && pathMeta.defaultValue !== this.formatter) {

--- a/src/providers/latexformatter.ts
+++ b/src/providers/latexformatter.ts
@@ -49,7 +49,7 @@ export class LaTexFormatter {
             const configuration = vscode.workspace.getConfiguration('latex-workshop.latexindent')
             this.formatter = configuration.get<string>('path') || 'latexindent'
             this.formatterArgs = configuration.get<string[]>('args')
-                || [ '-c', '%DIR%', '%TMPFILE%', '-y="defaultIndent: \'%INDENT%\'"' ]
+                || [ '-c', '%DIR%/', '%TMPFILE%', '-y="defaultIndent: \'%INDENT%\'"' ]
             const pathMeta = configuration.inspect('path')
 
             if (pathMeta && pathMeta.defaultValue && pathMeta.defaultValue !== this.formatter) {
@@ -122,7 +122,7 @@ export class LaTexFormatter {
                 .replace('%DOCFILE%', path.basename(document.fileName, '.tex').split(path.sep).join('/'))
                 .replace('%DIR%', path.dirname(document.fileName).split(path.sep).join('/'))
                 // latexformatter.ts specific tokens
-                .replace('%TMPFILE%', temporaryFile)
+                .replace('%TMPFILE%', temporaryFile.split(path.sep).join('/'))
                 .replace('%INDENT%', indent))
 
             const worker = cp.spawn(this.formatter, args, { stdio: 'pipe', shell: true })


### PR DESCRIPTION
Hello, I'm using LaTeX-Workshop everyday!! 
I wrote new option ”latex-workshop.latexindent.args”, which make arguments for latexindent configurable. I think it is minor problem but it would improve this extension.
regards,