### PR TITLE
Add command to switch between equation environments.

### DIFF
--- a/package.json
+++ b/package.json
@@ -195,6 +195,11 @@
         "category": "LaTeX Workshop"
       },
       {
+        "command": "latex-workshop.switch-equation-environment",
+        "title": "Switch equation environment",
+        "category": "LaTeX Workshop"
+      },
+      {
         "command": "latex-workshop.saveWithoutBuilding",
         "title": "Save without Building",
         "category": "LaTeX Workshop"

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -679,7 +679,7 @@ export class Commander {
             return
         }
 
-        // Environment names should look like '(begintext) ... (endtext)' to handled properly
+        // Environment names should look like '(begintext) ... (endtext)' to be handled properly
         const equationEnvironments = [
             '\\[ ... \\]',
             '\\begin{equation} ... \\end{equation}',

--- a/src/main.ts
+++ b/src/main.ts
@@ -242,6 +242,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
     vscode.commands.registerCommand('latex-workshop.increment-sectioning', () => extension.commander.shiftSectioningLevel('increment'))
     vscode.commands.registerCommand('latex-workshop.decrement-sectioning', () => extension.commander.shiftSectioningLevel('decrement'))
+    vscode.commands.registerCommand('latex-workshop.switch-equation-environment', () => extension.commander.switchEquationEnvironment())
 
     vscode.commands.registerCommand('latex-workshop.showCompilationPanel', () => extension.buildInfo.showPanel())
 


### PR DESCRIPTION
![Example of feature](https://user-images.githubusercontent.com/7917549/57236448-19142f00-6ff3-11e9-9f0c-47f2ed5657de.gif)

I wanted to add this feature because I often find myself needing to change from `\[ ... \]` to `\begin{equation} ... \end{equation}` if I want to add a label later or to change to `\begin{align*} ... \end{align*}` if I need multiple lines.

The code is pretty basic, it just searches backwards and forwards until it finds the beginning and end of some equation environment and then does a replace. As such, it can produce garbage if the user feeds it a bad starting point. Nonetheless, I'm happy with how it works.