### PR TITLE
Support math preview on \ref with multiple input files.

### DIFF
--- a/src/components/textdocumentlike.ts
+++ b/src/components/textdocumentlike.ts
@@ -9,9 +9,10 @@ export class TextDocumentLike {
     private _eol: string
 
     static load(filePath: string) : TextDocumentLike | vscode.TextDocument {
-        const uri = vscode.Uri.parse(filePath)
-        if (vscode.workspace.name === undefined) {
-            return new TextDocumentLike(fs.readFileSync(filePath).toString())
+        const uri = vscode.Uri.file(filePath)
+        const editor = vscode.window.activeTextEditor
+        if (editor !== undefined && editor.document.uri.fsPath === uri.fsPath) {
+            return editor.document
         }
         for ( const doc of vscode.workspace.textDocuments ) {
             if (doc.uri.fsPath === uri.fsPath) {

--- a/src/components/textdocumentlike.ts
+++ b/src/components/textdocumentlike.ts
@@ -1,0 +1,60 @@
+import * as vscode from 'vscode'
+
+class TextDocumentLike {
+    private _lines: string[]
+    readonly lineCount: number
+    readonly eol: vscode.EndOfLine
+
+    constructor(s: string) {
+        let eol: string
+        if (s.match(/\r\n/)) {
+            this.eol = vscode.EndOfLine.CRLF
+            eol = '\r\n'
+        } else {
+            this.eol = vscode.EndOfLine.LF
+            eol = '\n'
+        }
+        this._lines = s.split(eol)
+        this.lineCount = this._lines.length
+    }
+
+    getText(range: vscode.Range) : string {
+        let ret = ''
+        let line
+        const startLineNum = range.start.line
+        const endLineNum = range.end.line
+        if (this.lineCount <= startLineNum) {
+            return ''
+        }
+        if (startLineNum == endLineNum) {
+            line = this._lines[startLineNum]
+            return line.slice(range.start.character, range.end.character)
+        }
+        line = this._lines[startLineNum]
+        ret += line.slice(range.start.character)
+        for (let i = startLineNum + 1; i < endLineNum; i++) {
+            ret += this._lines[i]
+        }
+        ret += this._lines[endLineNum].slice(0, range.end.character)
+        return ret
+    }
+
+    getWordRangeAtPosition(position: vscode.Position, regex = /(-?\d.\d\w)|([^`~!\@@#\%\^\&*()-\=+[{]}\|\;\:\'\"\,.\<>\/\?\s]+)/g): vscode.Range | undefined {
+        if (position.line > this.lineCount) {
+            return undefined
+        }
+        const line = this._lines[position.line]
+        for (let i = position.character; i >= 0; i--) {
+            const tmp = line.slice(i)
+            const m = tmp.match(regex)
+            if (m !== null) {
+                return new vscode.Range(position.line, i, position.line, i + m[0].length)
+            }
+        }
+        return undefined
+    }
+
+    lineAt(lineNum: number) : string {
+        return this._lines[lineNum]
+    }
+}

--- a/src/components/textdocumentlike.ts
+++ b/src/components/textdocumentlike.ts
@@ -26,7 +26,7 @@ class TextDocumentLike {
         if (this.lineCount <= startLineNum) {
             return ''
         }
-        if (startLineNum == endLineNum) {
+        if (startLineNum === endLineNum) {
             line = this._lines[startLineNum]
             return line.slice(range.start.character, range.end.character)
         }
@@ -39,7 +39,7 @@ class TextDocumentLike {
         return ret
     }
 
-    getWordRangeAtPosition(position: vscode.Position, regex = /(-?\d.\d\w)|([^`~!\@@#\%\^\&*()-\=+[{]}\|\;\:\'\"\,.\<>\/\?\s]+)/g): vscode.Range | undefined {
+    getWordRangeAtPosition(position: vscode.Position, regex = /(-?\d.\d\w)|([^`~!\@@#\%\^\&*()-\=+[{]}\|\;\:\'\"\,.\<>\/\?\s]+)/g) : vscode.Range | undefined {
         if (position.line > this.lineCount) {
             return undefined
         }

--- a/src/providers/completer/reference.ts
+++ b/src/providers/completer/reference.ts
@@ -3,10 +3,20 @@ import * as fs from 'fs'
 
 import {Extension} from '../../main'
 
+export type ReferenceEntry = {
+    item: {
+        reference: string,
+        text: string,
+        position: vscode.Position
+    },
+    text: string,
+    file: string
+}
+
 export class Reference {
     extension: Extension
     suggestions: vscode.CompletionItem[]
-    referenceData: {[id: string]: {item: {reference: string, text: string, position: vscode.Position}, text: string, file: string}} = {}
+    referenceData: {[id: string]: ReferenceEntry} = {}
     refreshTimer: number
 
     constructor(extension: Extension) {
@@ -18,7 +28,7 @@ export class Reference {
             return this.suggestions
         }
         this.refreshTimer = Date.now()
-        const suggestions = {}
+        const suggestions: {[key: string]: ReferenceEntry['item']} = {}
         Object.keys(this.referenceData).forEach(key => {
             suggestions[key] = this.referenceData[key].item
         })
@@ -59,7 +69,7 @@ export class Reference {
 
     getReferenceItems(content: string) {
         const itemReg = /^(?:(?!%).*\\label(?:\[[^\[\]\{\}]*\])?|label=){([^}]*)}/gm
-        const items = {}
+        const items: {[key: string]: ReferenceEntry['item']} = {}
         const noELContent = content.split('\n').filter(para => para !== '').join('\n')
         while (true) {
             const result = itemReg.exec(content)

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -5,6 +5,7 @@ import * as stripJsonComments from 'strip-json-comments'
 import * as envpair from '../components/envpair'
 import {Extension} from '../main'
 import {tokenizer, onAPackage} from './tokenizer'
+import {ReferenceEntry} from './completer/reference'
 
 type TexMathEnv = { texString: string, range: vscode.Range, envname: string }
 type LabelsStore = {labels: {[k: string]: {tag: string, id: string}}, IDs: {[k: string]: number}, startNumber: number}
@@ -177,7 +178,7 @@ export class HoverProvider implements vscode.HoverProvider {
         return new vscode.Hover(new vscode.MarkdownString( `![equation](${md})`), tex.range )
     }
 
-    private async provideHoverOnRef(tex: TexMathEnv, refToken: string, refData: any) : Promise<vscode.Hover> {
+    private async provideHoverOnRef(tex: TexMathEnv, refToken: string, refData: ReferenceEntry) : Promise<vscode.Hover> {
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         const scale = configuration.get('hoverPreview.scale') as number
         const s = this.mathjaxify(tex.texString, tex.envname, {stripLabel: false})

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs-extra'
 import * as path from 'path'
 import * as stripJsonComments from 'strip-json-comments'
 import * as envpair from '../components/envpair'
+import {TextDocumentLike} from '../components/textdocumentlike'
 import {Extension} from '../main'
 import {tokenizer, onAPackage} from './tokenizer'
 import {ReferenceEntry} from './completer/reference'
@@ -78,7 +79,7 @@ export class HoverProvider implements vscode.HoverProvider {
                 const mdLink = new vscode.MarkdownString(`[View on pdf](command:latex-workshop.synctexto?${line})`)
                 mdLink.isTrusted = true
                 if (configuration.get('hoverPreview.ref.enabled') as boolean) {
-                    const tex = this.findHoverOnRef(document, position, token, refData.item.position)
+                    const tex = this.findHoverOnRef(document, position, token, refData)
                     if (tex) {
                         const newCommand = this.findNewCommand(document.getText())
                         tex.texString = newCommand + tex.texString
@@ -381,7 +382,7 @@ export class HoverProvider implements vscode.HoverProvider {
         return s
     }
 
-    private findHoverOnTex(document: vscode.TextDocument, position: vscode.Position) : TexMathEnv | undefined {
+    private findHoverOnTex(document: vscode.TextDocument | TextDocumentLike, position: vscode.Position) : TexMathEnv | undefined {
         const envBeginPat = /\\begin\{(align|align\*|alignat|alignat\*|aligned|alignedat|array|Bmatrix|bmatrix|cases|CD|eqnarray|eqnarray\*|equation|equation\*|gather|gather\*|gathered|matrix|multline|multline\*|pmatrix|smallmatrix|split|subarray|Vmatrix|vmatrix)\}/
         let r = document.getWordRangeAtPosition(position, envBeginPat)
         if (r) {
@@ -397,17 +398,18 @@ export class HoverProvider implements vscode.HoverProvider {
         return this.findHoverOnInline(document, position)
     }
 
-    private findHoverOnRef(document: vscode.TextDocument, position: vscode.Position, token: string, labelPos0: vscode.Position)
+    private findHoverOnRef(document: vscode.TextDocument, position: vscode.Position, token: string, refData: ReferenceEntry)
     : TexMathEnv | undefined {
+        const docOfRef = TextDocumentLike.load(refData.file)
         const envBeginPatMathMode = /\\begin\{(align|align\*|alignat|alignat\*|eqnarray|eqnarray\*|equation|equation\*|gather|gather\*)\}/
-        const l = document.lineAt(labelPos0.line).text
+        const l = docOfRef.lineAt(refData.item.position.line).text
         const pat = new RegExp('\\\\label\\{' + envpair.escapeRegExp(token) + '\\}')
         const m  = l.match(pat)
         if (m && m.index !== undefined) {
-            const labelPos = new vscode.Position(labelPos0.line, m.index)
-            const beginPos = this.findBeginPair(document, envBeginPatMathMode, labelPos)
+            const labelPos = new vscode.Position(refData.item.position.line, m.index)
+            const beginPos = this.findBeginPair(docOfRef, envBeginPatMathMode, labelPos)
             if (beginPos) {
-                const t = this.findHoverOnTex(document, beginPos)
+                const t = this.findHoverOnTex(docOfRef, beginPos)
                 if (t) {
                     const beginEndRange = t.range
                     const refRange = document.getWordRangeAtPosition(position, /\{.*?\}/)
@@ -436,7 +438,7 @@ export class HoverProvider implements vscode.HoverProvider {
     //  \begin{...}                \end{...}
     //             ^
     //             startPos1
-    private findEndPair(document: vscode.TextDocument, endPat: RegExp, startPos1: vscode.Position) : vscode.Position | undefined {
+    private findEndPair(document: vscode.TextDocument | TextDocumentLike, endPat: RegExp, startPos1: vscode.Position) : vscode.Position | undefined {
         const currentLine = document.lineAt(startPos1).text.substring(startPos1.character)
         const l = this.removeComment(currentLine)
         let m = l.match(endPat)
@@ -458,7 +460,7 @@ export class HoverProvider implements vscode.HoverProvider {
     //  \begin{...}                \end{...}
     //  ^                          ^
     //  return pos                 endPos1
-    private findBeginPair(document: vscode.TextDocument, beginPat: RegExp, endPos1: vscode.Position, limit= 20) : vscode.Position | undefined {
+    private findBeginPair(document: vscode.TextDocument | TextDocumentLike, beginPat: RegExp, endPos1: vscode.Position, limit= 20) : vscode.Position | undefined {
         const currentLine = document.lineAt(endPos1).text.substr(0, endPos1.character)
         let l = this.removeComment(currentLine)
         let m  = l.match(beginPat)
@@ -483,7 +485,7 @@ export class HoverProvider implements vscode.HoverProvider {
     //  \begin{...}                \end{...}
     //  ^
     //  startPos
-    private findHoverOnEnv(document: vscode.TextDocument, envname: string, startPos: vscode.Position) : TexMathEnv | undefined {
+    private findHoverOnEnv(document: vscode.TextDocument | TextDocumentLike, envname: string, startPos: vscode.Position) : TexMathEnv | undefined {
         const pattern = new RegExp('\\\\end\\{' + envpair.escapeRegExp(envname) + '\\}')
         const startPos1 = new vscode.Position(startPos.line, startPos.character + envname.length + '\\begin{}'.length)
         const endPos = this.findEndPair(document, pattern, startPos1)
@@ -497,7 +499,7 @@ export class HoverProvider implements vscode.HoverProvider {
     //  \[                \]
     //  ^
     //  startPos
-    private findHoverOnParen(document: vscode.TextDocument, envname: string, startPos: vscode.Position) : TexMathEnv | undefined {
+    private findHoverOnParen(document: vscode.TextDocument | TextDocumentLike, envname: string, startPos: vscode.Position) : TexMathEnv | undefined {
         const pattern = envname === '\\[' ? /\\\]/ : /\\\)/
         const startPos1 = new vscode.Position(startPos.line, startPos.character + envname.length)
         const endPos = this.findEndPair(document, pattern, startPos1)
@@ -508,7 +510,7 @@ export class HoverProvider implements vscode.HoverProvider {
         return undefined
     }
 
-    private findHoverOnInline(document: vscode.TextDocument, position: vscode.Position) : TexMathEnv | undefined {
+    private findHoverOnInline(document: vscode.TextDocument | TextDocumentLike, position: vscode.Position) : TexMathEnv | undefined {
         const currentLine = document.lineAt(position.line).text
         let s = currentLine
         let base = 0


### PR DESCRIPTION
This is a patch to support math preview on \ref with multiple input files. To emulate the API of vscode.TextDocument, we introduce class TextDocumentLike. When a document in which the text referred by `\ref` exists is not opened, we load the document and treat it with the API of TextDocumentLike.