### PR TITLE
Merge latex-mathsymbols_cmd.json into commands.json

### DIFF
--- a/data/commands.json
+++ b/data/commands.json
@@ -253,7 +253,9 @@
   },
   "underline":{
     "command":"underline",
-    "snippet":"underline{${1}}"
+    "snippet":"underline{${1}}",
+    "detail":" ̲",
+    "documentation":"COMBINING LOW LINE"
   },
   "rule":{
     "command":"rule{width}{height}",
@@ -949,11 +951,15 @@
   },
   "overbrace": {
     "command": "overbrace",
-    "snippet": "overbrace{${1:text}}"
+    "snippet": "overbrace{${1:text}}",
+    "detail": "⏞",
+    "documentation": "TOP CURLY BRACKET"
   },
   "overline": {
     "command": "overline",
-    "snippet": "overline{${1:text}}"
+    "snippet": "overline{${1:text}}",
+    "detail": " ̅",
+    "documentation": "overbar embellishment"
   },
   "pagebreak[]": {
     "command": "pagebreak[number]",
@@ -1365,7 +1371,9 @@
   },
   "diamond":{
     "command":"diamond",
-    "snippet":"diamond"
+    "snippet":"diamond",
+    "detail":"⋄",
+    "documentation":"DIAMOND OPERATOR"
   },
   "diamondsuit":{
     "command":"diamondsuit",
@@ -1559,7 +1567,9 @@
   },
   "lgroup":{
     "command":"lgroup",
-    "snippet":"lgroup"
+    "snippet":"lgroup",
+    "detail":"⟮",
+    "documentation":"MATHEMATICAL LEFT FLATTENED PARENTHESIS"
   },
   "lim":{
     "command":"lim",
@@ -1805,7 +1815,9 @@
   },
   "rgroup":{
     "command":"rgroup",
-    "snippet":"rgroup"
+    "snippet":"rgroup",
+    "detail":"⟯",
+    "documentation":"MATHEMATICAL RIGHT FLATTENED PARENTHESIS"
   },
   "rightharpoondown":{
     "command":"rightharpoondown",

--- a/data/commands.json
+++ b/data/commands.json
@@ -499,10 +499,12 @@
     "detail":"∉"
   },
   "subset":{
-    "command":"subset"
+    "command":"subset",
+    "detail":"⊂"
   },
   "supset":{
-    "command":"supset"
+    "command":"supset",
+    "detail":"⊃"
   },
   "leftarrow":{
     "command":"leftarrow",
@@ -537,7 +539,8 @@
     "detail":"≈"
   },
   "mid":{
-    "command":"mid"
+    "command":"mid",
+    "detail":"∣"
   },
   "neg":{
     "command":"neg",
@@ -629,14 +632,6 @@
   "ddot":{
     "command":"ddot",
     "snippet":"ddot{$1}"
-  },
-  "dddot":{
-    "command":"dddot",
-    "snippet":"dddot{$1}"
-  },
-  "ddddot":{
-    "command":"ddddot",
-    "snippet":"ddddot{$1}"
   },
   "cdot":{
     "command":"cdot",
@@ -784,7 +779,8 @@
   },
   "ddots": {
     "command": "ddots",
-    "snippet": "ddots"
+    "snippet": "ddots",
+    "detail":"⋱"
   },
   "documentclass[]{}": {
     "command": "documentclass[options]{style}",
@@ -1407,7 +1403,8 @@
   },
   "emptyset":{
     "command":"emptyset",
-    "snippet":"emptyset"
+    "snippet":"emptyset",
+    "detail":"∅"
   },
   "exp":{
     "command":"exp",
@@ -1431,7 +1428,8 @@
   },
   "ge":{
     "command":"ge",
-    "snippet":"ge"
+    "snippet":"ge",
+    "detail":">"
   },
   "gets":{
     "command":"gets",
@@ -1445,7 +1443,8 @@
   },
   "hbar":{
     "command":"hbar",
-    "snippet":"hbar"
+    "snippet":"hbar",
+    "detail":"ℏ"
   },
   "heartsuit":{
     "command":"heartsuit",
@@ -1527,7 +1526,8 @@
   },
   "le":{
     "command":"le",
-    "snippet":"le"
+    "snippet":"le",
+    "detail":"<"
   },
   "leftharpoondown":{
     "command":"leftharpoondown",
@@ -2001,11 +2001,13 @@
   },
   "varpi":{
     "command":"varpi",
-    "snippet":"varpi"
+    "snippet":"varpi",
+    "detail":"ϖ"
   },
   "varrho":{
     "command":"varrho",
-    "snippet":"varrho"
+    "snippet":"varrho",
+    "detail": "ϱ"
   },
   "vdash":{
     "command":"vdash",

--- a/data/commands.json
+++ b/data/commands.json
@@ -180,6 +180,31 @@
     "command":"textup",
     "snippet":"textup{${1}}"
   },
+  "mathbf{}": {
+    "command": "mathbf{text}",
+    "package": "latex-document",
+    "snippet": "mathbf{${1:text}}"
+  },
+  "mathcal{}": {
+    "command": "mathcal{text}",
+    "package": "latex-document",
+    "snippet": "mathcal{${1:text}}"
+  },
+  "mathit{}": {
+    "command": "mathit{text}",
+    "package": "latex-document",
+    "snippet": "mathit{${1:text}}"
+  },
+  "mathrm{}": {
+    "command": "mathrm{text}",
+    "package": "latex-document",
+    "snippet": "mathrm{${1:text}}"
+  },
+  "mathsf{}": {
+    "command": "mathsf{text}",
+    "package": "latex-document",
+    "snippet": "mathsf{${1:text}}"
+  },
   "label":{
     "command":"label{...}",
     "snippet":"label{${1}}"
@@ -250,6 +275,13 @@
   },
   "today":{
     "command":"today"
+  },
+  "underbrace{}": {
+    "command": "underbrace{text}",
+    "package": "latex-document",
+    "snippet": "underbrace{${1:text}}",
+    "detail": "⏟",
+    "documentation": "BOTTOM CURLY BRACKET (mathematical use)"
   },
   "underline":{
     "command":"underline",

--- a/data/commands.json
+++ b/data/commands.json
@@ -1106,6 +1106,935 @@
   "renewenvironment": {
     "command": "renewenvironment{name}{begdef}{enddef}",
     "snippet": "renewenvironment{${1:name}}{${2:begdef}}{${3:enddef}}"
+  },
+  "aleph":{
+    "command":"aleph",
+    "snippet":"aleph",
+    "detail":"ℵ",
+    "documentation":"Aleph, hebrew"
+  },
+  "amalg":{
+    "command":"amalg",
+    "snippet":"amalg",
+    "detail":"⨿",
+    "documentation":"Amalgamation or coproduct"
+  },
+  "angle":{
+    "command":"angle",
+    "snippet":"angle",
+    "detail":"∠",
+    "documentation":"Angle"
+  },
+  "arccos":{
+    "command":"arccos",
+    "snippet":"arccos"
+  },
+  "arcsin":{
+    "command":"arcsin",
+    "snippet":"arcsin"
+  },
+  "arctan":{
+    "command":"arctan",
+    "snippet":"arctan"
+  },
+  "arg":{
+    "command":"arg",
+    "snippet":"arg"
+  },
+  "Arrowvert":{
+    "command":"Arrowvert",
+    "snippet":"Arrowvert"
+  },
+  "arrowvert":{
+    "command":"arrowvert",
+    "snippet":"arrowvert"
+  },
+  "ast":{
+    "command":"ast",
+    "snippet":"ast",
+    "detail":"∗",
+    "documentation":"Asterisk operator (hodge star operator)"
+  },
+  "asymp":{
+    "command":"asymp",
+    "snippet":"asymp",
+    "detail":"≍",
+    "documentation":"Asymptotically equal to"
+  },
+  "backslash":{
+    "command":"backslash",
+    "snippet":"backslash",
+    "detail":"\\",
+    "documentation":"Reverse solidus"
+  },
+  "Big":{
+    "command":"Big",
+    "snippet":"Big"
+  },
+  "big":{
+    "command":"big",
+    "snippet":"big"
+  },
+  "bigcirc":{
+    "command":"bigcirc",
+    "snippet":"bigcirc"
+  },
+  "Bigg":{
+    "command":"Bigg",
+    "snippet":"Bigg"
+  },
+  "bigg":{
+    "command":"bigg",
+    "snippet":"bigg"
+  },
+  "Biggl":{
+    "command":"Biggl",
+    "snippet":"Biggl"
+  },
+  "biggl":{
+    "command":"biggl",
+    "snippet":"biggl"
+  },
+  "Biggm":{
+    "command":"Biggm",
+    "snippet":"Biggm"
+  },
+  "biggm":{
+    "command":"biggm",
+    "snippet":"biggm"
+  },
+  "Biggr":{
+    "command":"Biggr",
+    "snippet":"Biggr"
+  },
+  "biggr":{
+    "command":"biggr",
+    "snippet":"biggr"
+  },
+  "Bigl":{
+    "command":"Bigl",
+    "snippet":"Bigl"
+  },
+  "bigl":{
+    "command":"bigl",
+    "snippet":"bigl"
+  },
+  "Bigm":{
+    "command":"Bigm",
+    "snippet":"Bigm"
+  },
+  "bigm":{
+    "command":"bigm",
+    "snippet":"bigm"
+  },
+  "bigodot":{
+    "command":"bigodot",
+    "snippet":"bigodot",
+    "detail":"⨀",
+    "documentation":"N-ary circled dot operator"
+  },
+  "bigoplus":{
+    "command":"bigoplus",
+    "snippet":"bigoplus",
+    "detail":"⨁",
+    "documentation":"N-ary circled plus operator"
+  },
+  "bigotimes":{
+    "command":"bigotimes",
+    "snippet":"bigotimes",
+    "detail":"⨂",
+    "documentation":"N-ary circled times operator"
+  },
+  "Bigr":{
+    "command":"Bigr",
+    "snippet":"Bigr"
+  },
+  "bigr":{
+    "command":"bigr",
+    "snippet":"bigr"
+  },
+  "bigsqcup":{
+    "command":"bigsqcup",
+    "snippet":"bigsqcup",
+    "detail":"⨆",
+    "documentation":"N-ary square union operator"
+  },
+  "bigtriangledown":{
+    "command":"bigtriangledown",
+    "snippet":"bigtriangledown",
+    "detail":"▽",
+    "documentation":"Big down triangle, open"
+  },
+  "bigtriangleup":{
+    "command":"bigtriangleup",
+    "snippet":"bigtriangleup",
+    "detail":"△",
+    "documentation":"big up triangle, open"
+  },
+  "biguplus":{
+    "command":"biguplus",
+    "snippet":"biguplus",
+    "detail":"⨄",
+    "documentation":"N-ary union operator with plus"
+  },
+  "bigvee":{
+    "command":"bigvee",
+    "snippet":"bigvee",
+    "detail":"⋁",
+    "documentation":"Logical or operator"
+  },
+  "bigwedge":{
+    "command":"bigwedge",
+    "snippet":"bigwedge",
+    "detail":"⋀",
+    "documentation":"Logical and operator"
+  },
+  "bot":{
+    "command":"bot",
+    "snippet":"bot",
+    "detail":"⊥",
+    "documentation":"Up tack, bottom"
+  },
+  "bracevert":{
+    "command":"bracevert",
+    "snippet":"bracevert"
+  },
+  "bullet":{
+    "command":"bullet",
+    "snippet":"bullet"
+  },
+  "clubsuit":{
+    "command":"clubsuit",
+    "snippet":"clubsuit",
+    "detail":"♣",
+    "documentation":"Club suit symbol"
+  },
+  "cong":{
+    "command":"cong",
+    "snippet":"cong",
+    "detail":"≅",
+    "documentation":"Congruent with"
+  },
+  "coprod":{
+    "command":"coprod",
+    "snippet":"coprod",
+    "detail":"∐",
+    "documentation":"Coproduct operator"
+  },
+  "cos":{
+    "command":"cos",
+    "snippet":"cos"
+  },
+  "cosh":{
+    "command":"cosh",
+    "snippet":"cosh"
+  },
+  "cot":{
+    "command":"cot",
+    "snippet":"cot"
+  },
+  "coth":{
+    "command":"coth",
+    "snippet":"coth"
+  },
+  "csc":{
+    "command":"csc",
+    "snippet":"csc"
+  },
+  "dagger":{
+    "command":"dagger",
+    "snippet":"dagger",
+    "detail":"†",
+    "documentation":"Dagger relation"
+  },
+  "dashv":{
+    "command":"dashv",
+    "snippet":"dashv",
+    "detail":"⊣",
+    "documentation":"Left tack, non-theorem, does not yield, (dash and vertical)"
+  },
+  "ddagger":{
+    "command":"ddagger",
+    "snippet":"ddagger",
+    "detail":"‡",
+    "documentation":"Double dagger relation"
+  },
+  "deg":{
+    "command":"deg",
+    "snippet":"deg"
+  },
+  "det":{
+    "command":"det",
+    "snippet":"det"
+  },
+  "diamond":{
+    "command":"diamond",
+    "snippet":"diamond"
+  },
+  "diamondsuit":{
+    "command":"diamondsuit",
+    "snippet":"diamondsuit",
+    "detail":"♢",
+    "documentation":"Diamond suit symbol"
+  },
+  "dim":{
+    "command":"dim",
+    "snippet":"dim"
+  },
+  "doteq":{
+    "command":"doteq",
+    "snippet":"doteq",
+    "detail":"≐",
+    "documentation":"equals, single dot above"
+  },
+  "Downarrow":{
+    "command":"Downarrow",
+    "snippet":"Downarrow",
+    "detail":"⇓",
+    "documentation":"Down double arrow"
+  },
+  "downarrow":{
+    "command":"downarrow",
+    "snippet":"downarrow",
+    "detail":"↓",
+    "documentation":"Downward arrow"
+  },
+  "ell":{
+    "command":"ell",
+    "snippet":"ell",
+    "detail":"ℓ",
+    "documentation":"Cursive small l"
+  },
+  "emptyset":{
+    "command":"emptyset",
+    "snippet":"emptyset"
+  },
+  "exp":{
+    "command":"exp",
+    "snippet":"exp"
+  },
+  "flat":{
+    "command":"flat",
+    "snippet":"flat",
+    "detail":"♭",
+    "documentation":"Musical flat"
+  },
+  "frown":{
+    "command":"frown",
+    "snippet":"frown",
+    "detail":"⌢",
+    "documentation":"frown (down curve)"
+  },
+  "gcd":{
+    "command":"gcd",
+    "snippet":"gcd"
+  },
+  "ge":{
+    "command":"ge",
+    "snippet":"ge"
+  },
+  "gets":{
+    "command":"gets",
+    "snippet":"gets"
+  },
+  "gg":{
+    "command":"gg",
+    "snippet":"gg",
+    "detail":"≫",
+    "documentation":"Much greater than, type 2"
+  },
+  "hbar":{
+    "command":"hbar",
+    "snippet":"hbar"
+  },
+  "heartsuit":{
+    "command":"heartsuit",
+    "snippet":"heartsuit",
+    "detail":"♡",
+    "documentation":"Heart suit symbol"
+  },
+  "hom":{
+    "command":"hom",
+    "snippet":"hom"
+  },
+  "hookleftarrow":{
+    "command":"hookleftarrow",
+    "snippet":"hookleftarrow",
+    "detail":"↩",
+    "documentation":"Left arrow-hooked"
+  },
+  "hookrightarrow":{
+    "command":"hookrightarrow",
+    "snippet":"hookrightarrow",
+    "detail":"↪",
+    "documentation":"Right arrow-hooked"
+  },
+  "Im":{
+    "command":"Im",
+    "snippet":"Im",
+    "detail":"ℑ",
+    "documentation":"imaginary part"
+  },
+  "imath":{
+    "command":"imath",
+    "snippet":"imath",
+    "detail":"𝚤",
+    "documentation":"Mathematical italic small dotless i"
+  },
+  "inf":{
+    "command":"inf",
+    "snippet":"inf"
+  },
+  "int":{
+    "command":"int",
+    "snippet":"int",
+    "detail":"∫",
+    "documentation":"Integral operator"
+  },
+  "jmath":{
+    "command":"jmath",
+    "snippet":"jmath",
+    "detail":"𝚥",
+    "documentation":"Mathematical italic small dotless j"
+  },
+  "ker":{
+    "command":"ker",
+    "snippet":"ker"
+  },
+  "langle":{
+    "command":"langle",
+    "snippet":"langle",
+    "detail":"⟨",
+    "documentation":"Mathematical left angle bracket"
+  },
+  "lbrace":{
+    "command":"lbrace",
+    "snippet":"lbrace",
+    "detail":"{",
+    "documentation":"left curly bracket"
+  },
+  "lbrack":{
+    "command":"lbrack",
+    "snippet":"lbrack",
+    "detail":"[",
+    "documentation":"Left square bracket"
+  },
+  "lceil":{
+    "command":"lceil",
+    "snippet":"lceil",
+    "detail":"⌈",
+    "documentation":"Left ceiling"
+  },
+  "le":{
+    "command":"le",
+    "snippet":"le"
+  },
+  "leftharpoondown":{
+    "command":"leftharpoondown",
+    "snippet":"leftharpoondown",
+    "detail":"↽",
+    "documentation":"Left harpoon-down"
+  },
+  "leftharpoonup":{
+    "command":"leftharpoonup",
+    "snippet":"leftharpoonup",
+    "detail":"↼",
+    "documentation":"Left harpoon-up"
+  },
+  "leftrightarrow":{
+    "command":"leftrightarrow",
+    "snippet":"leftrightarrow",
+    "detail":"↔",
+    "documentation":"left right arrow, relation"
+  },
+  "lfloor":{
+    "command":"lfloor",
+    "snippet":"lfloor",
+    "detail":"⌊",
+    "documentation":"Left floor"
+  },
+  "lg":{
+    "command":"lg",
+    "snippet":"lg"
+  },
+  "lgroup":{
+    "command":"lgroup",
+    "snippet":"lgroup"
+  },
+  "lim":{
+    "command":"lim",
+    "snippet":"lim"
+  },
+  "liminf":{
+    "command":"liminf",
+    "snippet":"liminf"
+  },
+  "limsup":{
+    "command":"limsup",
+    "snippet":"limsup"
+  },
+  "ll":{
+    "command":"ll",
+    "snippet":"ll",
+    "detail":"≪",
+    "documentation":"Much less than, type 2"
+  },
+  "lmoustache":{
+    "command":"lmoustache",
+    "snippet":"lmoustache",
+    "detail":"⎰",
+    "documentation":"? upper left or lower right curly bracket section"
+  },
+  "ln":{
+    "command":"ln",
+    "snippet":"ln"
+  },
+  "log":{
+    "command":"log",
+    "snippet":"log"
+  },
+  "Longleftarrow":{
+    "command":"Longleftarrow",
+    "snippet":"Longleftarrow",
+    "detail":"⟸",
+    "documentation":"long leftwards double arrow"
+  },
+  "longleftarrow":{
+    "command":"longleftarrow",
+    "snippet":"longleftarrow",
+    "detail":"⟵",
+    "documentation":"Long leftwards arrow"
+  },
+  "longleftrightarrow":{
+    "command":"longleftrightarrow",
+    "snippet":"longleftrightarrow",
+    "detail":"⟷",
+    "documentation":"Long left right arrow"
+  },
+  "Longleftrightarrow":{
+    "command":"Longleftrightarrow",
+    "snippet":"Longleftrightarrow",
+    "detail":"⟺",
+    "documentation":"long left right double arrow"
+  },
+  "longmapsto":{
+    "command":"longmapsto",
+    "snippet":"longmapsto",
+    "detail":"⟼",
+    "documentation":"Long rightwards arrow from bar"
+  },
+  "Longrightarrow":{
+    "command":"Longrightarrow",
+    "snippet":"Longrightarrow",
+    "detail":"⟹",
+    "documentation":"long rightwards double arrow"
+  },
+  "longrightarrow":{
+    "command":"longrightarrow",
+    "snippet":"longrightarrow",
+    "detail":"⟶",
+    "documentation":"Long rightwards arrow"
+  },
+  "mapsto":{
+    "command":"mapsto",
+    "snippet":"mapsto",
+    "detail":"↦",
+    "documentation":"Maps to, rightward, maplet"
+  },
+  "max":{
+    "command":"max",
+    "snippet":"max"
+  },
+  "min":{
+    "command":"min",
+    "snippet":"min"
+  },
+  "models":{
+    "command":"models",
+    "snippet":"models",
+    "detail":"⊧",
+    "documentation":"Models (vertical, short double dash)"
+  },
+  "mp":{
+    "command":"mp",
+    "snippet":"mp",
+    "detail":"∓",
+    "documentation":"Minus-or-plus sign"
+  },
+  "nabla":{
+    "command":"nabla",
+    "snippet":"nabla",
+    "detail":"∇",
+    "documentation":"Nabla, del, hamilton operator"
+  },
+  "natural":{
+    "command":"natural",
+    "snippet":"natural",
+    "detail":"♮",
+    "documentation":"Music natural"
+  },
+  "nearrow":{
+    "command":"nearrow",
+    "snippet":"nearrow",
+    "detail":"↗",
+    "documentation":"Ne pointing arrow"
+  },
+  "ni":{
+    "command":"ni",
+    "snippet":"ni",
+    "detail":"∋",
+    "documentation":"contains, variant"
+  },
+  "not":{
+    "command":"not",
+    "snippet":"not",
+    "detail":" ̸",
+    "documentation":"Combining long solidus overlay"
+  },
+  "nwarrow":{
+    "command":"nwarrow",
+    "snippet":"nwarrow",
+    "detail":"↖",
+    "documentation":"Nw pointing arrow"
+  },
+  "odot":{
+    "command":"odot",
+    "snippet":"odot",
+    "detail":"⊙",
+    "documentation":"Middle dot in circle"
+  },
+  "oint":{
+    "command":"oint",
+    "snippet":"oint",
+    "detail":"∮",
+    "documentation":"Contour integral operator"
+  },
+  "ominus":{
+    "command":"ominus",
+    "snippet":"ominus",
+    "detail":"⊖",
+    "documentation":"Minus sign in circle"
+  },
+  "oplus":{
+    "command":"oplus",
+    "snippet":"oplus",
+    "detail":"⊕",
+    "documentation":"Plus sign in circle"
+  },
+  "oslash":{
+    "command":"oslash",
+    "snippet":"oslash",
+    "detail":"⊘",
+    "documentation":"Solidus in circle"
+  },
+  "otimes":{
+    "command":"otimes",
+    "snippet":"otimes",
+    "detail":"⊗",
+    "documentation":"Multiply sign in circle"
+  },
+  "parallel":{
+    "command":"parallel",
+    "snippet":"parallel",
+    "detail":"∥",
+    "documentation":"Parallel"
+  },
+  "perp":{
+    "command":"perp",
+    "snippet":"perp",
+    "detail":"⟂",
+    "documentation":"Perpendicular"
+  },
+  "Pr":{
+    "command":"Pr",
+    "snippet":"Pr"
+  },
+  "prec":{
+    "command":"prec",
+    "snippet":"prec",
+    "detail":"≺",
+    "documentation":"Precedes"
+  },
+  "preceq":{
+    "command":"preceq",
+    "snippet":"preceq",
+    "detail":"⪯",
+    "documentation":"Precedes above single-line equals sign"
+  },
+  "propto":{
+    "command":"propto",
+    "snippet":"propto",
+    "detail":"∝",
+    "documentation":"is proportional to"
+  },
+  "rangle":{
+    "command":"rangle",
+    "snippet":"rangle",
+    "detail":"⟩",
+    "documentation":"Mathematical right angle bracket"
+  },
+  "rbrace":{
+    "command":"rbrace",
+    "snippet":"rbrace",
+    "detail":"}",
+    "documentation":"right curly bracket"
+  },
+  "rbrack":{
+    "command":"rbrack",
+    "snippet":"rbrack",
+    "detail":"]",
+    "documentation":"Right square bracket"
+  },
+  "rceil":{
+    "command":"rceil",
+    "snippet":"rceil",
+    "detail":"⌉",
+    "documentation":"Right ceiling"
+  },
+  "Re":{
+    "command":"Re",
+    "snippet":"Re",
+    "detail":"ℜ",
+    "documentation":"real part"
+  },
+  "rfloor":{
+    "command":"rfloor",
+    "snippet":"rfloor",
+    "detail":"⌋",
+    "documentation":"Right floor"
+  },
+  "rgroup":{
+    "command":"rgroup",
+    "snippet":"rgroup"
+  },
+  "rightharpoondown":{
+    "command":"rightharpoondown",
+    "snippet":"rightharpoondown",
+    "detail":"⇁",
+    "documentation":"Right harpoon-down"
+  },
+  "rightharpoonup":{
+    "command":"rightharpoonup",
+    "snippet":"rightharpoonup",
+    "detail":"⇀",
+    "documentation":"Right harpoon-up"
+  },
+  "rightleftharpoons":{
+    "command":"rightleftharpoons",
+    "snippet":"rightleftharpoons",
+    "detail":"⇌",
+    "documentation":"right harpoon over left"
+  },
+  "rmoustache":{
+    "command":"rmoustache",
+    "snippet":"rmoustache",
+    "detail":"⎱",
+    "documentation":"? upper right or lower left curly bracket section"
+  },
+  "searrow":{
+    "command":"searrow",
+    "snippet":"searrow",
+    "detail":"↘",
+    "documentation":"Se pointing arrow"
+  },
+  "sec":{
+    "command":"sec",
+    "snippet":"sec"
+  },
+  "sharp":{
+    "command":"sharp",
+    "snippet":"sharp",
+    "detail":"♯",
+    "documentation":"music sharp sign, infix bag count"
+  },
+  "sim":{
+    "command":"sim",
+    "snippet":"sim",
+    "detail":"∼",
+    "documentation":"Similar to, tilde operator"
+  },
+  "simeq":{
+    "command":"simeq",
+    "snippet":"simeq",
+    "detail":"≃",
+    "documentation":"Similar, equals"
+  },
+  "sin":{
+    "command":"sin",
+    "snippet":"sin"
+  },
+  "sinh":{
+    "command":"sinh",
+    "snippet":"sinh"
+  },
+  "smile":{
+    "command":"smile",
+    "snippet":"smile",
+    "detail":"⌣",
+    "documentation":"smile (up curve)"
+  },
+  "spadesuit":{
+    "command":"spadesuit",
+    "snippet":"spadesuit",
+    "detail":"♠",
+    "documentation":"Spades suit symbol"
+  },
+  "sqcup":{
+    "command":"sqcup",
+    "snippet":"sqcup",
+    "detail":"⊔",
+    "documentation":"Square union"
+  },
+  "sqsupseteq":{
+    "command":"sqsupseteq",
+    "snippet":"sqsupseteq",
+    "detail":"⊒",
+    "documentation":"Square superset, equals"
+  },
+  "star":{
+    "command":"star",
+    "snippet":"star",
+    "detail":"⋆",
+    "documentation":"Small star, filled, low"
+  },
+  "subseteq":{
+    "command":"subseteq",
+    "snippet":"subseteq",
+    "detail":"⊆",
+    "documentation":"Subset, equals"
+  },
+  "succ":{
+    "command":"succ",
+    "snippet":"succ",
+    "detail":"≻",
+    "documentation":"Succeeds"
+  },
+  "succeq":{
+    "command":"succeq",
+    "snippet":"succeq",
+    "detail":"⪰",
+    "documentation":"Succeeds above single-line equals sign"
+  },
+  "sup":{
+    "command":"sup",
+    "snippet":"sup"
+  },
+  "supseteq":{
+    "command":"supseteq",
+    "snippet":"supseteq",
+    "detail":"⊇",
+    "documentation":"Superset, equals"
+  },
+  "surd":{
+    "command":"surd",
+    "snippet":"surd"
+  },
+  "swarrow":{
+    "command":"swarrow",
+    "snippet":"swarrow",
+    "detail":"↙",
+    "documentation":"Sw pointing arrow"
+  },
+  "tan":{
+    "command":"tan",
+    "snippet":"tan"
+  },
+  "tanh":{
+    "command":"tanh",
+    "snippet":"tanh"
+  },
+  "to":{
+    "command":"to",
+    "snippet":"to"
+  },
+  "top":{
+    "command":"top",
+    "snippet":"top",
+    "detail":"⊤",
+    "documentation":"Down tack, top"
+  },
+  "triangle":{
+    "command":"triangle",
+    "snippet":"triangle"
+  },
+  "triangleleft":{
+    "command":"triangleleft",
+    "snippet":"triangleleft",
+    "detail":"◁",
+    "documentation":"(large) left triangle, open; domain restriction"
+  },
+  "triangleright":{
+    "command":"triangleright",
+    "snippet":"triangleright",
+    "detail":"▷",
+    "documentation":"(large) right triangle, open; range restriction"
+  },
+  "Uparrow":{
+    "command":"Uparrow",
+    "snippet":"Uparrow",
+    "detail":"⇑",
+    "documentation":"Up double arrow"
+  },
+  "uparrow":{
+    "command":"uparrow",
+    "snippet":"uparrow",
+    "detail":"↑",
+    "documentation":"Upward arrow"
+  },
+  "Updownarrow":{
+    "command":"Updownarrow",
+    "snippet":"Updownarrow",
+    "detail":"⇕",
+    "documentation":"Up and down double arrow"
+  },
+  "updownarrow":{
+    "command":"updownarrow",
+    "snippet":"updownarrow",
+    "detail":"↕",
+    "documentation":"Up and down arrow"
+  },
+  "uplus":{
+    "command":"uplus",
+    "snippet":"uplus",
+    "detail":"⊎",
+    "documentation":"plus sign in union"
+  },
+  "varpi":{
+    "command":"varpi",
+    "snippet":"varpi"
+  },
+  "varrho":{
+    "command":"varrho",
+    "snippet":"varrho"
+  },
+  "vdash":{
+    "command":"vdash",
+    "snippet":"vdash",
+    "detail":"⊢",
+    "documentation":"Right tack, proves, implies, yields, (vertical and dash)"
+  },
+  "Vert":{
+    "command":"Vert",
+    "snippet":"Vert",
+    "detail":"‖",
+    "documentation":"double vertical bar"
+  },
+  "vert":{
+    "command":"vert",
+    "snippet":"vert",
+    "detail":"|",
+    "documentation":"vertical bar"
+  },
+  "wp":{
+    "command":"wp",
+    "snippet":"wp",
+    "detail":"℘",
+    "documentation":"Weierstrass p"
+  },
+  "wr":{
+    "command":"wr",
+    "snippet":"wr",
+    "detail":"≀",
+    "documentation":"Wreath product"
   }
-
 }

--- a/data/commands.json
+++ b/data/commands.json
@@ -181,28 +181,23 @@
     "snippet":"textup{${1}}"
   },
   "mathbf{}": {
-    "command": "mathbf{text}",
-    "package": "latex-document",
+    "command": "mathbf",
     "snippet": "mathbf{${1:text}}"
   },
   "mathcal{}": {
-    "command": "mathcal{text}",
-    "package": "latex-document",
+    "command": "mathcal",
     "snippet": "mathcal{${1:text}}"
   },
   "mathit{}": {
-    "command": "mathit{text}",
-    "package": "latex-document",
+    "command": "mathit",
     "snippet": "mathit{${1:text}}"
   },
   "mathrm{}": {
-    "command": "mathrm{text}",
-    "package": "latex-document",
+    "command": "mathrm",
     "snippet": "mathrm{${1:text}}"
   },
   "mathsf{}": {
-    "command": "mathsf{text}",
-    "package": "latex-document",
+    "command": "mathsf",
     "snippet": "mathsf{${1:text}}"
   },
   "label":{
@@ -277,8 +272,7 @@
     "command":"today"
   },
   "underbrace{}": {
-    "command": "underbrace{text}",
-    "package": "latex-document",
+    "command": "underbrace",
     "snippet": "underbrace{${1:text}}",
     "detail": "⏟",
     "documentation": "BOTTOM CURLY BRACKET (mathematical use)"

--- a/data/commands.json
+++ b/data/commands.json
@@ -180,23 +180,23 @@
     "command":"textup",
     "snippet":"textup{${1}}"
   },
-  "mathbf{}": {
+  "mathbf": {
     "command": "mathbf",
     "snippet": "mathbf{${1:text}}"
   },
-  "mathcal{}": {
+  "mathcal": {
     "command": "mathcal",
     "snippet": "mathcal{${1:text}}"
   },
-  "mathit{}": {
+  "mathit": {
     "command": "mathit",
     "snippet": "mathit{${1:text}}"
   },
-  "mathrm{}": {
+  "mathrm": {
     "command": "mathrm",
     "snippet": "mathrm{${1:text}}"
   },
-  "mathsf{}": {
+  "mathsf": {
     "command": "mathsf",
     "snippet": "mathsf{${1:text}}"
   },
@@ -271,7 +271,7 @@
   "today":{
     "command":"today"
   },
-  "underbrace{}": {
+  "underbrace": {
     "command": "underbrace",
     "snippet": "underbrace{${1:text}}",
     "detail": "⏟",


### PR DESCRIPTION
This is a PR to merge `data/packages/latex-mathsymbols_cmd.json` into `data/commands.json`. Commands in `latex-mathsymbols_cmd.json` are defined by default in LaTeX. So, we should merge them into `commands.json`.

`dddot` and `ddddot` are deleted because they are defined in `amsmath_cmd.json`.