### PR TITLE
fix typo.

### DIFF
--- a/syntax/LaTeX.plist
+++ b/syntax/LaTeX.plist
@@ -1436,7 +1436,7 @@ Put specific matches for particular LaTeX keyword.functions before the last two 
 				<key>0</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.definition.arguments.begin.latex</string>
+					<string>punctuation.definition.arguments.end.latex</string>
 				</dict>
 			</dict>
 			<key>name</key>
@@ -1479,7 +1479,7 @@ Put specific matches for particular LaTeX keyword.functions before the last two 
 				<key>0</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.definition.arguments.begin.latex</string>
+					<string>punctuation.definition.arguments.end.latex</string>
 				</dict>
 			</dict>
 			<key>name</key>


### PR DESCRIPTION
In some cases, `}` is highlighted as `arguments.begin`, not as `arguments.end`.