### PR TITLE
Add multicursor to the current environment name

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ LaTeX Workshop is an extension for [Visual Studio Code](https://code.visualstudi
 - LaTeX file formatting.
 - Auto close LaTeX environments: just call _LaTeX Workshop: Close current environment_ from the **Command Palette**. You can easily assign a shortcut to this action through the **Keyboard Shortcuts** menu, search for `latex-workshop.close-env`.
 - Navigate from `\begin/\end` to the corresponding `\end/\begin`: while on the `begin` or `end` keyword, call _LaTeX Workshop: Navigate to matching begin/end_ from the **Command Palette**. To define a shortcut, search for `latex-workshop.navigate-envpair` in the **Keyboard Shortcuts** menu.
-- Add a multicursor on the current environment name: call _LaTeX Workshop: Multicursor selection of the current environment name_ from the **Command Palette**. For this command to work, the cursor must be strictly between `\begin{...}` and `\end{...}`. To define a shortcut, search for `latex-workshop.select-envname` in the **Keyboard Shortcuts** menu. Repeated calls result in selecting the outer environments.
+- Add a multicursor to the current environment name: call _LaTeX Workshop: Multicursor selection of the current environment name_ from the **Command Palette**. For this command to work, the cursor must be strictly between `\begin{...}` and `\end{...}`. To define a shortcut, search for `latex-workshop.select-envname` in the **Keyboard Shortcuts** menu. Repeated calls result in selecting the outer environments.
 
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ LaTeX Workshop is an extension for [Visual Studio Code](https://code.visualstudi
 - LaTeX file formatting.
 - Auto close LaTeX environments: just call _LaTeX Workshop: Close current environment_ from the **Command Palette**. You can easily assign a shortcut to this action through the **Keyboard Shortcuts** menu, search for `latex-workshop.close-env`.
 - Navigate from `\begin/\end` to the corresponding `\end/\begin`: while on the `begin` or `end` keyword, call _LaTeX Workshop: Navigate to matching begin/end_ from the **Command Palette**. To define a shortcut, search for `latex-workshop.navigate-envpair` in the **Keyboard Shortcuts** menu.
+- Add a multicursor on the current environment name: call _LaTeX Workshop: Multicursor selection of the current environment name_ from the **Command Palette**. For this command to work, the cursor must be strictly between `\begin{...}` and `\end{...}`. To define a shortcut, search for `latex-workshop.select-envname` in the **Keyboard Shortcuts** menu. Repeated calls result in selecting the outer environments.
 
 
 ## Requirements

--- a/package.json
+++ b/package.json
@@ -155,6 +155,11 @@
         "category": "LaTeX Workshop"
       },
       {
+        "command": "latex-workshop.select-envname",
+        "title": "Multicursor selection of the current environment name",
+        "category": "LaTeX Workshop"
+      },
+      {
         "command": "latex-workshop.close-env",
         "title": "Close current environment",
         "category": "LaTeX Workshop"

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -233,6 +233,14 @@ export class Commander {
         this.extension.envPair.gotoPair()
     }
 
+    selectEnvName() {
+        this.extension.logger.addLogMessage(`SelectEnvName command invoked.`)
+        if (!vscode.window.activeTextEditor || !this.extension.manager.isTex(vscode.window.activeTextEditor.document.fileName)) {
+            return
+        }
+        this.extension.envPair.selectEnvName()
+    }
+
     closeEnv() {
         this.extension.logger.addLogMessage(`CloseEnv command invoked.`)
         if (!vscode.window.activeTextEditor || !this.extension.manager.isTex(vscode.window.activeTextEditor.document.fileName)) {

--- a/src/components/envpair.ts
+++ b/src/components/envpair.ts
@@ -143,6 +143,32 @@ export class EnvPair {
         }
     }
 
+    selectEnvName() {
+        const editor = vscode.window.activeTextEditor
+        if (!editor || editor.document.languageId !== 'latex') {
+            return
+        }
+        const curPos = editor.selection.active
+        const document = editor.document
+
+        const pattern = '\\\\(begin|end)\\{[^\\{\\}]*\\}'
+        const dirUp = -1
+        const beginEnv = this.locateMatchingPair(pattern, dirUp, curPos, document)
+        if (!beginEnv) {
+            return
+        }
+        const dirDown = 1
+        const endEnv = this.locateMatchingPair(pattern, dirDown, beginEnv.pos, document)
+        if (!endEnv) {
+            return
+        }
+
+        const envStartPos = beginEnv.pos.translate(0, 'begin{'.length)
+        const envEndPos = endEnv.pos.translate(0, 'end{'.length)
+        editor.selections = [new vscode.Selection(envStartPos, envStartPos), new vscode.Selection(envEndPos, envEndPos)]
+        editor.revealRange(new vscode.Range(envStartPos, envEndPos))
+    }
+
     closeEnv() {
         const editor = vscode.window.activeTextEditor
         if (!editor || editor.document.languageId !== 'latex') {

--- a/src/main.ts
+++ b/src/main.ts
@@ -143,6 +143,7 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('latex-workshop.code-action', (d, r, c, m) => extension.codeActions.runCodeAction(d, r, c, m))
     vscode.commands.registerCommand('latex-workshop.goto-section', (filePath, lineNumber) => extension.commander.gotoSection(filePath, lineNumber))
     vscode.commands.registerCommand('latex-workshop.navigate-envpair', () => extension.commander.navigateToEnvPair())
+    vscode.commands.registerCommand('latex-workshop.select-envname', () => extension.commander.selectEnvName())
     vscode.commands.registerCommand('latex-workshop.close-env', () => extension.commander.closeEnv())
 
     const formatter = new LatexFormatterProvider(extension)


### PR DESCRIPTION
Run `latex-workshop.select-envname` or call _Multicursor selection of
current environment name_ from the Command Palette to add a multicursor
to the current environment name. Repeated calls result in selecting the
outer environments.

For this feature to work, the cursor must be  strictly between
\begin{...} and \end{...}. This is required to allow for repeated calls.

This PR is related to #543.