### PR TITLE
Add ability to increment/decrement sectioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -337,13 +337,25 @@
       {
         "key": "ctrl+alt+]",
         "mac": "cmd+alt+]",
-        "when": "editorTextFocus && !editorReadonly && editorLangId == 'latex'",
+        "when": "editorTextFocus && !editorReadonly && editorLangId == 'latex' && !latex-workshop:altkeymap",
         "command": "latex-workshop.increment-sectioning"
       },
       {
         "key": "ctrl+alt+[",
         "mac": "cmd+alt+[",
-        "when": "editorTextFocus && !editorReadonly && editorLangId == 'latex'",
+        "when": "editorTextFocus && !editorReadonly && editorLangId == 'latex'&& !latex-workshop:altkeymap",
+        "command": "latex-workshop.decrement-sectioning"
+      },
+      {
+        "key": "ctrl+l ctrl+]",
+        "mac": "cmd+l cmd+]",
+        "when": "editorTextFocus && !editorReadonly && editorLangId == 'latex' && latex-workshop:altkeymap",
+        "command": "latex-workshop.increment-sectioning"
+      },
+      {
+        "key": "ctrl+l ctrl+[",
+        "mac": "cmd+l cmd+[",
+        "when": "editorTextFocus && !editorReadonly && editorLangId == 'latex'&& latex-workshop:altkeymap",
         "command": "latex-workshop.decrement-sectioning"
       },
       {
@@ -693,7 +705,9 @@
           "type": "object",
           "default": {
             "command": "",
-            "args": [ "" ]
+            "args": [
+              ""
+            ]
           },
           "markdownDescription": "The command to execute when using external viewer.\nThis function is not officially supported. %PDF% is the placeholder for the absolute path to the generated PDF file."
         },
@@ -744,19 +758,22 @@
           "default": false,
           "markdownDescription": "Execute forward synctex at cursor position after compiling LaTeX project."
         },
-        "latex-workshop.synctex.synctexjs.enabled" : {
+        "latex-workshop.synctex.synctexjs.enabled": {
           "type": "boolean",
           "default": true,
           "markdownDescription": "Enable using a builtin synctex function. The command set in latex-workshop.synctex.path will not be used."
         },
         "latex-workshop.chktex.enabled": {
           "type": "boolean",
-          "default": false,	
+          "default": false,
           "markdownDescription": "Enable linting LaTeX with ChkTeX.\nCheck `latex-workshop.chktex.run` to control when the linting is executed if this config is set to `true`."
         },
         "latex-workshop.chktex.run": {
           "type": "string",
-          "enum": ["onSave", "onType"],
+          "enum": [
+            "onSave",
+            "onType"
+          ],
           "default": "onSave",
           "markdownDescription": "When LaTeX should be linted by ChkTeX.\nIf set to `onSave`, the whole LaTeX project will be linted upon saving.\nIf set to `onType`, the active document will be linted when input is stopped for a period of time defined in `latex-workshop.chktex.delay`, besides the behavior of `onSave`."
         },

--- a/package.json
+++ b/package.json
@@ -335,6 +335,18 @@
         "when": "editorTextFocus && latex-workshop:altkeymap"
       },
       {
+        "key": "ctrl+alt+]",
+        "mac": "cmd+alt+]",
+        "when": "editorTextFocus && !editorReadonly && editorLangId == 'latex'",
+        "command": "latex-workshop.increment-sectioning"
+      },
+      {
+        "key": "ctrl+alt+[",
+        "mac": "cmd+alt+[",
+        "when": "editorTextFocus && !editorReadonly && editorLangId == 'latex'",
+        "command": "latex-workshop.decrement-sectioning"
+      },
+      {
         "key": "ctrl+l ctrl+enter",
         "mac": "cmd+l cmd+enter",
         "when": "editorTextFocus && !editorReadonly && editorLangId == 'latex'",

--- a/package.json
+++ b/package.json
@@ -347,14 +347,14 @@
         "command": "latex-workshop.decrement-sectioning"
       },
       {
-        "key": "ctrl+l ctrl+]",
-        "mac": "cmd+l cmd+]",
+        "key": "ctrl+l ]",
+        "mac": "cmd+l ]",
         "when": "editorTextFocus && !editorReadonly && editorLangId == 'latex' && latex-workshop:altkeymap",
         "command": "latex-workshop.increment-sectioning"
       },
       {
-        "key": "ctrl+l ctrl+[",
-        "mac": "cmd+l cmd+[",
+        "key": "ctrl+l [",
+        "mac": "cmd+l [",
         "when": "editorTextFocus && !editorReadonly && editorLangId == 'latex'&& latex-workshop:altkeymap",
         "command": "latex-workshop.decrement-sectioning"
       },

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -602,19 +602,6 @@ export class Commander {
             const lines = someText.split(/\n/)
             return lines.slice(lines.length - 1, lines.length)[0].length
         }
