### PR TITLE
Fix mathbf shortcut

### DIFF
--- a/snippets/latex.json
+++ b/snippets/latex.json
@@ -244,7 +244,7 @@
 	},
 	"mathbf": {
 		"prefix": "MBF",
-		"body": "\\mathbb{${1:${TM_SELECTED_TEXT:text}}}",
+		"body": "\\mathbf{${1:${TM_SELECTED_TEXT:text}}}",
 		"description": "Use a bold font"
 	},
 	"mathbb": {


### PR DESCRIPTION
Mathbf used to have `mathbb` as the snippet contents.