### PR TITLE
Pass 'DeclareMathOperator's to mathjax

### DIFF
--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -130,7 +130,7 @@ export class HoverProvider implements vscode.HoverProvider {
         if (!configuration.get('hover.preview.newcommand.parseTeXFile.enabled') as boolean) {
             return commandsString
         }
-        const regex = /(\\(?:(?:(?:re)?new|provide)command(\*)?{\\[a-zA-Z]+}(?:\[[^\[\]\{\}]*\])*{.*})|\\(?:def\\[a-zA-Z]+(?:#[0-9])*{.*}))/gm
+        const regex = /(\\(?:(?:(?:(?:re)?new|provide)command|DeclareMathOperator)(\*)?{\\[a-zA-Z]+}(?:\[[^\[\]\{\}]*\])*{.*})|\\(?:def\\[a-zA-Z]+(?:#[0-9])*{.*}))/gm
         const commands: string[] = []
         const noCommentContent = content.replace(/([^\\]|^)%.*$/gm, '$1') // Strip comments
         let result


### PR DESCRIPTION
Because I was tired of seeing this:

![Untitled](https://user-images.githubusercontent.com/7917549/60209332-68732080-9828-11e9-89fe-c2c45154b127.png)