### PR TITLE
Use mutex instead of ChildProcess.kill

### DIFF
--- a/package.json
+++ b/package.json
@@ -1160,6 +1160,7 @@
     "workspaceSymbolProvider": "true"
   },
   "dependencies": {
+    "await-semaphore": "^0.1.3",
     "chokidar": "^2.0.3",
     "fs-extra": "^5.0.0",
     "glob": "^7.1.1",

--- a/package.json
+++ b/package.json
@@ -1160,7 +1160,6 @@
     "workspaceSymbolProvider": "true"
   },
   "dependencies": {
-    "await-semaphore": "^0.1.3",
     "chokidar": "^2.0.3",
     "fs-extra": "^5.0.0",
     "glob": "^7.1.1",

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -38,7 +38,7 @@ export class Commander {
         const externalBuildCommand = configuration.get('latex.external.build.command') as ExternalCommand
         if (externalBuildCommand.command) {
             const pwd  = path.dirname(vscode.window.activeTextEditor.document.fileName)
-            this.extension.builder.buildWithExternalCommand(externalBuildCommand, pwd)
+            await this.extension.builder.buildWithExternalCommand(externalBuildCommand, pwd)
             return
         }
         const rootFile = await this.extension.manager.findRoot()

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -49,7 +49,7 @@ export class Commander {
         }
         if (skipSelection) {
             this.extension.logger.addLogMessage(`Building root file: ${rootFile}`)
-            this.extension.builder.build(rootFile, recipe)
+            await this.extension.builder.build(rootFile, recipe)
         } else {
             const subFileRoot = this.extension.manager.findSubFiles()
             if (subFileRoot) {
@@ -62,18 +62,18 @@ export class Commander {
                 }], {
                     placeHolder: 'Subfiles package detected. Which file to build?',
                     matchOnDescription: true
-                }).then(selected => {
+                }).then(async selected => {
                     if (!selected) {
                         return
                     }
                     switch (selected.label) {
                         case 'Default root file':
                             this.extension.logger.addLogMessage(`Building root file: ${rootFile}`)
-                            this.extension.builder.build(rootFile, recipe)
+                            await this.extension.builder.build(rootFile, recipe)
                             break
                         case 'Subfiles package root file':
                             this.extension.logger.addLogMessage(`Building root file: ${subFileRoot}`)
-                            this.extension.builder.build(subFileRoot, recipe)
+                            await this.extension.builder.build(subFileRoot, recipe)
                             break
                         default:
                             break
@@ -81,7 +81,7 @@ export class Commander {
                 })
             } else {
                 this.extension.logger.addLogMessage(`Building root file: ${rootFile}`)
-                this.extension.builder.build(rootFile, recipe)
+                await this.extension.builder.build(rootFile, recipe)
             }
         }
     }

--- a/src/components/builder.ts
+++ b/src/components/builder.ts
@@ -30,9 +30,10 @@ export class Builder {
     }
 
     kill() {
-        if (this.currentProcess) {
-            const pid = this.currentProcess.pid
-            this.currentProcess.kill()
+        const proc = this.currentProcess
+        if (proc) {
+            const pid = proc.pid
+            proc.kill()
             this.extension.logger.addLogMessage(`Kill the current process. PID: ${pid}.`)
         }
     }
@@ -45,9 +46,9 @@ export class Builder {
         this.disableBuildAfterSave = true
         await vscode.workspace.saveAll()
         setTimeout(() => this.disableBuildAfterSave = false, 1000)
-        const waitRelease = await this.waitingForBuildToFinishMutex.acquire()
+        const releaseWaiting = await this.waitingForBuildToFinishMutex.acquire()
         const releaseBuildMutex = await this.buildMutex.acquire()
-        waitRelease()
+        releaseWaiting()
         return releaseBuildMutex
     }
 

--- a/src/components/builder.ts
+++ b/src/components/builder.ts
@@ -99,6 +99,7 @@ export class Builder {
                     })
                 }
             } else {
+                this.extension.logger.addLogMessage(`Successfully built. PID: ${pid}`)
                 this.extension.logger.displayStatus('check', 'statusBar.foreground', `Build succeeded.`)
             }
             this.currentProcess = undefined
