### PR TITLE
Add the support of recursive root magic

### DIFF
--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -153,13 +153,24 @@ export class Manager {
             return undefined
         }
         const regex = /^(?:%\s*!\s*T[Ee]X\sroot\s*=\s*([^\s]*\.tex)$)/m
-        const content = vscode.window.activeTextEditor.document.getText()
+        var content = vscode.window.activeTextEditor.document.getText()
 
-        const result = content.match(regex)
+        var result = content.match(regex)
         if (result) {
-            const file = path.resolve(path.dirname(vscode.window.activeTextEditor.document.fileName), result[1])
+            var file = path.resolve(path.dirname(vscode.window.activeTextEditor.document.fileName), result[1])
             this.extension.logger.addLogMessage(`Found root file by magic comment: ${file}`)
-            return file
+
+            while (true) {
+                content = fs.readFileSync(file).toString()
+                result = content.match(regex)
+
+                if (result) {
+                    file = path.resolve(path.dirname(file), result[1])
+                    this.extension.logger.addLogMessage(`Recursively found root file by magic comment: ${file}`)
+                } else {
+                    return file
+                }
+            }
         }
         return undefined
     }

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -160,17 +160,17 @@ export class Manager {
             var file = path.resolve(path.dirname(vscode.window.activeTextEditor.document.fileName), result[1])
             this.extension.logger.addLogMessage(`Found root file by magic comment: ${file}`)
 
-            while (true) {
+            content = fs.readFileSync(file).toString()
+            result = content.match(regex)
+
+            while (result) {
+                file = path.resolve(path.dirname(file), result[1])
+                this.extension.logger.addLogMessage(`Recursively found root file by magic comment: ${file}`)
+
                 content = fs.readFileSync(file).toString()
                 result = content.match(regex)
-
-                if (result) {
-                    file = path.resolve(path.dirname(file), result[1])
-                    this.extension.logger.addLogMessage(`Recursively found root file by magic comment: ${file}`)
-                } else {
-                    return file
-                }
             }
+            return file
         }
         return undefined
     }


### PR DESCRIPTION
This patch implements #919: allows for support of recursive `%! TEX root` directives.
Now, when we have the redirections like file2.tex -> file1.tex -> main.tex, LaTeX-Workshop builds main.tex instead of file1.tex.

For now, this behavior cannot be controlled through an option, but this is something I should be able to implement.