### PR TITLE
Fix a problem that parsing a large bib file is slow.

### DIFF
--- a/src/providers/completer/citation.ts
+++ b/src/providers/completer/citation.ts
@@ -123,13 +123,16 @@ export class Citation {
         const itemReg = /@(\w+)\s*{/g
         let result = itemReg.exec(contentNoNewLine)
         let prevResult: RegExpExecArray | null = null
+        let numLines = 0
+        let prevPrevResultIndex = 0
         while (result || prevResult) {
             if (prevResult && bibEntries.indexOf(prevResult[1].toLowerCase()) > -1) {
                 const itemString = contentNoNewLine.substring(prevResult.index, result ? result.index : undefined).trim()
                 const item = this.parseBibString(itemString)
                 if (item !== undefined) {
                     items.push(item)
-                    const positionContent = content.substring(0, prevResult.index).split('\n')
+                    numLines = numLines + content.substring(prevPrevResultIndex, prevResult.index).split('\n').length
+                    prevPrevResultIndex = prevResult.index
                     this.citationData[item.key] = {
                         item,
                         text: Object.keys(item)
@@ -151,7 +154,7 @@ export class Citation {
                             })
                             .map(key => `${key}: ${item[key]}`)
                             .join('\n\n'),
-                        position: new vscode.Position(positionContent.length - 1, 0),
+                        position: new vscode.Position(numLines - 1, 0),
                         file: bibPath
                     }
                 } else {


### PR DESCRIPTION
Hi,
this patch will fix #251.

The bottleneck is in src/providers/completer/citation.ts:
```typescript
  const positionContent = content.substring(0, prevResult.index).split('\n')
```
This roughly creates O(N^2) strings for N entries in a bib file.

I have tested a bib file with 26^3 entries as follows.
When patched, parsing the bib file takes about 10 seconds.

```
@article{
 aaa,
 author = "Dr aaa",
 title  = "Study by Dr aaa"
}

@article{
 aab,
 author = "Dr aab",
 title  = "Study by Dr aab"
}
...
@article{
 zzz,
 author = "Dr zzz",
 title  = "Study by Dr zzz"
}
```

I hope this would help you develop your great extension.
Regards,