@@ -265,9 +266,8 @@ export class Builder {
     }
 
     buildFinished(rootFile: string) {
-        const pid = this.currentProcess !== undefined ? this.currentProcess.pid : undefined
         this.extension.buildInfo.buildEnded()
-        this.extension.logger.addLogMessage(`Successfully built ${rootFile}. PID: ${pid}`)
+        this.extension.logger.addLogMessage(`Successfully built ${rootFile}.`)
         this.extension.logger.displayStatus('check', 'statusBar.foreground', `Recipe succeeded.`)
         this.extension.viewer.refreshExistingViewer(rootFile)
         const configuration = vscode.workspace.getConfiguration('latex-workshop')

--- a/src/components/builder.ts
+++ b/src/components/builder.ts
@@ -4,7 +4,7 @@ import * as fs from 'fs-extra'
 import * as cp from 'child_process'
 import * as tmp from 'tmp'
 import * as pdfjsLib from 'pdfjs-dist'
-import {Mutex} from 'await-semaphore'
+import {Mutex} from '../lib/await-semaphore'
 
 import {Extension} from '../main'
 import {ExternalCommand} from '../utils'

--- a/src/lib/await-semaphore/LICENSE
+++ b/src/lib/await-semaphore/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Emma Kuo
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/lib/await-semaphore/README.md
+++ b/src/lib/await-semaphore/README.md
@@ -1,0 +1,106 @@
+# await-semaphore
+Awaitable semaphore/mutex
+
+A semaphore implementation using ES6 promises and supporting 3 styles:
+
+* async/await style (needs typescript)
+* thunk style (automatic acquire/release)
+* promise style
+
+Also includes `Mutex` as a convenience for `new Semaphore(1)`.
+
+## API
+
+### new Semaphore(count: number)
+
+Create a new semaphore with the given count.
+
+```javascript
+import {Semaphore} from 'await-semaphore';
+
+var semaphore = new Semaphore(10);
+```
+
+### semaphore.acquire(): Promise<() => void>
+
+Acquire the semaphore and returns a promise for the release function. Be sure to handle release for exception case.
+
+```javascript
+semaphore.acquire()
+.then(release => {
+    //critical section...
+    doSomething()
+    .then(res => {
+        //...
+        release();
+    })
+    .catch(err => {
+        //...
+        release();
+    });
+});
+```
+
+### semaphore.use<T>(thunk: () => Promise<T>): Promise<T>
+
+Alternate method for using the semaphore by providing a thunk. This automatically handles acquire/release.
+
+```javascript
+semaphore.use(() => {
+    //critical section...
+});
+```
+
+### new Mutex()
+
+An alias for `new Semaphore(1)`. Mutex has the same methods as Semaphore.
+
+```javascript
+import {Mutex} from 'await-semaphore';
+
+var mutex = new Mutex();
+```
+
+## Examples
+
+Create a version of `fetch()` with concurrency limited to 10.
+
+### async/await style (typescript)
+
+```typescript
+var semaphore = new Semaphore(10);
+
+async function niceFetch(url) {
+    var release = await semaphore.acquire();
+    var result = await fetch(url);
+    release();
+    return result;
+}
+```
+
+### thunk style (javascript)
+
+```javascript
+var semaphore = new Semaphore(10);
+
+function niceFetch(url) {
+    return semaphore.use(() => fetch(url));
+}
+```
+
+### promise style (javascript)
+
+```javascript
+var semaphore = new Semaphore(10);
+
+function niceFetch(url) {
+    return semaphore.acquire()
+    .then(release => {
+        return fetch(url)
+        .then(result => {
+            release();
+            return result;
+        });
+    });
+}
+```

--- a/src/lib/await-semaphore/index.ts
+++ b/src/lib/await-semaphore/index.ts
@@ -1,0 +1,62 @@
+export class Semaphore {
+    private tasks: (() => void)[] = [];
+    count: number;
+
+    constructor(count: number) {
+        this.count = count;
+    }
+
+    private sched() {
+        if (this.count > 0 && this.tasks.length > 0) {
+            this.count--;
+            let next = this.tasks.shift();
+            if (next === undefined) {
+                throw "Unexpected undefined value in tasks list";
+            }
+
+            next();
+        }
+    }
+
+    public acquire() {
+        return new Promise<() => void>((res) => {
+            var task = () => {
+                var released = false;
+                res(() => {
+                    if (!released) {
+                        released = true;
+                        this.count++;
+                        this.sched();
+                    }
+                });
+            };
+            this.tasks.push(task);
+            if (process && process.nextTick) {
+                process.nextTick(this.sched.bind(this));
+            } else {
+                setImmediate(this.sched.bind(this));
+            }
+        });
+    }
+
+    public use<T>(f: () => Promise<T>) {
+        return this.acquire()
+        .then(release => {
+            return f()
+            .then((res) => {
+                release();
+                return res;
+            })
+            .catch((err) => {
+                release();
+                throw err;
+            });
+        });
+    }
+}
+
+export class Mutex extends Semaphore {
+    constructor() {
+        super(1);
+    }
+}

--- a/src/lib/await-semaphore/package.json
+++ b/src/lib/await-semaphore/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "await-semaphore",
+  "version": "0.1.3",
+  "description": "Awaitable semaphore/mutex",
+  "main": "index.js",
+  "scripts": {
+    "prebuild": "typings install",
+    "build": "tsc",
+    "test": "mocha test.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/notenoughneon/await-semaphore.git"
+  },
+  "keywords": [
+    "promise",
+    "semaphore",
+    "mutex",
+    "typescript"
+  ],
+  "author": "Emma Kuo",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/notenoughneon/await-semaphore/issues"
+  },
+  "homepage": "https://github.com/notenoughneon/await-semaphore#readme",
+  "devDependencies": {
+    "mocha": "^2.5.3",
+    "typescript": "^1.8.10",
+    "typings": "^1.3.1"
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -229,7 +229,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
     vscode.commands.registerCommand('latex-workshop.showCompilationPanel', () => extension.buildInfo.showPanel())
 
-    context.subscriptions.push(vscode.workspace.onDidSaveTextDocument((e: vscode.TextDocument) => {
+    context.subscriptions.push(vscode.workspace.onDidSaveTextDocument(async (e: vscode.TextDocument) => {
         if (extension.manager.hasTexId(e.languageId)) {
             extension.linter.lintRootFileIfEnabled()
 
@@ -239,7 +239,7 @@ export async function activate(context: vscode.ExtensionContext) {
             configuration = vscode.workspace.getConfiguration('latex-workshop')
             if (configuration.get('latex.autoBuild.run') as string === 'onSave' && !extension.builder.disableBuildAfterSave) {
                 extension.logger.addLogMessage(`Auto-build ${e.fileName} upon save.`)
-                extension.commander.build(true)
+                await extension.commander.build(true)
             }
         }
     }))
@@ -317,7 +317,7 @@ export async function activate(context: vscode.ExtensionContext) {
         }
     }))
 
-    context.subscriptions.push(vscode.workspace.createFileSystemWatcher('**/*.tex', true, false, true).onDidChange((e: vscode.Uri) => {
+    context.subscriptions.push(vscode.workspace.createFileSystemWatcher('**/*.tex', true, false, true).onDidChange(async (e: vscode.Uri) => {
         if (vscode.window.activeTextEditor && vscode.window.activeTextEditor.document.fileName === e.fsPath) {
             return
         }
@@ -329,7 +329,7 @@ export async function activate(context: vscode.ExtensionContext) {
         const rootFile = extension.manager.findRoot()
         if (rootFile !== undefined) {
             extension.logger.addLogMessage(`Building root file: ${rootFile}`)
-            extension.builder.build(extension.manager.rootFile)
+            await extension.builder.build(extension.manager.rootFile)
         } else {
             extension.logger.addLogMessage(`Cannot find LaTeX root file.`)
         }

--- a/tslint.json
+++ b/tslint.json
@@ -1,7 +1,8 @@
 {
   "linterOptions": {
       "exclude": [
-          "src/mathjax/**/*"
+          "src/mathjax/**/*",
+          "src/lib/await-semaphore/*"
       ]
   },
   "rules": {


### PR DESCRIPTION

This is a PR to fix #1166.

I think the cause of the issue is that `ChildProcess.kill` is used to terminate a current latex processing. Immediately after calling it, we restart a new latex processing. Because we don't wait for the killing process to finish, `Builder.currentProcess` is not appropriately set, this issue occurs. One possible scenario is the following.

1. `Builder.currentProcess` is not appropriately set.
2. LaTeX Workshop tries to kill a wrong child process as a previous LaTeX building process.
3. Multiple LaTeX build processes run parallel and hang.
4. We cannot kill one of them.

Except for the above race condition, using kill might be problematic.

1. Signals are not supported on Windows. Node.js and libuv emulate them on Windows. So we should avoid using signals on Windows as possible as.
2. Killing latex processing leaves auxiliary files inconsistent.

In this PR, we use mutex to avoid such a race condition.

To avoid a build error related to an unused local variable, I include the npm module await-semaphore in this PR.
