### PR TITLE
Formatter is not respecting tab and space settings due to wrong option

### DIFF
--- a/package.json
+++ b/package.json
@@ -848,7 +848,7 @@
             "-c",
             "%DIR%/",
             "%TMPFILE%",
-            "-y=\"defaultIndent: '%INDENT%'\""
+            "-y=defaultIndent: '%INDENT%'"
           ],
           "markdownDescription": "Define the command line arguments for latexindent. Available placeholders:\n- %DOC%, %DOCFILE%, %DIR%: same as latex-workshop.latex.toolchain args.\n- %TMPFILE%: would be replaced with the path of file which contains raw TeX source to be formatted. At this moment you need to use it as an input file of `latexindent`.\n- %INDENT%: would be replaced with the string which represents indent of the target document.\n\nNote: At this moment -c option requires trailing slash."
         },

--- a/src/providers/latexformatter.ts
+++ b/src/providers/latexformatter.ts
@@ -57,7 +57,7 @@ export class LaTexFormatter {
                 }
             }
             this.formatterArgs = configuration.get<string[]>('latexindent.args')
-                || ['-c', '%DIR%/', '%TMPFILE%', '-y="defaultIndent: \'%INDENT%\'"']
+                || ['-c', '%DIR%/', '%TMPFILE%', '-y=defaultIndent: \'%INDENT%\'']
             const pathMeta = configuration.inspect('latexindent.path')
 
             if (pathMeta && pathMeta.defaultValue && pathMeta.defaultValue !== this.formatter) {


### PR DESCRIPTION
The formatter is still not respecting vscode's tab and space settings, despite it should have been fixed as in #366.

After digging, I found that the default formatting arguments for `latexindent` are 
```
['-c', '%DIR%/', '%TMPFILE%', '-y="defaultIndent: \'%INDENT%\'"']
```
However the double quotes in the last argument are preventing this option from working. Double quotes are only necessary when used in shell to indicate that the argument should not be separated by the space inside it, and are removed by shell when arguments are passed to process.

In this case the arguments are directly passed to process instead of through a shell, so double quotes will not be removed. I guess `latexindent` will get an option with key `"defaultIndent` and value `'%INDENT%'"`, and take it as an illegal argument. So I removed double quotes in the last argument. 
```
['-c', '%DIR%/', '%TMPFILE%', '-y=defaultIndent: \'%INDENT%\'']
```
The formatter is now working correctly. 

