### PR TITLE
Add first try for OS specific commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -654,10 +654,24 @@
         "latex-workshop.view.pdf.external.command": {
           "type": "object",
           "default": {
-            "command": "SumatraPDF.exe",
-            "args": [
-              "%PDF%"
-            ]
+            "windows": {
+              "command": "SumatraPDF.exe",
+              "args": [
+                "%PDF%"
+              ]
+            },
+            "linux": {
+              "command": "xdg-open",
+              "args": [
+                "%PDF%"
+              ]
+            },
+            "osx": {
+              "command": "open",
+              "args": [
+                "%PDF%"
+              ]
+            }
           },
           "markdownDescription": "The command to execute when using external viewer.\nThis function is not officially supported. %PDF% is the placeholder for the absolute path to the generated PDF file."
         },


### PR DESCRIPTION
See #1077.
Please check if that would work, since I do not know if "windows", "linux" and "osx" are valid in these cases here, I know you can use those labels for **tasks** in vscode but I do not know if you can use them in normal commands.


