### PR TITLE
Add command to switch between equation environments.

### DIFF
--- a/package.json
+++ b/package.json
@@ -195,6 +195,11 @@
         "category": "LaTeX Workshop"
       },
       {
+        "command": "latex-workshop.switch-equation-environment",
+        "title": "Switch equation environment",
+        "category": "LaTeX Workshop"
+      },
+      {
         "command": "latex-workshop.saveWithoutBuilding",
         "title": "Save without Building",
         "category": "LaTeX Workshop"

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -728,13 +728,9 @@ export class Commander {
                 return
             }
             const edit = new vscode.WorkspaceEdit()
-            edit.replace(document.uri, upRange, selected.replace(/ \.\.\. .*/, ''))
             edit.replace(document.uri, downRange, selected.replace(/.* \.\.\. /, ''))
-            vscode.workspace.applyEdit(edit).then(success => {
-                if (success) {
-                    editor.selection = startSelection
-                }
-            })
+            edit.replace(document.uri, upRange, selected.replace(/ \.\.\. .*/, ''))
+            vscode.workspace.applyEdit(edit)
         })
     }
 

--- a/src/components/envpair.ts
+++ b/src/components/envpair.ts
@@ -61,6 +61,19 @@ export class EnvPair {
         return null
     }
 
+    /**
+     * Searches upwards or downwards for a begin or end environment captured by `pattern`.
+     * Begin environment can also be `\[` and end environment can also be `\]`
+     *
+     * @param pattern A regex that matches begin or end environments.
+     *
+     * Note: the regex must capture (`begin` or `[`) or (`end` or `]`) in the first
+     * capturing group. If nesting is possible, the pattern must capture *both* `begin` and `end`.
+     * If `dir` is -1, regex must capture `begin` and/or `[` and likewise if `dir` is +1.
+     * @param dir +1 to search downwards, -1 to search upwards
+     * @param pos starting position (e.g. cursor position)
+     * @param doc the document in which the search is performed
+     */
     locateMatchingPair(pattern: string, dir: number, pos: vscode.Position, doc: vscode.TextDocument) : MatchEnv | null {
         const patRegexp = new RegExp(pattern, 'g')
         let lineNumber = pos.line
@@ -79,10 +92,10 @@ export class EnvPair {
                 allMatches = allMatches.reverse()
             }
             for (const m of allMatches) {
-                if ((m[1] === 'begin' && dir === 1) || (m[1] === 'end' && dir === -1)) {
+                if ((dir === 1 && (m[1] === 'begin' || m[1] === '[')) || (dir === -1 && (m[1] === 'end' || m[1] === ']'))) {
                     nested += 1
                 }
-                if ((m[1] === 'end' && dir === 1) || (m[1] === 'begin' && dir === -1))  {
+                if ((dir === 1 && (m[1] === 'end' || m[1] === ']')) || (dir === -1 && (m[1] === 'begin' || m[1] === '[')))  {
                     if (nested === 0) {
                         const matchPos = new vscode.Position(lineNumber, m.index + 1)
                         const matchName = m[2]

--- a/src/main.ts
+++ b/src/main.ts
@@ -242,6 +242,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
     vscode.commands.registerCommand('latex-workshop.increment-sectioning', () => extension.commander.shiftSectioningLevel('increment'))
     vscode.commands.registerCommand('latex-workshop.decrement-sectioning', () => extension.commander.shiftSectioningLevel('decrement'))
+    vscode.commands.registerCommand('latex-workshop.switch-equation-environment', () => extension.commander.switchEquationEnvironment())
 
     vscode.commands.registerCommand('latex-workshop.showCompilationPanel', () => extension.buildInfo.showPanel())
 


### PR DESCRIPTION
I've updated #1360 to use `envPair.locateMatchingPair()`. Functionality should remain the same.

Again, I'm creating a new command because I don't believe the current commands (e.g. `latex-workshop.select-envname`) can be made to work with `\[ ... \]` well.