### PR TITLE
Enable snippets usage on selected text

### DIFF
--- a/snippets/latex.json
+++ b/snippets/latex.json
@@ -71,22 +71,22 @@
 	},
 	"bf" : {
 		"prefix": "FBF",
-		"body": "\\textbf{$1}",
+		"body": "\\textbf{${1:${TM_SELECTED_TEXT:text}}}",
 		"description": "Use a bold font"
 	},
 	"it" : {
 		"prefix": "FIT",
-		"body": "\\textit{$1}",
+		"body": "\\textit{${1:${TM_SELECTED_TEXT:text}}}",
 		"description": "Use an italic font"
 	},
 	"em" : {
 		"prefix": "FEM",
-		"body": "\\emph{$1}",
+		"body": "\\emph{${1:${TM_SELECTED_TEXT:text}}}",
 		"description": "Use an emphasis font"
 	},
 	"tt" : {
 		"prefix": "FTT",
-		"body": "\\texttt{$1}",
+		"body": "\\texttt{${1:${TM_SELECTED_TEXT:text}}}",
 		"description": "Use a typewriter font"
 	},
 	/* Insert Gree letter with @ + corresponding latin letter */


### PR DESCRIPTION
These changes enable the usage of the `bf`, `it`, `em` and `tt` snippets on already selected tasks, adding the selected task into the brackets. With these changes, the user can set keyboard shortcuts to the snippets (like <kbd>Ctrl + I</kbd> for _italic_ or <kbd>Ctrl + B</kbd> for **bold**), select the text and press the keys without losing the selected text.
If no text is selected the current behaviour is kept.