### PR TITLE
Fix sorting completionItems of commands

### DIFF
--- a/src/providers/completer/command.ts
+++ b/src/providers/completer/command.ts
@@ -159,17 +159,9 @@ export class Command {
         }
         command.documentation = item.documentation
         command.detail = item.detail
-        command.sortText = item.command.replace(/[a-zA-Z]/g, c => {
-            let n: number | undefined
-            if (c.match(/[a-z]/)) {
-                n = c.toUpperCase().codePointAt(0)
-            } else {
-                n = c.toLowerCase().codePointAt(0)
-            }
-            if (n !== undefined) {
-                return n < 100 ? '0' + n.toString() : n.toString()
-            }
-            return c
+        command.sortText = item.command.replace(/^[a-zA-Z]/, c => {
+            const n = c.match(/[a-z]/) ? c.toUpperCase().charCodeAt(0) : c.toLowerCase().charCodeAt(0)
+            return n !== undefined ? n.toString(16) : c
         })
         if (item.postAction) {
             command.command = { title: 'Post-Action', command: item.postAction }

--- a/src/providers/completer/command.ts
+++ b/src/providers/completer/command.ts
@@ -159,7 +159,18 @@ export class Command {
         }
         command.documentation = item.documentation
         command.detail = item.detail
-        command.sortText = item.command.toLowerCase()
+        command.sortText = item.command.replace(/[a-zA-Z]/g, c => {
+            let n: number | undefined
+            if (c.match(/[a-z]/)) {
+                n = c.toUpperCase().codePointAt(0)
+            } else {
+                n = c.toLowerCase().codePointAt(0)
+            }
+            if (n !== undefined) {
+                return n < 100 ? '0' + n.toString() : n.toString()
+            }
+            return c
+        })
         if (item.postAction) {
             command.command = { title: 'Post-Action', command: item.postAction }
         } else if (/[a-zA-Z]*([Cc]ite|ref)[a-zA-Z]*/.exec(item.command)) {


### PR DESCRIPTION
This is a patch to fix sorting completionItems of commands as discussed in [#992](https://github.com/James-Yu/LaTeX-Workshop/pull/992#issuecomment-439787992). Although VS Code converts `item.sortText` to lower-case letters when comparing completionItems, by converting `item.sortText` to hex, we can sort items as we like. 

In this patch, only the first letter is converted.

![2018-12-01 20 54 42](https://user-images.githubusercontent.com/10665499/49327979-014fff00-f5ac-11e8-85ad-71e02a67013d.png)
