### PR TITLE
TikzPicture Preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -1294,6 +1294,11 @@
           "default": 1,
           "description": "Number of header rows to assume. Set to 0 to disable.`"
         },
+        "latex-workshop.tikzpreview.enabled": {
+          "type": "boolean",
+          "default": "true",
+          "markdownDescription": "Identify tikzpictures, and add a codelense that allows you to preview them"
+        },
         "latex-workshop.tikzpreview.preambleContents": {
           "type": "string",
           "default": "",

--- a/package.json
+++ b/package.json
@@ -297,6 +297,11 @@
         "command": "latex-workshop.formattedPaste",
         "title": "Paste formatted content",
         "category": "LaTeX Workshop"
+      },
+      {
+        "command": "latex-workshop.viewtikzpicture",
+        "title": "View TikzPicture",
+        "category": "LaTeX Workshop"
       }
     ],
     "keybindings": [
@@ -1288,6 +1293,21 @@
           "type": "integer",
           "default": 1,
           "description": "Number of header rows to assume. Set to 0 to disable.`"
+        },
+        "latex-workshop.tikzpreview.preambleContents": {
+          "type": "string",
+          "default": "",
+          "markdownDescription": "Set the path of a file containing LaTeX code to be included in the preamble of standalone documents for tikzpicture preview. If the path is relative, it is joined with the root dir."
+        },
+        "latex-workshop.tikzpreview.parseTeXFile": {
+          "type": "boolean",
+          "default": "true",
+          "markdownDescription": "Enable important tikz code in the current TeX file to be included in tikzpreview standalone file."
+        },
+        "latex-workshop.tikzpreview.delay": {
+          "type": "number",
+          "default": 100,
+          "markdownDescription": "Defines the delay in milliseconds to wait after typing stops. Set to 0 to disable."
         }
       }
     },

