### PR TITLE
Combine config items

### DIFF
--- a/package.json
+++ b/package.json
@@ -569,15 +569,11 @@
           "default": [],
           "markdownDescription": "List of directories where to look for `.bib` files.\nAbsolute paths are required. This setting is only used by the intellisense feature, you may also need to set the environment variable `BIBINPUTS` properly for the LaTeX compiler to find the `.bib` files."
         },
-        "latex-workshop.latex.autoBuild.onSave.enabled": {
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Build LaTeX after saving LaTeX source file.\nThis property defines whether LaTeX Workshop will execute the LaTeX toolchain command(s) to build the project after new LaTeX contents are saved."
-        },
-        "latex-workshop.latex.autoBuild.onTexChange.enabled": {
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "Build LaTeX after a LaTeX source file has changed in the workspace.\nThis property defines whether LaTeX Workshop will execute the LaTeX toolchain command(s) to build the project after any LaTeX file in the workspace is saved on the disk which is not open in the active editor window."
+        "latex-workshop.latex.autoBuild.run": {
+          "type": "string",
+          "enum": ["never", "onSave", "onFileChange"],
+          "default": "onSave",
+          "markdownDescription": "When the extension shall auto build LaTeX project using the default (first) recipe.\n`onSave` builds the project upon saving a `tex` file in vscode. `onFileChange` builds the project upon detecting a `tex` file change, even modified by other applications."
         },
         "latex-workshop.latex.autoBuild.cleanAndRetry.enabled": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -589,7 +589,7 @@
           "default": true,
           "markdownDescription": "Clear the LaTeX Compiler logs before every step of a recipe.\nSet this property to false to keep the logs of all tools in a recipe."
         },
-        "latex-workshop.latex.clean.run": {
+        "latex-workshop.latex.autoClean.run": {
           "type": "string",
           "enum": ["never", "onFailed", "onBuilt"],
           "default": "never",

--- a/package.json
+++ b/package.json
@@ -559,11 +559,6 @@
           "default": "%DIR%",
           "markdownDescription": "The directory where the extension tries to find project files (e.g., PDF and SyncTeX files) are located.\nBoth relative and absolute paths are supported. Relative path start from the root file location, so beware if it is located in sub-directory. The path must not contain a trailing slash.\nThe LaTeX toolchain should output files to this path.\nPlaceholders `%DOC%`, `%DOCFILE%`, `%DIR%` and `%TMPDIR%` are available."
         },
-        "latex-workshop.latex.additionalBib": {
-          "type": "array",
-          "default": [],
-          "markdownDescription": "Addition bibliography files to watch.\nBoth relative and absolute paths/globs are supported, but absolute ones are suggested. Relative path start from the root file location, so be ware if it is located in sub-directory.\n**This setting has been deprecated in favor of `latex-workshop.latex.bibDirs`."
-        },
         "latex-workshop.latex.bibDirs": {
           "type": "array",
           "default": [],
@@ -814,11 +809,6 @@
           "type": "number",
           "default": 5,
           "markdownDescription": "Defines the maximum bibtex file size for the extension to parse in MB."
-        },
-        "latex-workshop.intellisense.surroundCommand.enabled": {
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "When `\\` is typed with text selected, surround the selection with LaTeX command.\n**This feature is deprecated, use `ctrl+l`,`ctrl+w`."
         },
         "latex-workshop.intellisense.unimathsymbols.enabled": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -632,10 +632,10 @@
           ],
           "markdownDescription": "The section names of LaTeX outline hierarchy. It is also used by the folding mechanism.\nThis property is an array of case-sensitive strings in the order of document structure hierarchy. For multiple tags in the same level, separate the tags with `|` as delimiters, e.g., `section|alternative`."
         },
