### PR TITLE
Fix trim mode when refresh

### DIFF
--- a/viewer/latexworkshop.js
+++ b/viewer/latexworkshop.js
@@ -220,7 +220,9 @@ const trimPage = (page) => {
   const canvasWrapper = page.getElementsByClassName("canvasWrapper")[0];
   const canvas = page.getElementsByTagName("canvas")[0];
   if ( !canvasWrapper || !canvas ) {
-    page.style.width = "250px";
+    if (page.style.width !== "250px") {
+      page.style.width = "250px";
+    }
     return;
   }
   const w = canvas.style.width;
@@ -274,6 +276,9 @@ window.addEventListener("pagerendered", () => {
   })
   const viewer = document.getElementById("viewer");
   for( let page of viewer.getElementsByClassName("page") ){
-    observer.observe(page, {attributes: true, childList: true});
+    if (!page.isObserved) {
+      observer.observe(page, {attributes: true, childList: true, attributeFilter: ['style']});
+      page.isObserved = true;
+    }
   }
-}, {once: true});
+});

--- a/viewer/latexworkshop.js
+++ b/viewer/latexworkshop.js
@@ -286,5 +286,7 @@ const setObserverToTrim = () => {
   }
 }
 
+// Set observers after a pdf file is loaded in the first time.
 window.addEventListener('pagerendered', setObserverToTrim, {once: true});
+// Set observers each time a pdf file is refresed.
 window.addEventListener('refreshed', setObserverToTrim);


### PR DESCRIPTION
This is a patch to fix trim mode of pdf viewer.

After a pdf file is refreshed, we have to set observers again for `div.page,` HTML elements newly created. Otherwise, an unnecessary horizontal scroll bar appears.