--- a/src/components/tikzpictureview.ts
+++ b/src/components/tikzpictureview.ts
@@ -1,0 +1,276 @@
+import * as vscode from 'vscode'
+import * as path from 'path'
+import * as fs from 'fs'
+import * as fse from 'fs-extra'
+import * as child_process from 'child_process'
+import { tmpdir } from 'os'
+import { promisify } from 'util'
+
+import { Extension } from '../main'
+
+const mkdtemp = promisify(fs.mkdtemp)
+const mkdir = promisify(fs.mkdir)
+const writeFile = promisify(fs.writeFile)
+const readFile = promisify(fs.readFile)
+const removeDir = promisify(fse.remove)
+
+interface IFileTikzCollection {
+    location: string
+    tempDir: string
+    tikzPictures: IFileTikzPicture[]
+    preamble: string
+    lastChange: number
+}
+
+interface IFileTikzPicture {
+    range: vscode.Range
+    content: string[]
+    tempFile: string
+    lastChange: number
+}
+
+export class TikzPictureView {
+    extension: Extension
+    tikzCollections: { [filePath: string]: IFileTikzCollection } = {}
+
+    constructor(extension: Extension) {
+        this.extension = extension
+    }
+
+    public async view(document: vscode.TextDocument, range: vscode.Range) {
+        const fileTikzCollection = await this.getFileTikzCollection(document)
+
+        const tikzPicture = await this.getTikzEntry(fileTikzCollection, {
+            range,
+            content: document.getText(range).split('\n')
+        })
+
+        const generatedPreamble = await this.generatePreamble(fileTikzCollection)
+        if (fileTikzCollection.preamble !== generatedPreamble) {
+            fileTikzCollection.preamble = generatedPreamble
+            await this.precompilePreamble(
+                path.join(fileTikzCollection.tempDir, 'preamble.tex'),
+                fileTikzCollection.preamble
+            )
+        }
+
+        this.updateTikzPicture(tikzPicture)
+    }
+
+    public async onFileChange(
+        document: vscode.TextDocument,
+        changes: vscode.TextDocumentContentChangeEvent[],
+        waitedDelay?: boolean
+    ) {
+        const changeDelay = vscode.workspace.getConfiguration('latex-workshop.tikzpreview').get('delay') as number
+        if (changeDelay === 0 || this.tikzCollections[document.uri.fsPath] === undefined) {
+            return
+        } else if (+new Date() - this.tikzCollections[document.uri.fsPath].lastChange < changeDelay) {
+            if (!waitedDelay) {
+                this.tikzCollections[document.uri.fsPath].lastChange = +new Date()
+                setTimeout(() => {
+                    this.onFileChange(document, changes, true)
+                }, changeDelay)
+            }
+            return
+        }
+
+        const tikzPictures: IFileTikzPicture[] = this.tikzCollections[document.uri.fsPath].tikzPictures
+
+        for (const change of changes) {
+            for (const tikzPicture of tikzPictures) {
+                const lineDelta =
+                    change.text.split('\n').length - 1 - (change.range.end.line - change.range.start.line)
+                if (tikzPicture.range.end.isBefore(change.range.start)) {
+                    // change after tikzpicture
+                    continue
+                } else if (tikzPicture.range.start.isAfter(change.range.end)) {
+                    // change before tikzpicture
+                    tikzPicture.range = new vscode.Range(
+                        tikzPicture.range.start.translate(lineDelta, 0),
+                        tikzPicture.range.end.translate(lineDelta, 0)
+                    )
+                } else if (
+                    change.range.end.isAfter(tikzPicture.range.start) &&
+                    change.range.end.line - lineDelta < tikzPicture.range.start.line
+                ) {
+                    // tikzpicture removed
+                    tikzPictures.splice(tikzPictures.indexOf(tikzPicture), 1)
+                } else {
+                    // tikzpicture modified
+                    tikzPicture.range = new vscode.Range(
+                        tikzPicture.range.start,
+                        tikzPicture.range.end.translate(lineDelta, 0)
+                    )
+                    tikzPicture.content = document.getText(tikzPicture.range).split('\n')
+                    this.updateTikzPicture(tikzPicture)
+                }
+            }
+        }
+    }
+
+    public async updateTikzPicture(tikzPicture: IFileTikzPicture) {
+        // await writeFile(
+        //     tikzPicture.tempFile,
+        //     `%&preamble\n\\begin{document}\n${tikzPicture.content.join('\n')}\n\\end{document}`
+        // ).catch(() => {
+        //     throw new Error('unable to write tikzpicture to tempfile')
+        // })
+
+        fs.writeFileSync(
+            tikzPicture.tempFile,
+            `%&preamble\n\\begin{document}\n${tikzPicture.content.join('\n')}\n\\end{document}`
+        )
+
+        const startTime = +new Date()
+
+        child_process.execSync(`latexmk ${path.basename(tikzPicture.tempFile)} -pdf`, {
+            cwd: path.dirname(tikzPicture.tempFile)
+        })
+
+        console.log(`took ${+new Date() - startTime}ms to recompile tikzpicture`)
+
+        if (
+            this.extension.viewer.clients[tikzPicture.tempFile.replace(/\.tex$/, '.pdf').toLocaleUpperCase()] !==
+            undefined
+        ) {
+            this.extension.viewer.refreshExistingViewer(tikzPicture.tempFile)
+        } else {
+            this.extension.viewer.openTab(tikzPicture.tempFile, false, true)
+        }
+    }
+
+    public async cleanupTempFiles() {
+        const rmPromises: Promise<unknown>[] = []
+        for (const tikzCollection in this.tikzCollections) {
+            rmPromises.push(removeDir(this.tikzCollections[tikzCollection].tempDir))
+        }
+        await Promise.all(rmPromises)
+    }
+
+    private async getFileTikzCollection(document: vscode.TextDocument) : Promise<IFileTikzCollection> {
+        if (!(document.uri.fsPath in this.tikzCollections)) {
+            if (!fs.existsSync(path.join(tmpdir(), 'vscode-latexworkshop'))) {
+                await mkdir(path.join(tmpdir(), 'vscode-latexworkshop'))
+            }
+
+            const tempDir: string = await mkdtemp(
+                path.join(
+                    tmpdir(),
+                    'vscode-latexworkshop',
+                    `tikzpreview-${path.basename(document.uri.fsPath, '.tex')}-`
+                )
+            )
+
+            const thisFileTikzCollection: IFileTikzCollection = {
+                location: document.uri.fsPath,
+                tempDir,
+                tikzPictures: [],
+                preamble: '',
+                lastChange: +new Date()
+            }
+
+            this.tikzCollections[document.uri.fsPath] = thisFileTikzCollection
+        }
+
+        return this.tikzCollections[document.uri.fsPath]
+    }
+
+    private async getTikzEntry(
+        tikzCollection: IFileTikzCollection,
+        tikzPictureContent: {
+            range: vscode.Range;
+            content: string[];
+        }
+    ) : Promise<IFileTikzPicture> {
+        for (const tikzPicture of tikzCollection.tikzPictures) {
+            if (tikzPicture.range.isEqual(tikzPictureContent.range)) {
+                return tikzPicture
+            }
+        }
+
+        const tempFile: string = path.join(tikzCollection.tempDir, `tikzpicture-${+new Date() % 100000000}.tex`)
+
+        tikzCollection.tikzPictures.push({
+            range: tikzPictureContent.range,
+            content: tikzPictureContent.content,
+            tempFile,
+            lastChange: +new Date()
+        })
+
+        return tikzCollection.tikzPictures[tikzCollection.tikzPictures.length - 1]
+    }
+
+    private async generatePreamble(fileTikzCollection: IFileTikzCollection) {
+        const configuration = vscode.workspace.getConfiguration('latex-workshop.tikzpreview')
+        let commandsString = ''
+        const newCommandFile = configuration.get('preambleContents') as string
+        if (newCommandFile !== '') {
+            if (path.isAbsolute(newCommandFile)) {
+                if (fs.existsSync(newCommandFile)) {
+                    commandsString = await readFile(newCommandFile, { encoding: 'utf8' })
+                }
+            } else {
+                if (this.extension.manager.rootFile === undefined) {
+                    await this.extension.manager.findRoot()
+                }
+                const rootDir = this.extension.manager.rootDir
+                const newCommandFileAbs = path.join(rootDir, newCommandFile)
+                if (fs.existsSync(newCommandFileAbs)) {
+                    commandsString = await readFile(newCommandFileAbs, { encoding: 'utf8' })
+                }
+            }
+        }
+        commandsString = commandsString.replace(/^\s*$/gm, '')
+        if (!configuration.get('parseTeXFile') as boolean) {
+            return commandsString
+        }
+        const regex = /(\\tikzset{(?:(?:[^\{\}]|{[^\{\}]+})*)}|\\usetikzlibrary{[\w\.]+})/gm
+        const commands: string[] = []
+
+        const content = await readFile(fileTikzCollection.location, { encoding: 'utf8' })
+        const noCommentContent = content.replace(/([^\\]|^)%.*$/gm, '$1') // Strip comments
+
+        let result: RegExpExecArray | null
+        do {
+            result = regex.exec(noCommentContent)
+            if (result) {
+                commands.push(result[1])
+            }
+        } while (result)
+        let preamble = commandsString + '\n' + commands.join('\n')
+        preamble = preamble.includes('\\usepackage{tikz}') ? preamble : '\n\\usepackage{tikz}\n' + preamble
+        return preamble
+    }
+
+    private precompilePreamble(file: string, preamble: string) {
+        return new Promise((resolve, reject) => {
+            writeFile(file, `\\documentclass{standalone}\n\n${preamble}\n\n\\begin{document}\\end{document}`)
+                .then(() => {
+                    const process = child_process.spawn(
+                        'pdftex',
+                        [
+                            '-ini',
+                            '-interaction=nonstopmode',
+                            '-shell-escape',
+                            '-file-line-error',
+                            '-jobname="preamble"',
+                            '"&pdflatex"',
+                            'mylatexformat.ltx',
+                            `"${file}"`
+                        ],
+                        { cwd: path.dirname(file) }
+                    )
+                    process.on('exit', code => {
+                        resolve(code)
+                    })
+                    process.on('error', err => {
+                        reject(err)
+                    })
+                })
+                .catch(err => {
+                    reject(err)
+                })
+        })
+    }
+}

