### PR TITLE
set the version of engine to 1.34

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/James-Yu/LaTeX-Workshop.git"
   },
   "engines": {
-    "vscode": "^1.36.0"
+    "vscode": "^1.34.0"
   },
   "categories": [
     "Programming Languages",


### PR DESCRIPTION
We do not have to require users to use VS Code 1.36. 