### PR TITLE
Recipe progress in statusbar

### DIFF
--- a/src/components/logger.ts
+++ b/src/components/logger.ts
@@ -35,8 +35,8 @@ export class Logger {
         this.compilerLogPanel.clear()
     }
 
-    displayStatus(icon: string, color: string, message: string | undefined = undefined, severity: string = 'info') {
-        this.status.text = `$(${icon})`
+    displayStatus(icon: string, color: string, message: string | undefined = undefined, severity: string = 'info', build: string = '') {
+        this.status.text = `$(${icon})${build}`
         this.status.tooltip = message
         this.status.color = new vscode.ThemeColor(color)
         if (message === undefined) {


### PR DESCRIPTION
As far as I've seen there is no progress/status except the spinning wheel after launching a build/recipe. 

I've added an optional argument called "build" to the `logger.showStatus(...)` function to display some build message. 

In `builder.ts` I've added a function  [`progressString`](https://github.com/oerpli/LaTeX-Workshop/blob/eb846de1579001b3c5a8638a955cd8b5f5c8370b/src/components/builder.ts#L51) that returns something like: `recipeName: 2/4 (pdflatex)`

I'm not entirely sure about the following things:

- The way I passed the default name ([builder.ts, line  39](https://github.com/oerpli/LaTeX-Workshop/blob/eb846de1579001b3c5a8638a955cd8b5f5c8370b/src/components/builder.ts#L39))
- How I passed the 3rd optional argument ([builder.ts, line 65](https://github.com/oerpli/LaTeX-Workshop/blob/eb846de1579001b3c5a8638a955cd8b5f5c8370b/src/components/builder.ts#L65))
- If the recipeName should be abbreviated if it is longer than [x] chars or similar
- If the progressString should also be passed to `addLogMessage`
- Where exactly the call to `showStatus` should be placed inside the `buildStep` function (currently [here](https://github.com/oerpli/LaTeX-Workshop/blob/eb846de1579001b3c5a8638a955cd8b5f5c8370b/src/components/builder.ts#L65))
- Whether the additional argument for `progressString` is a good idea. Maybe changing the handling of the already existing message-argument would be better.