### PR TITLE
highlighting \} followed by non-whitespace.

### DIFF
--- a/syntax/TeX.plist
+++ b/syntax/TeX.plist
@@ -332,7 +332,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(\\)(?!begin\{)([^a-zA-Z]|[A-Za-z]+)(?=\b|\s|\{|\}|\[|\]|\(|\)|\^|\_|\\|,|\.)</string>
+					<string>(\\)(?!begin\{)([^a-zA-Z]|[A-Za-z]+)</string>
 					<key>name</key>
 					<string>constant.other.general.math.tex</string>
 				</dict>

--- a/syntax/TeX.plist
+++ b/syntax/TeX.plist
@@ -332,7 +332,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(\\)(?!begin\{)([^a-zA-Z]|[A-Za-z]+)</string>
+					<string>(\\)(?!begin\{)([A-Za-z]+)</string>
 					<key>name</key>
 					<string>constant.other.general.math.tex</string>
 				</dict>


### PR DESCRIPTION
Hi,

Highlighting \\} followed by non-whitespace does not work well in the following example:
```
$\{\}$
$\{a\}+b$
```

![2018-09-25 17 07 19](https://user-images.githubusercontent.com/10665499/46001382-19a42900-c0e6-11e8-867f-ea69675e5874.png)

This patch fixes the problem. Even without the removed part of regex, an example in #668 is highlighted well. I cannot find conditions under which the removed part is required. Please check.

Regards,