### PR TITLE
Show label or given number to ref in hover on the ref

### DIFF
--- a/package.json
+++ b/package.json
@@ -1103,6 +1103,11 @@
           "default": true,
           "markdownDescription": "Enable Hover on References."
         },
+        "latex-workshop.hover.ref.numberAtLastCompilation.enabled": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Show number given to ref at the last compilation."
+        },
         "latex-workshop.hover.citation.enabled": {
           "type": "boolean",
           "default": true,

--- a/src/components/builder.ts
+++ b/src/components/builder.ts
@@ -300,6 +300,7 @@ export class Builder {
             return
         }
         this.extension.viewer.refreshExistingViewer(rootFile)
+        this.extension.completer.reference.setNumbersFromAuxFile(rootFile)
         this.extension.manager.findAdditionalDependentFilesFromFls(rootFile)
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         if (configuration.get('synctex.afterBuild.enabled') as boolean) {

--- a/src/providers/completer/reference.ts
+++ b/src/providers/completer/reference.ts
@@ -102,12 +102,12 @@ export class Reference {
         const outDir = this.extension.manager.getOutputDir(rootFile)
         const auxFile = path.join(outDir, path.basename(rootFile, '.tex') + '.aux')
         const refKeys = Object.keys(this.referenceData)
-        if (!fs.existsSync(auxFile)) {
-            return
-        }
         for (const key of refKeys) {
             const refData = this.referenceData[key]
             refData.item.atLastCompilation = undefined
+        }
+        if (!fs.existsSync(auxFile)) {
+            return
         }
         const newLabelReg = /^\\newlabel\{(.*?)\}\{\{(.*?)\}\{(.*?)\}/gm
         const auxContent = fs.readFileSync(auxFile, {encoding: 'utf8'})

--- a/src/providers/completer/reference.ts
+++ b/src/providers/completer/reference.ts
@@ -116,7 +116,7 @@ export class Reference {
             if (result === null) {
                 break
             }
-            if (result[1] in refKeys) {
+            if (result[1] in this.referenceData) {
                 const refData = this.referenceData[result[1]]
                 refData.item.atLastCompilation = {refNumber: result[2], pageNumber: result[3]}
             }

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -197,9 +197,9 @@ export class HoverProvider implements vscode.HoverProvider {
         }
         const md = '```latex\n' + refData.text + '\n```\n'
         const refRange = document.getWordRangeAtPosition(position, /\{.*?\}/)
-        const refMessage = this.refNumberMessage(refData)
-        if (refMessage !== undefined && configuration.get('hover.ref.numberAtLastCompilation.enabled') as boolean) {
-            return new vscode.Hover([md, refMessage, mdLink], refRange)
+        const refNumberMessage = this.refNumberMessage(refData)
+        if (refNumberMessage !== undefined && configuration.get('hover.ref.numberAtLastCompilation.enabled') as boolean) {
+            return new vscode.Hover([md, refNumberMessage, mdLink], refRange)
         }
         return new vscode.Hover([md, mdLink], refRange)
     }
@@ -226,9 +226,9 @@ export class HoverProvider implements vscode.HoverProvider {
         const link = vscode.Uri.parse('command:latex-workshop.synctexto').with({ query: JSON.stringify([line, refData.file]) })
         const mdLink = new vscode.MarkdownString(`[View on pdf](${link})`)
         mdLink.isTrusted = true
-        const refMessage = this.refNumberMessage(refData)
-        if (refMessage !== undefined && configuration.get('hover.ref.numberAtLastCompilation.enabled') as boolean) {
-            return new vscode.Hover( [eqNumAndLabels, this.addDummyCodeBlock(`![equation](${md})`), refMessage, mdLink], tex.range )
+        const refNumberMessage = this.refNumberMessage(refData)
+        if (refNumberMessage !== undefined && configuration.get('hover.ref.numberAtLastCompilation.enabled') as boolean) {
+            return new vscode.Hover( [eqNumAndLabels, this.addDummyCodeBlock(`![equation](${md})`), refNumberMessage, mdLink], tex.range )
         }
         return new vscode.Hover( [eqNumAndLabels, this.addDummyCodeBlock(`![equation](${md})`), mdLink], tex.range )
     }

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -198,7 +198,7 @@ export class HoverProvider implements vscode.HoverProvider {
         const md = '```latex\n' + refData.text + '\n```\n'
         const refRange = document.getWordRangeAtPosition(position, /\{.*?\}/)
         const refMessage = this.refNumberMessage(refData)
-        if (refMessage !== undefined) {
+        if (refMessage !== undefined && configuration.get('hover.ref.numberAtLastCompilation.enabled') as boolean) {
             return new vscode.Hover([md, refMessage, mdLink], refRange)
         }
         return new vscode.Hover([md, mdLink], refRange)
@@ -227,7 +227,7 @@ export class HoverProvider implements vscode.HoverProvider {
         const mdLink = new vscode.MarkdownString(`[View on pdf](${link})`)
         mdLink.isTrusted = true
         const refMessage = this.refNumberMessage(refData)
-        if (refMessage !== undefined) {
+        if (refMessage !== undefined && configuration.get('hover.ref.numberAtLastCompilation.enabled') as boolean) {
             return new vscode.Hover( [eqNumAndLabels, this.addDummyCodeBlock(`![equation](${md})`), refMessage, mdLink], tex.range )
         }
         return new vscode.Hover( [eqNumAndLabels, this.addDummyCodeBlock(`![equation](${md})`), mdLink], tex.range )

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -264,7 +264,7 @@ export class HoverProvider implements vscode.HoverProvider {
         // To work around a bug of \tag with multi-line environments,
         // we have to put \tag after the environments.
         // See https://github.com/mathjax/MathJax/issues/1020
-        newTex = newTex.replace(/(\\tag\{.*?\})([\r\n\s]*)(\\begin\{(split|aligned||alignedat|array|Bmatrix|bmatrix|cases|CD|gathered|matrix|pmatrix|smallmatrix|split|subarray|Vmatrix|vmatrix)\}[^]*?\\end\{\4\})/gm, '$3$2$1')
+        newTex = newTex.replace(/(\\tag\{.*?\})([\r\n\s]*)(\\begin\{(aligned|alignedat|gathered|split)\}[^]*?\\end\{\4\})/gm, '$3$2$1')
         newTex = newTex.replace(/^\\begin\{(\w+)\}/, '\\begin{$1*}')
         newTex = newTex.replace(/\\end\{(\w+)\}$/, '\\end{$1*}')
         return newTex

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -261,6 +261,9 @@ export class HoverProvider implements vscode.HoverProvider {
             }
         })
         newTex = newTex.replace(/^$/g, '')
+        // To work around a bug of \tag with multi-line environments,
+        // we have to put \tag after the environments.
+        // See https://github.com/mathjax/MathJax/issues/1020
         newTex = newTex.replace(/(\\tag\{.*?\})([\r\n\s]*)(\\begin\{(split|aligned||alignedat|array|Bmatrix|bmatrix|cases|CD|gathered|matrix|pmatrix|smallmatrix|split|subarray|Vmatrix|vmatrix)\}[^]*?\\end\{\4\})/gm, '$3$2$1')
         newTex = newTex.replace(/^\\begin\{(\w+)*?\}/, '\\begin{$1*}')
         newTex = newTex.replace(/\\end\{(\w+)*?\}$/, '\\end{$1*}')

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -265,8 +265,8 @@ export class HoverProvider implements vscode.HoverProvider {
         // we have to put \tag after the environments.
         // See https://github.com/mathjax/MathJax/issues/1020
         newTex = newTex.replace(/(\\tag\{.*?\})([\r\n\s]*)(\\begin\{(split|aligned||alignedat|array|Bmatrix|bmatrix|cases|CD|gathered|matrix|pmatrix|smallmatrix|split|subarray|Vmatrix|vmatrix)\}[^]*?\\end\{\4\})/gm, '$3$2$1')
-        newTex = newTex.replace(/^\\begin\{(\w+)*?\}/, '\\begin{$1*}')
-        newTex = newTex.replace(/\\end\{(\w+)*?\}$/, '\\end{$1*}')
+        newTex = newTex.replace(/^\\begin\{(\w+)\}/, '\\begin{$1*}')
+        newTex = newTex.replace(/\\end\{(\w+)\}$/, '\\end{$1*}')
         return newTex
     }
 

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -192,7 +192,7 @@ export class HoverProvider implements vscode.HoverProvider {
         if (configuration.get('hover.preview.ref.enabled') as boolean) {
             const tex = this.findHoverOnRef(document, position, token, refData)
             if (tex) {
-                return this.provideHoverPreviewOnRef(tex, this.findNewCommand(document.getText()), token, refData)
+                return this.provideHoverPreviewOnRef(tex, this.findNewCommand(document.getText()), refData)
             }
         }
         const md = '```latex\n' + refData.text + '\n```\n'
@@ -204,11 +204,11 @@ export class HoverProvider implements vscode.HoverProvider {
         return new vscode.Hover([md, mdLink], refRange)
     }
 
-    private async provideHoverPreviewOnRef(tex: TexMathEnv, newCommand: string, refToken: string, refData: ReferenceEntry) : Promise<vscode.Hover> {
+    private async provideHoverPreviewOnRef(tex: TexMathEnv, newCommand: string, refData: ReferenceEntry) : Promise<vscode.Hover> {
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         const scale = configuration.get('hover.preview.scale') as number
 
-        let tag : string
+        let tag: string
         if (refData.item.atLastCompilation !== undefined && configuration.get('hover.ref.numberAtLastCompilation.enabled') as boolean) {
             tag = refData.item.atLastCompilation.refNumber
         } else {

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -197,6 +197,10 @@ export class HoverProvider implements vscode.HoverProvider {
         }
         const md = '```latex\n' + refData.text + '\n```\n'
         const refRange = document.getWordRangeAtPosition(position, /\{.*?\}/)
+        const refMessage = this.refNumberMessage(refData)
+        if (refMessage !== undefined) {
+            return new vscode.Hover([md, refMessage, mdLink], refRange)
+        }
         return new vscode.Hover([md, mdLink], refRange)
     }
 
@@ -222,7 +226,20 @@ export class HoverProvider implements vscode.HoverProvider {
         const link = vscode.Uri.parse('command:latex-workshop.synctexto').with({ query: JSON.stringify([line, refData.file]) })
         const mdLink = new vscode.MarkdownString(`[View on pdf](${link})`)
         mdLink.isTrusted = true
+        const refMessage = this.refNumberMessage(refData)
+        if (refMessage !== undefined) {
+            return new vscode.Hover( [eqNumAndLabels, this.addDummyCodeBlock(`![equation](${md})`), refMessage, mdLink], tex.range )
+        }
         return new vscode.Hover( [eqNumAndLabels, this.addDummyCodeBlock(`![equation](${md})`), mdLink], tex.range )
+    }
+
+    refNumberMessage(refData: ReferenceEntry) : string | undefined {
+        if (refData.item.atLastCompilation) {
+            const refNum = refData.item.atLastCompilation.refNumber
+            const refMessage = `numbered ${refNum} at last compilation`
+            return refMessage
+        }
+        return undefined
     }
 
     private eqNumAndLabel(obj: LabelsStore, tex: TexMathEnv, refToken: string) : string {


### PR DESCRIPTION
This is a PR to show a label or a number given to the ref on the hover. The numbers are read from the aux file just after compilation finished.

When enabled and after compilation.

![スクリーンショット 2019-04-21 16 58 12](https://user-images.githubusercontent.com/10665499/56467198-cf561100-6456-11e9-9312-9123f0a035c7.png)

When disabled or not yet compiled.

![スクリーンショット 2019-04-21 17 02 07](https://user-images.githubusercontent.com/10665499/56467241-3bd11000-6457-11e9-8841-6e594efec162.png)
