### PR TITLE
Clean output directory recursively

### DIFF
--- a/src/components/cleaner.ts
+++ b/src/components/cleaner.ts
@@ -23,7 +23,7 @@ export class Cleaner {
             outdir += path.sep
         }
         if (outdir !== './') {
-            globs = globs.concat(globs.map(globType => outdir + globType))
+            globs = globs.concat(globs.map(globType => outdir + globType), globs.map(globType => outdir + '**/' + globType))
         }
 
         return Promise.all(


### PR DESCRIPTION
This PR implements recursive cleaning for the output directory (only when an output directory other than `./` is specified) when invoking the "Clean up auxiliary files" action. This is needed for projects where some latex files are in a sub directory e.g.:

```
main.tex
chapters/chapter1.tex
chapters/chapter2.tex
```

@James-Yu @tamuratak This is a new version of PR #928 with the concerns from issue #930 in mind. The concerns are handled by only cleaning in the specified output directory, which shouldn't contain any files apart from those generated by the build.