### PR TITLE
option to configure rootFile explicitly in (workspace)settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,6 +170,11 @@
     ],
     "commands": [
       {
+        "command": "latex-workshop.configureRootfile",
+        "title": "Choose your LaTeX rootFile from the current directory",
+        "category": "LaTeX Workshop"
+      },
+      {
         "command": "latex-workshop.navigate-envpair",
         "title": "Navigate to matching begin/end",
         "category": "LaTeX Workshop"
@@ -533,6 +538,10 @@
       "type": "object",
       "title": "LaTeX",
       "properties": {
+        "latex-workshop.rootFile": {
+          "type": "string",
+          "default": null
+        },
         "latex-workshop.latex.recipes": {
           "type": "array",
           "default": [

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -84,7 +84,7 @@ export class Manager {
 
     async findRoot() : Promise<string | undefined> {
         this.updateWorkspace()
-        const findMethods = [() => this.findRootMagic(), () => this.findRootSelf(), () => this.findRootDir()]
+        const findMethods = [() => this.findRootConfig(), () => this.findRootMagic(), () => this.findRootSelf(), () => this.findRootDir()]
         for (const method of findMethods) {
             const rootFile = await method()
             if (rootFile !== undefined) {
@@ -99,6 +99,10 @@ export class Manager {
             }
         }
         return undefined
+    }
+
+    findRootConfig() : string | undefined {
+      return vscode.workspace.getConfiguration('latex-workshop').get('rootFile')
     }
 
     findRootMagic() : string | undefined {

--- a/src/main.ts
+++ b/src/main.ts
@@ -239,6 +239,20 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('latex-workshop.shortcut.mathbb', () => extension.commander.toggleSelectedKeyword('mathbb'))
     vscode.commands.registerCommand('latex-workshop.shortcut.mathcal', () => extension.commander.toggleSelectedKeyword('mathcal'))
     vscode.commands.registerCommand('latex-workshop.surround', () => extension.completer.command.surround())
+    vscode.commands.registerCommand('latex-workshop.configureRootfile', async () => {
+      if (vscode.workspace.workspaceFolders === null) {
+        return
+      }
+      const dir = (vscode.workspace.workspaceFolders as vscode.WorkspaceFolder[])[0].uri.fsPath
+      const files = (await vscode.workspace.findFiles('**/*.{tex,latex}'))
+        .map(f => path.relative(dir, f.fsPath))
+      const file = await vscode.window.showQuickPick(files, {
+        placeHolder: 'Select Document RootFile'
+      })
+      if (file !== null) {
+        vscode.workspace.getConfiguration('latex-workshop').update('rootFile', path.resolve(dir, file as string), vscode.ConfigurationTarget.Workspace);
+      }
+    })
 
     vscode.commands.registerCommand('latex-workshop.increment-sectioning', () => extension.commander.shiftSectioningLevel('increment'))
     vscode.commands.registerCommand('latex-workshop.decrement-sectioning', () => extension.commander.shiftSectioningLevel('decrement'))


### PR DESCRIPTION
Sorry, the other pull-request was on the wrong branch...
I made a setting *latex-workshop.rootFile* available and implemented a convenient command *latex-workshop.configureRootfile* that let's you choose a rootFile from **\*\*/\*.{tex,latex}** files in the current working directory and saves the setting to the workspace configuration. I think this is really useful, as I would always choose defining the rootFile explicitly over some kind of magic to find it. Also it is very convenient to switch rootFiles via *vscode.showQuickPick()*, although during the most projects I think one workspace equals to one rootFile.
I placed the order first in the *manager.findRoot()* order, so the eplicit config will always be first. This might be debatable though