### PR TITLE
add: reveal output folder in OS; auto-remove %TMPDIR% even if not empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,12 +145,12 @@ When building the project, the first recipe is used. You can compile with anothe
 ```
 As you may notice, there is a mystic `%DOC%` in the arguments. Symbols surrounded by `%` are placeholders, which are replaced with its representing string on-the-fly. LaTeX Workshop registers the following placeholders:
 
-| Placeholder | Replaced by                                                |
-| ----------- | ---------------------------------------------------------- |
-| `%DOC%`     | The LaTeX root file path and name without `.tex` extension |
-| `%DOCFILE%` | The LaTeX root file name without `.tex` extension          |
-| `%DIR%`     | The LaTeX root file path                                   |
-| `%TMPDIR%`  | A temporary folder for storing ancillary files             |
+| Placeholder | Replaced by                                                                         |
+| ----------- | ----------------------------------------------------------------------------------- |
+| `%DOC%`     | The LaTeX root file path and name without `.tex` extension                          |
+| `%DOCFILE%` | The LaTeX root file name without `.tex` extension                                   |
+| `%DIR%`     | The LaTeX root file path                                                            |
+| `%TMPDIR%`  | A temporary folder for storing ancillary files, and will be auto-removed when exit. |
 
 Alternatively, you can also set your commands without the placeholder, just like what you may input in a terminal.
 As most LaTeX compiler accepts root file name without extension, `%DOC%` and `%DOCFILE%` do not include `.tex` extension. Meanwhile, `texify` requires the extension. So in the above tool `%DOC%` and `.tex` are concatenated for completeness.

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode'
 import * as fs from 'fs-extra'
+import * as path from 'path'
 
 import {Extension} from './main'
 import {getLongestBalancedString} from './providers/structure'
@@ -73,6 +74,15 @@ export class Commander {
                 this.extension.builder.build(rootFile, recipe)
             }
         }
+    }
+
+    async revealOutputDir() {
+        var outputDir = this.extension.manager.getOutputDir(this.extension.manager.rootFile)
+        if (!path.isAbsolute(outputDir)) {
+            outputDir = path.join(this.extension.manager.rootDir, this.extension.manager.getOutputDir(this.extension.manager.rootFile))
+        }
+        this.extension.logger.addLogMessage(`Reveal ${vscode.Uri.file(outputDir)}`)
+        await vscode.commands.executeCommand('revealFileInOS', vscode.Uri.file(outputDir))
     }
 
     recipes(recipe?: string) {

--- a/src/components/builder.ts
+++ b/src/components/builder.ts
@@ -18,7 +18,7 @@ export class Builder {
 
     constructor(extension: Extension) {
         this.extension = extension
-        this.tmpDir = tmp.dirSync().name.split(path.sep).join('/')
+        this.tmpDir = tmp.dirSync({unsafeCleanup: true}).name.split(path.sep).join('/')
     }
 
     kill() {

--- a/src/components/commander.ts
+++ b/src/components/commander.ts
@@ -50,6 +50,7 @@ export class LaTeXCommander implements vscode.TreeDataProvider<LaTeXCommand> {
         this.commands.push(miscCommand)
         miscCommand.children.push(new LaTeXCommand('Open citation browser', vscode.TreeItemCollapsibleState.None, {command: 'latex-workshop.citation', title: ''}))
         miscCommand.children.push(new LaTeXCommand('Count words in LaTeX project', vscode.TreeItemCollapsibleState.None, {command: 'latex-workshop.wordcount', title: ''}))
+        miscCommand.children.push(new LaTeXCommand('Reveal output folder in OS', vscode.TreeItemCollapsibleState.None, {command: 'latex-workshop.revealOutputDir', title: ''}))
     }
 
     getTreeItem(element: LaTeXCommand) : vscode.TreeItem {

--- a/src/main.ts
+++ b/src/main.ts
@@ -130,6 +130,7 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('latex-workshop.wrap-env', () => extension.commander.insertSnippet('wrapEnv'))
     vscode.commands.registerCommand('latex-workshop.onEnterKey', () => extension.commander.onEnterKey())
     vscode.commands.registerCommand('latex-workshop.onAltEnterKey', () => extension.commander.onEnterKey('alt'))
+    vscode.commands.registerCommand('latex-workshop.revealOutputDir', () => extension.commander.revealOutputDir())
     vscode.commands.registerCommand('latex-workshop-dev.parselog', () => extension.commander.devParseLog())
 
     vscode.commands.registerCommand('latex-workshop.shortcut.item', () => extension.commander.insertSnippet('item'))


### PR DESCRIPTION
Add a shortcut to reveal the output folder in OS. Using vscode command `revealFileInOS`.