### PR TITLE
fix the width of textLayer on pdf viewer

### DIFF
--- a/viewer/latexworkshop.js
+++ b/viewer/latexworkshop.js
@@ -244,6 +244,7 @@ if (embedded) {
 document.addEventListener('pagerendered', (evPageRendered) => {
     const page = evPageRendered.target.dataset.pageNumber
     const target = evPageRendered.target
+    // textLayer
     const canvas_dom = evPageRendered.target.childNodes[1]
     canvas_dom.onclick = (e) => {
         if (!(e.ctrlKey || e.metaKey)) {
@@ -418,7 +419,7 @@ const trimPage = (page) => {
   const m = w.match(/(\d+)/);
   if (m) {
     // add -4px to ensure that no horizontal scroll bar appears.
-    const widthNum = Math.floor(Number(m[1])/trimScale) - 4
+    const widthNum = Math.floor(Number(m[1])/trimScale) - 4;
     const width = widthNum  + 'px';
     page.style.width = width;
     canvasWrapper.style.width = width;

--- a/viewer/latexworkshop.js
+++ b/viewer/latexworkshop.js
@@ -418,7 +418,8 @@ const trimPage = (page) => {
   const m = w.match(/(\d+)/);
   if (m) {
     // add -4px to ensure that no horizontal scroll bar appears.
-    const width = ( Math.floor(Number(m[1])/trimScale) - 4 )  + 'px';
+    const widthNum = Math.floor(Number(m[1])/trimScale) - 4
+    const width = widthNum  + 'px';
     page.style.width = width;
     canvasWrapper.style.width = width;
     const offsetX = - Number(m[1]) * (1 - 1/trimScale) / 2;
@@ -426,7 +427,7 @@ const trimPage = (page) => {
     canvas.style.position = 'relative';
     canvas.setAttribute('data-is-trimmed', 'trimmed');
     if ( textLayer && textLayer.dataset.isTrimmed !== 'trimmed' ) {
-      textLayer.style.width = width;
+      textLayer.style.width = widthNum - offsetX + 'px';
       textLayer.style.left = offsetX + 'px';
       textLayer.setAttribute('data-is-trimmed', 'trimmed');
     }


### PR DESCRIPTION
fixed the width of textLayer on pdf viewer when trim mode is turned on.

Now, we can select texts on the right side of the viewer when trim mode is turned on. SyncTeX from pdf to TeX also works on the right side of the viewer.

before

![2019-06-01 7 17 53](https://user-images.githubusercontent.com/10665499/58737789-e3ba0000-843d-11e9-91f5-574b91e10274.png)

after

![2019-06-01 7 16 32](https://user-images.githubusercontent.com/10665499/58737802-eddbfe80-843d-11e9-9c3b-7a011e5f04c1.png)
