### PR TITLE
 fix a bug when latex-workshop.latex.outputDir is an absolute path

### DIFF
--- a/package.json
+++ b/package.json
@@ -528,7 +528,7 @@
         "latex-workshop.latex.outputDir": {
           "type": "string",
           "default": "./",
-          "description": "The directory where the extension tries to find project files (e.g., PDF and SyncTeX files) are located.\nBoth relative and absolute pathes are supported. Relative path start from the root file location, so beware if it is located in sub-directory.\nThe LaTeX toolchain should output files to this path."
+          "description": "The directory where the extension tries to find project files (e.g., PDF and SyncTeX files) are located.\nBoth relative and absolute paths are supported. Relative path start from the root file location, so beware if it is located in sub-directory.\nThe LaTeX toolchain should output files to this path."
         },
         "latex-workshop.latex.additionalBib": {
           "type": "array",
@@ -593,7 +593,7 @@
             "subsection",
             "subsubsection"
           ],
-          "description": "The section names of LaTeX outline hierarchy.\nThis property is an array of case-sensitive strings in the order of document structure hierarchy. For multiple tags in the same level, seperate the tags with `|` as delimiters, e.g., `section|alternative`."
+          "description": "The section names of LaTeX outline hierarchy.\nThis property is an array of case-sensitive strings in the order of document structure hierarchy. For multiple tags in the same level, separate the tags with `|` as delimiters, e.g., `section|alternative`."
         },
         "latex-workshop.view.pdf.viewer": {
           "type": "string",
@@ -724,7 +724,7 @@
         "latex-workshop.texcount.args": {
           "type": "array",
           "default": [],
-          "description": "TeXCount arguments to count words in LaTeX document of the entire project from the root file, or the currect document.\nArguments must be in separate strings in the array. Additional arguments, i.e., `-merge %DOC%` for the project and the current document path for counting current file will be appended when constructing the command."
+          "description": "TeXCount arguments to count words in LaTeX document of the entire project from the root file, or the current document.\nArguments must be in separate strings in the array. Additional arguments, i.e., `-merge %DOC%` for the project and the current document path for counting current file will be appended when constructing the command."
         },
         "latex-workshop.intellisense.citation.type": {
           "type": "string",

--- a/src/components/builder.ts
+++ b/src/components/builder.ts
@@ -53,14 +53,18 @@ export class Builder {
         this.extension.logger.displayStatus('sync~spin', 'statusBar.foreground')
         this.preprocess(rootFile)
 
-        // Create sub directories of output directory
+        // Create directories of output directory
         if (this.extension.manager.getOutputDir(rootFile) !== './') {
-            const directories = new Set<string>(this.extension.manager.watched
-                .map(file => path.dirname(file.replace(this.extension.manager.rootDir, ''))))
-            const outputDir = path.join(this.extension.manager.rootDir, this.extension.manager.getOutputDir(rootFile))
-            directories.forEach(directory => {
-                fs.ensureDirSync(path.join(outputDir, directory))
-            })
+            if (path.isAbsolute(this.extension.manager.getOutputDir(rootFile))) {
+                fs.ensureDirSync(this.extension.manager.getOutputDir(rootFile))
+            } else {
+                const directories = new Set<string>(this.extension.manager.watched
+                    .map(file => path.dirname(file.replace(this.extension.manager.rootDir, ''))))
+                const outputDir = path.join(this.extension.manager.rootDir, this.extension.manager.getOutputDir(rootFile))
+                directories.forEach(directory => {
+                    fs.ensureDirSync(path.join(outputDir, directory))
+                })
+            }
         }
 
         if (this.nextBuildRootFile === undefined) {

--- a/src/components/builder.ts
+++ b/src/components/builder.ts
@@ -53,18 +53,17 @@ export class Builder {
         this.extension.logger.displayStatus('sync~spin', 'statusBar.foreground')
         this.preprocess(rootFile)
 
-        // Create directories of output directory
+        // Create sub directories of output directory
         if (this.extension.manager.getOutputDir(rootFile) !== './') {
-            if (path.isAbsolute(this.extension.manager.getOutputDir(rootFile))) {
-                fs.ensureDirSync(this.extension.manager.getOutputDir(rootFile))
-            } else {
-                const directories = new Set<string>(this.extension.manager.watched
-                    .map(file => path.dirname(file.replace(this.extension.manager.rootDir, ''))))
-                const outputDir = path.join(this.extension.manager.rootDir, this.extension.manager.getOutputDir(rootFile))
-                directories.forEach(directory => {
-                    fs.ensureDirSync(path.join(outputDir, directory))
-                })
+            const directories = new Set<string>(this.extension.manager.watched
+                .map(file => path.dirname(file.replace(this.extension.manager.rootDir, ''))))
+            let outputDir = this.extension.manager.getOutputDir(rootFile)
+            if (!path.isAbsolute(outputDir)) {
+                outputDir = path.join(this.extension.manager.rootDir, this.extension.manager.getOutputDir(rootFile))
             }
+            directories.forEach(directory => {
+                fs.ensureDirSync(path.join(outputDir, directory))
+            })
         }
 
         if (this.nextBuildRootFile === undefined) {


### PR DESCRIPTION
According to the description of `latex-workshop.latex.outputDir`:
> Both relative and absolute paths are supported. 

However, current codes only support sub directories. If a user specified an absolute path, unnecessary sub directories will be created in the directory of the main tex file. This pull request fixes this issue by checking whether `latex-workshop.latex.outputDir` is relative or absolute before calling `fs.ensureDirSync`.