### PR TITLE
Clean output directory recursively

### DIFF
--- a/src/components/cleaner.ts
+++ b/src/components/cleaner.ts
@@ -23,7 +23,9 @@ export class Cleaner {
             outdir += path.sep
         }
         if (outdir !== './') {
-            globs = globs.concat(globs.map(globType => outdir + globType))
+            globs = globs.concat(globs.map(globType => outdir + globType), globs.map(globType => outdir + '**/' + globType))
+        } else {
+            globs = globs.concat(globs.map(globType => outdir + '**/' + globType))
         }
 
         return Promise.all(


### PR DESCRIPTION
This PR implements recursive cleaning when invoking the "Clean up auxiliary files" action. This is needed for projects where some latex files are in a sub directory e.g.:
```
main.tex
chapters/chapter1.tex
chapters/chapter2.tex
```