### PR TITLE
Change $0 in ^{} and _{} snippets to $1

### DIFF
--- a/snippets/latex.json
+++ b/snippets/latex.json
@@ -6,12 +6,12 @@
 	},
 	"subscript": {
 		"prefix": "__",
-		"body": "_{$0}",
+		"body": "_{$1}",
 		"description": "Add a subscript"
 	},
 	"superscript": {
 		"prefix": "**",
-		"body": "^{$0}",
+		"body": "^{$1}",
 		"description": "Add a superscript"
 	},
 	"etc": {


### PR DESCRIPTION
This is pretty minor, and there may well be a good reason for this, in which case please dismiss this.

However, I find myself repeatedly typing something along the lines of (`**`+`<tab>` → `^{ <cursor> }`) + `-1` + `<tab>` → <code>^{-1&nbsp;&nbsp;&nbsp;&nbsp;}</code>. As a result I'm wondering why the shortcuts aren't of the form `^{$1}` instead of `^{$0}`.

In case there's no significant reason for this I have made this pull request since I find it likely that I'm not the only one that gets tripped up by this.