### PR TITLE
Use the last compilation to find and watch all the dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -636,11 +636,10 @@
           "type": "string",
           "enum": [
             "never",
-            "onSave",
             "onFileChange"
           ],
-          "default": "onSave",
-          "markdownDescription": "When the extension shall auto build LaTeX project using the default (first) recipe.\n`onSave` builds the project upon saving a `tex` file in vscode. `onFileChange` builds the project upon detecting a `tex` file change, even modified by other applications."
+          "default": "onFileChange",
+          "markdownDescription": "When the extension shall auto build LaTeX project using the default (first) recipe.\n `onFileChange` builds the project upon detecting a file change in any of the dependencies, even modified by other applications."
         },
         "latex-workshop.latex.autoBuild.cleanAndRetry.enabled": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -632,6 +632,23 @@
           "default": [],
           "markdownDescription": "Patterns of files to exclude from the root detection mechanism.\nSee also `latex-workshop.latex.search.rootFiles.include`. For more details the [wiki](https://github.com/James-Yu/LaTeX-Workshop/wiki/Multi-File-Projects)."
         },
+        "latex-workshop.latex.watch.files.ignore": {
+          "type": "array",
+          "default": [
+            "**/*.bbx",
+            "**/*.cbx",
+            "**/*.cfg",
+            "**/*.clo",
+            "**/*.cnf",
+            "**/*.def",
+            "**/*.fmt",
+            "**/*.lbx",
+            "**/*.map",
+            "**/*.pfb",
+            "**/*.tfm"
+          ],
+          "markdownDescription": "Files to ignore from the watching mechanism used for triggering autobuild.\nThis property must be an array of globs pattern. The patterns are matched against the absolute file path. To ignore everything inside the `texmf` tree, `**/texmf/**` can be used."
+        },
         "latex-workshop.latex.autoBuild.run": {
           "type": "string",
           "enum": [

--- a/src/components/builder.ts
+++ b/src/components/builder.ts
@@ -284,6 +284,7 @@ export class Builder {
         this.extension.logger.addLogMessage(`Successfully built ${rootFile}.`)
         this.extension.logger.displayStatus('check', 'statusBar.foreground', 'Recipe succeeded.')
         this.extension.viewer.refreshExistingViewer(rootFile)
+        this.extension.manager.findAdditionalDependentFilesFromFls(rootFile)
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         if (configuration.get('synctex.afterBuild.enabled') as boolean) {
             this.extension.locator.syncTeX()

--- a/src/components/builder.ts
+++ b/src/components/builder.ts
@@ -131,7 +131,7 @@ export class Builder {
 
     async build(rootFile: string, recipe: string | undefined = undefined) {
         if (this.isWaitingForBuildToFinish()) {
-            this.extension.logger.addLogMessage(`Another LaTeX build proccesing is already waiting for the current LaTeX build to finish. Exit.`)
+            this.extension.logger.addLogMessage(`Another LaTeX build processing is already waiting for the current LaTeX build to finish. Exit.`)
             return
         }
         const releaseBuildMutex = await this.preprocess()
@@ -200,7 +200,7 @@ export class Builder {
             this.currentProcess = cp.spawn(steps[index].command, steps[index].args, {cwd: path.dirname(rootFile), env: envVars})
         }
         const pid = this.currentProcess.pid
-        this.extension.logger.addLogMessage(`LaTeX buid process spawned. PID: ${pid}.`)
+        this.extension.logger.addLogMessage(`LaTeX build process spawned. PID: ${pid}.`)
 
         let stdout = ''
         this.currentProcess.stdout.on('data', newStdout => {

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode'
 import * as path from 'path'
 import * as fs from 'fs'
 import * as chokidar from 'chokidar'
+import * as micromatch from 'micromatch'
 
 import {Extension} from '../main'
 
@@ -401,8 +402,13 @@ export class Manager {
             }
         })
 
+        const configuration = vscode.workspace.getConfiguration('latex-workshop')
+        const globsToIgnore = configuration.get('latex.watch.files.ignore') as string[]
         inputFiles.forEach(inputFile => {
             const inputFilePath = path.resolve(rootDir, inputFile)
+            if (micromatch.some(inputFile, globsToIgnore)) {
+                return
+            }
             if (this.texFileTree.hasOwnProperty(rootFile) && this.texFileTree[rootFile].has(inputFilePath)) {
                 return
             }

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -368,11 +368,11 @@ export class Manager {
             return
         }
         const flsContent = fs.readFileSync(flsFile).toString()
-        const regex = /^(?:(PWD)\s*(.*))|(?:(INPUT)\s*(.*\.(tex|sty|cls)))|(?:(OUTPUT)\s*(.*\.aux))$/gm
+        const regex = /^(?:(PWD)\s*(.*))|(?:(INPUT)\s*(.*))|(?:(OUTPUT)\s*(.*\.aux))$/gm
         // regex groups
         // #1: a PWD entry --> #2 gives the path
-        // #3: an INPUT entry --> #4: input file path, #5: extension of the input file
-        // #6: an OUTPUT entry --> #7: output file path
+        // #3: an INPUT entry --> #4: input file path
+        // #5: an OUTPUT entry --> #6: output file path
         let pwd
         while (true) {
             const result = regex.exec(flsContent)
@@ -386,7 +386,7 @@ export class Manager {
                 if (this.texFileTree.hasOwnProperty(rootFile) && this.texFileTree[rootFile].has(inputFilePath)) {
                     continue
                 }
-                if (result[5] === 'tex') {
+                if (path.extname(result[5]) === 'tex') {
                     this.texFileTree[rootFile].add(inputFilePath)
                     this.findDependentFiles(inputFilePath, rootDir)
                 }
@@ -395,8 +395,8 @@ export class Manager {
                     this.fileWatcher.add(inputFilePath)
                     this.filesWatched.push(inputFilePath)
                 }
-            } else if (result[6] && !fast) {
-                const auxFilePath = path.resolve(pwd, result[7])
+            } else if (result[5] && !fast) {
+                const auxFilePath = path.resolve(pwd, result[6])
                 this.findBibFileFromAux(auxFilePath, rootDir, outDir)
             }
         }

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -353,7 +353,7 @@ export class Manager {
         // regex groups
         // #1: a PWD entry --> #2 gives the path
         // #3: an INPUT entry --> #4: input file path
-        // #5: an OUPUT entry --> #6: output file path
+        // #5: an OUTPUT entry --> #6: output file path
         let pwd
         while (true) {
             const result = regex.exec(flsContent)

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -263,7 +263,7 @@ export class Manager {
             this.fileWatcher = chokidar.watch(rootFile)
             this.filesWatched.push(rootFile)
             this.fileWatcher.on('change', (filePath: string) => {
-                if (path.extname(filePath) === 'tex') {
+                if (path.extname(filePath) === '.tex') {
                     this.findDependentFiles(filePath)
                 }
                 if (filePath === rootFile) {
@@ -386,7 +386,7 @@ export class Manager {
                 if (this.texFileTree.hasOwnProperty(rootFile) && this.texFileTree[rootFile].has(inputFilePath)) {
                     continue
                 }
-                if (path.extname(result[5]) === 'tex') {
+                if (path.extname(result[4]) === '.tex') {
                     this.texFileTree[rootFile].add(inputFilePath)
                     this.findDependentFiles(inputFilePath, rootDir)
                 }

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -364,7 +364,9 @@ export class Manager {
                 pwd = result[2]
             } else if (result[3]) {
                 const inputFilePath = path.resolve(rootDir, result[4])
-                // ! Handle full vs relative path
+                if (this.texFileTree.hasOwnProperty(rootFile) && this.texFileTree[rootFile].has(inputFilePath)) {
+                    continue
+                }
                 this.texFileTree[rootFile].add(inputFilePath)
                 if (this.fileWatcher && this.filesWatched.indexOf(inputFilePath) < 0) {
                     this.extension.logger.addLogMessage(`Adding ${inputFilePath} to file watcher.`)

--- a/src/main.ts
+++ b/src/main.ts
@@ -310,28 +310,6 @@ export async function activate(context: vscode.ExtensionContext) {
         }
     }))
 
-    context.subscriptions.push(vscode.workspace.createFileSystemWatcher('**/*.tex', true, false, true).onDidChange(async (e: vscode.Uri) => {
-        if (vscode.window.activeTextEditor && vscode.window.activeTextEditor.document.fileName === e.fsPath) {
-            return
-        }
-        configuration = vscode.workspace.getConfiguration('latex-workshop')
-        if (configuration.get('latex.autoBuild.run') as string !== 'onFileChange') {
-            return
-        }
-        if (extension.builder.disableBuildAfterSave) {
-            extension.logger.addLogMessage('Auto Build Run is temporarily disabled during a second.')
-            return
-        }
-        extension.logger.addLogMessage(`${e.fsPath} changed. Auto build project.`)
-        const rootFile = extension.manager.findRoot()
-        if (rootFile !== undefined) {
-            extension.logger.addLogMessage(`Building root file: ${rootFile}`)
-            await extension.builder.build(extension.manager.rootFile)
-        } else {
-            extension.logger.addLogMessage(`Cannot find LaTeX root file.`)
-        }
-    }))
-
     extension.manager.findRoot()
 
     const formatter = new LatexFormatterProvider(extension)

--- a/src/providers/structure.ts
+++ b/src/providers/structure.ts
@@ -243,7 +243,7 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
 export class Section extends vscode.TreeItem {
 
     public children: Section[] = []
-    public parent: Section | undefined = undefined // The parent of a toplevel section must be undefined
+    public parent: Section | undefined = undefined // The parent of a top level section must be undefined
     public subfiles: string[] = []
 
     constructor(


### PR DESCRIPTION
This PR is related to #1153 and [#1194](https://github.com/James-Yu/LaTeX-Workshop/issues/1194#issuecomment-466745848).

Running the LaTeX compiler with the -recorder option (automatically added by `latexmk`) generates a `.fls` file, which contains the list of all input files (`.tex`, `.sty`,...) and output files (`.aux` in particular). Then, we can extract the tree of `.tex` files and from the `.aux` files, we get all the `.bib` files.

The results provided are of course always a bit outdated as they do not take into account the changes since the last compilation but it will undoubtedly help with files included using personal macros.

This new mechanism helps 
- intellisense for commands, references and citations
- finding the correct root file when the current file is included via personal macros or the file name itself is a macro.

I am making a call for testers before merging.