### PR TITLE
Display user-defined control sequence as is.

### DIFF
--- a/src/components/viewer.ts
+++ b/src/components/viewer.ts
@@ -132,7 +132,7 @@ export class Viewer {
                     useGlobalCache: false
                 },
                 TeX: {
-                    extensions: ["AMSmath.js", "AMSsymbols.js", "autoload-all.js"]
+                    extensions: ["AMSmath.js", "AMSsymbols.js", "noUndefined.js", "autoload-all.js"]
                 },
                 tex2jax: {
                     inlineMath: [ ['\$','\$'], ['\\\\(', '\\\\)'] ]


### PR DESCRIPTION
Hi,
this is a patch to display user-defined control sequence as is. Related to ![link](https://github.com/James-Yu/LaTeX-Workshop/issues/875#issuecomment-429690261).