### PR TITLE
Change default math preview cursor symbol

### DIFF
--- a/package.json
+++ b/package.json
@@ -1167,7 +1167,7 @@
         },
         "latex-workshop.hover.preview.cursor.symbol": {
           "type": "string",
-          "default": "\\ddagger",
+          "default": "\\!|\\!",
           "markdownDescription": "Cursor symbol in Hover Preview."
         },
         "latex-workshop.hover.preview.cursor.color": {


### PR DESCRIPTION
`\!|\!` looks kinda like a cursor in between two symbols.
![image](https://user-images.githubusercontent.com/20903656/58749786-d728bc80-84bc-11e9-8b0d-1a16647d8765.png)
I suspect that this will lead to fewer bug reports of _"there's this funny symbol in the math preview…"_
Just an idea.