### PR TITLE
Parse multiline error messages of LaTeX

### DIFF
--- a/src/components/parser.ts
+++ b/src/components/parser.ts
@@ -254,8 +254,9 @@ export class Parser {
         }
     }
 
+    // find a LaTeX error message beginning with '!' and parse it.
     parseLaTeXExclamationError(log: string) {
-        const exclamationErrorRegex = /^!([^]*?)^l.(\d+?)\s+?(\\input{(.*?)})?/m
+        const exclamationErrorRegex = /^!([^]*?)^l\.(\d+?)\s+?(\\input{(.*?)})?/m
         const result = log.match(exclamationErrorRegex)
         if (result) {
             const currentResult = {


### PR DESCRIPTION
LaTeX Workshop cannot recognize a line number and a input filename of a LaTeX error message beginning with `!`, for example,
```
! File ended while scanning use of \align.
<inserted text> 
                \par 
l.18 \input{t1.tex}
```
This PR enables the extension to parse the multiline error messages of LaTeX properly.   ` \input{t1.tex}` in the error message can be recognized too.

Before

![2019-05-19 7 55 50](https://user-images.githubusercontent.com/10665499/57975792-be73cd80-7a0b-11e9-9bb2-09fd21578317.png)

After

![2019-05-19 7 56 16](https://user-images.githubusercontent.com/10665499/57975793-c7649f00-7a0b-11e9-83b6-71f1549a3294.png)


I have left `Parser.parseLaTeX` unchanged as possible as.

`Parser.parseLaTeX` is not able to recognize `\input{...}` in an error message of `latexmk`. That is another issue.