### PR TITLE
Fix ctrl+l ctrl+e keybinding

### DIFF
--- a/package.json
+++ b/package.json
@@ -285,12 +285,6 @@
         "key": "ctrl+alt+x"
       },
       {
-        "key": "ctrl+l ctrl+enter",
-        "mac": "cmd+l cmd+enter",
-        "when": "editorTextFocus && !editorReadonly && editorLangId == 'latex'",
-        "command": "latex-workshop.shortcut.item"
-      },
-      {
         "key": "ctrl+l ctrl+b",
         "mac": "cmd+l cmd+b",
         "when": "editorTextFocus && !editorReadonly && editorLangId == 'latex'",
@@ -312,7 +306,7 @@
         "key": "ctrl+l ctrl+e",
         "mac": "cmd+l cmd+e",
         "when": "editorTextFocus && !editorReadonly && editorLangId == 'latex'",
-        "command": "latex-workshop.shortcut.textem"
+        "command": "latex-workshop.shortcut.emph"
       },
       {
         "key": "ctrl+l ctrl+r",

--- a/snippets/latex.json
+++ b/snippets/latex.json
@@ -190,7 +190,7 @@
 		"body": "\\textrm{${1:${TM_SELECTED_TEXT:text}}}",
 		"description": "Use a roman font"
 	},
-	"textem": {
+	"emph": {
 		"prefix": "FEM",
 		"body": "\\emph{${1:${TM_SELECTED_TEXT:text}}}",
 		"description": "Use an emphasis font"

--- a/src/main.ts
+++ b/src/main.ts
@@ -127,7 +127,6 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('latex-workshop.shortcut.textbf', () => extension.commander.toggleSelectedKeyword('textbf'))
     vscode.commands.registerCommand('latex-workshop.shortcut.textit', () => extension.commander.toggleSelectedKeyword('textit'))
     vscode.commands.registerCommand('latex-workshop.shortcut.underline', () => extension.commander.toggleSelectedKeyword('underline'))
-    vscode.commands.registerCommand('latex-workshop.shortcut.textem', () => extension.commander.toggleSelectedKeyword('textem'))
     vscode.commands.registerCommand('latex-workshop.shortcut.textrm', () => extension.commander.toggleSelectedKeyword('textrm'))
     vscode.commands.registerCommand('latex-workshop.shortcut.texttt', () => extension.commander.toggleSelectedKeyword('texttt'))
     vscode.commands.registerCommand('latex-workshop.shortcut.textsl', () => extension.commander.toggleSelectedKeyword('textsl'))

--- a/src/main.ts
+++ b/src/main.ts
@@ -123,6 +123,7 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('latex-workshop-dev.parselog', () => extension.commander.devParseLog())
 
     vscode.commands.registerCommand('latex-workshop.shortcut.item', () => extension.commander.insertSnippet('item'))
+    vscode.commands.registerCommand('latex-workshop.shortcut.emph', () => extension.commander.toggleSelectedKeyword('emph'))
     vscode.commands.registerCommand('latex-workshop.shortcut.textbf', () => extension.commander.toggleSelectedKeyword('textbf'))
     vscode.commands.registerCommand('latex-workshop.shortcut.textit', () => extension.commander.toggleSelectedKeyword('textit'))
     vscode.commands.registerCommand('latex-workshop.shortcut.underline', () => extension.commander.toggleSelectedKeyword('underline'))


### PR DESCRIPTION
### Issue
Due to silly naming I did when creating the `\emph` snippet (called it `"textem"`) when the implementation was changed, since it was referred to as `textem`  — <kbd>ctrl</kbd>+<kbd>l</kbd> <kbd>ctrl</kbd>+<kbd>e</kbd> now toggles the nonexistant `\textem` command.
### What's in this PR
- Renamed all instances of `textem` to `emph`
- Removed `\item` inserting keybinding while I was at it
- Removed toggle `textem` function, since it isn't a thing