### PR TITLE
update @types/node to 8.9.1 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1007,7 +1007,7 @@
     "@types/fs-extra": "^5.0.0",
     "@types/glob": "^5.0.30",
     "@types/micromatch": "^3.0.0",
-    "@types/node": "^7.0.59",
+    "@types/node": "^8.9.1",
     "@types/tmp": "^0.0.33",
     "@types/ws": "^4.0.2",
     "ts-loader": "^5.2.1",

--- a/src/providers/latexformatter.ts
+++ b/src/providers/latexformatter.ts
@@ -161,7 +161,7 @@ export class LaTexFormatter {
                 if (stdout !== '') {
                     const edit = [vscode.TextEdit.replace(range ? range : fullRange(document), stdout)]
                     try {
-                        fs.unlink(temporaryFile)
+                        fs.unlinkSync(temporaryFile)
                         fs.unlinkSync(documentDirectory + path.sep + 'indent.log')
                     } catch (ignored) {
                     }


### PR DESCRIPTION
Now, VSCode ships with Electron with node 8.x. [link](https://github.com/Microsoft/vscode/blob/master/package.json#L66). We should use an appropriate version.