### PR TITLE
add a delay to open pdf files as a work-around.

### DIFF
--- a/src/components/viewer.ts
+++ b/src/components/viewer.ts
@@ -102,7 +102,8 @@ export class Viewer {
         })
         panel.webview.html = this.getPDFViewerContent(uri)
         if (editor) {
-            vscode.window.showTextDocument(editor.document, editor.viewColumn)
+            // We need a delay here. VS Code bug?
+            setTimeout( () => { vscode.window.showTextDocument(editor.document, editor.viewColumn) }, 1000)
         }
         this.extension.logger.addLogMessage(`Open PDF tab for ${pdfFile}`)
     }


### PR DESCRIPTION
This is a patch to solve #1050. @jerlich,  @jlelong, please try.