### PR TITLE
Use scope support.class.key for keys in bib files

### DIFF
--- a/syntax/Bibtex.plist
+++ b/syntax/Bibtex.plist
@@ -171,7 +171,7 @@
 						<key>1</key>
 						<dict>
 							<key>name</key>
-							<string>support.variable.key.bibtex</string>
+							<string>support.function.key.bibtex</string>
 						</dict>
 						<key>2</key>
 						<dict>
@@ -245,7 +245,7 @@
 						<key>1</key>
 						<dict>
 							<key>name</key>
-							<string>support.variable.key.bibtex</string>
+							<string>support.function.key.bibtex</string>
 						</dict>
 						<key>2</key>
 						<dict>


### PR DESCRIPTION
This scope seems better customized by standard themes than
`support.variable`.
Related to #509.