### PR TITLE
Update unimathsymbols.py for consistently capitalized sentences

### DIFF
--- a/dev/unimathsymbols.py
+++ b/dev/unimathsymbols.py
@@ -21,7 +21,7 @@ with open('unimathsymbols.txt', encoding='utf-8') as f:
         data[segments[3]] = {
             'command': segments[3],
             'detail': segments[1],
-            'documentation': segments[7].strip()
+            'documentation': segments[7].strip().capitalize()
         }
         if segments[6] is not '' and segments[6][0] is not '-':
             data[segments[3]]['detail'] += ' ("{}" command)'.format(segments[6])


### PR DESCRIPTION
Enables transition from
```
  "enclosecircle": {
    "command": "enclosecircle",
    "detail": "x⃝",
    "documentation": "COMBINING ENCLOSING CIRCLE"
  },
  "enclosediamond": {
    "command": "enclosediamond",
    "detail": "x⃟",
    "documentation": "COMBINING ENCLOSING DIAMOND"
  },
  "enclosesquare": {
    "command": "enclosesquare",
    "detail": "x⃞",
    "documentation": "COMBINING ENCLOSING SQUARE" 
}
```

to
```
  "enclosecircle": {
    "command": "enclosecircle",
    "detail": "x⃝",
    "documentation": "Combining enclosing circle"
  },
  "enclosediamond": {
    "command": "enclosediamond",
    "detail": "x⃟",
    "documentation": "Combining enclosing diamond"
  },
  "enclosesquare": {
    "command": "enclosesquare",
    "detail": "x⃞",
    "documentation": "Combining enclosing square" <--–normalized
  }
```


