### PR TITLE
skip an escaped character in \section

### DIFF
--- a/src/providers/structure.ts
+++ b/src/providers/structure.ts
@@ -19,6 +19,10 @@ function getLongestBalancedString(s: string) : string {
             case '}':
                 nested --
                 break
+            case '\\':
+                // skip an escaped character
+                i++
+                break
             default:
         }
         if (nested === 0) {


### PR DESCRIPTION
Hi,
we should skip an escaped character in `\section` to treat something like `\section{\} is a right curly bracket}` properly.