### PR TITLE
Match all braces delimiting arguments uniformly

### DIFF
--- a/syntax/LaTeX.plist
+++ b/syntax/LaTeX.plist
@@ -849,7 +849,7 @@
 				<key>3</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.definition.arguments.latex</string>
+					<string>punctuation.definition.arguments.begin.latex</string>
 				</dict>
 				<key>4</key>
 				<dict>
@@ -859,7 +859,7 @@
 				<key>5</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.definition.arguments.latex</string>
+					<string>punctuation.definition.arguments.end.latex</string>
 				</dict>
 			</dict>
 			<key>end</key>
@@ -892,7 +892,7 @@
 				<key>3</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.definition.arguments.latex</string>
+					<string>punctuation.definition.arguments.begin.latex</string>
 				</dict>
 				<key>4</key>
 				<dict>
@@ -902,7 +902,7 @@
 				<key>5</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.definition.arguments.latex</string>
+					<string>punctuation.definition.arguments.end.latex</string>
 				</dict>
 			</dict>
 			<key>end</key>
@@ -935,7 +935,7 @@
 				<key>3</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.definition.arguments.latex</string>
+					<string>punctuation.definition.arguments.begin.latex</string>
 				</dict>
 				<key>4</key>
 				<dict>
@@ -945,7 +945,7 @@
 				<key>5</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.definition.arguments.latex</string>
+					<string>punctuation.definition.arguments.end.latex</string>
 				</dict>
 			</dict>
 			<key>end</key>
@@ -1328,7 +1328,7 @@ Put specific matches for particular LaTeX keyword.functions before the last two 
 				<key>7</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.definition.arguments.latex</string>
+					<string>punctuation.definition.arguments.begin.latex</string>
 				</dict>
 			</dict>
 			<key>end</key>
@@ -1338,7 +1338,7 @@ Put specific matches for particular LaTeX keyword.functions before the last two 
 				<key>0</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.definition.arguments.latex</string>
+					<string>punctuation.definition.arguments.begin.latex</string>
 				</dict>
 			</dict>
 			<key>name</key>


### PR DESCRIPTION
Wherever '{...}' is used as an argument of a command but not as a group,
the braces are matched as
    `punctuation.definition.arguments.begin.latex`
    `punctuation.definition.arguments.end.latex`
We get rid of the scope `punctuation.definition.arguments.latex`

PR related to https://github.com/James-Yu/LaTeX-Workshop/issues/461#issuecomment-373165202