### PR TITLE
display trimSelectContainer on a narrow pdf viewer

### DIFF
--- a/viewer/latexworkshop.css
+++ b/viewer/latexworkshop.css
@@ -121,7 +121,7 @@ html #outerContainer.sidebarOpen > #sidebarContainer {
     }
 }
 
-@media all and (max-width: 650px) {
+@media all and (max-width: 500px) {
     #trimSelectContainer {
         display: none;
     }

--- a/viewer/latexworkshop.css
+++ b/viewer/latexworkshop.css
@@ -115,8 +115,14 @@ html #outerContainer.sidebarOpen > #sidebarContainer {
     }
 }
 
+@media all and (max-width: 700px) {
+    #scaleSelectContainer {
+      display: none;
+    }
+}
+
 @media all and (max-width: 650px) {
-    #scaleSelectContainer, #trimSelectContainer {
+    #trimSelectContainer {
         display: none;
     }
 }

--- a/viewer/viewer.css
+++ b/viewer/viewer.css
@@ -2383,7 +2383,7 @@ html[dir='rtl'] #documentPropertiesOverlay .row > * {
   }
 }
 
-@media all and (max-width: 700px) {
+@media all and (max-width: 535px) {
   #scaleSelectContainer {
     display: none;
   }


### PR DESCRIPTION
displayed trimSelectContainer on a narrow pdf viewer.

We should not edit viewer.css. We should edit latexworkshop.css. #1321. I had forgotten.