-        "latex-workshop.view.autoActivateLatex.enabled": {
+        "latex-workshop.view.autoFocus.enabled": {
           "type": "boolean",
           "default": false,
-          "markdownDescription": "Auto activate the LaTeX view when switching from non-tex to tex files.\nThis will cause the view to appear consistently upon activating the extension."
+          "markdownDescription": "Auto focus the LaTeX view when switching from non-tex to tex files.\nThis will cause the view to appear consistently upon activating the extension."
         },
         "latex-workshop.view.pdf.viewer": {
           "type": "string",
@@ -895,22 +895,22 @@
           "default": false,
           "markdownDescription": "Use alternative keymap combo, i.e., `ctrl`+`l` `alt`+key, to replace the default `ctrl`/`cmd`+`alt` shortcuts.\nReload vscode to make this configuration effective."
         },
-        "latex-workshop.hoverReference.enabled": {
+        "latex-workshop.hover.ref.enabled": {
           "type": "boolean",
           "default": true,
           "markdownDescription": "Enable Hover on References."
         },
-        "latex-workshop.hoverCitation.enabled": {
+        "latex-workshop.hover.citation.enabled": {
           "type": "boolean",
           "default": true,
           "markdownDescription": "Enable Hover on Citations."
         },
-        "latex-workshop.hoverCommandDoc.enabled": {
+        "latex-workshop.hover.command.enabled": {
           "type": "boolean",
           "default": true,
           "markdownDescription": "Enable Hover on Commands to show the possible signatures."
         },
-        "latex-workshop.hoverPreview.enabled": {
+        "latex-workshop.hover.preview.enabled": {
           "type": "boolean",
           "default": true,
           "markdownDescription": "Enable Hover Preview."

--- a/package.json
+++ b/package.json
@@ -915,22 +915,22 @@
           "default": true,
           "markdownDescription": "Enable Hover Preview."
         },
-        "latex-workshop.hoverPreview.scale": {
+        "latex-workshop.hover.preview.scale": {
           "type": "number",
           "default": 1,
           "markdownDescription": "Scaling of Hover Preview."
         },
-        "latex-workshop.hoverPreview.cursor.enabled": {
+        "latex-workshop.hover.preview.cursor.enabled": {
           "type": "boolean",
           "default": true,
           "markdownDescription": "Render cursor in Hover Preview at the current position."
         },
-        "latex-workshop.hoverPreview.cursor.symbol": {
+        "latex-workshop.hover.preview.cursor.symbol": {
           "type": "string",
           "default": "\\ddagger",
           "markdownDescription": "Cursor symbol in Hover Preview."
         },
-        "latex-workshop.hoverPreview.cursor.color": {
+        "latex-workshop.hover.preview.cursor.color": {
           "type": "string",
           "default": "auto",
           "enum": [
@@ -957,7 +957,7 @@
           ],
           "markdownDescription": "The color of cursor in Hover Preview."
         },
-        "latex-workshop.hoverPreview.ref.enabled": {
+        "latex-workshop.hover.preview.ref.enabled": {
           "type": "boolean",
           "default": true,
           "markdownDdescription": "Render Hover Preview on \\ref."

--- a/package.json
+++ b/package.json
@@ -589,20 +589,16 @@
           "default": true,
           "markdownDescription": "Clear the LaTeX Compiler logs before every step of a recipe.\nSet this property to false to keep the logs of all tools in a recipe."
         },
-        "latex-workshop.latex.clean.enabled": {
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "Delete LaTeX auxillary files after building project.\nThis property defines whether LaTeX Workshop will clean up all unnecessary files after building the project. The folder to be cleaned is defined in `latex-workshop.latex.outDir`."
+        "latex-workshop.latex.clean.run": {
+          "type": "string",
+          "enum": ["never", "onFailed", "onBuilt"],
+          "default": "never",
+          "markdownDescription": "When LaTeX auxillary files should be deleted.\nThe folder to be cleaned is defined in `latex-workshop.latex.outDir`.\n`onFailed` clean the project when compilation is failed. `onBuilt` clean the project when compilation is terminated, whether successful or failed."
         },
         "latex-workshop.latex.clean.subfolder.enabled": {
           "type": "boolean",
           "default": false,
           "markdownDescription": "Delete LaTeX auxillary files recursively in sub-folders of `latex-workshop.latex.outDir`."
-        },
-        "latex-workshop.latex.clean.onFailBuild.enabled": {
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "Delete LaTeX auxillary files after a failed building process.\nThis property defines whether LaTeX Workshop will clean up all unnecessary files upon building errors."
         },
         "latex-workshop.latex.clean.fileTypes": {
           "type": "array",

--- a/src/components/builder.ts
+++ b/src/components/builder.ts
@@ -132,7 +132,7 @@ export class Builder {
                     }
                 } else {
                     this.extension.logger.displayStatus('x', 'errorForeground')
-                    if (['onFailed', 'onBuilt'].indexOf(configuration.get('latex.clean.run') as string) > -1) {
+                    if (['onFailed', 'onBuilt'].indexOf(configuration.get('latex.autoClean.run') as string) > -1) {
                         this.extension.commander.clean()
                     }
                     const res = this.extension.logger.showErrorMessage('Recipe terminated with error.', 'Open compiler log')
@@ -171,7 +171,7 @@ export class Builder {
         if (configuration.get('synctex.afterBuild.enabled') as boolean) {
             this.extension.locator.syncTeX()
         }
-        if (configuration.get('latex.clean.run') as string === 'onBuilt') {
+        if (configuration.get('latex.autoClean.run') as string === 'onBuilt') {
             this.extension.cleaner.clean()
         }
     }

--- a/src/components/builder.ts
+++ b/src/components/builder.ts
@@ -132,7 +132,7 @@ export class Builder {
                     }
                 } else {
                     this.extension.logger.displayStatus('x', 'errorForeground')
-                    if (configuration.get('latex.clean.run') as string === 'onFailed') {
+                    if (['onFailed', 'onBuilt'].indexOf(configuration.get('latex.clean.run') as string) > -1) {
                         this.extension.commander.clean()
                     }
                     const res = this.extension.logger.showErrorMessage('Recipe terminated with error.', 'Open compiler log')

--- a/src/main.ts
+++ b/src/main.ts
@@ -56,8 +56,8 @@ function combineConfig(extension: Extension, originalConfig1: string, originalCo
     const key = config1.toString() + config2.toString()
     configuration.update(newConfig, truthTable[key], true)
 
-    const msg = `"latex-workshop.latex.clean.enabled" and "latex-workshop.latex.clean.onFailBuild.enabled" have been replaced by "latex-workshop.latex.clean.run", which is set to "${truthTable[key]}". See https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#cleaning-generated-files.`
-    const markdownMsg = `\`latex-workshop.latex.clean.enabled\` and \`latex-workshop.latex.clean.onFailBuild.enabled\` have been replaced by \`latex-workshop.latex.clean.run\`, which is set to \`${truthTable[key]}\`. See the [wiki](https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#cleaning-generated-files).`
+    const msg = `"latex-workshop.latex.clean.enabled" and "latex-workshop.latex.clean.onFailBuild.enabled" have been replaced by "latex-workshop.latex.autoClean.run", which is set to "${truthTable[key]}". See https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#cleaning-generated-files.`
+    const markdownMsg = `\`latex-workshop.latex.clean.enabled\` and \`latex-workshop.latex.clean.onFailBuild.enabled\` have been replaced by \`latex-workshop.latex.autoClean.run\`, which is set to \`${truthTable[key]}\`. See the [wiki](https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#cleaning-generated-files).`
 
     extension.logger.addLogMessage(msg)
     extension.logger.displayStatus('check', 'statusBar.foreground', markdownMsg, 'warning')
@@ -72,7 +72,7 @@ function obsoleteConfigCheck(extension: Extension) {
     renameConfig('maxPrintLine.option.enabled', 'latex.option.maxPrintLine.enabled')
     renameConfig('chktex.interval', 'chktex.delay')
     renameConfig('latex.outputDir', 'latex.outDir')
-    combineConfig(extension, 'latex.clean.enabled', 'latex.clean.onFailBuild.enabled', 'latex.clean.run', {
+    combineConfig(extension, 'latex.clean.enabled', 'latex.clean.onFailBuild.enabled', 'latex.autoClean.run', {
         'falsefalse': 'never',
         'falsetrue': 'onFailed',
         'truefalse': 'onBuilt',

--- a/src/main.ts
+++ b/src/main.ts
@@ -72,6 +72,16 @@ function obsoleteConfigCheck(extension: Extension) {
     renameConfig('maxPrintLine.option.enabled', 'latex.option.maxPrintLine.enabled')
     renameConfig('chktex.interval', 'chktex.delay')
     renameConfig('latex.outputDir', 'latex.outDir')
+    renameConfig('view.autoActivateLatex.enabled', 'view.autoFocus.enabled')
+    renameConfig('hoverPreview.enabled', 'hover.preview.enabled')
+    renameConfig('hoverReference.enabled', 'hover.ref.enabled')
+    renameConfig('hoverCitation.enabled', 'hover.citation.enabled')
+    renameConfig('hoverCommandDoc.enabled', 'hover.command.enabled')
+    renameConfig('hoverPreview.scale', 'hover.preview.scale')
+    renameConfig('hoverPreview.cursor.enabled', 'hover.preview.cursor.enabled')
+    renameConfig('hoverPreview.cursor.symbol', 'hover.preview.cursor.symbol')
+    renameConfig('hoverPreview.cursor.color', 'hover.preview.cursor.color')
+    renameConfig('hoverPreview.ref.enabled', 'hover.preview.ref.enabled')
     combineConfig(extension, 'latex.clean.enabled', 'latex.clean.onFailBuild.enabled', 'latex.autoClean.run', {
         'falsefalse': 'never',
         'falsetrue': 'onFailed',
@@ -88,7 +98,7 @@ function obsoleteConfigCheck(extension: Extension) {
 
 function checkDeprecatedFeatures(extension: Extension) {
     const configuration = vscode.workspace.getConfiguration('latex-workshop')
-    if ((configuration.get('latex.additionalBib') as string[]).length > 0) {
+    if (configuration.get('latex.additionalBib') && (configuration.get('latex.additionalBib') as string[]).length > 0) {
         const msg = '"latex-workshop.latex.additionalBib" has been deprecated in favor of "latex-workshop.latex.bibDirs". See https://github.com/James-Yu/LaTeX-Workshop/wiki/Intellisense#Citations.'
         const markdownMsg = '`latex-workshop.latex.additionalBibs` has been deprecated in favor of  `latex-workshop.latex.bibDirs`. See the [wiki](https://github.com/James-Yu/LaTeX-Workshop/wiki/Intellisense#Citations.)'
 
@@ -269,7 +279,7 @@ export async function activate(context: vscode.ExtensionContext) {
             extension.logger.status.show()
             vscode.commands.executeCommand('setContext', 'latex-workshop:enabled', true).then(() => {
                 const gits = vscode.window.visibleTextEditors.filter(editor => editor.document.uri.scheme === 'git')
-                if (configuration.get('view.autoActivateLatex.enabled') && !isLaTeXActive && gits.length === 0) {
+                if (configuration.get('view.autoFocus.enabled') && !isLaTeXActive && gits.length === 0) {
                     vscode.commands.executeCommand('workbench.view.extension.latex').then(() => vscode.commands.executeCommand('workbench.action.focusActiveEditorGroup'))
                 } else if (gits.length > 0) {
                     vscode.commands.executeCommand('workbench.view.scm').then(() => vscode.commands.executeCommand('workbench.action.focusActiveEditorGroup'))
@@ -279,7 +289,7 @@ export async function activate(context: vscode.ExtensionContext) {
         } else if (vscode.window.activeTextEditor && vscode.window.activeTextEditor.document.languageId.toLowerCase() === 'log') {
             extension.logger.status.show()
             vscode.commands.executeCommand('setContext', 'latex-workshop:enabled', true)
-        } else if (!configuration.get('view.autoActivateLatex.enabled')) {
+        } else if (!configuration.get('view.autoFocus.enabled')) {
             extension.logger.status.hide()
             vscode.commands.executeCommand('setContext', 'latex-workshop:enabled', false)
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -78,6 +78,12 @@ function obsoleteConfigCheck(extension: Extension) {
         'truefalse': 'onBuilt',
         'truetrue': 'onBuilt'
     })
+    combineConfig(extension, 'latex.autoBuild.onSave.enabled', 'latex.autoBuild.onTexChange.enabled', 'latex.autoBuild.run', {
+        'falsefalse': 'never',
+        'falsetrue': 'onFileChange',
+        'truefalse': 'onSave',
+        'truetrue': 'onFileChange'
+    })
 }
 
 function checkDeprecatedFeatures(extension: Extension) {
@@ -215,7 +221,7 @@ export async function activate(context: vscode.ExtensionContext) {
             extension.structureProvider.update()
 
             configuration = vscode.workspace.getConfiguration('latex-workshop')
-            if (configuration.get('latex.autoBuild.onSave.enabled') && !extension.builder.disableBuildAfterSave) {
+            if (configuration.get('latex.autoBuild.run') as string === 'onSave' && !extension.builder.disableBuildAfterSave) {
                 extension.logger.addLogMessage(`Auto-build ${e.fileName} upon save.`)
                 extension.commander.build(true)
             }
@@ -300,7 +306,7 @@ export async function activate(context: vscode.ExtensionContext) {
             return
         }
         configuration = vscode.workspace.getConfiguration('latex-workshop')
-        if (!configuration.get('latex.autoBuild.onTexChange.enabled') || extension.builder.disableBuildAfterSave) {
+        if (configuration.get('latex.autoBuild.run') as string !== 'onFileChange' || extension.builder.disableBuildAfterSave) {
             return
         }
         extension.logger.addLogMessage(`${e.fsPath} changed. Auto build project.`)

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -46,10 +46,10 @@ export class HoverProvider implements vscode.HoverProvider {
         this.getColor()
         return new Promise((resolve, _reject) => {
             const configuration = vscode.workspace.getConfiguration('latex-workshop')
-            const hov = configuration.get('hoverPreview.enabled') as boolean
-            const hovReference = configuration.get('hoverReference.enabled') as boolean
-            const hovCitation = configuration.get('hoverCitation.enabled') as boolean
-            const hovCommand = configuration.get('hoverCommandDoc.enabled') as boolean
+            const hov = configuration.get('hover.preview.enabled') as boolean
+            const hovReference = configuration.get('hover.ref.enabled') as boolean
+            const hovCitation = configuration.get('hover.citation.enabled') as boolean
+            const hovCommand = configuration.get('hover.command.enabled') as boolean
             if (hov) {
                 const tex = this.findHoverOnTex(document, position)
                 if (tex) {
@@ -86,7 +86,7 @@ export class HoverProvider implements vscode.HoverProvider {
                 const link = vscode.Uri.parse('command:latex-workshop.synctexto').with({ query: JSON.stringify([line, refData.file]) })
                 const mdLink = new vscode.MarkdownString(`[View on pdf](${link})`)
                 mdLink.isTrusted = true
-                if (configuration.get('hoverPreview.ref.enabled') as boolean) {
+                if (configuration.get('hover.preview.ref.enabled') as boolean) {
                     const tex = this.findHoverOnRef(document, position, token, refData)
                     if (tex) {
                         this.provideHoverOnRef(tex, this.findNewCommand(document.getText()), token, refData)
@@ -169,7 +169,7 @@ export class HoverProvider implements vscode.HoverProvider {
 
     private async provideHoverOnTex(document: vscode.TextDocument, tex: TexMathEnv, newCommand: string) : Promise<vscode.Hover> {
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
-        const scale = configuration.get('hoverPreview.scale') as number
+        const scale = configuration.get('hover.preview.scale') as number
         let s = this.renderCursor(document, tex.range)
         s = this.mathjaxify(s, tex.envname)
         const data = await this.mj.typeset({
@@ -186,7 +186,7 @@ export class HoverProvider implements vscode.HoverProvider {
 
     private async provideHoverOnRef(tex: TexMathEnv, newCommand: string, refToken: string, refData: ReferenceEntry) : Promise<vscode.Hover> {
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
-        const scale = configuration.get('hoverPreview.scale') as number
+        const scale = configuration.get('hover.preview.scale') as number
         const s = this.mathjaxify(tex.texString, tex.envname, {stripLabel: false})
         const obj = { labels : {}, IDs: {}, startNumber: 0 }
         const data = await this.mj.typeset({
@@ -358,11 +358,11 @@ export class HoverProvider implements vscode.HoverProvider {
     private renderCursor(document: vscode.TextDocument, range: vscode.Range) : string {
         const editor = vscode.window.activeTextEditor
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
-        const conf = configuration.get('hoverPreview.cursor.enabled') as boolean
+        const conf = configuration.get('hover.preview.cursor.enabled') as boolean
         if (editor && conf && !this.isCursorInTeXCommand(document)) {
             const cursor = editor.selection.active
-            const symbol = configuration.get('hoverPreview.cursor.symbol') as string
-            const color = configuration.get('hoverPreview.cursor.color') as string
+            const symbol = configuration.get('hover.preview.cursor.symbol') as string
+            const color = configuration.get('hover.preview.cursor.color') as string
             let sym = `{\\color{${this.color}}${symbol}}`
             if (color !== 'auto') {
                 sym = `{\\color{${color}}${symbol}}`


### PR DESCRIPTION
This is an initial PR to merge the two configs to one. This may reduce the clutter in the config of this extension.

I also have a plan to merge `latex.autoBuild.onSave.enabled` with `latex-workshop.latex.autoBuild.onTexChange.enabled`, but use the experience here.

One more thing that makes me hesitate is on whether a `latex.clean.enabled` is required, just like what we did for `chktex.enabled` and `chktex.run`. Also, whether `latex.clean.enabled` should be renamed to something like `latex.autoClean.enabled`.