### PR TITLE
Item shortcut should have space after item

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -125,7 +125,7 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('latex-workshop.onAltEnterKey', () => extension.commander.onEnterKey('alt'))
     vscode.commands.registerCommand('latex-workshop-dev.parselog', () => extension.commander.devParseLog())
 
-    vscode.commands.registerCommand('latex-workshop.shortcut.item', () => extension.commander.insertSnippet('item'))
+    vscode.commands.registerCommand('latex-workshop.shortcut.item', () => extension.commander.insertSnippet('item '))
     vscode.commands.registerCommand('latex-workshop.shortcut.emph', () => extension.commander.toggleSelectedKeyword('emph'))
     vscode.commands.registerCommand('latex-workshop.shortcut.textbf', () => extension.commander.toggleSelectedKeyword('textbf'))
     vscode.commands.registerCommand('latex-workshop.shortcut.textit', () => extension.commander.toggleSelectedKeyword('textit'))


### PR DESCRIPTION
This makes it Ctrl+L Ctrl+Enter:
 (a) slightly better to use
 (b) consistent with item-on-enter