### PR TITLE
Fix inline math \(...\) highlighting

### DIFF
--- a/syntax/LaTeX.plist
+++ b/syntax/LaTeX.plist
@@ -1726,6 +1726,10 @@ Put specific matches for particular LaTeX keyword.functions before the last two 
 			<array>
 				<dict>
 					<key>include</key>
+					<string>text.tex#math</string>
+				</dict>
+				<dict>
+					<key>include</key>
 					<string>$base</string>
 				</dict>
 			</array>


### PR DESCRIPTION
This scope seems better customized by standard themes than
`support.variable`.
Related to 611bf18. This closes #535.