### PR TITLE
add selinux label for docker volume mounts

### DIFF
--- a/scripts/latexindent
+++ b/scripts/latexindent
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker run -i --rm -w "$(pwd)" -v "$(pwd):$(pwd)" $LATEXWORKSHOP_DOCKER_LATEX latexindent "$@"
+docker run -i --rm -w "$(pwd)" -v "$(pwd):$(pwd):Z" $LATEXWORKSHOP_DOCKER_LATEX latexindent "$@"

--- a/scripts/latexmk
+++ b/scripts/latexmk
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker run -i --rm -w "$(pwd)" -v "$(pwd):$(pwd)" $LATEXWORKSHOP_DOCKER_LATEX latexmk "$@"
+docker run -i --rm -w "$(pwd)" -v "$(pwd):$(pwd):Z" $LATEXWORKSHOP_DOCKER_LATEX latexmk "$@"

--- a/scripts/synctex
+++ b/scripts/synctex
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker run -i --rm -w "$(pwd)" -v "$(pwd):$(pwd)" $LATEXWORKSHOP_DOCKER_LATEX synctex "$@"
+docker run -i --rm -w "$(pwd)" -v "$(pwd):$(pwd):Z" $LATEXWORKSHOP_DOCKER_LATEX synctex "$@"

--- a/scripts/texcount
+++ b/scripts/texcount
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker run -i --rm -w "$(pwd)" -v "$(pwd):$(pwd)" $LATEXWORKSHOP_DOCKER_LATEX texcount "$@"
+docker run -i --rm -w "$(pwd)" -v "$(pwd):$(pwd):Z" $LATEXWORKSHOP_DOCKER_LATEX texcount "$@"


### PR DESCRIPTION
On Fedora the docker build scripts fail because of selinux. This PR adds the necessary selinux labels for the docker volume mounts.