### PR TITLE
Literate haskell

### DIFF
--- a/syntax/LaTeX.plist
+++ b/syntax/LaTeX.plist
@@ -521,6 +521,34 @@
 		</dict>
 		<dict>
 			<key>begin</key>
+			<string>((?:\s*)\\begin\{(hscode(?:\*)?)\}(?:\[.*\])?)</string>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>#code-env</string>
+						</dict>
+					</array>
+				</dict>
+			</dict>
+			<key>contentName</key>
+			<string>source.haskell</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>source.haskell</string>
+				</dict>
+			</array>
+			<key>end</key>
+			<string>(\\end\{\2\}(?:\s*\n)?)</string>
+		</dict>
+		<dict>
+			<key>begin</key>
 			<string>((?:\s*)\\begin\{(luacode(?:\*)?)\}(?:\[.*\])?)</string>
 			<key>captures</key>
 			<dict>

--- a/syntax/LaTeX.plist
+++ b/syntax/LaTeX.plist
@@ -1991,7 +1991,7 @@ Put specific matches for particular LaTeX keyword.functions before the last two 
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>((\\)(?:lstinline|inlinecode))((?:\[[^\[]*?\])?)(?:(?:([^a-zA-Z\{])(.*?)(\4))|(?:(\{)(.*?)(\})))</string>
+			<string>((\\)(?:lstinline|hsinline))((?:\[[^\[]*?\])?)(?:(?:([^a-zA-Z\{])(.*?)(\4))|(?:(\{)(.*?)(\})))</string>
 			<key>name</key>
 			<string>meta.function.verb.latex</string>
 		</dict>


### PR DESCRIPTION
This pull request alphabetically inserts an `hscode` declaration, as discussed at https://github.com/James-Yu/LaTeX-Workshop/issues/1185, which I based on the `luacode` declaration below it.

It also renames the `inlinecode` declaration to `hsinline`, which had been added for that same issue. This makes the naming consistent with the way `minted` and `listings` work, by suffixing instead of prefixing, and is specific to Haskell. e.g. from the minted `\newmintinline` docs:

```latex
\newmintinline{perl}{showspaces}

X\perlinline/my $foo = $bar;/X
```

and it's `code` equivalent which will work with the new `hscode`:

```latex
\newminted{cpp}{gobble=2,linenos}

\begin{cppcode}
```

`code` or `inline` get added after the language name. i.e. `hscode` and `hsinline`.