--- a/src/components/tikzpictureview.ts
+++ b/src/components/tikzpictureview.ts
@@ -133,8 +133,7 @@ export class TikzPictureView {
                                 startMatch = document.lineAt(++lineNo).text.match(startRegex)
                             } while (!startMatch && lineNo <= tikzPicture.range.end.line)
 
-                            if (startMatch) {
-                                // @ts-ignore
+                            if (startMatch && startMatch.index !== undefined) {
                                 startLocation = new vscode.Position(lineNo, startMatch.index)
                             }
                         }
@@ -150,8 +149,7 @@ export class TikzPictureView {
                             endMatch = document.lineAt(++lineNo).text.match(endRegex)
                         } while (!endMatch && lineNo <= change.range.end.line)
 
-                        if (endMatch) {
-                            // @ts-ignore
+                        if (endMatch && endMatch.index !== undefined) {
                             endLocation = new vscode.Position(lineNo, endMatch.index + endMatch[0].length)
                         }
                     }

--- a/src/components/tikzpictureview.ts
+++ b/src/components/tikzpictureview.ts
@@ -7,6 +7,7 @@ import { tmpdir } from 'os'
 import { promisify } from 'util'
 
 import { Extension } from '../main'
+import { stripComments } from '../utils'
 
 const removeDir = promisify(fse.remove)
 
