### PR TITLE
Fix mathcal shortcut

### DIFF
--- a/package.json
+++ b/package.json
@@ -419,7 +419,7 @@
         "key": "ctrl+m ctrl+c",
         "mac": "cmd+m cmd+c",
         "when": "editorTextFocus && !editorReadonly && editorLangId == 'latex'",
-        "command": "latex-workshop.shorcut.mathcal"
+        "command": "latex-workshop.shortcut.mathcal"
       },
       {
         "key": "ctrl+l ctrl+w",


### PR DESCRIPTION
 Reference misspelt. Closes #924 