### PR TITLE
Update Reccomended Extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,6 @@
 	// for the documentation about the extensions.json format
 	"recommendations": [
 		// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
-		"eg2.tslint"
+		"ms-vscode.vscode-typescript-tslint-plugin"
 	]
 }


### PR DESCRIPTION
As mentioned on the `eg2.tslint`:

_"This extension has been deprecated in favor of the vscode-typescript-tslint-plugin."_

This PR updates the extension reccomendation accordingly.