### PR TITLE
Prevent completion for \\

### DIFF
--- a/data/commands.json
+++ b/data/commands.json
@@ -194,10 +194,6 @@
   "pagebreak":{
     "command":"pagebreak"
   },
-  " ":{
-    "command":" Press ENTER to insert a new line.",
-    "snippet":"\n"
-  },
   "noindent":{
     "command":"noindent"
   },

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -48,8 +48,12 @@ export class Completer implements vscode.CompletionItemProvider {
     provideCompletionItems(document: vscode.TextDocument, position: vscode.Position, _token: vscode.CancellationToken) : Promise<vscode.CompletionItem[]> {
         return new Promise((resolve, _reject) => {
             const invokeChar = document.lineAt(position.line).text[position.character - 1]
+            const currentLine = document.lineAt(position.line).text
+            if (position.character > 1 && currentLine[position.character - 2] === '\\') {
+                resolve()
+                return
+            }
             if (this.command.specialBrackets.hasOwnProperty(invokeChar)) {
-                const currentLine = document.lineAt(position.line).text
                 if (position.character > 1 && currentLine[position.character - 2] === '\\') {
                     const mathSnippet = Object.assign({}, this.command.specialBrackets[invokeChar])
                     if (vscode.workspace.getConfiguration('editor', document.uri).get('autoClosingBrackets') &&


### PR DESCRIPTION
When hitting the secong backslash, the intellisense menu is cleared.
It closes #560.