### PR TITLE
Non-breaking space in components/cleaner.ts.

### DIFF
--- a/src/components/cleaner.ts
+++ b/src/components/cleaner.ts
@@ -58,7 +58,7 @@ export class Cleaner {
             glob(pattern, options, (err, files) => {
                 if (err) {
                     reject(err)
-                } else {
+                } else {
                     resolve(files)
                 }
             })


### PR DESCRIPTION
[Non-breaking space](https://en.wikipedia.org/wiki/Non-breaking_space#Encodings), 0xc2 0xa0, is used in components/cleaner.ts. We should replace it with a whitespace, 0x20.

![2018-12-04 14 10 37](https://user-images.githubusercontent.com/10665499/49420514-2a040e80-f7cf-11e8-89ac-5e2e41fc2596.png)

Before.
![2018-12-04 14 11 46](https://user-images.githubusercontent.com/10665499/49420645-d8a84f00-f7cf-11e8-93d1-627edeb0ca4d.png)

After.
![2018-12-04 14 13 22](https://user-images.githubusercontent.com/10665499/49420687-07262a00-f7d0-11e8-89f2-83c937e2ca80.png)

