### PR TITLE
Turns the step name into the program name

### DIFF
--- a/src/components/builder.ts
+++ b/src/components/builder.ts
@@ -133,12 +133,12 @@ export class Builder {
         const [magicTex, magicBib] = this.findProgramMagic(rootFile)
         if (recipeName === undefined && magicTex) {
             const magicTexStep = {
-                name: 'magictex',
+                name: magicTex,
                 command: magicTex,
                 args: configuration.get('latex.magic.args') as string[]
             }
             const magicBibStep = {
-                name: 'magicbib',
+                name: magicBib,
                 command: magicBib,
                 args: configuration.get('latex.magic.bib.args') as string[]
             }


### PR DESCRIPTION
Since the step name is appearing in the statusbar, it makes sense that it's set to be the name of the program being executed rather than a generic name.