### PR TITLE
Parse multiline error messages of LaTeX

### DIFF
--- a/src/components/parser.ts
+++ b/src/components/parser.ts
@@ -254,8 +254,9 @@ export class Parser {
         }
     }
 
+    // find a LaTeX error message beginning with '!' and parse it.
     parseLaTeXExclamationError(log: string) {
-        const exclamationErrorRegex = /^!([^]*?)^l.(\d+?)\s+?(\\input{(.*?)})?/m
+        const exclamationErrorRegex = /^!([^]*?)^l\.(\d+?)\s+?(\\input{(.*?)})?/m
         const result = log.match(exclamationErrorRegex)
         if (result) {
             const currentResult = {

--- a/src/components/parser.ts
+++ b/src/components/parser.ts
@@ -256,13 +256,13 @@ export class Parser {
 
     // find a LaTeX error message beginning with '!' and parse it.
     parseLaTeXExclamationError(log: string) {
-        const exclamationErrorRegex = /^!([^]*?)^l\.(\d+?)\s+?(\\input{(.*?)})?/m
+        const exclamationErrorRegex = /^!([^]*?)^l\.(\d+)/m
         const result = log.match(exclamationErrorRegex)
         if (result) {
             const currentResult = {
                 type: 'error',
                 text: result[1],
-                file: result[4] ? path.resolve(this.extension.manager.rootDir, result[4]) : this.extension.manager.rootFile,
+                file: this.extension.manager.rootFile,
                 line: Number(result[2])
             }
             this.buildLog.push(currentResult)


### PR DESCRIPTION
LaTeX Workshop cannot recognize  a line number and a input filename of a LaTeX error message beginning with `!`, for example,
```
! Undefined control sequence.
l.17 \abc
```
This PR enables the extension to parse the multiline error messages of LaTeX properly.   

![2019-05-19 9 15 51](https://user-images.githubusercontent.com/10665499/57976315-a904a080-7a17-11e9-9663-829a7191275f.png)

I have left `Parser.parseLaTeX` unchanged as possible as.

