### PR TITLE
Make .ltx be treated as LaTeX not TeX

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,8 +55,7 @@
           ".sty",
           ".cls",
           ".bbx",
-          ".cbx",
-          ".ltx"
+          ".cbx"
         ],
         "configuration": "./syntax/syntax.json"
       },
@@ -78,7 +77,8 @@
           "latex"
         ],
         "extensions": [
-          ".tex"
+          ".tex",
+          ".ltx"
         ],
         "configuration": "./syntax/syntax.json"
       },


### PR DESCRIPTION
This is rather minor but I noticed that `.ltx` is in the TeX category not LaTeX.

![image](https://user-images.githubusercontent.com/20903656/59105139-de8d1180-8965-11e9-91a7-e295b13d0224.png)
