### PR TITLE
Allow all printable ASCII characters except ",(,) in paths.

### DIFF
--- a/src/components/parser.ts
+++ b/src/components/parser.ts
@@ -257,8 +257,8 @@ export class Parser {
         if (result && result.index !== undefined && result.index > -1) {
             line = line.substr(result.index + 1)
             if (result[1] === '(') {
-                const pathResult = line.match(/^"?((?:(?:[a-zA-Z]:|\.|\/)?(?:\/|\\\\?))[\w\u00a1-\uffff\-. \/\\#]*)/)
-                const mikTeXPathResult = line.match(/^"?([\w\u00a1-\uffff\-\/. #]*\.[a-z]{3,})/)
+                const pathResult = line.match(/^"?((?:(?:[a-zA-Z]:|\.|\/)?(?:\/|\\\\?))[ !\u0023-\u0027\u002A-\u00FE\u00a1-\uffff]*)/)
+                const mikTeXPathResult = line.match(/^"?([ !\u0023-\u0027\u002A-\u00FE\u00a1-\uffff]*\.[a-z]{3,})/)
                 if (pathResult) {
                     fileStack.push(pathResult[1].trim())
                 } else if (mikTeXPathResult) {


### PR DESCRIPTION
Fixes #1487 

Attempt number 2. Allowing parentheses and " produced garbage paths the last time I tried this.

I've tested this for a while on both Windows (but TeXLive, not MikTeX) and Linux and haven't seen anything matched by the regex that shouldn't have been.

This requires more testing I think.

Edit: I've tested this with MikTeX now on a large-ish file with a lot of path information contained within it (mostly LaTeX packages and stuff). From what I've seen, as long as `"` and `)` aren't included in the regex, this should work.