### PR TITLE
fix the style of trimSelectContainer

### DIFF
--- a/viewer/latexworkshop.css
+++ b/viewer/latexworkshop.css
@@ -126,3 +126,14 @@ html #outerContainer.sidebarOpen > #sidebarContainer {
       display: none;
     }
 }
+
+#trimSelectContainer {
+    max-width: none !important;
+    width: auto !important;
+}
+
+#trimSelectContainer > select {
+    -webkit-appearance: button;
+    -moz-appearance: button;
+    appearance: button;
+}

--- a/viewer/latexworkshop.css
+++ b/viewer/latexworkshop.css
@@ -136,4 +136,9 @@ html #outerContainer.sidebarOpen > #sidebarContainer {
     -webkit-appearance: button;
     -moz-appearance: button;
     appearance: button;
+    height: 23px !important;
+}
+
+#scaleSelectContainer > select {
+    height: 23px !important;
 }


### PR DESCRIPTION
This is a patch to undefine the max-width of trimSelectContainer.  We don't have to do this for scaleSelectContainer because viewer.js dynamically sets an appropriate width. Without this patch, the select element is not appropriately displayed as follows.

![2018-11-13 20 56 58](https://user-images.githubusercontent.com/10665499/48412122-0aa53300-e787-11e8-8f85-a363e25856da.png)
