### PR TITLE
Prettify default recipie names

### DIFF
--- a/package.json
+++ b/package.json
@@ -485,13 +485,13 @@
           "type": "array",
           "default": [
             {
-              "name": "latexmk",
+              "name": "latexmk 🔃",
               "tools": [
                 "latexmk"
               ]
             },
             {
-              "name": "pdflatex -> bibtex -> pdflatex*2",
+              "name": "pdflatex ➞ bibtex ➞ pdflatex × 2",
               "tools": [
                 "pdflatex",
                 "bibtex",


### PR DESCRIPTION
This is quite minor, I just got tired of looking at the somewhat ugly `->` in the 'build from recipe' menu, looked up some Unicode characters and changed it, then thought: "_Hey, other people might appreciate this too!_" (all be it in quite minorly).

Before:

![image](https://user-images.githubusercontent.com/20903656/51794134-3780b800-21c4-11e9-9580-45f52e6bf08c.png)

After:

![image](https://user-images.githubusercontent.com/20903656/51794129-1e780700-21c4-11e9-81df-2d2246c4477d.png)

I know the 🔃 with the `latexmk` might be a bit excessive, but I got a bit icon-happy and though it made sense at some level given that latexmk does pdflatex repeatedly untill the document is right (along with other stuff like bibtex).

#### Non-ASCII characters used:

 - `U+1F503` 🔃 (Clockwise Downwards and Upwards Open Circle Arrows) 
 - `U+279E` ➞ (Heavy Triangle-Headed Rightwards Arrow)
 - `U+200A` ' ' (Hair Space)
 - `U+00D7` × (Multiplication Sign)

#### Bonus

For anybody who sees this who is like me using SageMath, you may like this one:
##### pdflatex ➞ ⬡ sage ➞ pdflatex