-        function sortPositions(position1: vscode.Position, position2: vscode.Position) {
-            if (position1.line < position2.line) {
-                return [position1, position2]
-            } else if (position1.line > position2.line) {
-                return [position2, position1]
-            } else {
-                if (position2.character < position1.character) {
-                    return [position2, position1]
-                } else {
-                    return [position1, position2]
-                }
-            }
-        }
 
         const document = editor.document
         const selections = editor.selections
@@ -633,11 +620,10 @@ export class Commander {
             edit.replace(document.uri, selection, newText)
 
             const changeInEndCharacterPosition = getLastLineLength(newText) - getLastLineLength(selectionText)
-            const [selectionStart, selectionEnd] = sortPositions(selection.anchor, selection.active)
             newSelections.push(
-                new vscode.Selection(selectionStart,
-                    new vscode.Position(selectionEnd.line,
-                        selectionEnd.character + changeInEndCharacterPosition
+                new vscode.Selection(selection.start,
+                    new vscode.Position(selection.end.line,
+                        selection.end.character + changeInEndCharacterPosition
                     )
                 )
             )

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -547,9 +547,9 @@ export class Commander {
     }
 
     /**
-     * Shift the level sectioning in the selection by one (up or down)
-     * @param change
-     */
+   * Shift the level sectioning in the selection by one (up or down)
+   * @param change
+   */
     shiftSectioningLevel(change: 'increment' | 'decrement') {
         if (change !== 'increment' && change !== 'decrement') {
             throw TypeError(
@@ -561,15 +561,6 @@ export class Commander {
         if (editor === undefined) {
             return
         }
-
-        const document = editor.document
-        let selection = editor.selection
-        if (selection.isEmpty) {
-            const line = document.lineAt(selection.anchor)
-            selection = new vscode.Selection(line.range.start, line.range.end)
-        }
-
-        const selectionText = document.getText(selection)
 
         const increments = {
             part: 'part',
@@ -597,21 +588,33 @@ export class Commander {
             contents: string
         ) {
             if (change === 'increment') {
-            return '\\' + increments[sectionName] + (options ? options : '') + contents
+                return '\\' + increments[sectionName] + (options ? options : '') + contents
             } else {
-            // if (change === 'decrement')
-            return '\\' + decrements[sectionName] + (options ? options : '') + contents
+                // if (change === 'decrement')
+                return '\\' + decrements[sectionName] + (options ? options : '') + contents
             }
         }
 
         // when supported, negative lookbehind at start would be nice --- (?<!\\)
         const pattern = /\\(part|chapter|section|subsection|subsection|subsubsection|paragraph|subparagraph)(\[.+?\])?(\{.+?\})/g
 
-        const newText = selectionText.replace(pattern, replacer)
+        const document = editor.document
+        const selections = editor.selections
 
         const edit = new vscode.WorkspaceEdit()
-        edit.replace(document.uri, selection, newText)
-        return vscode.workspace.applyEdit(edit)
+
+        for (let selection of selections) {
+            if (selection.isEmpty) {
+            const line = document.lineAt(selection.anchor)
+            selection = new vscode.Selection(line.range.start, line.range.end)
+            }
+
+            const selectionText = document.getText(selection)
+            const newText = selectionText.replace(pattern, replacer)
+            edit.replace(document.uri, selection, newText)
+        }
+
+        vscode.workspace.applyEdit(edit)
     }
 
     devParseLog() {

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -602,6 +602,19 @@ export class Commander {
             const lines = someText.split(/\n/)
             return lines.slice(lines.length - 1, lines.length)[0].length
         }
+        function sortPositions(position1: vscode.Position, position2: vscode.Position) {
+            if (position1.line < position2.line) {
+                return [position1, position2]
+            } else if (position1.line > position2.line) {
+                return [position2, position1]
+            } else {
+                if (position2.character < position1.character) {
+                    return [position2, position1]
+                } else {
+                    return [position1, position2]
+                }
+            }
+        }
 
         const document = editor.document
         const selections = editor.selections
@@ -619,11 +632,12 @@ export class Commander {
             const newText = selectionText.replace(pattern, replacer)
             edit.replace(document.uri, selection, newText)
 
-            const changeInEndLineLength = getLastLineLength(newText) - getLastLineLength(selectionText)
+            const changeInEndCharacterPosition = getLastLineLength(newText) - getLastLineLength(selectionText)
+            const [selectionStart, selectionEnd] = sortPositions(selection.anchor, selection.active)
             newSelections.push(
-                new vscode.Selection(selection.anchor,
-                    new vscode.Position(selection.active.line,
-                        selection.active.character + changeInEndLineLength
+                new vscode.Selection(selectionStart,
+                    new vscode.Position(selectionEnd.line,
+                        selectionEnd.character + changeInEndCharacterPosition
                     )
                 )
             )

--- a/src/main.ts
+++ b/src/main.ts
@@ -176,6 +176,9 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('latex-workshop.shortcut.mathcal', () => extension.commander.toggleSelectedKeyword('mathcal'))
     vscode.commands.registerCommand('latex-workshop.surround', () => extension.completer.command.surround())
 
+    vscode.commands.registerCommand('latex-workshop.increment-sectioning', () => extension.commander.shiftSectioningLevel('increment'))
+    vscode.commands.registerCommand('latex-workshop.decrement-sectioning', () => extension.commander.shiftSectioningLevel('decrement'))
+
     context.subscriptions.push(vscode.workspace.onDidSaveTextDocument((e: vscode.TextDocument) => {
         if (extension.manager.hasTexId(e.languageId)) {
             extension.linter.lintRootFileIfEnabled()


### PR DESCRIPTION
## What this PR addresses

### Case One

Every so often I want to change the 'sectioning level' is a section of my document. Sometimes I start writing content thinking it will be a section, then half an hour later realise that it should really be a subsection.
So, within a certain region, I want to downgrade all `sections` to `subsections`, `subsections` to `subsubsections` etc. This is usually done via a series of 3-5 scoped text replacements. Not the easiest.

This is something I infrequently do, but every time I do I wish it were a less involved process.

### Case Two

Quite frequently I create a `paragraph`, only to think it should be a `subparagraph`; or a `subsubsection`, only to change it to a `subsection`.
This is quick to change, move cursor, either type `sub` or press <kbd>del</kbd>/<kbd>backspace</kbd> three times. However, this adds up, and is what I currently consider to be mildly irritating.

## What this PR does

This PR adds a function to `commander.ts` - `shiftSectioningLevel` which operates on a line/selection and takes one argument, indicating whether the selection/line should have all sectioning within it 'incremented' or 'decremented'; significantly simplifying the processes outlined previously.

Likewise, there are two commands added to `main.ts`:
 - `latex-workshop.increment-sectioning`
 - `latex-workshop.decrement-sectioning`

I have also added keyboard shortcuts for this:
 - <kbd>ctrl</kbd>+<kbd>alt</kbd>+<kbd>]</kbd> - Increments Sectioning
 - <kbd>ctrl</kbd>+<kbd>alt</kbd>+<kbd>[</kbd> - Decrements Sectioning

## What I Haven't Added

At the moment when this command is applied to a selection, the selection disappears when the contents is replaced. I think this feature would be better if that selection would remain, or if a line had this applied 