### PR TITLE
make the width of math preview on hover larger.

### DIFF
--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -167,6 +167,12 @@ export class HoverProvider implements vscode.HoverProvider {
         return undefined
     }
 
+    addDummyCodeBlock(md: string) : string {
+        // We need a dummy code block in hover to make the width of hover larger.
+        const dummyCodeBlock = '```\n```'
+        return dummyCodeBlock + '\n' + md + '\n' + dummyCodeBlock
+    }
+
     private async provideHoverOnTex(document: vscode.TextDocument, tex: TexMathEnv, newCommand: string) : Promise<vscode.Hover> {
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         const scale = configuration.get('hover.preview.scale') as number
@@ -181,9 +187,7 @@ export class HoverProvider implements vscode.HoverProvider {
         this.colorSVG(data)
         const xml = data.svgNode.outerHTML
         const md = this.svgToDataUrl(xml)
-        // We need a dummy code block in hover to make the width of hover larger.
-        const dummyCodeBlock = '```\n```'
-        return new vscode.Hover(new vscode.MarkdownString(dummyCodeBlock + '\n' + `![equation](${md})`+ '\n' + dummyCodeBlock), tex.range )
+        return new vscode.Hover(new vscode.MarkdownString(this.addDummyCodeBlock(`![equation](${md})`)), tex.range )
     }
 
     private async provideHoverOnRef(tex: TexMathEnv, newCommand: string, refToken: string, refData: ReferenceEntry) : Promise<vscode.Hover> {
@@ -208,9 +212,7 @@ export class HoverProvider implements vscode.HoverProvider {
         const link = vscode.Uri.parse('command:latex-workshop.synctexto').with({ query: JSON.stringify([line, refData.file]) })
         const mdLink = new vscode.MarkdownString(`[View on pdf](${link})`)
         mdLink.isTrusted = true
-        // We need a dummy code block in hover to make the width of hover larger.
-        const dummyCodeBlock = '```\n```'
-        return new vscode.Hover( [eqNumAndLabels, dummyCodeBlock + '\n' + `![equation](${md})` + '\n' + dummyCodeBlock, mdLink], tex.range )
+        return new vscode.Hover( [eqNumAndLabels, this.addDummyCodeBlock(`![equation](${md})`), mdLink], tex.range )
     }
 
     private eqNumAndLabel(obj: LabelsStore, tex: TexMathEnv, refToken: string) : string {

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -181,7 +181,9 @@ export class HoverProvider implements vscode.HoverProvider {
         this.colorSVG(data)
         const xml = data.svgNode.outerHTML
         const md = this.svgToDataUrl(xml)
-        return new vscode.Hover(new vscode.MarkdownString( `![equation](${md})`), tex.range )
+        // We need a dummy code block in hover to make the width of hover larger.
+        const dummyCodeBlock = '```\n```'
+        return new vscode.Hover(new vscode.MarkdownString(dummyCodeBlock + '\n' + `![equation](${md})`+ '\n' + dummyCodeBlock), tex.range )
     }
 
     private async provideHoverOnRef(tex: TexMathEnv, newCommand: string, refToken: string, refData: ReferenceEntry) : Promise<vscode.Hover> {
@@ -206,7 +208,9 @@ export class HoverProvider implements vscode.HoverProvider {
         const link = vscode.Uri.parse('command:latex-workshop.synctexto').with({ query: JSON.stringify([line, refData.file]) })
         const mdLink = new vscode.MarkdownString(`[View on pdf](${link})`)
         mdLink.isTrusted = true
-        return new vscode.Hover( [eqNumAndLabels, `![equation](${md})`, mdLink], tex.range )
+        // We need a dummy code block in hover to make the width of hover larger.
+        const dummyCodeBlock = '```\n```'
+        return new vscode.Hover( [eqNumAndLabels, dummyCodeBlock + '\n' + `![equation](${md})` + '\n' + dummyCodeBlock, mdLink], tex.range )
     }
 
     private eqNumAndLabel(obj: LabelsStore, tex: TexMathEnv, refToken: string) : string {


### PR DESCRIPTION
This is a patch to make the width of math preview on hover larger. In the next release of VSCode, hovers with code blocks have larger width. By inserting empty code blocks as dummies, we can obtain a larger math preview.

We can check the effect in the VSCode Insiders.

Before:
<img width="1902" alt="2019-03-01 10 01 03" src="https://user-images.githubusercontent.com/10665499/53609168-f89db200-3c08-11e9-8845-4746ab1bf829.png">

After:
<img width="1914" alt="2019-03-01 10 00 35" src="https://user-images.githubusercontent.com/10665499/53609170-005d5680-3c09-11e9-8ef5-15e58fa02557.png">

