### PR TITLE
Do not capture {...} groups

### DIFF
--- a/syntax/DocTeX.plist
+++ b/syntax/DocTeX.plist
@@ -174,47 +174,6 @@
 			<key>name</key>
 			<string>entity.name.function.filename.latex</string>
 		</dict>
-		<key>macrocode-braces</key>
-		<dict>
-			<key>begin</key>
-			<string>\{</string>
-			<key>beginCaptures</key>
-			<dict>
-				<key>0</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.section.group.begin.tex</string>
-				</dict>
-			</dict>
-			<key>end</key>
-			<string>(\})|(?=^%    (\\end\{macrocode\}))</string>
-			<key>endCaptures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.section.group.end.tex</string>
-				</dict>
-			</dict>
-			<key>name</key>
-			<string>meta.group.braces.tex</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>include</key>
-					<string>#guards</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#macrocode-braces</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>text.tex</string>
-				</dict>
-			</array>
-		</dict>
-
 	</dict>
 	<key>scopeName</key>
 	<string>text.tex.doctex</string>

--- a/syntax/TeX.plist
+++ b/syntax/TeX.plist
@@ -121,7 +121,7 @@
 				</dict>
 			</array>
 		</dict>
-		<dict>
+		<!-- <dict>
 			<key>begin</key>
 			<string>\{</string>
 			<key>beginCaptures</key>
@@ -151,7 +151,7 @@
 					<string>$base</string>
 				</dict>
 			</array>
-		</dict>
+		</dict> -->
 		<dict>
 			<key>match</key>
 			<string>[\[\]]</string>
@@ -281,7 +281,7 @@
 		<dict>
 			<key>patterns</key>
 			<array>
-				<dict>
+				<!-- <dict>
 					<key>begin</key>
 					<string>(?<!\\)\{</string>
 					<key>beginCaptures</key>
@@ -311,7 +311,7 @@
 							<string>#math</string>
 						</dict>
 					</array>
-				</dict>
+				</dict> -->
 				<dict>
 					<key>captures</key>
 					<dict>


### PR DESCRIPTION
To avoid troubles with constructions like
\newenvironment{mathenv}{$}{$}
we stop capturing {...} groups. It does not change anything visually as
it was set to a meta scope calling the whole syntax file again but it
solves many issues with elaborated constructs.

This closes #574