### PR TITLE
Clear text selection after inserting citation from browser

### DIFF
--- a/src/providers/completer/citation.ts
+++ b/src/providers/completer/citation.ts
@@ -145,6 +145,7 @@ export class Citation {
                     start = editor.document.positionAt(curlyStart > commaStart ? curlyStart : commaStart)
                 }
                 editor.edit(edit => edit.replace(new vscode.Range(start, editor.selection.start), selected.description || ''))
+                    .then(() => editor.selection = new vscode.Selection(editor.selection.end, editor.selection.end))
             }
         })
     }


### PR DESCRIPTION
I use a stripped down version of this package for inserting citations in markdown and noticed a difference between inline and browser citations.  

The inline citations work just like how I'd expect them to:
![inlinecite](https://user-images.githubusercontent.com/9019681/51078772-f8f9e200-1688-11e9-9ae8-25c53f38ec82.gif)
but the same steps using the browser result in:
![browsercite](https://user-images.githubusercontent.com/9019681/51078789-2fcff800-1689-11e9-81a8-afc98e19da6b.gif)

The difference is that the browser keeps the inserted text selected, so the next keystroke (a comma, in my case) erases it. Don't know if this difference was intended.
 
This PR clears the text selection from the browser, so it matches the inline behaviour. 