### PR TITLE
New subfiles package support

### DIFF
--- a/package.json
+++ b/package.json
@@ -680,6 +680,11 @@
           "default": [],
           "markdownDescription": "Patterns of files to exclude from the root detection mechanism.\nSee also `latex-workshop.latex.search.rootFiles.include`. For more details the [wiki](https://github.com/James-Yu/LaTeX-Workshop/wiki/Multi-File-Projects)."
         },
+        "latex-workshop.latex.rootFile.useSubFile": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "When the `subfile` package is used, either the main file or any subfile containing `\\documentclass[main.tex]{subfile}` can be LaTeXing. When set to `true`, the extension uses the subfile as the rootFile for the `autobuild`, `clean` and `synctex` commands. Note that this setting does not affect the `build` and `view` command as they both ask the user's choice first."
+        },
         "latex-workshop.latex.watch.files.ignore": {
           "type": "array",
           "default": [

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -137,16 +137,24 @@ export class Commander {
             this.extension.logger.addLogMessage(`Cannot find LaTeX root PDF to view.`)
             return
         }
+        let pickedRootFile: string | undefined = rootFile
+        if (this.extension.manager.localRootFile) {
+            // We are using the subfile package
+            pickedRootFile = await quickPickRootFile(rootFile, this.extension.manager.localRootFile)
+            if (! pickedRootFile) {
+                return
+            }
+        }
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         const useActiveGroup = configuration.get('view.pdf.tab.useNewGroup') as boolean
         if (mode === 'browser') {
-            this.extension.viewer.openBrowser(rootFile)
+            this.extension.viewer.openBrowser(pickedRootFile)
             return
         } else if (mode === 'tab') {
-            this.extension.viewer.openTab(rootFile, true, useActiveGroup)
+            this.extension.viewer.openTab(pickedRootFile, true, useActiveGroup)
             return
         } else if (mode === 'external') {
-            this.extension.viewer.openExternal(rootFile)
+            this.extension.viewer.openExternal(pickedRootFile)
             return
         } else if (mode === 'set') {
             this.setViewer()
@@ -154,16 +162,19 @@ export class Commander {
         }
         const promise = (configuration.get('view.pdf.viewer') as string === 'none') ? this.setViewer() : Promise.resolve()
         promise.then(() => {
+            if (!pickedRootFile) {
+                return
+            }
             switch (configuration.get('view.pdf.viewer')) {
                 case 'browser':
-                    this.extension.viewer.openBrowser(rootFile)
+                    this.extension.viewer.openBrowser(pickedRootFile)
                     break
                 case 'tab':
                 default:
-                    this.extension.viewer.openTab(rootFile, true, useActiveGroup)
+                    this.extension.viewer.openTab(pickedRootFile, true, useActiveGroup)
                     break
                 case 'external':
-                    this.extension.viewer.openExternal(rootFile)
+                    this.extension.viewer.openExternal(pickedRootFile)
                     break
             }
         })

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode'
 import * as fs from 'fs-extra'
 import * as path from 'path'
 import * as cp from 'child_process'
+import * as utils from './utils'
 
 import {Extension} from './main'
 import { ExternalCommand, getLongestBalancedString } from './utils'
@@ -52,7 +53,8 @@ export class Commander {
             this.extension.logger.addLogMessage(`Building root file: ${rootFile}`)
             await this.extension.builder.build(rootFile, recipe)
         } else {
-            const subFileRoot = this.extension.manager.findSubFiles()
+            const editorContent = utils.stripComments(vscode.window.activeTextEditor.document.getText(), '%')
+            const subFileRoot = this.extension.manager.findSubFiles(editorContent)
             if (subFileRoot) {
                 vscode.window.showQuickPick([{
                     label: 'Default root file',

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -203,7 +203,14 @@ export class Commander {
         if (!vscode.window.activeTextEditor || !this.extension.manager.hasTexId(vscode.window.activeTextEditor.document.languageId)) {
             return
         }
-        this.extension.locator.syncTeX()
+        const configuration = vscode.workspace.getConfiguration('latex-workshop')
+        let pdfFile: string
+        if (this.extension.manager.localRootFile && configuration.get("latex.rootFile.useSubFile")) {
+            pdfFile = this.extension.manager.tex2pdf(this.extension.manager.localRootFile)
+        } else {
+            pdfFile = this.extension.manager.tex2pdf(this.extension.manager.rootFile)
+        }
+        this.extension.locator.syncTeX(undefined, undefined, pdfFile)
     }
 
     async synctexonref(line: number, filePath: string) {

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -223,8 +223,20 @@ export class Commander {
 
     async clean() : Promise<void> {
         this.extension.logger.addLogMessage(`CLEAN command invoked.`)
-        await this.extension.manager.findRoot()
-        return this.extension.cleaner.clean()
+        const rootFile = await this.extension.manager.findRoot()
+        if (rootFile === undefined) {
+            this.extension.logger.addLogMessage(`Cannot find LaTeX root file to clean.`)
+            return
+        }
+        let pickedRootFile: string | undefined = rootFile
+        if (this.extension.manager.localRootFile) {
+            // We are using the subfile package
+            pickedRootFile = await quickPickRootFile(rootFile, this.extension.manager.localRootFile)
+            if (! pickedRootFile) {
+                return
+            }
+        }
+        return this.extension.cleaner.clean(pickedRootFile)
     }
 
     addTexRoot() {

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -190,7 +190,6 @@ export class Commander {
 
     async synctex() {
         this.extension.logger.addLogMessage(`SYNCTEX command invoked.`)
-        await this.extension.manager.findRoot()
         if (!vscode.window.activeTextEditor || !this.extension.manager.hasTexId(vscode.window.activeTextEditor.document.languageId)) {
             return
         }
@@ -199,7 +198,6 @@ export class Commander {
 
     async synctexonref(line: number, filePath: string) {
         this.extension.logger.addLogMessage(`SYNCTEX command invoked.`)
-        await this.extension.manager.findRoot()
         if (!vscode.window.activeTextEditor || !this.extension.manager.hasTexId(vscode.window.activeTextEditor.document.languageId)) {
             return
         }

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -120,7 +120,11 @@ export class Commander {
     }
 
     async view(mode?: string) {
-        this.extension.logger.addLogMessage(`VIEW command invoked.`)
+        if (mode) {
+            this.extension.logger.addLogMessage(`VIEW command invoked with mode: ${mode}.`)
+        } else {
+            this.extension.logger.addLogMessage(`VIEW command invoked.`)
+        }
         if (!vscode.window.activeTextEditor) {
             this.extension.logger.addLogMessage('Cannot find active TextEditor.')
             return
@@ -174,33 +178,6 @@ export class Commander {
     kill() {
         this.extension.logger.addLogMessage(`KILL command invoked.`)
         this.extension.builder.kill()
-    }
-
-    async browser() {
-        this.extension.logger.addLogMessage(`BROWSER command invoked.`)
-        if (!vscode.window.activeTextEditor || !this.extension.manager.hasTexId(vscode.window.activeTextEditor.document.languageId)) {
-            return
-        }
-        const rootFile = await this.extension.manager.findRoot()
-        if (rootFile !== undefined) {
-            this.extension.viewer.openBrowser(rootFile)
-        } else {
-            this.extension.logger.addLogMessage(`Cannot find LaTeX root PDF to view.`)
-        }
-    }
-
-    async tab() {
-        this.extension.logger.addLogMessage(`TAB command invoked.`)
-        if (!vscode.window.activeTextEditor || !this.extension.manager.hasTexId(vscode.window.activeTextEditor.document.languageId)) {
-            return
-        }
-        const rootFile = await this.extension.manager.findRoot()
-        if (rootFile !== undefined) {
-            const configuration = vscode.workspace.getConfiguration('latex-workshop')
-            this.extension.viewer.openTab(rootFile, true, configuration.get('view.pdf.tab.useNewGroup'))
-        } else {
-            this.extension.logger.addLogMessage(`Cannot find LaTeX root PDF to view.`)
-        }
     }
 
     pdf(uri: vscode.Uri | undefined) {

--- a/src/components/builder.ts
+++ b/src/components/builder.ts
@@ -238,7 +238,7 @@ export class Builder {
         })
 
         this.currentProcess.on('exit', (exitCode, signal) => {
-            this.extension.parser.parse(stdout)
+            this.extension.parser.parse(stdout, rootFile)
             if (exitCode !== 0) {
                 this.extension.logger.addLogMessage(`Recipe returns with error: ${exitCode}/${signal}. PID: ${pid}. message: ${stderr}.`)
                 this.extension.buildInfo.buildEnded()

--- a/src/components/builder.ts
+++ b/src/components/builder.ts
@@ -250,7 +250,7 @@ export class Builder {
                         this.extension.logger.displayStatus('x', 'errorForeground', `Recipe terminated with error. Retry building the project.`, 'warning')
                         this.extension.logger.addLogMessage(`Cleaning auxillary files and retrying build after toolchain error.`)
 
-                        this.extension.commander.clean().then(() => {
+                        this.extension.cleaner.clean(rootFile).then(() => {
                             this.buildStep(rootFile, steps, 0, recipeName, releaseBuildMutex)
                         })
                     } else {
@@ -261,7 +261,7 @@ export class Builder {
                 } else {
                     this.extension.logger.displayStatus('x', 'errorForeground')
                     if (['onFailed', 'onBuilt'].indexOf(configuration.get('latex.autoClean.run') as string) > -1) {
-                        this.extension.commander.clean()
+                        this.extension.cleaner.clean(rootFile)
                     }
                     const res = this.extension.logger.showErrorMessage(`Recipe terminated with error.`, 'Open compiler log')
                     if (res) {
@@ -312,7 +312,7 @@ export class Builder {
         // }
         if (configuration.get('latex.autoClean.run') as string === 'onBuilt') {
             this.extension.logger.addLogMessage('Auto Clean invoked.')
-            this.extension.cleaner.clean()
+            this.extension.cleaner.clean(rootFile)
         }
     }
 

--- a/src/components/builder.ts
+++ b/src/components/builder.ts
@@ -306,10 +306,10 @@ export class Builder {
         this.extension.completer.reference.setNumbersFromAuxFile(rootFile)
         this.extension.manager.findAdditionalDependentFilesFromFls(rootFile)
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
-        if (configuration.get('synctex.afterBuild.enabled') as boolean) {
-            this.extension.logger.addLogMessage('SyncTex after build invoked.')
-            this.extension.locator.syncTeX()
-        }
+        // if (configuration.get('synctex.afterBuild.enabled') as boolean) {
+        //     this.extension.logger.addLogMessage('SyncTex after build invoked.')
+        //     this.extension.locator.syncTeX(undefined, undefined, rootFile)
+        // }
         if (configuration.get('latex.autoClean.run') as string === 'onBuilt') {
             this.extension.logger.addLogMessage('Auto Clean invoked.')
             this.extension.cleaner.clean()

--- a/src/components/cleaner.ts
+++ b/src/components/cleaner.ts
@@ -12,19 +12,19 @@ export class Cleaner {
         this.extension = extension
     }
 
-    async clean() : Promise<void> {
-        if (this.extension.manager.rootFile !== undefined) {
-            await this.extension.manager.findRoot()
+    async clean(rootFile?: string) : Promise<void> {
+        if (! rootFile) {
+            if (this.extension.manager.rootFile !== undefined) {
+                await this.extension.manager.findRoot()
+            }
+            rootFile = this.extension.manager.rootFile
+            if (! rootFile) {
+                return
+            }
         }
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         let globs = configuration.get('latex.clean.fileTypes') as string[]
-        const outdir = this.extension.manager.getOutputDir(this.extension.manager.rootFile)
-        // if (!outdir.endsWith('/') && !outdir.endsWith('\\')) {
-        //     outdir += path.sep
-        // }
-        // if (outdir !== './' && outdir !== '.') {
-        //     globs = globs.concat(globs.map(globType => outdir + globType), globs.map(globType => outdir + '**/' + globType))
-        // }
+        const outdir = this.extension.manager.getOutputDir(rootFile)
         if (configuration.get('latex.clean.subfolder.enabled') as boolean) {
             globs = globs.map(globType => './**/' + globType)
         }

--- a/src/components/locator.ts
+++ b/src/components/locator.ts
@@ -119,6 +119,7 @@ export class Locator {
             filePath = args.filePath
         }
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
+        this.extension.manager.findRoot()
         const pdfFile = this.extension.manager.tex2pdf(this.extension.manager.rootFile)
         if (vscode.window.activeTextEditor.document.lineCount === line &&
             vscode.window.activeTextEditor.document.lineAt(line - 1).text === '') {

--- a/src/components/locator.ts
+++ b/src/components/locator.ts
@@ -93,7 +93,7 @@ export class Locator {
         }
     }
 
-    syncTeX(args?: {line: number, filePath: string}, forcedViewer: string = 'auto') {
+    syncTeX(args?: {line: number, filePath: string}, forcedViewer: string = 'auto', pdfFile?: string) {
         let line: number
         let filePath: string
         let character = 0
@@ -119,14 +119,17 @@ export class Locator {
             filePath = args.filePath
         }
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
-        this.extension.manager.findRoot()
-        const pdfFile = this.extension.manager.tex2pdf(this.extension.manager.rootFile)
+        const rootFile = this.extension.manager.rootFile
+        if (! pdfFile) {
+            this.extension.manager.findRoot()
+            pdfFile = this.extension.manager.tex2pdf(rootFile)
+        }
         if (vscode.window.activeTextEditor.document.lineCount === line &&
             vscode.window.activeTextEditor.document.lineAt(line - 1).text === '') {
                 line -= 1
         }
         if (forcedViewer === 'external' || (forcedViewer === 'auto' && configuration.get('view.pdf.viewer') === 'external') ) {
-            this.syncTeXExternal(line, pdfFile, this.extension.manager.rootFile)
+            this.syncTeXExternal(line, pdfFile, rootFile)
             return
         }
 
@@ -149,7 +152,7 @@ export class Locator {
             }
         } else {
             this.invokeSyncTeXCommandForward(line, character, filePath, pdfFile).then( (record) => {
-                this.extension.viewer.syncTeX(pdfFile, record)
+                this.extension.viewer.syncTeX(pdfFile as string, record)
             })
         }
     }

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -10,8 +10,8 @@ import {Extension} from '../main'
 
 export class Manager {
     extension: Extension
-    rootFiles: object
-    localRootFiles: object
+    rootFiles: { [key: string]: string }
+    localRootFiles: { [key: string]: string | undefined }
     workspace: string
     texFileTree: { [id: string]: Set<string> } = {}
     fileWatcher: chokidar.FSWatcher

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -11,6 +11,7 @@ import {Extension} from '../main'
 export class Manager {
     extension: Extension
     rootFiles: object
+    localRootFiles: object
     workspace: string
     texFileTree: { [id: string]: Set<string> } = {}
     fileWatcher: chokidar.FSWatcher
@@ -28,6 +29,7 @@ export class Manager {
         this.filesWatched = []
         this.bibsWatched = []
         this.rootFiles = {}
+        this.localRootFiles = {}
         this.workspace = ''
     }
 
@@ -54,6 +56,14 @@ export class Manager {
 
     set rootFile(root: string) {
         this.rootFiles[this.workspace] = root
+    }
+
+    get localRootFile() {
+        return this.localRootFiles[this.workspace]
+    }
+
+    set localRootFile(localRoot: string | undefined) {
+        this.localRootFiles[this.workspace] = localRoot
     }
 
     tex2pdf(texPath: string, respectOutDir: boolean = true) {
@@ -89,6 +99,7 @@ export class Manager {
 
     async findRoot() : Promise<string | undefined> {
         this.updateWorkspace()
+        this.localRootFile = undefined
         const findMethods = [() => this.findRootMagic(), () => this.findRootSelf(), () => this.findRootDir()]
         for (const method of findMethods) {
             const rootFile = await method()
@@ -149,19 +160,24 @@ export class Manager {
         const content = utils.stripComments(vscode.window.activeTextEditor.document.getText(), '%')
         const result = content.match(regex)
         if (result) {
+            const rootSubFile = this.findSubFiles(content)
             const file = vscode.window.activeTextEditor.document.fileName
-            this.extension.logger.addLogMessage(`Found root file from active editor: ${file}`)
-            return file
+            if (rootSubFile) {
+               this.localRootFile = file
+               return rootSubFile
+            } else {
+                this.extension.logger.addLogMessage(`Found root file from active editor: ${file}`)
+                return file
+            }
         }
         return undefined
     }
 
-    findSubFiles() : string | undefined {
+    findSubFiles(content: string) : string | undefined {
         if (!vscode.window.activeTextEditor) {
             return undefined
         }
         const regex = /(?:\\documentclass\[(.*(?:\.tex))\]{subfiles})/
-        const content = utils.stripComments(vscode.window.activeTextEditor.document.getText(), '%')
         const result = content.match(regex)
         if (result) {
             const file = path.resolve(path.dirname(vscode.window.activeTextEditor.document.fileName), result[1])

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -279,7 +279,11 @@ export class Manager {
                     return
                 }
                 this.extension.logger.addLogMessage(`${filePath} changed. Auto build project.`)
-                this.extension.commander.build(true, rootFile)
+                if (this.localRootFile && configuration.get("latex.rootFile.useSubFile")) {
+                    this.extension.commander.build(true, this.localRootFile)
+                } else {
+                    this.extension.commander.build(true, rootFile)
+                }
             })
             this.fileWatcher.on('unlink', async (filePath: string) => {
                 this.extension.logger.addLogMessage(`File watcher: ${filePath} deleted.`)

--- a/src/components/server.ts
+++ b/src/components/server.ts
@@ -13,7 +13,6 @@ export class Server {
     wsServer: ws.Server
     address: string
     port: number
-    pdfFile: string | undefined = undefined
 
     constructor(extension: Extension) {
         this.extension = extension

--- a/src/components/server.ts
+++ b/src/components/server.ts
@@ -54,7 +54,6 @@ export class Server {
         if (request.url.indexOf('pdf:') >= 0 && request.url.indexOf('viewer.html') < 0) {
             // The second backslash was encoded as %2F, and the first one is prepended by request
             const fileName = decodeURIComponent(request.url.replace('/pdf:', ''))
-            this.pdfFile = fileName
             try {
                 const pdfSize = fs.statSync(fileName).size
                 response.writeHead(200, {'Content-Type': 'application/pdf', 'Content-Length': pdfSize})
@@ -74,7 +73,6 @@ export class Server {
                 root = path.resolve(`${this.extension.extensionRoot}/viewer`)
             }
             const fileName = path.resolve(root, '.' + request.url.split('?')[0])
-            this.pdfFile = fileName
             let contentType = 'text/html'
             switch (path.extname(fileName)) {
                 case '.js':

--- a/src/components/server.ts
+++ b/src/components/server.ts
@@ -13,6 +13,7 @@ export class Server {
     wsServer: ws.Server
     address: string
     port: number
+    pdfFile: string | undefined = undefined
 
     constructor(extension: Extension) {
         this.extension = extension
@@ -54,6 +55,7 @@ export class Server {
         if (request.url.indexOf('pdf:') >= 0 && request.url.indexOf('viewer.html') < 0) {
             // The second backslash was encoded as %2F, and the first one is prepended by request
             const fileName = decodeURIComponent(request.url.replace('/pdf:', ''))
+            this.pdfFile = fileName
             try {
                 const pdfSize = fs.statSync(fileName).size
                 response.writeHead(200, {'Content-Type': 'application/pdf', 'Content-Length': pdfSize})
@@ -73,6 +75,7 @@ export class Server {
                 root = path.resolve(`${this.extension.extensionRoot}/viewer`)
             }
             const fileName = path.resolve(root, '.' + request.url.split('?')[0])
+            this.pdfFile = fileName
             let contentType = 'text/html'
             switch (path.extname(fileName)) {
                 case '.js':

--- a/src/components/viewer.ts
+++ b/src/components/viewer.ts
@@ -233,6 +233,7 @@ export class Viewer {
                         }))
                     }
                     if (configuration.get('synctex.afterBuild.enabled') as boolean) {
+                        this.extension.logger.addLogMessage('SyncTex after build invoked.')
                         this.extension.locator.syncTeX(undefined, undefined, decodeURIComponent(data.path))
                     }
                 }

--- a/src/components/viewer.ts
+++ b/src/components/viewer.ts
@@ -233,7 +233,7 @@ export class Viewer {
                         }))
                     }
                     if (configuration.get('synctex.afterBuild.enabled') as boolean) {
-                        this.extension.locator.syncTeX()
+                        this.extension.locator.syncTeX(undefined, undefined, decodeURIComponent(data.path))
                     }
                 }
                 break

--- a/src/main.ts
+++ b/src/main.ts
@@ -197,7 +197,7 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('latex-workshop.recipes', (recipe) => extension.commander.recipes(recipe))
     vscode.commands.registerCommand('latex-workshop.view', (mode) => extension.commander.view(mode))
     vscode.commands.registerCommand('latex-workshop.refresh-viewer', () => extension.commander.refresh())
-    vscode.commands.registerCommand('latex-workshop.tab', () => extension.commander.tab())
+    vscode.commands.registerCommand('latex-workshop.tab', () => extension.commander.view('tab'))
     vscode.commands.registerCommand('latex-workshop.kill', () => extension.commander.kill())
     vscode.commands.registerCommand('latex-workshop.synctex', () => extension.commander.synctex())
     vscode.commands.registerCommand('latex-workshop.texdoc', (pkg) => extension.commander.texdoc(pkg))


### PR DESCRIPTION
This PR aims at solving 
- #1438, #1443: completion issues
- #1445: wrong root directory.

The `subfiles` package enables either to compile the main file or any subfile containing `\documentclass[main.tex]{subfiles}`, which breaks the automatic detection of the `rootFile`. So far, the `rootFile` detection was not consistent
- If the main file is not opened, then the `rootFile` is the subfile. This creates issues #1438, #1443, #1445
- If the main file is opened, then the `rootFile` is the main file and switching the subfile editor does not change anything.

The new approach of this PR.
- The internal `rootFile` is **always** defined as the main file, which solves all the issues listed above.
- All the interactive commands `build, `clean` and `view` use a quick pick box to ask the user which file is to be considered as the root File.
- The non-interactive functions `autobuild`, `autoclean` and forward `synctex` rely on the value of the new configuration variable `latex-workshop.latex.rootFile.useSubFile` to choose between the main file and the subfile. When set to `true` (its default value), the subfile is considered.
- The `synctex` after build automatically picks the right root file from the `build` function.

This is a major refactoring and change of the `build`, `clean`, `synctex` and `view` tools. On top of my tests, I would like other people to test this before merging, especially because I do not use `subfiles` that much.