### PR TITLE
refactor regex.

### DIFF
--- a/syntax/LaTeX.plist
+++ b/syntax/LaTeX.plist
@@ -715,7 +715,7 @@
 		<dict>
 			<key>begin</key>
 			<string>(?x)
-					(?:^|(?:\s*))										# Optional whitespace
+					(?:\s*)										# Optional whitespace
 					((\\)begin)									# Marker - Function
 					(\{)										# Open Bracket
 						(


### PR DESCRIPTION
Hi,
this is minor refactoring.
\\s* matches zero-length string immediately after the beginning of a line. So we can drop ^ .

Regards,