### PR TITLE
Fix inconsistent highlighting of math content

### DIFF
--- a/syntax/LaTeX.plist
+++ b/syntax/LaTeX.plist
@@ -727,6 +727,10 @@
 			<array>
 				<dict>
 					<key>include</key>
+					<string>text.tex#math</string>
+				</dict>
+				<dict>
+					<key>include</key>
 					<string>$base</string>
 				</dict>
 			</array>
@@ -1751,6 +1755,10 @@ Put specific matches for particular LaTeX keyword.functions before the last two 
 			<string>support.class.math.latex</string>
 			<key>patterns</key>
 			<array>
+				<dict>
+					<key>include</key>
+					<string>text.tex#math</string>
+				</dict>
 				<dict>
 					<key>include</key>
 					<string>$base</string>

--- a/syntax/TeX.plist
+++ b/syntax/TeX.plist
@@ -282,6 +282,37 @@
 			<key>patterns</key>
 			<array>
 				<dict>
+					<key>begin</key>
+					<string>\{</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.section.group.begin.tex</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>\}</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.section.group.end.tex</string>
+						</dict>
+					</dict>
+					<key>name</key>
+					<string>meta.group.braces.tex</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>#math</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
 					<key>captures</key>
 					<dict>
 						<key>1</key>


### PR DESCRIPTION
Maths commands are highlighted as `constant.character.math.tex`.
Fixes #476.