### PR TITLE
update @types/node

### DIFF
--- a/package.json
+++ b/package.json
@@ -1120,7 +1120,7 @@
     "@types/fs-extra": "^5.0.0",
     "@types/glob": "^5.0.30",
     "@types/micromatch": "^3.0.0",
-    "@types/node": "^8.9.1",
+    "@types/node": "^10.12.12",
     "@types/tmp": "^0.0.33",
     "@types/ws": "^4.0.2",
     "ts-loader": "^5.2.1",

--- a/src/components/server.ts
+++ b/src/components/server.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs'
 import * as path from 'path'
 
 import {Extension} from '../main'
+import {AddressInfo} from 'net'
 
 export class Server {
     extension: Extension
@@ -18,7 +19,7 @@ export class Server {
             if (err) {
                 this.extension.logger.addLogMessage(`Error creating LaTeX Workshop http server: ${err}.`)
             } else {
-                const {address, port} = this.httpServer.address()
+                const {address, port} = this.httpServer.address() as AddressInfo
                 if (address.indexOf(':') > -1) {
                     // the colon is reserved in URL to separate IPv4 address from port number. IPv6 address needs to be enclosed in square brackets when used in URL
                     this.address = `[${address}]:${port}`


### PR DESCRIPTION
Now, VS Code ships with node.js v10. See [link](https://github.com/Microsoft/vscode/blob/1.31.1/package.json#L66). This patch updates @types/node.