### PR TITLE
Fix external reverse synctex on Windows

### DIFF
--- a/src/components/locator.ts
+++ b/src/components/locator.ts
@@ -269,7 +269,12 @@ export class Locator {
             }
         } else {
             record = await this.invokeSyncTeXCommandBackward(data.page, data.pos[0], data.pos[1], pdfPath)
+            record.input = record.input.replace(/(\r\n|\n|\r)/gm, '')
+            if (docker && process.platform === 'win32') {
+                record.input = path.join(path.dirname(pdfPath), record.input.replace('/data/', ''))
+            }
         }
+
         // kpathsea/SyncTeX follow symlinks.
         // see http://tex.stackexchange.com/questions/25578/why-is-synctex-in-tl-2011-so-fussy-about-filenames.
         // We compare the return of symlink with the files list in the texFileTree and try to pickup the correct one.
@@ -280,11 +285,7 @@ export class Locator {
             }
         }
 
-        let filePath = path.resolve( record.input.replace(/(\r\n|\n|\r)/gm, '') )
-        if (docker && process.platform === 'win32') {
-            filePath = path.resolve(path.dirname(pdfPath), record.input as string)
-        }
-
+        let filePath = path.resolve(record.input)
         this.extension.logger.addLogMessage(`SyncTeX to file ${filePath}`)
         vscode.workspace.openTextDocument(filePath).then((doc) => {
             let viewColumn: vscode.ViewColumn | undefined = undefined


### PR DESCRIPTION
Fixes #1240, however I couldn't verify that it doesn't break anything on other platforms.