### PR TITLE
pdf Viewer: Allow multi-page view

### DIFF
--- a/viewer/viewer.css
+++ b/viewer/viewer.css
@@ -271,6 +271,7 @@
 }
 
 .pdfViewer .page {
+  display: inline-block;
   direction: ltr;
   width: 816px;
   height: 1056px;


### PR DESCRIPTION
I like having pdf-pages shown side by side. Using "inline-block" allows to select a zoom-level to allow for that.

Perhaps an option to display as inline-block would be better than forcing this setting.