@@ -119,7 +120,9 @@ export class TikzPictureView {
                     let startLocation: vscode.Position | null = null
                     if (change.range.start.line <= tikzPicture.range.start.line) {
                         const startLine = document.lineAt(tikzPicture.range.start.line)
-                        const tikzPictureStartIndex = startLine.text.indexOf('\\begin{tikzpicture}')
+                        const tikzPictureStartIndex = stripComments(startLine.text, '%').indexOf(
+                            '\\begin{tikzpicture}'
+                        )
                         if (tikzPictureStartIndex !== -1) {
                             startLocation = tikzPicture.range.start.translate(
                                 0,
@@ -146,7 +149,7 @@ export class TikzPictureView {
                         let endMatch: RegExpMatchArray | null = null
                         let lineNo = tikzPicture.range.start.line - 1
                         do {
-                            endMatch = document.lineAt(++lineNo).text.match(endRegex)
+                            endMatch = stripComments(document.lineAt(++lineNo).text, '%').match(endRegex)
                         } while (!endMatch && lineNo <= change.range.end.line)
 
                         if (endMatch && endMatch.index !== undefined) {

--- a/src/components/tikzpictureview.ts
+++ b/src/components/tikzpictureview.ts
@@ -299,7 +299,7 @@ export class TikzPictureView {
         if (!configuration.get('parseTeXFile') as boolean) {
             return commandsString
         }
-        const regex = /(\\tikzset{(?:(?:[^\{\}]|{[^\{\}]+})*)}|\\usetikzlibrary{[\w\.]+})/gm
+        const regex = /(\\usepackage{(?:tikz|pgfplots)}|\\(?:tikzset|pgfplotsset){(?:(?:[^\{\}]|{[^\{\}]+})*)}|\\(?:usetikzlibrary|usepgfplotslibrary){[\w\.,]+}|\\definecolor{\w+}{\w+}{[^}]+}|\\colorlet{\w+}{{[^}]+}})/gm
         const commands: string[] = []
 
         const content = await fs.readFileSync(fileTikzCollection.location, { encoding: 'utf8' })

--- a/src/components/tikzpictureview.ts
+++ b/src/components/tikzpictureview.ts
@@ -83,6 +83,7 @@ export class TikzPictureView {
         this.checkPreamble(tikzFileCollection)
 
         const tikzPictures: IFileTikzPicture[] = tikzFileCollection.tikzPictures
+        const tikzPicturesToUpdate: IFileTikzPicture[] = []
 
         for (const tikzPicture of tikzPictures) {
             if (
@@ -93,8 +94,6 @@ export class TikzPictureView {
                 this.cleanupTikzPicture(tikzPicture)
                 continue
             }
-
-            const tikzPicturesToUpdate: IFileTikzPicture[] = []
 
             for (const change of changes) {
                 const lineDelta =
@@ -168,11 +167,10 @@ export class TikzPictureView {
                     }
                 }
             }
-
-            tikzPicturesToUpdate.forEach(tikzP => {
-                this.updateTikzPicture(tikzP)
-            })
         }
+        tikzPicturesToUpdate.forEach(tikzP => {
+            this.updateTikzPicture(tikzP)
+        })
     }
 
     private async updateTikzPicture(tikzPicture: IFileTikzPicture) {

--- a/src/providers/tikzcodelense.ts
+++ b/src/providers/tikzcodelense.ts
@@ -53,8 +53,7 @@ function findTikzPictures(document: vscode.TextDocument) {
             line = document.lineAt(++lineNo)
             text = line.text.substr(0, 1000)
             endMatch = text.match(endRegex)
-            if (endMatch) {
-                // @ts-ignore
+            if (endMatch && endMatch.index) {
                 endColumn = endMatch.index + endMatch[0].length
             }
         } while (!endMatch)

--- a/src/providers/tikzcodelense.ts
+++ b/src/providers/tikzcodelense.ts
@@ -5,6 +5,10 @@ export class TikzCodeLense implements vscode.CodeLensProvider {
     onDidChangeCodeLenses?: vscode.Event<void> | undefined
 
     async provideCodeLenses(document: vscode.TextDocument) : Promise<vscode.CodeLens[]> {
+        if (!vscode.workspace.getConfiguration('latex-workshop.tikzpreview').get('enabled') as boolean) {
+            return []
+        }
+
         const matches = findTikzPictures(document)
         return matches.map(
             match =>

--- a/src/providers/tikzcodelense.ts
+++ b/src/providers/tikzcodelense.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode'
+import { stripComments } from '../utils'
 
 export class TikzCodeLense implements vscode.CodeLensProvider {
     onDidChangeCodeLenses?: vscode.Event<void> | undefined
@@ -28,7 +29,7 @@ function findTikzPictures(document: vscode.TextDocument) {
     const endRegex = /\\end{tikzpicture}/
     for (let i = 0; i < document.lineCount; i++) {
         let line = document.lineAt(i)
-        let text = line.text.substr(0, 1000)
+        let text = stripComments(line.text, '%')
         const startMatch: RegExpMatchArray | null = text.match(startRegex)
         if (!startMatch) {
             continue

--- a/src/providers/tikzcodelense.ts
+++ b/src/providers/tikzcodelense.ts
@@ -1,0 +1,70 @@
+import * as vscode from 'vscode'
+
+export class TikzCodeLense implements vscode.CodeLensProvider {
+    onDidChangeCodeLenses?: vscode.Event<void> | undefined
+
+    async provideCodeLenses(document: vscode.TextDocument) : Promise<vscode.CodeLens[]> {
+        const matches = findTikzPictures(document)
+        return matches.map(
+            match =>
+                new vscode.CodeLens(match.range, {
+                    title: 'View TikzPicture',
+                    tooltip: 'Open view of this TikzPicture',
+                    command: 'latex-workshop.viewtikzpicture',
+                    arguments: [match.document, match.range]
+                })
+        )
+    }
+}
+
+interface TikzPictureMatch {
+    document: vscode.TextDocument
+    range: vscode.Range
+}
+
+function findTikzPictures(document: vscode.TextDocument) {
+    const matches: TikzPictureMatch[] = []
+    const startRegex = /\\begin{tikzpicture}/
+    const endRegex = /\\end{tikzpicture}/
+    for (let i = 0; i < document.lineCount; i++) {
+        let line = document.lineAt(i)
+        let text = line.text.substr(0, 1000)
+        const startMatch: RegExpMatchArray | null = text.match(startRegex)
+        if (!startMatch) {
+            continue
+        }
+        const startColumn = startMatch.index
+        if (startColumn === null || startColumn === undefined) {
+            continue
+        }
+
+        let lineNo = i
+        let endMatch: RegExpMatchArray | null = null
+        let endColumn: number | undefined
+        do {
+            if (lineNo - 1 === document.lineCount) {
+                continue
+            }
+            line = document.lineAt(++lineNo)
+            text = line.text.substr(0, 1000)
+            endMatch = text.match(endRegex)
+            if (endMatch) {
+                // @ts-ignore
+                endColumn = endMatch.index + endMatch[0].length
+            }
+        } while (!endMatch)
+
+        if (endColumn === null || endColumn === undefined) {
+            continue
+        }
+
+        matches.push({
+            document,
+            range: new vscode.Range(i, startColumn, lineNo, endColumn)
+        })
+
+        i = lineNo + 1
+    }
+
+    return matches
+}


### PR DESCRIPTION
# TikzPicture Preview

![gif preview](https://user-images.githubusercontent.com/20903656/61054276-b63f7980-a421-11e9-99ed-22b0d531e20c.gif)

## Overview

 - Adds codelense before `\begin{tikzpicture}`
 - when clicked, starts tracking that tikzpicture by a `vscode.Range` using `vscode.workspace.onDidChangeTextDocument` and re-fetching the content of that range
 - when the tikzpicture content changes (and on initialisation)
 - a preamble is generated, and compared to the last preamble generated for the file
   - if the preamble has changed (and on initialisation) a standalone document with that preamble is written and compiled to a `.fmt` file (within a tempdir)
 - the tikzpicture associated file in the tempdir is compiled using the format file
 - on successful compilation the viewer refreshes

Closes #1450

## Needs work
Not quite at the stage where it would be good for merging. However! It is at the stage where you can take it out for a spin and provide feedback (please do).