### PR TITLE
Set working directory when calling LaTex binaries

### DIFF
--- a/src/components/linter.ts
+++ b/src/components/linter.ts
@@ -64,7 +64,7 @@ export class Linter {
 
         let stdout: string
         try {
-            stdout = await this.processWrapper('active file', command, args.concat(requiredArgs).filter(arg => arg !== ''), {}, content)
+            stdout = await this.processWrapper('active file', command, args.concat(requiredArgs).filter(arg => arg !== ''), {cwd: path.dirname(filePath)}, content)
         } catch (err) {
             if ('stdout' in err) {
                 stdout = err.stdout

--- a/src/components/locator.ts
+++ b/src/components/locator.ts
@@ -77,7 +77,7 @@ export class Locator {
         const args = ['view', '-i', `${line}:${position.character + 1}:${filePath}`, '-o', pdfFile]
         this.extension.logger.addLogMessage(`Executing synctex with args ${args}`)
 
-        const proc = cp.spawn(configuration.get('synctex.path') as string, args)
+        const proc = cp.spawn(configuration.get('synctex.path') as string, args, {cwd: path.dirname(pdfFile)})
         proc.stdout.setEncoding('utf8')
         proc.stderr.setEncoding('utf8')
 
@@ -109,7 +109,7 @@ export class Locator {
         const args = ['edit', '-o', `${data.page}:${data.pos[0]}:${data.pos[1]}:${pdfPath}`]
         this.extension.logger.addLogMessage(`Executing synctex with args ${args}`)
 
-        const proc = cp.spawn(configuration.get('synctex.path') as string, args)
+        const proc = cp.spawn(configuration.get('synctex.path') as string, args, {cwd: path.dirname(pdfPath)})
         proc.stdout.setEncoding('utf8')
         proc.stderr.setEncoding('utf8')
 

--- a/src/providers/latexformatter.ts
+++ b/src/providers/latexformatter.ts
@@ -125,7 +125,7 @@ export class LaTexFormatter {
                 .replace('%TMPFILE%', temporaryFile.split(path.sep).join('/'))
                 .replace('%INDENT%', indent))
 
-            const worker = cp.spawn(this.formatter, args, { stdio: 'pipe' })
+            const worker = cp.spawn(this.formatter, args, { stdio: 'pipe', cwd: path.dirname(document.fileName) })
             // handle stdout/stderr
             const stdoutBuffer = [] as string[]
             const stderrBuffer = [] as string[]


### PR DESCRIPTION
I created Docker shims for the LaTex binaries (see https://github.com/Arxisos/LaTex-Workshop-Docker). 

The shims are based on the idea presented in  https://github.com/James-Yu/LaTeX-Workshop/issues/302. However, the shims require the working directory to be set accordingly because the shims use `$(pwd)` to specify the Docker volume.

The changes included in this pull request were necessary for linting, formatting and SyncTex with the Docker shims.

