### PR TITLE
Wait for WebSocket to open

### DIFF
--- a/viewer/latexworkshop.js
+++ b/viewer/latexworkshop.js
@@ -220,7 +220,8 @@ socket.addEventListener("message", (event) => {
 })
 socket.onclose = () => { document.title = `[Disconnected] ${document.title}` }
 
-document.addEventListener('pagesinit', (e) => {
+document.addEventListener('pagesinit', () => {
+  // check whether WebSocket is open (readyState === 1).
   if (socket.readyState === 1) {
     socket.send(JSON.stringify({type:"loaded", path:file}))
   } else {

--- a/viewer/latexworkshop.js
+++ b/viewer/latexworkshop.js
@@ -221,7 +221,13 @@ socket.addEventListener("message", (event) => {
 socket.onclose = () => { document.title = `[Disconnected] ${document.title}` }
 
 document.addEventListener('pagesinit', (e) => {
+  if (socket.readyState === 1) {
     socket.send(JSON.stringify({type:"loaded", path:file}))
+  } else {
+    socket.addEventListener("open", () => {
+      socket.send(JSON.stringify({type:"loaded", path:file}))
+    }, {once: true})
+  }
 })
 
 // if we're embedded we cannot open external links here. So we intercept clicks and forward them to the extension


### PR DESCRIPTION
Before we call `socket.send`, we have to check that the socket is open, i.e., `socket.readyState === 1`. [link](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/readyState), [link](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/send), and [spec](https://html.spec.whatwg.org/multipage/web-sockets.html#dom-websocket-send).

Close #1395. 