### PR TITLE
Add [View on pdf] link  in hover on \ref

### DIFF
--- a/package.json
+++ b/package.json
@@ -593,6 +593,16 @@
             "[Experimental] Open PDF with the external viewer set in \"View > Pdf > External: command\"."
           ]
         },
+        "latex-workshop.view.pdf.ref.viewer": {
+          "type": "string",
+          "default": "auto",
+          "enum": [
+            "auto",
+            "tabOrBrowser",
+            "external"
+          ],
+          "description": "PDF viewer used for [View on PDF] link on \\ref."
+        },
         "latex-workshop.view.pdf.external.command": {
           "type": "object",
           "default": {

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -173,13 +173,13 @@ export class Commander {
         this.extension.viewer.openTab(uri.fsPath, false, false)
     }
 
-    async synctex() {
+    async synctex(line: number | undefined = undefined) {
         this.extension.logger.addLogMessage(`SYNCTEX command invoked.`)
         await this.extension.manager.findRoot()
         if (!vscode.window.activeTextEditor || !this.extension.manager.hasTexId(vscode.window.activeTextEditor.document.languageId)) {
             return
         }
-        this.extension.locator.syncTeX()
+        this.extension.locator.syncTeX(line)
     }
 
     async clean() : Promise<void> {

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -173,13 +173,22 @@ export class Commander {
         this.extension.viewer.openTab(uri.fsPath, false, false)
     }
 
-    async synctex(line: number | undefined = undefined) {
+    async synctex() {
         this.extension.logger.addLogMessage(`SYNCTEX command invoked.`)
         await this.extension.manager.findRoot()
         if (!vscode.window.activeTextEditor || !this.extension.manager.hasTexId(vscode.window.activeTextEditor.document.languageId)) {
             return
         }
-        this.extension.locator.syncTeX(line)
+        this.extension.locator.syncTeX()
+    }
+
+    async synctexonref(line: number) {
+        this.extension.logger.addLogMessage(`SYNCTEX command invoked.`)
+        await this.extension.manager.findRoot()
+        if (!vscode.window.activeTextEditor || !this.extension.manager.hasTexId(vscode.window.activeTextEditor.document.languageId)) {
+            return
+        }
+        this.extension.locator.syncTeXOnRef(line)
     }
 
     async clean() : Promise<void> {

--- a/src/components/locator.ts
+++ b/src/components/locator.ts
@@ -122,6 +122,7 @@ export class Locator {
     syncTeXOnRef(line: number) {
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         const viewer = configuration.get('view.pdf.ref.viewer') as string
+        line += 1
         if (viewer) {
             this.syncTeX(line, viewer)
         } else {

--- a/src/components/locator.ts
+++ b/src/components/locator.ts
@@ -49,7 +49,7 @@ export class Locator {
         return record
     }
 
-    syncTeX(line: number | undefined = undefined) {
+    syncTeX(line: number | undefined = undefined, forced_viewer: string = 'auto') {
         let character = 0
         if (!vscode.window.activeTextEditor) {
             return
@@ -74,7 +74,7 @@ export class Locator {
             vscode.window.activeTextEditor.document.lineAt(line - 1).text === '') {
                 line -= 1
         }
-        if (configuration.get('view.pdf.viewer') === 'external') {
+        if (forced_viewer === 'external' || (forced_viewer === 'auto' && configuration.get('view.pdf.viewer') === 'external') ) {
             this.syncTeXExternal(line, pdfFile, this.extension.manager.rootFile)
             return
         }
@@ -117,6 +117,16 @@ export class Locator {
                 this.extension.viewer.syncTeX(pdfFile, this.parseSyncTeX(stdout))
             }
         })
+    }
+
+    syncTeXOnRef(line: number) {
+        const configuration = vscode.workspace.getConfiguration('latex-workshop')
+        const viewer = configuration.get('view.pdf.ref.viewer') as string
+        if (viewer) {
+            this.syncTeX(line, viewer)
+        } else {
+            this.syncTeX(line)
+        }
     }
 
     locate(data: any, pdfPath: string) {

--- a/src/components/locator.ts
+++ b/src/components/locator.ts
@@ -49,7 +49,8 @@ export class Locator {
         return record
     }
 
-    syncTeX() {
+    syncTeX(line: number | undefined = undefined) {
+        let character = 0
         if (!vscode.window.activeTextEditor) {
             return
         }
@@ -58,14 +59,17 @@ export class Locator {
             this.extension.logger.addLogMessage(`${filePath} is not a valid LaTeX file.`)
             return
         }
-        const position = vscode.window.activeTextEditor.selection.active
-        if (!position) {
-            this.extension.logger.addLogMessage(`Cannot get cursor position: ${position}`)
-            return
+        if (!line) {
+            const position = vscode.window.activeTextEditor.selection.active
+            if (!position) {
+                this.extension.logger.addLogMessage(`Cannot get cursor position: ${position}`)
+                return
+            }
+            line = position.line + 1
+            character = position.character
         }
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         const pdfFile = this.extension.manager.tex2pdf(this.extension.manager.rootFile)
-        let line = position.line + 1
         if (vscode.window.activeTextEditor.document.lineCount === line &&
             vscode.window.activeTextEditor.document.lineAt(line - 1).text === '') {
                 line -= 1
@@ -76,7 +80,7 @@ export class Locator {
         }
 
         const docker = configuration.get('docker.enabled')
-        const args = ['view', '-i', `${line}:${position.character + 1}:${docker ? path.basename(filePath) : filePath}`, '-o', docker ? path.basename(pdfFile) : pdfFile]
+        const args = ['view', '-i', `${line}:${character + 1}:${docker ? path.basename(filePath) : filePath}`, '-o', docker ? path.basename(pdfFile) : pdfFile]
         this.extension.logger.addLogMessage(`Executing synctex with args ${args}`)
 
         let command = configuration.get('synctex.path') as string

--- a/src/main.ts
+++ b/src/main.ts
@@ -106,7 +106,7 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('latex-workshop.tab', () => extension.commander.tab())
     vscode.commands.registerCommand('latex-workshop.kill', () => extension.commander.kill())
     vscode.commands.registerCommand('latex-workshop.synctex', () => extension.commander.synctex())
-    vscode.commands.registerCommand('latex-workshop.synctexto', (line) => extension.commander.synctex(line))
+    vscode.commands.registerCommand('latex-workshop.synctexto', (line) => extension.commander.synctexonref(line))
     vscode.commands.registerCommand('latex-workshop.clean', () => extension.commander.clean())
     vscode.commands.registerCommand('latex-workshop.actions', () => extension.commander.actions())
     vscode.commands.registerCommand('latex-workshop.citation', () => extension.commander.citation())

--- a/src/main.ts
+++ b/src/main.ts
@@ -106,6 +106,7 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('latex-workshop.tab', () => extension.commander.tab())
     vscode.commands.registerCommand('latex-workshop.kill', () => extension.commander.kill())
     vscode.commands.registerCommand('latex-workshop.synctex', () => extension.commander.synctex())
+    vscode.commands.registerCommand('latex-workshop.synctexto', (line) => extension.commander.synctex(line))
     vscode.commands.registerCommand('latex-workshop.clean', () => extension.commander.clean())
     vscode.commands.registerCommand('latex-workshop.actions', () => extension.commander.actions())
     vscode.commands.registerCommand('latex-workshop.citation', () => extension.commander.citation())

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -63,9 +63,12 @@ export class HoverProvider implements vscode.HoverProvider {
                 return
             }
             if (token in this.extension.completer.reference.referenceData) {
-                resolve(new vscode.Hover(
-                    {language: 'latex', value: this.extension.completer.reference.referenceData[token].text }
-                ))
+                const refData = this.extension.completer.reference.referenceData[token]
+                const line = refData.item.position.line
+                const md = new vscode.MarkdownString(`[View on pdf](command:latex-workshop.synctexto?${line})`)
+                const md1 = '```latex\n' + refData.text + '\n```\n'
+                md.isTrusted = true
+                resolve( new vscode.Hover([md,md1]) )
                 return
             }
             if (token in this.extension.completer.citation.citationData) {

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -65,10 +65,10 @@ export class HoverProvider implements vscode.HoverProvider {
             if (token in this.extension.completer.reference.referenceData) {
                 const refData = this.extension.completer.reference.referenceData[token]
                 const line = refData.item.position.line
-                const md = new vscode.MarkdownString(`[View on pdf](command:latex-workshop.synctexto?${line})`)
-                const md1 = '```latex\n' + refData.text + '\n```\n'
-                md.isTrusted = true
-                resolve( new vscode.Hover([md,md1]) )
+                const md_link = new vscode.MarkdownString(`[View on pdf](command:latex-workshop.synctexto?${line})`)
+                md_link.isTrusted = true
+                const md = '```latex\n' + refData.text + '\n```\n'
+                resolve( new vscode.Hover([md, md_link]) )
                 return
             }
             if (token in this.extension.completer.citation.citationData) {


### PR DESCRIPTION
Hi,
this is a patch to add  [View on pdf] link in hover on \ref. When clicking the link, SyncTeX command is executed for \\label{...} corresponding to \\ref{...}. We can do the same thing by clicking [Go to definition] or [Peek definition], moving a cursor to the label, then executing SyncTeX. But, the advantage of this patch is that SyncTeX command can be executed for other than the current PDF viewer. We can use the current viewer to view a sentence we are editing now, and use tab viewer or browser to view a part \\ref{...} refers to, and vice versa. With this patch, we overcome the imperfect navigation of PDF viewers in a measure.

---
![oct-21-2018 16-32-19](https://user-images.githubusercontent.com/10665499/47264319-69dca280-d54f-11e8-9072-a3a2f005ac47.gif)
