### PR TITLE
Do not highlight strings in .bib files

### DIFF
--- a/syntax/Bibtex.plist
+++ b/syntax/Bibtex.plist
@@ -325,37 +325,6 @@
 			<array>
 				<dict>
 					<key>begin</key>
-					<string>"</string>
-					<key>beginCaptures</key>
-					<dict>
-						<key>0</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.definition.string.begin.bibtex</string>
-						</dict>
-					</dict>
-					<key>end</key>
-					<string>"</string>
-					<key>endCaptures</key>
-					<dict>
-						<key>0</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.definition.string.end.bibtex</string>
-						</dict>
-					</dict>
-					<key>name</key>
-					<string>string.quoted.double.bibtex</string>
-					<key>patterns</key>
-					<array>
-						<dict>
-							<key>include</key>
-							<string>#nested_braces</string>
-						</dict>
-					</array>
-				</dict>
-				<dict>
-					<key>begin</key>
 					<string>\{</string>
 					<key>beginCaptures</key>
 					<dict>


### PR DESCRIPTION
This closes #589.