### PR TITLE
Improve outdir handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ As you may notice, there is a mystic `%DOC%` in the arguments. Symbols surrounde
 | `%DOCFILE%` | The LaTeX root file name without `.tex` extension                                   |
 | `%DIR%`     | The LaTeX root file path                                                            |
 | `%TMPDIR%`  | A temporary folder for storing ancillary files, and will be auto-removed when exit. |
+| `%OUTDIR%`  | The output directory configured in `latex-workshop.latex.outputDir`                 |
 
 Alternatively, you can also set your commands without the placeholder, just like what you may input in a terminal.
 As most LaTeX compiler accepts root file name without extension, `%DOC%` and `%DOCFILE%` do not include `.tex` extension. Meanwhile, `texify` requires the extension. So in the above tool `%DOC%` and `.tex` are concatenated for completeness.

--- a/package.json
+++ b/package.json
@@ -503,6 +503,7 @@
                 "-interaction=nonstopmode",
                 "-file-line-error",
                 "-pdf",
+                "-outdir=%OUTDIR%",
                 "%DOC%"
               ]
             },
@@ -524,7 +525,7 @@
               ]
             }
           ],
-          "markdownDescription": "Define LaTeX compiling tools to be used in recipes.\nEach tool is labeled by its `name`. When invoked, `command` is spawned with arguments defined in `args`. Typically no spaces should appear in each argument unless in paths.\nPlaceholder `%DOC%`, `%DOCFILE`, `%DIR%`, and `%TMPDIR%` is available. For details, please visit https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#latex-recipe."
+          "markdownDescription": "Define LaTeX compiling tools to be used in recipes.\nEach tool is labeled by its `name`. When invoked, `command` is spawned with arguments defined in `args`. Typically no spaces should appear in each argument unless in paths.\nPlaceholders `%DOC%`, `%DOCFILE`, `%DIR%`, `%TMPDIR%` and `%OUTDIR%` are available. For details, please visit https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#latex-recipe."
         },
         "latex-workshop.latex.magic.args": {
           "type": "array",
@@ -546,7 +547,7 @@
         "latex-workshop.latex.outputDir": {
           "type": "string",
           "default": "./",
-          "markdownDescription": "The directory where the extension tries to find project files (e.g., PDF and SyncTeX files) are located.\nBoth relative and absolute paths are supported. Relative path start from the root file location, so beware if it is located in sub-directory.\nThe LaTeX toolchain should output files to this path."
+          "markdownDescription": "The directory where the extension tries to find project files (e.g., PDF and SyncTeX files) are located.\nBoth relative and absolute paths are supported. Relative path start from the root file location, so beware if it is located in sub-directory.\nThe LaTeX toolchain should output files to this path.\nPlaceholders `%DOC%`, `%DOCFILE`, `%DIR%` and `%TMPDIR%` are available."
         },
         "latex-workshop.latex.additionalBib": {
           "type": "array",

--- a/src/components/builder.ts
+++ b/src/components/builder.ts
@@ -244,7 +244,8 @@ export class Builder {
                 step.args = step.args.map(arg => arg.replace('%DOC%', docker ? docfile : doc)
                                                     .replace('%DOCFILE%', docfile)
                                                     .replace('%DIR%', path.dirname(rootFile).split(path.sep).join('/'))
-                                                    .replace('%TMPDIR%', this.tmpDir))
+                                                    .replace('%TMPDIR%', this.tmpDir)
+                                                    .replace('%OUTDIR%', this.extension.manager.getOutputDir(rootFile)))
             }
             if (configuration.get('latex.option.maxPrintLine.enabled') && process.platform === 'win32') {
                 if (!step.args) {


### PR DESCRIPTION
This PR improves the handling of output directories by making 3 changes:
- Documenting the availability of placeholders when setting `latex-workshop.latex.outputDir`
- Adding a %OUTDIR% placeholder for the toolchain steps
- Adding the `-outdir` option to the latexmk tool configuration so that output directories work out of the box if a user configures `latex-workshop.latex.outputDir`

I also considered adding `-output-directory` to the pdflatex tool configuration but since bibtex doesn't support it I did not make that change.