### PR TITLE
Make go back and forward buttons on pdf viewer work with SyncTeX

### DIFF
--- a/viewer/latexworkshop.js
+++ b/viewer/latexworkshop.js
@@ -258,12 +258,16 @@ document.addEventListener('pagerendered', (evPageRendered) => {
     }
 }, true)
 
-document.getElementById('viewerContainer').addEventListener("click", function() {
+const setHistory = () => {
+  console.log('history click')
   const container = document.getElementById('viewerContainer')
   // set positions before and after clicking to history
   viewerHistory.set(container.scrollTop)
   setTimeout(() => {viewerHistory.set(container.scrollTop)}, 500)
-})
+}
+
+document.getElementById('viewerContainer').addEventListener("click", setHistory)
+document.getElementById('sidebarContainer').addEventListener("click", setHistory)
 
 // back button (mostly useful for the embedded viewer)
 document.getElementById("historyBack").addEventListener("click", function() {

--- a/viewer/latexworkshop.js
+++ b/viewer/latexworkshop.js
@@ -32,12 +32,12 @@ class ViewerHistory {
   set(scroll, force = false) {
     if (this._history.length === 0) {
       this._history.push({scroll: scroll, temporary: false})
-      this._current = this._history.length - 1
+      this._current = 0
       return
     }
 
     if (this._current === undefined) {
-      console.log('this._current === undefined never happen.')
+      console.log('this._current === undefined never happens here.')
     }
 
     const curScroll = this._history[this._current].scroll

--- a/viewer/latexworkshop.js
+++ b/viewer/latexworkshop.js
@@ -166,6 +166,11 @@ document.addEventListener('pagerendered', (evPageRendered) => {
     }
 }, true)
 
+document.getElementById('viewerContainer').addEventListener("click", function() {
+  const container = document.getElementById('viewerContainer')
+  pushViewerHistory(container.scrollTop)
+})
+
 // back button (mostly useful for the embedded viewer)
 document.getElementById("historyBack").addEventListener("click", function() {
   const container = document.getElementById('viewerContainer')

--- a/viewer/latexworkshop.js
+++ b/viewer/latexworkshop.js
@@ -29,7 +29,7 @@ class ViewerHistory {
     return this._history.length
   }
 
-  push(scroll) {
+  set(scroll, force = false) {
     if (this._history.length === 0) {
       this._history.push({scroll: scroll, temporary: false})
       this._current = this._history.length - 1
@@ -41,7 +41,7 @@ class ViewerHistory {
     }
 
     const curScroll = this._history[this._current].scroll
-    if (curScroll !== scroll) {
+    if (curScroll !== scroll || force) {
       this._history = this._history.slice(0, this._current + 1)
       if (this.last()) {
         this.last().temporary = false
@@ -58,7 +58,6 @@ class ViewerHistory {
     const container = document.getElementById('viewerContainer')
     let cur = this._current
     let prevScroll = this._history[cur].scroll
-    console.log({length: this.length(), cur: this._current, v: this._history[cur].scroll})
     if (this.length() > 0 && prevScroll !== container.scrollTop) {
       if (this._current === this.lastIndex() && this.last()) {
         if (this.last().temporary) {
@@ -68,14 +67,7 @@ class ViewerHistory {
         } else {
           this._history.push({scroll: container.scrollTop, temporary: true})
         }
-      } /* else if (this._history[cur+1] !== undefined && this._history[cur+1].temporary) {
-        this._history[cur+1] = {scroll: container.scrollTop, temporary: true}
-      }  else {
-        const ha = this._history.split(0, cur+1)
-        const hb = this._history.split(cur+1, this.length())
-        const c = {scroll: container.scrollTop, temporary: true}
-        this._history = ha.concat([c], hb)
-      }*/
+      }
     }
     if (prevScroll !== container.scrollTop) {
       this._current = cur
@@ -143,9 +135,9 @@ socket.addEventListener("message", (event) => {
             let page = document.getElementsByClassName('page')[data.data.page - 1]
             let scrollX = page.offsetLeft + pos[0]
             let scrollY = page.offsetTop + page.offsetHeight - pos[1]
-            viewerHistory.push(container.scrollTop)
+            viewerHistory.set(container.scrollTop)
             container.scrollTop = scrollY - document.body.offsetHeight * 0.4
-            viewerHistory.push(container.scrollTop)
+            viewerHistory.set(container.scrollTop)
 
             let indicator = document.getElementById('synctex-indicator')
             indicator.className = 'show'
@@ -267,7 +259,7 @@ document.addEventListener('pagerendered', (evPageRendered) => {
 
 document.getElementById('viewerContainer').addEventListener("click", function() {
   const container = document.getElementById('viewerContainer')
-  viewerHistory.push(container.scrollTop)
+  viewerHistory.set(container.scrollTop, true)
 })
 
 // back button (mostly useful for the embedded viewer)

--- a/viewer/latexworkshop.js
+++ b/viewer/latexworkshop.js
@@ -29,9 +29,9 @@ class ViewerHistory {
     return this._history.length
   }
 
-  push(scroll, flag = false) {
+  push(scroll) {
     if (this._history.length === 0) {
-      this._history.push({scroll: scroll, temporary: flag})
+      this._history.push({scroll: scroll, temporary: false})
       this._current = this._history.length - 1
       return
     }
@@ -43,13 +43,12 @@ class ViewerHistory {
     const curScroll = this._history[this._current].scroll
     if (curScroll !== scroll) {
       this._history = this._history.slice(0, this._current + 1)
-      if (flag && this.last().temporary) {
-        this._history[this._history.length-1] = {scroll: scroll, temporary: flag}
-      } else {
-        this._history.push({scroll: scroll, temporary: flag})
+      if (this.last()) {
+        this.last().temporary = false
       }
-      this._current = this.lastIndex()
+      this._history.push({scroll: scroll, temporary: false})
     }
+    this._current = this.lastIndex()
   }
 
   back() {
@@ -57,11 +56,26 @@ class ViewerHistory {
       return
     }
     const container = document.getElementById('viewerContainer')
-    const cur = this._current
-    const prevScroll = this._history[cur].scroll
-    if (this.length() > 0 && this._current === this.lastIndex()) {
-      viewerHistory.push(container.scrollTop, true)
-      this._current = cur
+    let cur = this._current
+    let prevScroll = this._history[cur].scroll
+    console.log({length: this.length(), cur: this._current, v: this._history[cur].scroll})
+    if (this.length() > 0 && prevScroll !== container.scrollTop) {
+      if (this._current === this.lastIndex() && this.last()) {
+        if (this.last().temporary) {
+          this.last().scroll = container.scrollTop
+          cur = cur - 1
+          prevScroll = this._history[cur].scroll
+        } else {
+          this._history.push({scroll: container.scrollTop, temporary: true})
+        }
+      } /* else if (this._history[cur+1] !== undefined && this._history[cur+1].temporary) {
+        this._history[cur+1] = {scroll: container.scrollTop, temporary: true}
+      }  else {
+        const ha = this._history.split(0, cur+1)
+        const hb = this._history.split(cur+1, this.length())
+        const c = {scroll: container.scrollTop, temporary: true}
+        this._history = ha.concat([c], hb)
+      }*/
     }
     if (prevScroll !== container.scrollTop) {
       this._current = cur

--- a/viewer/latexworkshop.js
+++ b/viewer/latexworkshop.js
@@ -17,6 +17,14 @@ class ViewerHistory {
     return this._history[this._history.length-1]
   }
 
+  lastIndex() {
+    if (this._history.length === 0) {
+      return undefined
+    } else {
+      return this._history.length - 1
+    }
+  }
+
   length() {
     return this._history.length
   }
@@ -35,20 +43,23 @@ class ViewerHistory {
     const curScroll = this._history[this._current].scroll
     if (curScroll !== scroll) {
       this._history = this._history.slice(0, this._current + 1)
-      if (flag && this._history[this._history.length-1].temporary) {
+      if (flag && this.last().temporary) {
         this._history[this._history.length-1] = {scroll: scroll, temporary: flag}
       } else {
         this._history.push({scroll: scroll, temporary: flag})
       }
-      this._current = this._history.length - 1
+      this._current = this.lastIndex()
     }
   }
 
   back() {
+    if (this.length() === 0) {
+      return
+    }
     const container = document.getElementById('viewerContainer')
     const cur = this._current
     const prevScroll = this._history[cur].scroll
-    if (this._current === this._history.length - 1) {
+    if (this.length() > 0 && this._current === this.lastIndex()) {
       viewerHistory.push(container.scrollTop, true)
       this._current = cur
     }
@@ -66,7 +77,7 @@ class ViewerHistory {
   }
 
   forward() {
-    if (this._current === this._history.length - 1) {
+    if (this._current === this.lastIndex()) {
       return
     }
     const container = document.getElementById('viewerContainer')
@@ -76,7 +87,7 @@ class ViewerHistory {
       this._current = cur + 1
       container.scrollTop = nextScroll
     } else {
-      if (cur === this._history.length - 2) {
+      if (cur >= this._history.length - 2) {
         return
       }
       const scrl = this._history[cur+2].scroll

--- a/viewer/latexworkshop.js
+++ b/viewer/latexworkshop.js
@@ -47,6 +47,9 @@ class ViewerHistory {
         this.last().temporary = false
       }
       this._history.push({scroll: scroll, temporary: false})
+      if (this.length() > 30) {
+        this._history = this._history.slice(this.length() - 30)
+      }
       this._current = this.lastIndex()
     }
   }

--- a/viewer/latexworkshop.js
+++ b/viewer/latexworkshop.js
@@ -269,7 +269,6 @@ document.addEventListener('pagerendered', (evPageRendered) => {
 }, true)
 
 const setHistory = () => {
-  console.log('history click')
   const container = document.getElementById('viewerContainer')
   // set positions before and after clicking to viewerHistory
   viewerHistory.set(container.scrollTop)

--- a/viewer/latexworkshop.js
+++ b/viewer/latexworkshop.js
@@ -136,6 +136,8 @@ socket.addEventListener("message", (event) => {
             let page = document.getElementsByClassName('page')[data.data.page - 1]
             let scrollX = page.offsetLeft + pos[0]
             let scrollY = page.offsetTop + page.offsetHeight - pos[1]
+
+            // set positions before and after SyncTeX to viewerHistory
             viewerHistory.set(container.scrollTop)
             container.scrollTop = scrollY - document.body.offsetHeight * 0.4
             viewerHistory.set(container.scrollTop)
@@ -154,7 +156,8 @@ socket.addEventListener("message", (event) => {
                                         scrollMode:PDFViewerApplication.pdfViewer.scrollMode,
                                         spreadMode:PDFViewerApplication.pdfViewer.spreadMode,
                                         scrollTop:document.getElementById('viewerContainer').scrollTop,
-                                        scrollLeft:document.getElementById('viewerContainer').scrollLeft}))
+                                        scrollLeft:document.getElementById('viewerContainer').scrollLeft,
+                                        viewerHistory:{history: viewerHistory._history, current: viewerHistory._current}}))
             PDFViewerApplicationOptions.set('showPreviousViewOnLoad', false);
             PDFViewerApplication.open(`/pdf:${decodeURIComponent(file)}`).then( () => {
               // reset the document title to the original value to avoid duplication
@@ -175,6 +178,9 @@ socket.addEventListener("message", (event) => {
             PDFViewerApplication.pdfViewer.spreadMode = data.spreadMode
             document.getElementById('viewerContainer').scrollTop = data.scrollTop
             document.getElementById('viewerContainer').scrollLeft = data.scrollLeft
+            viewerHistory = new ViewerHistory()
+            viewerHistory._history = data.viewerHistory.history
+            viewerHistory._current = data.viewerHistory.current
             break
         case "params":
             if (data.scale) {
@@ -261,7 +267,7 @@ document.addEventListener('pagerendered', (evPageRendered) => {
 const setHistory = () => {
   console.log('history click')
   const container = document.getElementById('viewerContainer')
-  // set positions before and after clicking to history
+  // set positions before and after clicking to viewerHistory
   viewerHistory.set(container.scrollTop)
   setTimeout(() => {viewerHistory.set(container.scrollTop)}, 500)
 }

--- a/viewer/latexworkshop.js
+++ b/viewer/latexworkshop.js
@@ -47,8 +47,8 @@ class ViewerHistory {
         this.last().temporary = false
       }
       this._history.push({scroll: scroll, temporary: false})
+      this._current = this.lastIndex()
     }
-    this._current = this.lastIndex()
   }
 
   back() {

--- a/viewer/latexworkshop.js
+++ b/viewer/latexworkshop.js
@@ -65,7 +65,8 @@ class ViewerHistory {
           cur = cur - 1
           prevScroll = this._history[cur].scroll
         } else {
-          this._history.push({scroll: container.scrollTop, temporary: true})
+          const tmp = {scroll: container.scrollTop, temporary: true};
+          this._history.push(tmp);
         }
       }
     }

--- a/viewer/latexworkshop.js
+++ b/viewer/latexworkshop.js
@@ -260,7 +260,9 @@ document.addEventListener('pagerendered', (evPageRendered) => {
 
 document.getElementById('viewerContainer').addEventListener("click", function() {
   const container = document.getElementById('viewerContainer')
-  viewerHistory.set(container.scrollTop, true)
+  // set positions before and after clicking to history
+  viewerHistory.set(container.scrollTop)
+  setTimeout(() => {viewerHistory.set(container.scrollTop)}, 500)
 })
 
 // back button (mostly useful for the embedded viewer)

--- a/viewer/latexworkshop.js
+++ b/viewer/latexworkshop.js
@@ -6,6 +6,14 @@ let documentTitle = ''
 // We dont want that, so we unset the flag here (to keep viewer.js as vanilla as possible)
 //
 PDFViewerApplication.isViewerEmbedded = false;
+let viewerHistory = []
+
+const pushViewerHistory = (currentScroll) => {
+  if (viewerHistory.length == 0 || viewerHistory[viewerHistory.length-1] !== currentScroll) {
+    viewerHistory.push(currentScroll)
+  }
+}
+
 let query = document.location.search.substring(1)
 let parts = query.split('&')
 let file
@@ -36,7 +44,9 @@ socket.addEventListener("message", (event) => {
             let page = document.getElementsByClassName('page')[data.data.page - 1]
             let scrollX = page.offsetLeft + pos[0]
             let scrollY = page.offsetTop + page.offsetHeight - pos[1]
+            pushViewerHistory(container.scrollTop)
             container.scrollTop = scrollY - document.body.offsetHeight * 0.4
+            pushViewerHistory(container.scrollTop)
 
             let indicator = document.getElementById('synctex-indicator')
             indicator.className = 'show'
@@ -158,7 +168,18 @@ document.addEventListener('pagerendered', (evPageRendered) => {
 
 // back button (mostly useful for the embedded viewer)
 document.getElementById("historyBack").addEventListener("click", function() {
-  history.back()
+  const container = document.getElementById('viewerContainer')
+  const prevScroll = viewerHistory.pop()
+  if (prevScroll !== undefined) {
+    if (prevScroll !== container.scrollTop) {
+      container.scrollTop = prevScroll
+    } else {
+      const scrl = viewerHistory.pop()
+      if (scrl !== undefined) {
+        container.scrollTop = scrl
+      }
+    }
+  }
 })
 
 // keyboard bindings

--- a/viewer/viewer.css
+++ b/viewer/viewer.css
@@ -2383,7 +2383,7 @@ html[dir='rtl'] #documentPropertiesOverlay .row > * {
   }
 }
 
-@media all and (max-width: 535px) {
+@media all and (max-width: 700px) {
   #scaleSelectContainer {
     display: none;
   }

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -200,6 +200,9 @@ See https://github.com/adobe-type-tools/cmap-resources
                 <button class="toolbarButton findPrevious" title="Back" id="historyBack">
                   <span>Back</span>
                 </button>
+                <button class="toolbarButton findNext" title="Forward" id="historyForward">
+                  <span>Forward</span>
+                </button>
                 <div class="toolbarButtonSpacer"></div>
                 <button id="viewFind" class="toolbarButton" title="Find in Document" tabindex="12" data-l10n-id="findbar">
                   <span data-l10n-id="findbar_label">Find</span>


### PR DESCRIPTION
1. add a forward button on pdf viewer.
2. make the back and forward buttons work with SyncTeX. They also work with clicking links as before.

![Apr-20-2019 12-57-25](https://user-images.githubusercontent.com/10665499/56452453-0dc2d180-636c-11e9-96e3-14c492c5c08b.gif)
