### PR TITLE
add option for newcommand on hover preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -1136,7 +1136,7 @@
         "latex-workshop.hover.preview.newcommand.newcommandFile": {
           "type": "string",
           "default": "",
-          "markdownDescription": "Set the path of a file in which newcommands of LaTeX defined for Hover Preview. If the path is relative, it is joined with the root dir."
+          "markdownDescription": "Set the path of a file containing newcommands to be used in Hover Preview. If the path is relative, it is joined with the root dir."
         },
         "latex-workshop.hover.preview.cursor.enabled": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -1128,6 +1128,16 @@
           "default": 1,
           "markdownDescription": "Scaling of Hover Preview."
         },
+        "latex-workshop.hover.preview.newcommand.parseTeXFile.enabled": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Enable newcommands defined in the current TeX file to be included in Hover Preview."
+        },
+        "latex-workshop.hover.preview.newcommand.newcommandFile": {
+          "type": "string",
+          "default": "",
+          "markdownDescription": "Set the path of a file in which newcommands of LaTeX defined for Hover Preview. If the path is relative, it is joined with the root dir."
+        },
         "latex-workshop.hover.preview.cursor.enabled": {
           "type": "boolean",
           "default": true,


### PR DESCRIPTION
Added an option that a TeX file in which newcommands defined can be used for hover preview. Requested in #1071.