### PR TITLE
fixed documentation for bigvee and bigwedge

### DIFF
--- a/data/unimathsymbols.json
+++ b/data/unimathsymbols.json
@@ -1187,12 +1187,12 @@
   "bigvee": {
     "command": "bigvee",
     "detail": "⋁",
-    "documentation": "logical and operator"
+    "documentation": "logical or operator"
   },
   "bigwedge": {
     "command": "bigwedge",
     "detail": "⋀",
-    "documentation": "logical or operator"
+    "documentation": "logical and operator"
   },
   "bigwhitestar": {
     "command": "bigwhitestar",


### PR DESCRIPTION
The documentation popup for bigvee and bigwedge currently has "and" and "or" flipped.