### PR TITLE
check whether selection.anchorNode is null.

### DIFF
--- a/viewer/latexworkshop.js
+++ b/viewer/latexworkshop.js
@@ -238,7 +238,8 @@ document.addEventListener('pagerendered', (evPageRendered) => {
         const selection = window.getSelection();
         let textBeforeSelection = ''
         let textAfterSelection = ''
-        if(selection.anchorNode.nodeName === '#text'){
+        // workaround for https://github.com/James-Yu/LaTeX-Workshop/issues/1314
+        if(selection && selection.anchorNode && selection.anchorNode.nodeName === '#text'){
           const text = selection.anchorNode.textContent;
           textBeforeSelection = text.substring(0, selection.anchorOffset);
           textAfterSelection = text.substring(selection.anchorOffset);


### PR DESCRIPTION
Related to #1314.  `selection.anchorNode` is always set a value, not `null`. So, normally, we do not have to check whether it is `null`. However, in this [log](https://github.com/James-Yu/LaTeX-Workshop/issues/1314#issuecomment-487858272), it is said to be `null`. That might be a bug of VSCode.