### PR TITLE
add flag for pdf-to-tex synctex animation

### DIFF
--- a/package.json
+++ b/package.json
@@ -679,6 +679,11 @@
           "default": false,
           "description": "Execute forward synctex at cursor position after compiling LaTeX project."
         },
+        "latex-workshop.synctex.pdfToTex.animation": {
+          "type": "boolean",
+          "default": "true",
+          "description": "Animate to notify the position of the cursor after executing pdf-to-tex synctex."
+        },
         "latex-workshop.chktex.enabled": {
           "type": "boolean",
           "default": false,

--- a/src/components/locator.ts
+++ b/src/components/locator.ts
@@ -193,7 +193,11 @@ export class Locator {
                     vscode.window.showTextDocument(doc, viewColumn).then((editor) => {
                         editor.selection = new vscode.Selection(pos, pos)
                         vscode.commands.executeCommand('revealLine', {lineNumber: row, at: 'center'})
-                        this.animateToNotify(editor, pos)
+                        const configuration = vscode.workspace.getConfiguration('latex-workshop')
+                        const flag = configuration.get('synctex.pdfToTex.animation') as boolean
+                        if (flag) {
+                            this.animateToNotify(editor, pos)
+                        }
                     })
                 })
             }


### PR DESCRIPTION
This is a patch to add a flag for pdf-to-tex synctex animation. This closes #958.