### PR TITLE
Fix the completion of refs.

### DIFF
--- a/src/providers/completer/input.ts
+++ b/src/providers/completer/input.ts
@@ -16,7 +16,7 @@ export class Input {
         this.extension = extension
     }
 
-    provide(payload) : vscode.CompletionItem[] {
+    provide(payload: string[]) : vscode.CompletionItem[] {
         const mode = payload[0]
         const currentFile = payload[1]
         const typedFolder = payload[2]

--- a/src/providers/completer/reference.ts
+++ b/src/providers/completer/reference.ts
@@ -13,7 +13,7 @@ export class Reference {
         this.extension = extension
     }
 
-    provide() : vscode.CompletionItem[] {
+    provide(args: {document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken, context: vscode.CompletionContext}) : vscode.CompletionItem[] {
         if (Date.now() - this.refreshTimer < 1000) {
             return this.suggestions
         }
@@ -35,6 +35,7 @@ export class Reference {
             const item = suggestions[key]
             const command = new vscode.CompletionItem(item.reference, vscode.CompletionItemKind.Reference)
             command.documentation = item.text
+            command.range = args.document.getWordRangeAtPosition(args.position, /[a-zA-Z0-9_:]/)
             this.suggestions.push(command)
         })
         return this.suggestions

--- a/src/providers/completer/reference.ts
+++ b/src/providers/completer/reference.ts
@@ -35,7 +35,7 @@ export class Reference {
             const item = suggestions[key]
             const command = new vscode.CompletionItem(item.reference, vscode.CompletionItemKind.Reference)
             command.documentation = item.text
-            command.range = args.document.getWordRangeAtPosition(args.position, /[a-zA-Z0-9_:]/)
+            command.range = args.document.getWordRangeAtPosition(args.position, /[-a-zA-Z0-9_:\.]+/)
             this.suggestions.push(command)
         })
         return this.suggestions

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -8,7 +8,6 @@ import {Environment} from './completer/environment'
 import {Reference} from './completer/reference'
 import {Package} from './completer/package'
 import {Input} from './completer/input'
-import { posix } from 'path';
 
 export class Completer implements vscode.CompletionItemProvider {
     extension: Extension
@@ -98,32 +97,32 @@ export class Completer implements vscode.CompletionItemProvider {
         if (type === 'citation') {
             const reg = /(?:\\[a-zA-Z]*[Cc]ite[a-zA-Z]*\*?(?:\[[^\[\]]*\])*){([^}]*)$/
             const result = line.match(reg)
-            return result ? this.citation.provide() : []
+            return result !== null ? this.citation.provide() : []
         }
         if (type === 'reference') {
             const reg = /(?:\\hyperref\[([^\]]*)(?!\])$)|(?:(?:\\(?!hyper)[a-zA-Z]*ref[a-zA-Z]*\*?(?:\[[^\[\]]*\])?){([^}]*)$)/
             const result = line.match(reg)
-            return result ? this.reference.provide(args) : []
+            return result !== null ? this.reference.provide(args) : []
         }
         if (type === 'environment') {
             const reg = /(?:\\begin(?:\[[^\[\]]*\])?){([^}]*)$/
             const result = line.match(reg)
-            return result ? this.environment.provide() : []
+            return result !== null ? this.environment.provide() : []
         }
         if (type === 'command') {
             const reg = /\\([a-zA-Z]*)$/
             const result = line.match(reg)
-            return result ? this.command.provide() : []
+            return result !== null ? this.command.provide() : []
         }
         if (type === 'package') {
             const reg = /(?:\\usepackage(?:\[[^\[\]]*\])*){([^}]*)$/
             const result = line.match(reg)
-            return result ? this.package.provide() : []
+            return result !== null ? this.package.provide() : []
         }
         if (type === 'input') {
             const reg = /(?:\\(input|include|subfile|includegraphics)(?:\[[^\[\]]*\])*){([^}]*)$/
             const result = line.match(reg)
-            if (result) {
+            if (result !== null) {
                 const editor = vscode.window.activeTextEditor
                 if (editor) {
                     const payload = [result[1], editor.document.fileName, result[2]]


### PR DESCRIPTION
This is a patch to solve issues on the completion of refs reported in #121 and #661.  Now the completion works well even if labels include `:`, `-`, `.`, and `_`. To pass arguments to Reference.provide, we have to rewrite Completer.completion.

---

Before.
![dec-02-2018 11-21-35](https://user-images.githubusercontent.com/10665499/49334911-a1496f00-f624-11e8-9f9f-e392e2e77fd3.gif)

---

After.
![dec-02-2018 11-12-48](https://user-images.githubusercontent.com/10665499/49334853-5aa74500-f623-11e8-9fa4-fb1ec996a43a.gif)
