### PR TITLE
Autocomplete for \left command

### DIFF
--- a/data/commands.json
+++ b/data/commands.json
@@ -4,6 +4,21 @@
     "snippet":"begin{${1:env}}\n\t$2\n\\\\end{${1:env}}",
     "detail":"begin a new environment"
   },
+  "lrparen":{
+    "command":"left(",
+    "snippet":"left(${1}\\right)${0}",
+    "detail":"\\left( ... \\right)"
+  },
+  "lrbrack":{
+    "command":"left[",
+    "snippet":"left[${1}\\right]${0}",
+    "detail":"\\left[ ... \\right]"
+  },
+  "lrcurly":{
+    "command":"left\\{",
+    "snippet":"left\\{${1}\\right\\\\}${0}",
+    "detail":"\\left\\{ ... \\right\\}"
+  },
   "latexinlinemath":{
     "command":"(",
     "snippet":"(${1}\\)${0}",

--- a/src/providers/completer/command.ts
+++ b/src/providers/completer/command.ts
@@ -48,7 +48,7 @@ export class Command {
             command.insertText = new vscode.SnippetString(item.snippet)
             this.defaultCommands[key] = command
         })
-        const bracketCommands = {'latexinlinemath': '(', 'latexdisplaymath': '[', 'curlybrackets': '{'}
+        const bracketCommands = {'latexinlinemath': '(', 'latexdisplaymath': '[', 'curlybrackets': '{', 'lrparen': 'left(', 'lrbrack': 'left[', 'lrcurly': 'left\\{'}
         this.specialBrackets = Object.keys(this.defaultCommands)
             .filter(key => bracketCommands.hasOwnProperty(key))
             .reduce((obj, key) => {


### PR DESCRIPTION
Attempts to solve #596

If one of the new options, let's say `\left(`, is selected while typing, everything works as expected. However, when the command is typed all the way to the end, autocomplete does not work.

I tried to mimic the behavior of `\(`, `\[` and `\{` commands by modifying the command.ts file, but I didn't work.