### PR TITLE
Show number given to ref in hover on the ref

### DIFF
--- a/package.json
+++ b/package.json
@@ -1103,6 +1103,11 @@
           "default": true,
           "markdownDescription": "Enable Hover on References."
         },
+        "latex-workshop.hover.ref.numberAtLastCompilation.enabled": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Show number given to ref at the last compilation."
+        },
         "latex-workshop.hover.citation.enabled": {
           "type": "boolean",
           "default": true,

--- a/src/components/builder.ts
+++ b/src/components/builder.ts
@@ -300,6 +300,7 @@ export class Builder {
             return
         }
         this.extension.viewer.refreshExistingViewer(rootFile)
+        this.extension.completer.reference.setNumbersFromAuxFile(rootFile)
         this.extension.manager.findAdditionalDependentFilesFromFls(rootFile)
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         if (configuration.get('synctex.afterBuild.enabled') as boolean) {

--- a/src/providers/completer/reference.ts
+++ b/src/providers/completer/reference.ts
@@ -102,12 +102,12 @@ export class Reference {
         const outDir = this.extension.manager.getOutputDir(rootFile)
         const auxFile = path.join(outDir, path.basename(rootFile, '.tex') + '.aux')
         const refKeys = Object.keys(this.referenceData)
-        if (!fs.existsSync(auxFile)) {
-            return
-        }
         for (const key of refKeys) {
             const refData = this.referenceData[key]
             refData.item.atLastCompilation = undefined
+        }
+        if (!fs.existsSync(auxFile)) {
+            return
         }
         const newLabelReg = /^\\newlabel\{(.*?)\}\{\{(.*?)\}\{(.*?)\}/gm
         const auxContent = fs.readFileSync(auxFile, {encoding: 'utf8'})

--- a/src/providers/completer/reference.ts
+++ b/src/providers/completer/reference.ts
@@ -116,7 +116,7 @@ export class Reference {
             if (result === null) {
                 break
             }
-            if (result[1] in refKeys) {
+            if (result[1] in this.referenceData) {
                 const refData = this.referenceData[result[1]]
                 refData.item.atLastCompilation = {refNumber: result[2], pageNumber: result[3]}
             }

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -197,9 +197,9 @@ export class HoverProvider implements vscode.HoverProvider {
         }
         const md = '```latex\n' + refData.text + '\n```\n'
         const refRange = document.getWordRangeAtPosition(position, /\{.*?\}/)
-        const refMessage = this.refNumberMessage(refData)
-        if (refMessage !== undefined && configuration.get('hover.ref.numberAtLastCompilation.enabled') as boolean) {
-            return new vscode.Hover([md, refMessage, mdLink], refRange)
+        const refNumberMessage = this.refNumberMessage(refData)
+        if (refNumberMessage !== undefined && configuration.get('hover.ref.numberAtLastCompilation.enabled') as boolean) {
+            return new vscode.Hover([md, refNumberMessage, mdLink], refRange)
         }
         return new vscode.Hover([md, mdLink], refRange)
     }
@@ -226,9 +226,9 @@ export class HoverProvider implements vscode.HoverProvider {
         const link = vscode.Uri.parse('command:latex-workshop.synctexto').with({ query: JSON.stringify([line, refData.file]) })
         const mdLink = new vscode.MarkdownString(`[View on pdf](${link})`)
         mdLink.isTrusted = true
-        const refMessage = this.refNumberMessage(refData)
-        if (refMessage !== undefined && configuration.get('hover.ref.numberAtLastCompilation.enabled') as boolean) {
-            return new vscode.Hover( [eqNumAndLabels, this.addDummyCodeBlock(`![equation](${md})`), refMessage, mdLink], tex.range )
+        const refNumberMessage = this.refNumberMessage(refData)
+        if (refNumberMessage !== undefined && configuration.get('hover.ref.numberAtLastCompilation.enabled') as boolean) {
+            return new vscode.Hover( [eqNumAndLabels, this.addDummyCodeBlock(`![equation](${md})`), refNumberMessage, mdLink], tex.range )
         }
         return new vscode.Hover( [eqNumAndLabels, this.addDummyCodeBlock(`![equation](${md})`), mdLink], tex.range )
     }

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -198,7 +198,7 @@ export class HoverProvider implements vscode.HoverProvider {
         const md = '```latex\n' + refData.text + '\n```\n'
         const refRange = document.getWordRangeAtPosition(position, /\{.*?\}/)
         const refMessage = this.refNumberMessage(refData)
-        if (refMessage !== undefined) {
+        if (refMessage !== undefined && configuration.get('hover.ref.numberAtLastCompilation.enabled') as boolean) {
             return new vscode.Hover([md, refMessage, mdLink], refRange)
         }
         return new vscode.Hover([md, mdLink], refRange)
@@ -227,7 +227,7 @@ export class HoverProvider implements vscode.HoverProvider {
         const mdLink = new vscode.MarkdownString(`[View on pdf](${link})`)
         mdLink.isTrusted = true
         const refMessage = this.refNumberMessage(refData)
-        if (refMessage !== undefined) {
+        if (refMessage !== undefined && configuration.get('hover.ref.numberAtLastCompilation.enabled') as boolean) {
             return new vscode.Hover( [eqNumAndLabels, this.addDummyCodeBlock(`![equation](${md})`), refMessage, mdLink], tex.range )
         }
         return new vscode.Hover( [eqNumAndLabels, this.addDummyCodeBlock(`![equation](${md})`), mdLink], tex.range )

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -197,6 +197,10 @@ export class HoverProvider implements vscode.HoverProvider {
         }
         const md = '```latex\n' + refData.text + '\n```\n'
         const refRange = document.getWordRangeAtPosition(position, /\{.*?\}/)
+        const refMessage = this.refNumberMessage(refData)
+        if (refMessage !== undefined) {
+            return new vscode.Hover([md, refMessage, mdLink], refRange)
+        }
         return new vscode.Hover([md, mdLink], refRange)
     }
 
@@ -222,7 +226,20 @@ export class HoverProvider implements vscode.HoverProvider {
         const link = vscode.Uri.parse('command:latex-workshop.synctexto').with({ query: JSON.stringify([line, refData.file]) })
         const mdLink = new vscode.MarkdownString(`[View on pdf](${link})`)
         mdLink.isTrusted = true
+        const refMessage = this.refNumberMessage(refData)
+        if (refMessage !== undefined) {
+            return new vscode.Hover( [eqNumAndLabels, this.addDummyCodeBlock(`![equation](${md})`), refMessage, mdLink], tex.range )
+        }
         return new vscode.Hover( [eqNumAndLabels, this.addDummyCodeBlock(`![equation](${md})`), mdLink], tex.range )
+    }
+
+    refNumberMessage(refData: ReferenceEntry) : string | undefined {
+        if (refData.item.atLastCompilation) {
+            const refNum = refData.item.atLastCompilation.refNumber
+            const refMessage = `numbered ${refNum} at last compilation`
+            return refMessage
+        }
+        return undefined
     }
 
     private eqNumAndLabel(obj: LabelsStore, tex: TexMathEnv, refToken: string) : string {


### PR DESCRIPTION
This is a PR to show a number given to ref in hover on the ref. The numbers are read from `aux` files just after compilation finished. Ideally, the numbers should be displayed in the equation by MathJax using `\tag` command. However, the support of `\tag` by MathJax is not mature. 

I recommend that we leave this feature disabled by default and wait for new releases of MathJax.



![スクリーンショット 2019-04-21 8 52 41](https://user-images.githubusercontent.com/10665499/56463630-030f4780-6413-11e9-9c41-5205b5b94c3d.png)
