### PR TITLE
Highlight matching paren in math blocks

### DIFF
--- a/syntax/DTX.plist
+++ b/syntax/DTX.plist
@@ -107,7 +107,7 @@
 				</dict>
 			</dict>
 			<key>name</key>
-			<string>string.other.math.latex</string>
+			<string>support.class.math.latex</string>
 			<key>patterns</key>
 			<array>
 				<dict>
@@ -138,7 +138,7 @@
 				</dict>
 			</dict>
 			<key>name</key>
-			<string>string.other.math.latex</string>
+			<string>support.class.math.latex</string>
 			<key>patterns</key>
 			<array>
 				<dict>

--- a/syntax/DTX.plist
+++ b/syntax/DTX.plist
@@ -42,7 +42,7 @@
 				<key>0</key>
 				<dict>
 					<key>name</key>
-					<string>support.class.dtx</string>
+					<string>entity.name.tag.macrocode.dtx</string>
 				</dict>
 			</dict>
 			<key>end</key>

--- a/syntax/LaTeX Expl3.plist
+++ b/syntax/LaTeX Expl3.plist
@@ -34,7 +34,7 @@
 				</dict>
 			</dict>
 			<key>name</key>
-			<string>string.other.math.tex</string>
+			<string>support.class.math.tex</string>
 			<key>patterns</key>
 			<array>
 				<dict>

--- a/syntax/LaTeX.plist
+++ b/syntax/LaTeX.plist
@@ -710,7 +710,7 @@
 				</dict>
 			</dict>
 			<key>contentName</key>
-			<string>string.other.math.block.environment.latex</string>
+			<string>support.class.math.block.environment.latex</string>
 			<key>end</key>
 			<string>(?x)
 					(?:\s*)										# Optional whitespace
@@ -1672,7 +1672,7 @@ Put specific matches for particular LaTeX keyword.functions before the last two 
 				</dict>
 			</dict>
 			<key>name</key>
-			<string>string.other.math.latex</string>
+			<string>support.class.math.latex</string>
 			<key>patterns</key>
 			<array>
 				<dict>
@@ -1703,7 +1703,7 @@ Put specific matches for particular LaTeX keyword.functions before the last two 
 				</dict>
 			</dict>
 			<key>name</key>
-			<string>string.other.math.latex</string>
+			<string>support.class.math.latex</string>
 			<key>patterns</key>
 			<array>
 				<dict>

--- a/syntax/TeX.plist
+++ b/syntax/TeX.plist
@@ -180,7 +180,7 @@
 				</dict>
 			</dict>
 			<key>name</key>
-			<string>string.other.math.block.tex</string>
+			<string>support.class.math.block.tex</string>
 			<key>patterns</key>
 			<array>
 				<dict>
@@ -221,7 +221,7 @@
 				</dict>
 			</dict>
 			<key>name</key>
-			<string>string.other.math.tex</string>
+			<string>support.class.math.tex</string>
 			<key>patterns</key>
 			<array>
 				<dict>


### PR DESCRIPTION
Math block content is now matched as  against the scope `support.class.math.` instead `string.other.math.`.

This commit fixes #470.