### PR TITLE
Added "add root document" command

### DIFF
--- a/package.json
+++ b/package.json
@@ -213,7 +213,7 @@
         "category": "LaTeX Workshop"
       },
       {
-        "command": "latex-workshop.addroot",
+        "command": "latex-workshop.addtexroot",
         "title": "Insert %!TeX root magic command",
         "category": "LaTeX Workshop"
       },

--- a/package.json
+++ b/package.json
@@ -214,7 +214,7 @@
       },
       {
         "command": "latex-workshop.addroot",
-        "title": "Insert root document",
+        "title": "Insert %!TeX root magic command",
         "category": "LaTeX Workshop"
       },
       {

--- a/package.json
+++ b/package.json
@@ -213,6 +213,11 @@
         "category": "LaTeX Workshop"
       },
       {
+        "command": "latex-workshop.addroot",
+        "title": "Insert root document",
+        "category": "LaTeX Workshop"
+      },
+      {
         "command": "latex-workshop.wordcount",
         "title": "Count words in LaTeX document",
         "category": "LaTeX Workshop"

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -2,7 +2,6 @@ import * as vscode from 'vscode'
 import * as opn from 'opn'
 
 import {Extension} from './main'
-import {EOL} from 'os'
 
 export class Commander {
     extension: Extension
@@ -125,51 +124,9 @@ export class Commander {
         return this.extension.cleaner.clean()
     }
 
-    getFileName(file: string) : string {
-        return file.replace(/\\/g, '/').match(/([^\/]+$)/)[0]
-    }
-
-    getRelativePath(file: string, currentFile: string) : string {
-        // replace '\' in windows paths with '/'
-        file = file.replace(/\\/g, '/')
-        // get path of current folder, including to the last '/'
-        let currentFolder = currentFile.replace(/\\/g, '/').replace(/[^\/]+$/gi, '')
-        // find index up to which paths match
-        let i = 0
-        while ( file.charAt(i) === currentFolder.charAt(i)) {
-            i++
-        }
-        // select nonmatching substring
-        file = file.substring(i)
-        currentFolder = currentFolder.substring(i)
-        // replace each '/foldername/' in path with '/../'
-        currentFolder = currentFolder.replace(/[^/]+/g, '..')
-        return './' + currentFolder + file
-    }
-
     addroot() {
         this.extension.logger.addLogMessage(`ADDROOT command invoked.`)
-        if (vscode.window.activeTextEditor === null) {
-            console.log('File must be opened')
-        }
-        // taken from here: https://github.com/DonJayamanne/listFilesVSCode/blob/master/src/extension.ts (MIT licensed, should be fine)
-        vscode.workspace.findFiles('**/*.{tex}').then(files => {
-            const displayFiles = files.map(file => {
-                return { description: file.fsPath, label: this.getFileName(file.fsPath), filePath: file.fsPath }
-            })
-            vscode.window.showQuickPick(displayFiles).then(val => {
-                const editor = vscode.window.activeTextEditor
-                if (val != null && editor != null) {
-                    const relativePath = this.getRelativePath(val.filePath, editor.document.fileName)
-                    const edits = [vscode.TextEdit.insert(new vscode.Position(0, 0), `% !TeX root = ${relativePath}${EOL}`)]
-                    // Insert the text
-                    const uri = editor.document.uri
-                    const edit = new vscode.WorkspaceEdit()
-                    edit.set(uri, edits)
-                    vscode.workspace.applyEdit(edit)
-                }
-            })
-        })
+        this.extension.texMagician.addroot()
     }
 
 

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -124,12 +124,12 @@ export class Commander {
         return this.extension.cleaner.clean()
     }
 
-    addroot() {
-        this.extension.logger.addLogMessage(`ADDROOT command invoked.`)
+    addTexRoot() {
+        this.extension.logger.addLogMessage(`ADDTEXROOT command invoked.`)
         if (!vscode.window.activeTextEditor || !this.extension.manager.isTex(vscode.window.activeTextEditor.document.fileName)) {
             return
         }
-        this.extension.texMagician.addroot()
+        this.extension.texMagician.addTexRoot()
     }
 
     citation() {

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -132,7 +132,6 @@ export class Commander {
         this.extension.texMagician.addroot()
     }
 
-
     citation() {
         this.extension.logger.addLogMessage(`CITATION command invoked.`)
         this.extension.completer.citation.browser()

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode'
 import * as opn from 'opn'
 
 import {Extension} from './main'
+import {EOL} from 'os'
 
 export class Commander {
     extension: Extension
@@ -123,6 +124,54 @@ export class Commander {
         this.extension.manager.findRoot()
         return this.extension.cleaner.clean()
     }
+
+    getFileName(file: string) : string {
+        return file.replace(/\\/g, '/').match(/([^\/]+$)/)[0]
+    }
+
+    getRelativePath(file: string, currentFile: string) : string {
+        // replace '\' in windows paths with '/'
+        file = file.replace(/\\/g, '/')
+        // get path of current folder, including to the last '/'
+        let currentFolder = currentFile.replace(/\\/g, '/').replace(/[^\/]+$/gi, '')
+        // find index up to which paths match
+        let i = 0
+        while ( file.charAt(i) === currentFolder.charAt(i)) {
+            i++
+        }
+        // select nonmatching substring
+        file = file.substring(i)
+        currentFolder = currentFolder.substring(i)
+        // replace each '/foldername/' in path with '/../'
+        currentFolder = currentFolder.replace(/[^/]+/g, '..')
+        return './' + currentFolder + file
+    }
+
+    addroot() {
+        this.extension.logger.addLogMessage(`ADDROOT command invoked.`)
+        if (vscode.window.activeTextEditor === null) {
+            console.log('File must be opened')
+        }
+        // taken from here: https://github.com/DonJayamanne/listFilesVSCode/blob/master/src/extension.ts (MIT licensed, should be fine)
+        vscode.workspace.findFiles('**/*.{tex}').then(files => {
+            const displayFiles = files.map(file => {
+                return { description: file.fsPath, label: this.getFileName(file.fsPath), filePath: file.fsPath }
+            })
+            vscode.window.showQuickPick(displayFiles).then(val => {
+                const editor = vscode.window.activeTextEditor
+                if (val != null && editor != null) {
+                    const relativePath = this.getRelativePath(val.filePath, editor.document.fileName)
+                    const edits = [vscode.TextEdit.insert(new vscode.Position(0, 0), `% !TeX root = ${relativePath}${EOL}`)]
+                    // Insert the text
+                    const uri = editor.document.uri
+                    const edit = new vscode.WorkspaceEdit()
+                    edit.set(uri, edits)
+                    vscode.workspace.applyEdit(edit)
+                }
+            })
+        })
+    }
+
 
     citation() {
         this.extension.logger.addLogMessage(`CITATION command invoked.`)

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -126,6 +126,9 @@ export class Commander {
 
     addroot() {
         this.extension.logger.addLogMessage(`ADDROOT command invoked.`)
+        if (!vscode.window.activeTextEditor || !this.extension.manager.isTex(vscode.window.activeTextEditor.document.fileName)) {
+            return
+        }
         this.extension.texMagician.addroot()
     }
 

--- a/src/components/texmagician.ts
+++ b/src/components/texmagician.ts
@@ -32,9 +32,6 @@ export class TeXMagician {
     }
 
     addroot() {
-        if (vscode.window.activeTextEditor === null) {
-            console.log('File must be opened')
-        }
         // taken from here: https://github.com/DonJayamanne/listFilesVSCode/blob/master/src/extension.ts (MIT licensed, should be fine)
         vscode.workspace.findFiles('**/*.{tex}').then(files => {
             const displayFiles = files.map(file => {
@@ -54,6 +51,4 @@ export class TeXMagician {
             })
         })
     }
-
-
 }

--- a/src/components/texmagician.ts
+++ b/src/components/texmagician.ts
@@ -1,0 +1,59 @@
+import * as vscode from 'vscode'
+import {EOL} from 'os'
+import {Extension} from '../main'
+
+export class TeXMagician {
+    extension: Extension
+
+    constructor(extension: Extension) {
+        this.extension = extension
+    }
+
+    getFileName(file: string) : string {
+        return file.replace(/\\/g, '/').match(/([^\/]+$)/)[0]
+    }
+
+    getRelativePath(file: string, currentFile: string) : string {
+        // replace '\' in windows paths with '/'
+        file = file.replace(/\\/g, '/')
+        // get path of current folder, including to the last '/'
+        let currentFolder = currentFile.replace(/\\/g, '/').replace(/[^\/]+$/gi, '')
+        // find index up to which paths match
+        let i = 0
+        while ( file.charAt(i) === currentFolder.charAt(i)) {
+            i++
+        }
+        // select nonmatching substring
+        file = file.substring(i)
+        currentFolder = currentFolder.substring(i)
+        // replace each '/foldername/' in path with '/../'
+        currentFolder = currentFolder.replace(/[^/]+/g, '..')
+        return './' + currentFolder + file
+    }
+
+    addroot() {
+        if (vscode.window.activeTextEditor === null) {
+            console.log('File must be opened')
+        }
+        // taken from here: https://github.com/DonJayamanne/listFilesVSCode/blob/master/src/extension.ts (MIT licensed, should be fine)
+        vscode.workspace.findFiles('**/*.{tex}').then(files => {
+            const displayFiles = files.map(file => {
+                return { description: file.fsPath, label: this.getFileName(file.fsPath), filePath: file.fsPath }
+            })
+            vscode.window.showQuickPick(displayFiles).then(val => {
+                const editor = vscode.window.activeTextEditor
+                if (val != null && editor != null) {
+                    const relativePath = this.getRelativePath(val.filePath, editor.document.fileName)
+                    const edits = [vscode.TextEdit.insert(new vscode.Position(0, 0), `% !TeX root = ${relativePath}${EOL}`)]
+                    // Insert the text
+                    const uri = editor.document.uri
+                    const edit = new vscode.WorkspaceEdit()
+                    edit.set(uri, edits)
+                    vscode.workspace.applyEdit(edit)
+                }
+            })
+        })
+    }
+
+
+}

--- a/src/components/texmagician.ts
+++ b/src/components/texmagician.ts
@@ -9,11 +9,11 @@ export class TeXMagician {
         this.extension = extension
     }
 
-    getFileName(file: string): string {
+    getFileName(file: string) : string {
         return file.replace(/\\/g, '/').match(/([^\/]+$)/)[0]
     }
 
-    getRelativePath(file: string, currentFile: string): string {
+    getRelativePath(file: string, currentFile: string) : string {
         // replace '\' in windows paths with '/'
         file = file.replace(/\\/g, '/')
         // get path of current folder, including to the last '/'
@@ -31,7 +31,7 @@ export class TeXMagician {
         return ('./' + currentFolder + file).replace(/^\.\/\.\./, '..')
     }
 
-    addroot() {
+    addTexRoot() {
         // taken from here: https://github.com/DonJayamanne/listFilesVSCode/blob/master/src/extension.ts (MIT licensed, should be fine)
         vscode.workspace.findFiles('**/*.{tex}').then(files => {
             const displayFiles = files.map(file => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,7 @@ import {Parser} from './components/parser'
 import {Linter} from './components/linter'
 import {Cleaner} from './components/cleaner'
 import {Counter} from './components/counter'
+import {TeXMagician} from './components/texmagician'
 
 import {Completer} from './providers/completion'
 import {CodeActions} from './providers/codeactions'
@@ -230,6 +231,7 @@ export class Extension {
     counter: Counter
     codeActions: CodeActions
     nodeProvider: SectionNodeProvider
+    texMagician: TeXMagician
 
     constructor() {
         this.extensionRoot = path.resolve(`${__dirname}/../../`)
@@ -247,6 +249,7 @@ export class Extension {
         this.counter = new Counter(this)
         this.codeActions = new CodeActions(this)
         this.nodeProvider = new SectionNodeProvider(this)
+        this.texMagician = new TeXMagician(this)
 
         this.logger.addLogMessage(`LaTeX Workshop initialized.`)
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -107,6 +107,7 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('latex-workshop.clean', () => extension.commander.clean())
     vscode.commands.registerCommand('latex-workshop.actions', () => extension.commander.actions())
     vscode.commands.registerCommand('latex-workshop.citation', () => extension.commander.citation())
+    vscode.commands.registerCommand('latex-workshop.addroot', () => extension.commander.addroot())
     vscode.commands.registerCommand('latex-workshop.wordcount', () => extension.commander.wordcount())
     vscode.commands.registerCommand('latex-workshop.compilerlog', () => extension.commander.compilerlog())
     vscode.commands.registerCommand('latex-workshop.log', () => extension.commander.log())

--- a/src/main.ts
+++ b/src/main.ts
@@ -108,7 +108,7 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('latex-workshop.clean', () => extension.commander.clean())
     vscode.commands.registerCommand('latex-workshop.actions', () => extension.commander.actions())
     vscode.commands.registerCommand('latex-workshop.citation', () => extension.commander.citation())
-    vscode.commands.registerCommand('latex-workshop.addroot', () => extension.commander.addroot())
+    vscode.commands.registerCommand('latex-workshop.addtexroot', () => extension.commander.addtexroot())
     vscode.commands.registerCommand('latex-workshop.wordcount', () => extension.commander.wordcount())
     vscode.commands.registerCommand('latex-workshop.compilerlog', () => extension.commander.compilerlog())
     vscode.commands.registerCommand('latex-workshop.log', () => extension.commander.log())

--- a/src/main.ts
+++ b/src/main.ts
@@ -108,7 +108,7 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('latex-workshop.clean', () => extension.commander.clean())
     vscode.commands.registerCommand('latex-workshop.actions', () => extension.commander.actions())
     vscode.commands.registerCommand('latex-workshop.citation', () => extension.commander.citation())
-    vscode.commands.registerCommand('latex-workshop.addtexroot', () => extension.commander.addtexroot())
+    vscode.commands.registerCommand('latex-workshop.addtexroot', () => extension.commander.addTexRoot())
     vscode.commands.registerCommand('latex-workshop.wordcount', () => extension.commander.wordcount())
     vscode.commands.registerCommand('latex-workshop.compilerlog', () => extension.commander.compilerlog())
     vscode.commands.registerCommand('latex-workshop.log', () => extension.commander.log())


### PR DESCRIPTION
I've implemented a command that allows to add a root document to the current document.
This is done by specifying another .tex file from the current workspace, calculating the relative path and inserting the proper command in the first line of the active document. 

If there is already a tex root command there this is ignored and the new command gets added in the line above (always in line 0).

I think this additional feature would not work for some users (depending on the toolchain, etc), but they can just ignore this command and live happily until a more elaborate system is in place (related  issue:  #102 ).
If a more feature complete system is planned/implemented in the future it might be advisable to refactor this code to a component. I thought it would be fine to just add the function in commander.ts until that is the case. 