### PR TITLE
enable LaTeX Workshop to work with VSCode Remote Dev

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -29,10 +29,10 @@ RUN npm install -g tslint typescript
 
 # Install Tex Live
 RUN apt-get update && apt-get -y upgrade
-RUN apt-get -y install texlive-base texlive-latex-base texlive-math-extra
-RUN apt-get -y install biber latexmk make
-RUN apt-get -y install texlive-lang-chinese
-RUN apt-get -y install texlive-lang-japanese
+RUN apt-get -y install --no-install-recommends texlive-base texlive-latex-base texlive-math-extra
+RUN apt-get -y install --no-install-recommends biber latexmk make
+RUN apt-get -y install --no-install-recommends texlive-lang-chinese
+RUN apt-get -y install --no-install-recommends texlive-lang-japanese
 
 # Clean up
 RUN apt-get autoremove -y \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,41 @@
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+FROM node:10
+
+# Configure apt
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends apt-utils 2>&1
+
+# Verify git and needed tools are installed
+RUN apt-get install -y git procps
+
+# Remove outdated yarn from /opt and install via package 
+# so it can be easily updated via apt-get upgrade yarn
+RUN rm -rf /opt/yarn-* \
+    rm -f /usr/local/bin/yarn \
+    rm -f /usr/local/bin/yarnpkg \
+    && apt-get install -y curl apt-transport-https lsb-release \
+    && curl -sS https://dl.yarnpkg.com/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/pubkey.gpg | apt-key add - 2>/dev/null \
+    && echo "deb https://dl.yarnpkg.com/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
+    && apt-get update \
+    && apt-get -y install --no-install-recommends yarn
+
+# Install tslint and typescript
+RUN npm install -g tslint typescript
+
+# Install Tex Live
+RUN apt-get update && apt-get -y upgrade
+RUN apt-get -y install texlive-base texlive-latex-base texlive-math-extra
+RUN apt-get -y install biber latexmk make
+RUN apt-get -y install texlive-lang-chinese
+RUN apt-get -y install texlive-lang-japanese
+
+# Clean up
+RUN apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+ENV DEBIAN_FRONTEND=dialog

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,6 @@
 {
 	"name": "Node.js 10 & TypeScript & TeX Live Base",
 	"dockerFile": "Dockerfile",
-	"appPort": 3000,
 	"extensions": [
 		"ms-vscode.vscode-typescript-tslint-plugin"
 	]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,10 @@
+// See https://aka.ms/vscode-remote/containers for the
+// documentation about the devcontainer.json format
+{
+	"name": "Node.js 10 & TypeScript & TeX Live Base",
+	"dockerFile": "Dockerfile",
+	"appPort": 3000,
+	"extensions": [
+		"ms-vscode.vscode-typescript-tslint-plugin"
+	]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,6 +16,20 @@
             "preLaunchTask":"npm: watch"
         },
         {
+            "name":"Run Extension With Sample",
+            "type":"extensionHost",
+            "request":"launch",
+            "runtimeExecutable":"${execPath}",
+            "args":[
+                "--extensionDevelopmentPath=${workspaceFolder}",
+                "${workspaceFolder}/sample"
+            ],
+            "outFiles":[
+                "${workspaceFolder}/out/src/**/*.js"
+            ],
+            "preLaunchTask":"npm: watch"
+        },
+        {
             "name":"Run Extension Tests",
             "type":"extensionHost",
             "request":"launch",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/James-Yu/LaTeX-Workshop.git"
   },
   "engines": {
-    "vscode": "^1.27.0"
+    "vscode": "^1.34.0"
   },
   "categories": [
     "Programming Languages",

--- a/sample/t.tex
+++ b/sample/t.tex
@@ -1,0 +1,4 @@
+\documentclass[12pt]{article}
+\begin{document}
+  abcd
+\end{document}

--- a/src/components/server.ts
+++ b/src/components/server.ts
@@ -12,6 +12,7 @@ export class Server {
     httpServer: http.Server
     wsServer: ws.Server
     address: string
+    port: number
 
     constructor(extension: Extension) {
         this.extension = extension
@@ -23,6 +24,7 @@ export class Server {
                 this.extension.logger.addLogMessage(`Error creating LaTeX Workshop http server: ${err}.`)
             } else {
                 const {address, port} = this.httpServer.address() as AddressInfo
+                this.port = port
                 if (address.indexOf(':') > -1) {
                     // the colon is reserved in URL to separate IPv4 address from port number. IPv6 address needs to be enclosed in square brackets when used in URL
                     this.address = `[${address}]:${port}`

--- a/src/components/viewer.ts
+++ b/src/components/viewer.ts
@@ -70,10 +70,10 @@ export class Viewer {
             this.extension.logger.addLogMessage(`Cannot establish server connection.`)
             return
         }
-        // vscode.URI.parse and pdfjs viewer automatically call decodeURIComponent.
+        // pdfjs viewer automatically call decodeURIComponent.
         // So, to pass the encoded path of a pdf file to the http server,
-        // we have to call encodeURIComponent three times! 3 - 2 = 1 !
-        const url = `http://${this.extension.server.address}/viewer.html?file=/pdf:${encodeURIComponent(encodeURIComponent(encodeURIComponent(pdfFile)))}`
+        // we have to call encodeURIComponent two times! 2 - 1 = 1 !
+        const url = `http://localhost:${this.extension.server.port}/viewer.html?file=/pdf:${encodeURIComponent(encodeURIComponent(pdfFile))}`
         this.extension.logger.addLogMessage(`Serving PDF file at ${url}`)
         return url
     }
@@ -87,7 +87,7 @@ export class Viewer {
         this.clients[pdfFile.toLocaleUpperCase()] = this.clients[pdfFile.toLocaleUpperCase()] || []
 
         try {
-            vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(url))
+            vscode.env.openExternal(vscode.Uri.parse(url))
             this.extension.logger.addLogMessage(`Open PDF viewer for ${pdfFile}`)
         } catch (e) {
             vscode.window.showInputBox({

--- a/src/components/viewer.ts
+++ b/src/components/viewer.ts
@@ -110,7 +110,8 @@ export class Viewer {
         const editor = vscode.window.activeTextEditor
         const panel = vscode.window.createWebviewPanel('latex-workshop-pdf', path.basename(pdfFile), sideColumn ? vscode.ViewColumn.Beside : vscode.ViewColumn.Active, {
             enableScripts: true,
-            retainContextWhenHidden: true
+            retainContextWhenHidden: true,
+            portMapping : [{webviewPort: this.extension.server.port, extensionHostPort: this.extension.server.port}]
         })
         panel.webview.html = this.getPDFViewerContent(uri)
         if (editor && sideColumn) {
@@ -123,7 +124,7 @@ export class Viewer {
         // pdfjs viewer automatically call decodeURIComponent.
         // So, to pass the encoded path of a pdf file to the http server,
         // we have to call encodeURIComponent two times! 2 - 1 = 1 !
-        const url = `http://${this.extension.server.address}/viewer.html?incode=1&file=/pdf:${uri.authority ? `\\\\${uri.authority}` : ''}${encodeURIComponent(encodeURIComponent(uri.fsPath))}`
+        const url = `http://localhost:${this.extension.server.port}/viewer.html?incode=1&file=/pdf:${uri.authority ? `\\\\${uri.authority}` : ''}${encodeURIComponent(encodeURIComponent(uri.fsPath))}`
         return `
             <!DOCTYPE html><html><head></head>
             <body><iframe id="preview-panel" class="preview-panel" src="${url}" style="position:absolute; border: none; left: 0; top: 0; width: 100%; height: 100%;">


### PR DESCRIPTION
enabled LaTeX Workshop to work with [VSCode Remote Dev](https://code.visualstudio.com/blogs/2019/05/02/remote-development). We can edit a TeX file on a remote server and preview the pdf file. I have tested a case [Remote Development using SSH](https://code.visualstudio.com/docs/remote/ssh). Built-in pdf preview works fine with SyncTeX. Browser preview and external viewers do not work.

This PR works only with VSCode Insiders. So, merging must be postponed until the release. After merging, users using VSCode 1.33 and earlier versions will not get updates of this extension.