### PR TITLE
Fix the way of calling encodeURIComponent 

### DIFF
--- a/src/components/server.ts
+++ b/src/components/server.ts
@@ -43,10 +43,10 @@ export class Server {
         if (!request.url) {
             return
         }
-        request.url = decodeURIComponent(decodeURIComponent(request.url))
+
         if (request.url.indexOf('pdf:') >= 0 && request.url.indexOf('viewer.html') < 0) {
             // The second backslash was encoded as %2F, and the first one is prepended by request
-            const fileName = request.url.replace('/pdf:', '')
+            const fileName = decodeURIComponent(request.url.replace('/pdf:', ''))
             try {
                 const pdfSize = fs.statSync(fileName).size
                 response.writeHead(200, {'Content-Type': 'application/pdf', 'Content-Length': pdfSize})

--- a/src/components/viewer.ts
+++ b/src/components/viewer.ts
@@ -52,7 +52,7 @@ export class Viewer {
             this.extension.logger.addLogMessage(`Cannot establish server connection.`)
             return
         }
-        const url = `http://${this.extension.server.address}/viewer.html?file=/pdf:${encodeURIComponent(encodeURIComponent(pdfFile))}`
+        const url = `http://${this.extension.server.address}/viewer.html?file=/pdf:${encodeURIComponent(encodeURIComponent(encodeURIComponent(pdfFile)))}`
         this.extension.logger.addLogMessage(`Serving PDF file at ${url}`)
         return url
     }
@@ -105,7 +105,7 @@ export class Viewer {
     }
 
     getPDFViewerContent(uri: vscode.Uri) : string {
-        const url = `http://${this.extension.server.address}/viewer.html?incode=1&file=/pdf:${uri.authority ? `\\\\${uri.authority}` : ''}${encodeURIComponent(uri.fsPath)}`
+        const url = `http://${this.extension.server.address}/viewer.html?incode=1&file=/pdf:${uri.authority ? `\\\\${uri.authority}` : ''}${encodeURIComponent(encodeURIComponent(uri.fsPath))}`
         return `
             <!DOCTYPE html><html><head></head>
             <body><iframe id="preview-panel" class="preview-panel" src="${url}" style="position:absolute; border: none; left: 0; top: 0; width: 100%; height: 100%;">
@@ -145,7 +145,8 @@ export class Viewer {
         let client: Client | undefined
         switch (data.type) {
             case 'open':
-                client = this.clients[decodeURIComponent(data.path).toLocaleUpperCase()]
+                console.log(decodeURIComponent(decodeURIComponent(data.path)))
+                client = this.clients[decodeURIComponent(decodeURIComponent(data.path)).toLocaleUpperCase()]
                 if (client !== undefined) {
                     client.websocket = websocket
                     if (client.type === undefined && client.prevType !== undefined) {
@@ -172,7 +173,8 @@ export class Viewer {
                 }
                 break
             case 'loaded':
-                client = this.clients[decodeURIComponent(data.path).toLocaleUpperCase()]
+            console.log(decodeURIComponent(decodeURIComponent(data.path)))
+                client = this.clients[decodeURIComponent(decodeURIComponent(data.path)).toLocaleUpperCase()]
                 if (client !== undefined && client.websocket !== undefined) {
                     const configuration = vscode.workspace.getConfiguration('latex-workshop')
                     if (client.position !== undefined) {

--- a/src/components/viewer.ts
+++ b/src/components/viewer.ts
@@ -52,6 +52,9 @@ export class Viewer {
             this.extension.logger.addLogMessage(`Cannot establish server connection.`)
             return
         }
+        // vscode.URI.parse and pdfjs viewer automatically call decodeURIComponent.
+        // So, to pass the encoded path of a pdf file to the http server,
+        // we have to call encodeURIComponent three times! 3 - 2 = 1 !
         const url = `http://${this.extension.server.address}/viewer.html?file=/pdf:${encodeURIComponent(encodeURIComponent(encodeURIComponent(pdfFile)))}`
         this.extension.logger.addLogMessage(`Serving PDF file at ${url}`)
         return url
@@ -105,6 +108,9 @@ export class Viewer {
     }
 
     getPDFViewerContent(uri: vscode.Uri) : string {
+        // pdfjs viewer automatically call decodeURIComponent.
+        // So, to pass the encoded path of a pdf file to the http server,
+        // we have to call encodeURIComponent two times! 2 - 1 = 1 !
         const url = `http://${this.extension.server.address}/viewer.html?incode=1&file=/pdf:${uri.authority ? `\\\\${uri.authority}` : ''}${encodeURIComponent(encodeURIComponent(uri.fsPath))}`
         return `
             <!DOCTYPE html><html><head></head>
@@ -145,7 +151,6 @@ export class Viewer {
         let client: Client | undefined
         switch (data.type) {
             case 'open':
-                console.log(decodeURIComponent(decodeURIComponent(data.path)))
                 client = this.clients[decodeURIComponent(decodeURIComponent(data.path)).toLocaleUpperCase()]
                 if (client !== undefined) {
                     client.websocket = websocket
@@ -173,7 +178,6 @@ export class Viewer {
                 }
                 break
             case 'loaded':
-            console.log(decodeURIComponent(decodeURIComponent(data.path)))
                 client = this.clients[decodeURIComponent(decodeURIComponent(data.path)).toLocaleUpperCase()]
                 if (client !== undefined && client.websocket !== undefined) {
                     const configuration = vscode.workspace.getConfiguration('latex-workshop')

--- a/viewer/latexworkshop.js
+++ b/viewer/latexworkshop.js
@@ -12,7 +12,7 @@ for (let i = 0, ii = parts.length; i < ii; ++i) {
     let param = parts[i].split('=')
     if (param[0].toLowerCase() === 'file') {
         file = param[1].replace('/pdf:', '')
-        document.title = decodeURIComponent(file).split(/[\\/]/).pop()
+        document.title = decodeURIComponent(decodeURIComponent(file)).split(/[\\/]/).pop()
     } else if (param[0].toLowerCase() === 'incode' && param[1] === '1') {
         const dom = document.getElementsByClassName('print')
         for (let j = 0; j < dom.length; ++j) {


### PR DESCRIPTION
This is a patch to fix an issue reported in #941.  PDF viewer doesn't display a pdf file in a dir with the name including `#`. 

vscode.URI.parse and pdfjs viewer automatically call decodeURIComponent. So, to pass the encoded path of a pdf file to the http server, we have to encodeURIComponent three times. 😫