### PR TITLE
move label to end of figure environment

### DIFF
--- a/data/commands.json
+++ b/data/commands.json
@@ -27,7 +27,7 @@
   },
   "figure":{
     "command": "figure",
-    "snippet": "begin{figure}[${1:htbp}]\n\t\\label{${2:<label>}}\n\t\\centering\n\t$0\n\t\\caption{${3:<caption>}}\n\\end{figure}",
+    "snippet": "begin{figure}[${1:htbp}]\n\t\\centering\n\t$0\n\t\\caption{${2:<caption>}}\n\t\\label{${3:<label>}}\n\\end{figure}",
 		"description": "Insert a new figure"
   },
   "latexinlinemath":{

--- a/snippets/latex.json
+++ b/snippets/latex.json
@@ -177,7 +177,7 @@
 	},
 	"figure": {
 		"prefix": "BFI",
-		"body": "\\begin{figure}[${1:htbp}]\n\t\\label{${2:<label>}}\n\t\\centering\n\t$0\n\t\\caption{${3:<caption>}}\n\\end{figure}",
+		"body": "\\begin{figure}[${1:htbp}]\n\t\\centering\n\t$0\n\t\\caption{${2:<caption>}}\n\t\\label{${3:<label>}}\n\\end{figure}",
 		"description": "Insert a new figure"
 	},
 	"set font size": {


### PR DESCRIPTION
I forgot that the label has to appear after the caption to work right.