### PR TITLE
Fix section folding

### DIFF
--- a/src/providers/folding.ts
+++ b/src/providers/folding.ts
@@ -29,7 +29,9 @@ export class FoldingProvider implements vscode.FoldingRangeProvider {
         return sections.filter(section => section['level']).map((section, index, allSections) => {
             const startLine = section['lineNumber']
             let endLine
-            if (index < allSections.length - 1) { // Not the last section
+
+            // Not the last section
+            if (allSections.filter((element, elementIndex) => index < elementIndex && element['level'] <= section['level']).length > 0) {
                 for (let siblingSectionIndex = index + 1; siblingSectionIndex < allSections.length; siblingSectionIndex++) {
                     if (section['level'] >= allSections[siblingSectionIndex]['level']) {
                         endLine = allSections[siblingSectionIndex]['lineNumber'] - 1
@@ -38,9 +40,10 @@ export class FoldingProvider implements vscode.FoldingRangeProvider {
                 }
             } else {
                 endLine = document.lineCount - 1
-                for (; endLine > startLine; endLine--) {
-                    if (/\\end{document}/.test(document.lineAt(endLine).text)) {
-                        endLine--
+                // Handle included files which don't contain \end{document}
+                for (let endLineCopy = endLine; endLineCopy > startLine; endLineCopy--) {
+                    if (/\\end{document}/.test(document.lineAt(endLineCopy).text)) {
+                        endLine = endLineCopy--
                         break
                     }
                 }


### PR DESCRIPTION
The new folding implementation has two issues which are addressed in this PR:
1. To determine if a section is the last one, it checks whether there are any more sections instead of checking if there are any more section on the same level or on a higher level (line 32).
2. For the last section the endLine variable is decremented in the loop, but the value of endLine should only be changed if there is actually a `\end{document}` present (not the case for typical includes, line 41).

This should resolve issue #953 