### PR TITLE
fix toolbar in pdf viewer

### DIFF
--- a/viewer/latexworkshop.css
+++ b/viewer/latexworkshop.css
@@ -120,3 +120,9 @@ html #outerContainer.sidebarOpen > #sidebarContainer {
       display: none;
     }
 }
+
+@media all and (max-width: 450px) {
+    #trimSelectContainer {
+      display: none;
+    }
+}

--- a/viewer/latexworkshop.css
+++ b/viewer/latexworkshop.css
@@ -108,3 +108,15 @@ html #outerContainer.sidebarOpen > #sidebarContainer {
 #secondaryPresentationMode {
     display: none  !important;
 }
+
+@media all and (max-width: 700px) {
+    .hiddenSmallView, .hiddenSmallView * {
+        display: none;
+    }
+}
+
+@media all and (max-width: 600px) {
+    #scaleSelectContainer {
+      display: none;
+    }
+}

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -270,7 +270,7 @@ See https://github.com/adobe-type-tools/cmap-resources
                     <option id="trimOption" title="" disabled="disabled" hidden="true"> Trimming </option>
                   </select>
                 </span>
-                <span id="scaleSelectContainer" class="dropdownToolbarButton">
+                <span id="trimSelectContainer" class="dropdownToolbarButton">
                   <select id="trimSelect" title="Trim" tabindex="23" >
                     <option title="" value="0.0" selected="selected" >No page trimming</option>
                     <option title="" value="0.05" >Trim 5% at margin</option>


### PR DESCRIPTION
Hi,
this is a patch to fix the toolbar in pdf viewer broken for a certain width. This patch hides toolbar buttons in the following order.

1. next and previous buttons  
2. scaleSelect
3. trimSelect

![2018-11-01 21 26 48](https://user-images.githubusercontent.com/10665499/47851903-6255ad00-de1d-11e8-8ebc-e44d54ba1ca5.png)
