### PR TITLE
Fix unbalanced strings

### DIFF
--- a/syntax/LaTeX.plist
+++ b/syntax/LaTeX.plist
@@ -1639,7 +1639,7 @@ Put specific matches for particular LaTeX keyword.functions before the last two 
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>"&gt;</string>
+			<string>"</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>0</key>
@@ -1649,38 +1649,7 @@ Put specific matches for particular LaTeX keyword.functions before the last two 
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>"&lt;</string>
-			<key>endCaptures</key>
-			<dict>
-				<key>0</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.definition.string.end.latex</string>
-				</dict>
-			</dict>
-			<key>name</key>
-			<string>string.quoted.double.guillemot.latex</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>include</key>
-					<string>$base</string>
-				</dict>
-			</array>
-		</dict>
-		<dict>
-			<key>begin</key>
-			<string>"&lt;</string>
-			<key>beginCaptures</key>
-			<dict>
-				<key>0</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.definition.string.begin.latex</string>
-				</dict>
-			</dict>
-			<key>end</key>
-			<string>"&gt;</string>
+			<string>"</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>0</key>
@@ -1768,18 +1737,6 @@ Put specific matches for particular LaTeX keyword.functions before the last two 
 					<string>$base</string>
 				</dict>
 			</array>
-		</dict>
-		<dict>
-			<key>match</key>
-			<string>(?&lt;!\S)'.*?'</string>
-			<key>name</key>
-			<string>invalid.illegal.string.quoted.single.latex</string>
-		</dict>
-		<dict>
-			<key>match</key>
-			<string>(?&lt;!\S)".*?"</string>
-			<key>name</key>
-			<string>invalid.illegal.string.quoted.double.latex</string>
 		</dict>
 		<dict>
 			<key>captures</key>


### PR DESCRIPTION
The expressions `"> ... ">` and `"< .... "<` were matched against the string scope by declaring `">` and `"<` as pairs. This led to very weird highlighting and I could not find any reason to do so.
Therefore something like `">blabla"` was considered illegal.
This commit removes the above mechanism.
