### PR TITLE
Improve accuracy for reverse synctex by checking text selection

### DIFF
--- a/src/components/locator.ts
+++ b/src/components/locator.ts
@@ -300,9 +300,9 @@ export class Locator {
             // columns are typically not supplied by SyncTex, this could change in the future for some engines though
             if (col === 0) {
                 const line = doc.lineAt(row)
-                if (line.text.indexOf(data.textBeforeSelection) > -1) {
+                if (data.textBeforeSelection !== '' && line.text.indexOf(data.textBeforeSelection) > -1) {
                     col = line.text.indexOf(data.textBeforeSelection) + data.textBeforeSelection.length
-                } else if (line.text.indexOf(data.textAfterSelection) > -1) {
+                } else if (data.textAfterSelection !== '' && line.text.indexOf(data.textAfterSelection) > -1) {
                     col = line.text.indexOf(data.textAfterSelection)
                 }
             }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
         "alwaysStrict": true,
         "forceConsistentCasingInFileNames": true,
         "lib": [
-            "es6", "dom"
+            "es2017", "dom"
         ],
         "module": "commonjs",
         "noFallthroughCasesInSwitch": true,

--- a/viewer/latexworkshop.js
+++ b/viewer/latexworkshop.js
@@ -124,12 +124,12 @@ document.addEventListener('pagerendered', (evPageRendered) => {
         }
 
         const selection = window.getSelection();
-        let textBeforeSelection = ""
-        let textAfterSelection = ""
+        let textBeforeSelection = ''
+        let textAfterSelection = ''
         if(selection.anchorNode.nodeName === '#text'){
           const text = selection.anchorNode.textContent;
-          textBeforeSelection = text.substring(selection.anchorOffset - 10, selection.anchorOffset);
-          textAfterSelection = text.substring(selection.anchorOffset, selection.anchorOffset + 10);
+          textBeforeSelection = text.substring(0, selection.anchorOffset);
+          textAfterSelection = text.substring(selection.anchorOffset);
         }
 
         let viewerContainer = null

--- a/viewer/latexworkshop.js
+++ b/viewer/latexworkshop.js
@@ -123,6 +123,15 @@ document.addEventListener('pagerendered', (evPageRendered) => {
           return
         }
 
+        const selection = window.getSelection();
+        let textBeforeSelection = ""
+        let textAfterSelection = ""
+        if(selection.anchorNode.nodeName === '#text'){
+          const text = selection.anchorNode.textContent;
+          textBeforeSelection = text.substring(selection.anchorOffset - 10, selection.anchorOffset);
+          textAfterSelection = text.substring(selection.anchorOffset, selection.anchorOffset + 10);
+        }
+
         let viewerContainer = null
         // no spread
         if (PDFViewerApplication.pdfViewer.spreadMode === 0) {
@@ -142,7 +151,8 @@ document.addEventListener('pagerendered', (evPageRendered) => {
           left += offsetLeft
         }
         const pos = PDFViewerApplication.pdfViewer._pages[page-1].getPagePoint(left, canvas_dom.offsetHeight - top)
-        socket.send(JSON.stringify({type:"click", path:decodeURIComponent(file), pos:pos, page:page}))
+        socket.send(JSON.stringify({type:"click", path:decodeURIComponent(file), pos:pos, page:page,
+         textBeforeSelection:textBeforeSelection, textAfterSelection:textAfterSelection}))
     }
 }, true)
 


### PR DESCRIPTION
SyncTex only supports line level syncing (not column level). By also taking the text around the selection point into account we can greatly improve accuracy (see #1159).

This PR only implements the strategy for reverse synctex, because synctex provides a clear mapping to a line here. 

Forward synctex is not modified, since with forward synctex we would first have to try to find out which text corresponds with the line in the editor. Considering both repetition in the text and limits on the before and after text (if it gets too long we risk having latex constructs on both sides and being unable to find a match), there is a high risk of reducing the accuracy of forward synctex without implementing a complex heuristics based approach with fuzzy matching.