### PR TITLE
Handle nested {...} in macro arguments

### DIFF
--- a/syntax/LaTeX.plist
+++ b/syntax/LaTeX.plist
@@ -195,6 +195,10 @@
 			<array>
 				<dict>
 					<key>include</key>
+					<string>text.tex#braces</string>
+				</dict>
+				<dict>
+					<key>include</key>
 					<string>$self</string>
 				</dict>
 			</array>
@@ -1116,6 +1120,10 @@
 			<array>
 				<dict>
 					<key>include</key>
+					<string>text.tex#braces</string>
+				</dict>
+				<dict>
+					<key>include</key>
 					<string>$base</string>
 				</dict>
 			</array>
@@ -1185,6 +1193,10 @@
 			<array>
 				<dict>
 					<key>include</key>
+					<string>text.tex#braces</string>
+				</dict>
+				<dict>
+					<key>include</key>
 					<string>$base</string>
 				</dict>
 			</array>
@@ -1226,6 +1238,10 @@
 			<string>meta.function.emph.latex</string>
 			<key>patterns</key>
 			<array>
+				<dict>
+					<key>include</key>
+					<string>text.tex#braces</string>
+				</dict>
 				<dict>
 					<key>include</key>
 					<string>$base</string>
@@ -1275,6 +1291,10 @@ Put specific matches for particular LaTeX keyword.functions before the last two 
 			<array>
 				<dict>
 					<key>include</key>
+					<string>text.tex#braces</string>
+				</dict>
+				<dict>
+					<key>include</key>
 					<string>$base</string>
 				</dict>
 			</array>
@@ -1318,6 +1338,10 @@ Put specific matches for particular LaTeX keyword.functions before the last two 
 			<array>
 				<dict>
 					<key>include</key>
+					<string>text.tex#braces</string>
+				</dict>
+				<dict>
+					<key>include</key>
 					<string>$base</string>
 				</dict>
 			</array>
@@ -1359,6 +1383,10 @@ Put specific matches for particular LaTeX keyword.functions before the last two 
 			<string>meta.function.texttt.latex</string>
 			<key>patterns</key>
 			<array>
+				<dict>
+					<key>include</key>
+					<string>text.tex#braces</string>
+				</dict>
 				<dict>
 					<key>include</key>
 					<string>$base</string>

--- a/syntax/TeX.plist
+++ b/syntax/TeX.plist
@@ -384,6 +384,38 @@
 				</dict>
 			</array>
 		</dict>
+		<key>braces</key>
+		<dict>
+			<key>begin</key>
+			<string>(?<!\\)\{</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.group.begin.tex</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>(?<!\\)\}</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.group.end.tex</string>
+				</dict>
+			</dict>
+			<key>name</key>
+			<string>meta.group.braces.tex</string>
+			<!-- <key>patterns</key> -->
+			<!-- <array>
+				<dict>
+					<key>include</key>
+					<string>#braces</string>
+				</dict>
+			</array> -->
+		</dict>
 	</dict>
 	<key>scopeName</key>
 	<string>text.tex</string>

--- a/syntax/TeX.plist
+++ b/syntax/TeX.plist
@@ -408,13 +408,13 @@
 			</dict>
 			<key>name</key>
 			<string>meta.group.braces.tex</string>
-			<!-- <key>patterns</key> -->
-			<!-- <array>
+			<key>patterns</key>
+			<array>
 				<dict>
 					<key>include</key>
 					<string>#braces</string>
 				</dict>
-			</array> -->
+			</array>
 		</dict>
 	</dict>
 	<key>scopeName</key>


### PR DESCRIPTION
Since commit c10ca0c, we have stopped capturing {...}. This has a side
effect of mistakenly detecting the end of argument in constructions like
    \section{title \LaTeX{} some text \LaTeX{}}

To fix this, we only capture braces inside macro arguments, when the
argument itself is captured.
This solves #595.