### PR TITLE
use exact match for pdfjs version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1294,7 +1294,7 @@
     "mathjax": "2.7.5",
     "mathjax-node": "2.1.1",
     "micromatch": "^3.0.0",
-    "pdfjs-dist": "^2.0.943",
+    "pdfjs-dist": "2.0.943",
     "strip-json-comments": "^2.0.1",
     "tmp": "^0.0.33",
     "ws": "^5.1.1"


### PR DESCRIPTION
`"^2.0.943"` can match `2.1.x`.