### PR TITLE
removed # and 'z notation' in docs of unimath

### DIFF
--- a/data/unimathsymbols.json
+++ b/data/unimathsymbols.json
@@ -1172,7 +1172,7 @@
   "bigtriangleup": {
     "command": "bigtriangleup",
     "detail": "△",
-    "documentation": "\\triangle (amsfonts), # \\vartriangle (amssymb), big up triangle, open"
+    "documentation": "\\triangle (amsfonts), \\vartriangle (amssymb), big up triangle, open"
   },
   "biguplus": {
     "command": "biguplus",
@@ -1677,7 +1677,7 @@
   "coloneq": {
     "command": "coloneq",
     "detail": "≔ (\"mathabx -txfonts\" command)",
-    "documentation": "\\coloneqq (txfonts), \\setdelayed (wrisym), # := colon, equals"
+    "documentation": "\\coloneqq (txfonts), \\setdelayed (wrisym), := colon, equals"
   },
   "comma": {
     "command": "comma",
@@ -1897,7 +1897,7 @@
   "dashv": {
     "command": "dashv",
     "detail": "⊣ (\"amssymb\" command)",
-    "documentation": "Left tack, non-theorem, does not yield, (dash, vertical)"
+    "documentation": "Left tack, non-theorem, does not yield, (dash and vertical)"
   },
   "dbkarow": {
     "command": "dbkarow",
@@ -2297,7 +2297,7 @@
   "eqcolon": {
     "command": "eqcolon",
     "detail": "≕ (\"mathabx -txfonts\" command)",
-    "documentation": "\\eqqcolon (txfonts), # =:, equals, colon"
+    "documentation": "\\eqqcolon (txfonts), =:, equals, colon"
   },
   "eqdef": {
     "command": "eqdef",
@@ -10932,7 +10932,7 @@
   "triangleleft": {
     "command": "triangleleft",
     "detail": "◁ (\"amssymb wasysym\" command)",
-    "documentation": "\\dres (oz), \\lefttriangle (wrisym), (large) left triangle, open; z notation domain restriction"
+    "documentation": "\\dres (oz), \\lefttriangle (wrisym), (large) left triangle, open; domain restriction"
   },
   "triangleleftblack": {
     "command": "triangleleftblack",
@@ -10967,7 +10967,7 @@
   "triangleright": {
     "command": "triangleright",
     "detail": "▷ (\"amssymb wasysym\" command)",
-    "documentation": "\\rres (oz), \\righttriangle (wrisym), (large) right triangle, open; z notation range restriction"
+    "documentation": "\\rres (oz), \\righttriangle (wrisym), (large) right triangle, open; range restriction"
   },
   "trianglerightblack": {
     "command": "trianglerightblack",
@@ -11817,7 +11817,7 @@
   "vdash": {
     "command": "vdash",
     "detail": "⊢",
-    "documentation": "Right tack, proves, implies, yields, (vertical, dash)"
+    "documentation": "Right tack, proves, implies, yields, (vertical and dash)"
   },
   "vdots": {
     "command": "vdots",
@@ -11827,7 +11827,7 @@
   "vec": {
     "command": "vec",
     "detail": "x⃗",
-    "documentation": "\\vec (wrisym), # \\overrightarrow, combining right arrow above"
+    "documentation": "\\vec (wrisym), \\overrightarrow, combining right arrow above"
   },
   "vectimes": {
     "command": "vectimes",


### PR DESCRIPTION
removed # and 'z notation'  in docs of unimath.