### PR TITLE
Fix #504 Recipe being ignored in favor of magic comment // wrong behavior for magic comment

### DIFF
--- a/package.json
+++ b/package.json
@@ -294,6 +294,13 @@
           ],
           "description": "Define the arguments to be input to magic command executable."
         },
+        "latex-workshop.latex.magic.bib.args": {
+          "type": "array",
+          "default": [
+            "%DOCFILE%"
+          ],
+          "description": "Define the arguments to be input to BIB magic command executable."
+        },
         "latex-workshop.latex.outputDir": {
           "type": "string",
           "default": "./",

--- a/src/components/builder.ts
+++ b/src/components/builder.ts
@@ -31,12 +31,12 @@ export class Builder {
     }
 
     buildInitiator(rootFile: string, recipe: string | undefined = undefined) {
-       const steps = this.createSteps(rootFile, recipe)
-       if (steps === undefined) {
-           this.extension.logger.addLogMessage('Invalid toolchain.')
-           return
-       }
-       this.buildStep(rootFile, steps, 0)
+        const steps = this.createSteps(rootFile, recipe)
+        if (steps === undefined) {
+            this.extension.logger.addLogMessage('Invalid toolchain.')
+            return
+        }
+        this.buildStep(rootFile, steps, 0)
     }
 
     build(rootFile: string, recipe: string | undefined = undefined) {
@@ -114,17 +114,24 @@ export class Builder {
         }
     }
 
-    createSteps(rootFile: string, recipeName: string | undefined) : StepCommand[] | undefined {
+    createSteps(rootFile: string, recipeName: string | undefined): StepCommand[] | undefined {
         let steps: StepCommand[] = []
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
 
-        const magic = this.findProgramMagic(rootFile)
-        if (magic) {
-            steps = [{
-                name: 'magic',
-                command: magic,
+        const magicTex = this.findProgramMagic(rootFile)
+        const magicBib = this.findBibMagic(rootFile) || 'bibtex'
+        if (recipeName === undefined && magicTex) {
+            const magicTexStep = {
+                name: 'magictex',
+                command: magicTex,
                 args: configuration.get('latex.magic.args') as string[]
-            }]
+            }
+            const magicBibStep = {
+                name: 'magicbib',
+                command: magicBib,
+                args: configuration.get('latex.magic.bib.args') as string[]
+            }
+            steps = [magicTexStep, magicBibStep, magicTexStep, magicTexStep]
         } else {
             const recipes = configuration.get('latex.recipes') as {name: string, tools: (string | StepCommand)[]}[]
             const tools = configuration.get('latex.tools') as StepCommand[]
@@ -165,8 +172,21 @@ export class Builder {
         return steps
     }
 
-    findProgramMagic(rootFile: string) : string {
+    findProgramMagic(rootFile: string): string {
         const regex = /(?:%\s*!\s*T[Ee]X\s(?:TS-)?program\s*=\s*([^\s]*)$)/m
+        const content = fs.readFileSync(rootFile).toString()
+
+        const result = content.match(regex)
+        let program = ''
+        if (result) {
+            program = result[1]
+            this.extension.logger.addLogMessage(`Found program by magic comment: ${program}`)
+        }
+        return program
+    }
+
+    findBibMagic(rootFile: string): string {
+        const regex = /(?:%\s*!\s*BIB\s(?:TS-)?program\s*=\s*([^\s]*)$)/m
         const content = fs.readFileSync(rootFile).toString()
 
         const result = content.match(regex)

--- a/src/components/builder.ts
+++ b/src/components/builder.ts
@@ -118,8 +118,7 @@ export class Builder {
         let steps: StepCommand[] = []
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
 
-        const magicTex = this.findProgramMagic(rootFile)
-        const magicBib = this.findBibMagic(rootFile) || 'bibtex'
+        const [magicTex, magicBib] = this.findProgramMagic(rootFile)
         if (recipeName === undefined && magicTex) {
             const magicTexStep = {
                 name: 'magictex',
@@ -172,30 +171,27 @@ export class Builder {
         return steps
     }
 
-    findProgramMagic(rootFile: string): string {
-        const regex = /(?:%\s*!\s*T[Ee]X\s(?:TS-)?program\s*=\s*([^\s]*)$)/m
+    findProgramMagic(rootFile: string): [string, string] {
+        const regexTex = /(?:%\s*!\s*T[Ee]X\s(?:TS-)?program\s*=\s*([^\s]*)$)/m
+        const regexBib = /(?:%\s*!\s*BIB\s(?:TS-)?program\s*=\s*([^\s]*)$)/m
         const content = fs.readFileSync(rootFile).toString()
 
-        const result = content.match(regex)
-        let program = ''
-        if (result) {
-            program = result[1]
-            this.extension.logger.addLogMessage(`Found program by magic comment: ${program}`)
-        }
-        return program
-    }
+        const tex = content.match(regexTex)
+        const bib = content.match(regexBib)
+        let texProgram = ''
+        let bibProgram = 'bibtex'
 
-    findBibMagic(rootFile: string): string {
-        const regex = /(?:%\s*!\s*BIB\s(?:TS-)?program\s*=\s*([^\s]*)$)/m
-        const content = fs.readFileSync(rootFile).toString()
-
-        const result = content.match(regex)
-        let program = ''
-        if (result) {
-            program = result[1]
-            this.extension.logger.addLogMessage(`Found program by magic comment: ${program}`)
+        if (tex) {
+            texProgram = tex[1]
+            this.extension.logger.addLogMessage(`Found TeX program by magic comment: ${texProgram}`)
         }
-        return program
+
+        if (bib) {
+            bibProgram = bib[1]
+            this.extension.logger.addLogMessage(`Found BIB program by magic comment: ${bibProgram}`)
+        }
+
+        return [texProgram, bibProgram]
     }
 }
 


### PR DESCRIPTION
This should fix both issues, so selecting a recipe in menu should use that recipe and ignore the magic comment, while the build command should now use the magic command present making a 4 pass using also the !BIB program magic comment. I had to insert a new configuration for this, for the bib command args. Default bib program, in case no magic comment is found, is bibtex, as it seems to be the default in other tex applications.