### PR TITLE
add an invert color option for pdf viewer

### DIFF
--- a/viewer/latexworkshop.js
+++ b/viewer/latexworkshop.js
@@ -277,3 +277,17 @@ window.addEventListener("pagerendered", () => {
     observer.observe(page, {attributes: true, childList: true});
   }
 }, {once: true});
+
+document.getElementById("colorSelect").addEventListener("change", (ev) => {
+  const colorSelect = document.getElementById("colorSelect");
+  if (colorSelect.selectedIndex === 0) {
+    document.body.style.backgroundColor = "white";
+    document.getElementById("viewer").style.filter = "none";
+    return
+  }
+  if (colorSelect.selectedIndex === 1) {
+    document.body.style.backgroundColor = "black";
+    document.getElementById("viewer").style.filter = "invert(1)";
+    return
+  }
+});

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -150,6 +150,15 @@ See https://github.com/adobe-type-tools/cmap-resources
 
             <div class="horizontalToolbarSeparator"></div>
 
+            <span id="colorSelectContainer" class="dropdownToolbarButton">
+              <select id="colorSelect" title="Select Color Mode" tabindex="59" >
+                <option title="" value="normal" selected="selected" >normal</option>
+                <option title="" value="invert" >invert</option>
+              </select>
+            </span>
+
+            <div class="horizontalToolbarSeparator"></div>
+
             <button id="cursorSelectTool" class="secondaryToolbarButton selectTool toggled" title="Enable Text Selection Tool" tabindex="60" data-l10n-id="cursor_text_select_tool">
               <span data-l10n-id="cursor_text_select_tool_label">Text Selection Tool</span>
             </button>


### PR DESCRIPTION
Hi,
this is a patch to add an invert color option for pdf viewer. Requested in #322. We can implement it by using the [filter CSS property](https://developer.mozilla.org/en-US/docs/Web/CSS/filter). 

Although I am not sure this is what users want, I hope this will help users who need this feature.

![nov-14-2018 22-30-41](https://user-images.githubusercontent.com/10665499/48485705-f0d61f80-e85c-11e8-82c3-01ee4e9b09ae.gif)
