### PR TITLE
find output files (*.axu...) in outDir instead of rootDir

### DIFF
--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -390,7 +390,7 @@ export class Manager {
                     inputFiles.add(inputFilePath)
                 }
             } else if (result[3]) {
-                const outputFilePath = path.resolve(rootDir, result[4])
+                const outputFilePath = path.resolve(outDir, result[4])
                 if (outputFilePath) {
                     outputFiles.add(outputFilePath)
                 }


### PR DESCRIPTION
`result` contains *.aux, *.xdv files and the following codes try to find these files in `rootDir`:
```
const outputFilePath = path.resolve(rootDir, result[4])
```
If my understanding is correct, these files are actually located in `outDir` instead of `rootDir`, since if `-outdir=` is specified for `latexmk`, `latexmk` will output all these files to `outdir`. Therefore `rootDir` should be changed to `outDir`.