### PR TITLE
Use base64url to encode path

### DIFF
--- a/src/components/encodePath.ts
+++ b/src/components/encodePath.ts
@@ -1,0 +1,15 @@
+export const pdfFilePrefix = 'pdf..'
+
+export function encodePath(path: string) {
+    const s = encodeURIComponent(path)
+    const b64 = Buffer.from(s).toString('base64')
+    const b64url = b64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=/, '')
+    return b64url
+}
+
+export function decodePath(b64url: string) {
+    const tmp = b64url + '='.repeat((4 - b64url.length % 4) % 4)
+    const b64 = tmp.replace(/-/g, '+').replace(/_/g, '/')
+    const s = Buffer.from(b64, 'base64').toString()
+    return decodeURIComponent(s)
+}

--- a/src/components/encodePath.ts
+++ b/src/components/encodePath.ts
@@ -1,5 +1,15 @@
+// prefix that server.ts uses to distiguish requets on pdf files from others.
+// '.' is chosen because it is not converted by encodeURIComponent and others.
+// See https://stackoverflow.com/questions/695438/safe-characters-for-friendly-url
+// See https://tools.ietf.org/html/rfc3986#section-2.3
+
 export const pdfFilePrefix = 'pdf..'
 
+// We encode the path with base64url after calling encodeURIComponent.
+// The reason not using base64url directly is that we are not sure that
+// encodeURIComponent, unescape and btoa trick is valid on node.js.
+// See https://en.wikipedia.org/wiki/Base64#URL_applications
+// See https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/btoa#Unicode_strings
 export function encodePath(path: string) {
     const s = encodeURIComponent(path)
     const b64 = Buffer.from(s).toString('base64')

--- a/src/components/encodePath.ts
+++ b/src/components/encodePath.ts
@@ -13,3 +13,12 @@ export function decodePath(b64url: string) {
     const s = Buffer.from(b64, 'base64').toString()
     return decodeURIComponent(s)
 }
+
+export function encodePathWithPrefix(path: string) {
+    return pdfFilePrefix + encodePath(path)
+}
+
+export function decodePathWithPrefix(b64urlWithPrefix: string) {
+    const s = b64urlWithPrefix.replace(pdfFilePrefix, '')
+    return decodePath(s)
+}

--- a/src/components/encodePath.ts
+++ b/src/components/encodePath.ts
@@ -1,5 +1,5 @@
-// prefix that server.ts uses to distiguish requets on pdf files from others.
-// '.' is chosen because it is not converted by encodeURIComponent and others.
+// prefix that server.ts uses to distiguish requests on pdf files from others.
+// We use '.' because it is not converted by encodeURIComponent and other functions.
 // See https://stackoverflow.com/questions/695438/safe-characters-for-friendly-url
 // See https://tools.ietf.org/html/rfc3986#section-2.3
 
@@ -7,7 +7,7 @@ export const pdfFilePrefix = 'pdf..'
 
 // We encode the path with base64url after calling encodeURIComponent.
 // The reason not using base64url directly is that we are not sure that
-// encodeURIComponent, unescape and btoa trick is valid on node.js.
+// encodeURIComponent, unescape, and btoa trick is valid on node.js.
 // See https://en.wikipedia.org/wiki/Base64#URL_applications
 // See https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/btoa#Unicode_strings
 export function encodePath(path: string) {

--- a/src/components/server.ts
+++ b/src/components/server.ts
@@ -6,6 +6,7 @@ import * as vscode from 'vscode'
 
 import {Extension} from '../main'
 import {AddressInfo} from 'net'
+import {decodePath} from './encodePath'
 
 export class Server {
     extension: Extension
@@ -53,7 +54,7 @@ export class Server {
 
         if (request.url.indexOf('pdf:') >= 0 && request.url.indexOf('viewer.html') < 0) {
             // The second backslash was encoded as %2F, and the first one is prepended by request
-            const fileName = decodeURIComponent(request.url.replace('/pdf:', ''))
+            const fileName = decodePath(request.url.replace('/pdf:', ''))
             try {
                 const pdfSize = fs.statSync(fileName).size
                 response.writeHead(200, {'Content-Type': 'application/pdf', 'Content-Length': pdfSize})

--- a/src/components/server.ts
+++ b/src/components/server.ts
@@ -6,7 +6,7 @@ import * as vscode from 'vscode'
 
 import {Extension} from '../main'
 import {AddressInfo} from 'net'
-import {decodePath, pdfFilePrefix} from './encodePath'
+import {decodePathWithPrefix, pdfFilePrefix} from './encodePath'
 
 export class Server {
     extension: Extension
@@ -53,8 +53,8 @@ export class Server {
         }
 
         if (request.url.indexOf(pdfFilePrefix) >= 0 && request.url.indexOf('viewer.html') < 0) {
-            const s = request.url.replace('/' + pdfFilePrefix, '')
-            const fileName = decodePath(s)
+            const s = request.url.replace('/', '')
+            const fileName = decodePathWithPrefix(s)
             try {
                 const pdfSize = fs.statSync(fileName).size
                 response.writeHead(200, {'Content-Type': 'application/pdf', 'Content-Length': pdfSize})

--- a/src/components/server.ts
+++ b/src/components/server.ts
@@ -6,7 +6,7 @@ import * as vscode from 'vscode'
 
 import {Extension} from '../main'
 import {AddressInfo} from 'net'
-import {decodePath} from './encodePath'
+import {decodePath, pdfFilePrefix} from './encodePath'
 
 export class Server {
     extension: Extension
@@ -52,9 +52,9 @@ export class Server {
             return
         }
 
-        if (request.url.indexOf('pdf:') >= 0 && request.url.indexOf('viewer.html') < 0) {
-            // The second backslash was encoded as %2F, and the first one is prepended by request
-            const fileName = decodePath(request.url.replace('/pdf:', ''))
+        if (request.url.indexOf(pdfFilePrefix) >= 0 && request.url.indexOf('viewer.html') < 0) {
+            const s = request.url.replace('/' + pdfFilePrefix, '')
+            const fileName = decodePath(s)
             try {
                 const pdfSize = fs.statSync(fileName).size
                 response.writeHead(200, {'Content-Type': 'application/pdf', 'Content-Length': pdfSize})

--- a/src/components/viewer.ts
+++ b/src/components/viewer.ts
@@ -7,7 +7,7 @@ import * as cp from 'child_process'
 import {Extension} from '../main'
 import {SyncTeXRecordForward} from './locator'
 import {ExternalCommand} from '../utils'
-import {encodePathWithPrefix, pdfFilePrefix} from './encodePath'
+import {encodePathWithPrefix} from './encodePath'
 
 interface Position {}
 
@@ -73,7 +73,7 @@ export class Viewer {
         }
         const url = `http://localhost:${this.extension.server.port}/viewer.html?file=${encodePathWithPrefix(pdfFile)}`
         this.extension.logger.addLogMessage(`Serving PDF file at ${url}`)
-        this.extension.logger.addLogMessage(`The decoded path is ${pdfFile}`)
+        this.extension.logger.addLogMessage(`The encoded path is ${pdfFile}`)
         return url
     }
 

--- a/src/components/viewer.ts
+++ b/src/components/viewer.ts
@@ -73,6 +73,7 @@ export class Viewer {
         }
         const url = `http://localhost:${this.extension.server.port}/viewer.html?file=${pdfFilePrefix}${encodePath(pdfFile)}`
         this.extension.logger.addLogMessage(`Serving PDF file at ${url}`)
+        this.extension.logger.addLogMessage(`The decoded path is ${pdfFile}`)
         return url
     }
 

--- a/src/components/viewer.ts
+++ b/src/components/viewer.ts
@@ -7,7 +7,7 @@ import * as cp from 'child_process'
 import {Extension} from '../main'
 import {SyncTeXRecordForward} from './locator'
 import {ExternalCommand} from '../utils'
-import {encodePath} from './encodePath'
+import {encodePath, pdfFilePrefix} from './encodePath'
 
 interface Position {}
 
@@ -71,7 +71,7 @@ export class Viewer {
             this.extension.logger.addLogMessage(`Cannot establish server connection.`)
             return
         }
-        const url = `http://localhost:${this.extension.server.port}/viewer.html?file=/pdf:${encodePath(pdfFile)}`
+        const url = `http://localhost:${this.extension.server.port}/viewer.html?file=${pdfFilePrefix}${encodePath(pdfFile)}`
         this.extension.logger.addLogMessage(`Serving PDF file at ${url}`)
         return url
     }
@@ -119,7 +119,7 @@ export class Viewer {
     }
 
     getPDFViewerContent(uri: vscode.Uri) : string {
-        const url = `http://localhost:${this.extension.server.port}/viewer.html?incode=1&file=/pdf:${uri.authority ? `\\\\${uri.authority}` : ''}${encodePath(uri.fsPath)}`
+        const url = `http://localhost:${this.extension.server.port}/viewer.html?incode=1&file=${pdfFilePrefix}${uri.authority ? `\\\\${uri.authority}` : ''}${encodePath(uri.fsPath)}`
         return `
             <!DOCTYPE html><html><head></head>
             <body><iframe id="preview-panel" class="preview-panel" src="${url}" style="position:absolute; border: none; left: 0; top: 0; width: 100%; height: 100%;">

--- a/src/components/viewer.ts
+++ b/src/components/viewer.ts
@@ -7,7 +7,7 @@ import * as cp from 'child_process'
 import {Extension} from '../main'
 import {SyncTeXRecordForward} from './locator'
 import {ExternalCommand} from '../utils'
-import {encodePath, pdfFilePrefix} from './encodePath'
+import {encodePathWithPrefix, pdfFilePrefix} from './encodePath'
 
 interface Position {}
 
@@ -71,7 +71,7 @@ export class Viewer {
             this.extension.logger.addLogMessage(`Cannot establish server connection.`)
             return
         }
-        const url = `http://localhost:${this.extension.server.port}/viewer.html?file=${pdfFilePrefix}${encodePath(pdfFile)}`
+        const url = `http://localhost:${this.extension.server.port}/viewer.html?file=${encodePathWithPrefix(pdfFile)}`
         this.extension.logger.addLogMessage(`Serving PDF file at ${url}`)
         this.extension.logger.addLogMessage(`The decoded path is ${pdfFile}`)
         return url
@@ -120,7 +120,8 @@ export class Viewer {
     }
 
     getPDFViewerContent(uri: vscode.Uri) : string {
-        const url = `http://localhost:${this.extension.server.port}/viewer.html?incode=1&file=${pdfFilePrefix}${encodePath(uri.fsPath)}`
+        // viewer/viewer.js automatically requests the file to server.ts and server.ts decodes the encoded fsPath.
+        const url = `http://localhost:${this.extension.server.port}/viewer.html?incode=1&file=${encodePathWithPrefix(uri.fsPath)}`
         return `
             <!DOCTYPE html><html><head></head>
             <body><iframe id="preview-panel" class="preview-panel" src="${url}" style="position:absolute; border: none; left: 0; top: 0; width: 100%; height: 100%;">

--- a/src/components/viewer.ts
+++ b/src/components/viewer.ts
@@ -120,7 +120,7 @@ export class Viewer {
     }
 
     getPDFViewerContent(uri: vscode.Uri) : string {
-        const url = `http://localhost:${this.extension.server.port}/viewer.html?incode=1&file=${pdfFilePrefix}${uri.authority ? `\\\\${uri.authority}` : ''}${encodePath(uri.fsPath)}`
+        const url = `http://localhost:${this.extension.server.port}/viewer.html?incode=1&file=${pdfFilePrefix}${encodePath(uri.fsPath)}`
         return `
             <!DOCTYPE html><html><head></head>
             <body><iframe id="preview-panel" class="preview-panel" src="${url}" style="position:absolute; border: none; left: 0; top: 0; width: 100%; height: 100%;">

--- a/viewer/latexworkshop.js
+++ b/viewer/latexworkshop.js
@@ -110,6 +110,8 @@ class ViewerHistory {
 
 let viewerHistory = new ViewerHistory()
 
+const pdfFilePrefix = 'pdf..'
+
 function encodePath(path) {
   const s = encodeURIComponent(path)
   const b64 = window.btoa(s)
@@ -130,7 +132,7 @@ let file
 for (let i = 0, ii = parts.length; i < ii; ++i) {
     let param = parts[i].split('=')
     if (param[0].toLowerCase() === 'file') {
-        file = decodePath(param[1].replace('/pdf:', ''))
+        file = decodePath(param[1].replace(pdfFilePrefix, ''))
         documentTitle = file.split(/[\\/]/).pop()
         document.title = documentTitle
     } else if (param[0].toLowerCase() === 'incode' && param[1] === '1') {
@@ -177,7 +179,7 @@ socket.addEventListener("message", (event) => {
                                         scrollLeft:document.getElementById('viewerContainer').scrollLeft,
                                         viewerHistory:{history: viewerHistory._history, currentIndex: viewerHistory._currentIndex}}))
             PDFViewerApplicationOptions.set('showPreviousViewOnLoad', false);
-            PDFViewerApplication.open(`/pdf:${encodePath(file)}`).then( () => {
+            PDFViewerApplication.open(`${pdfFilePrefix}${encodePath(file)}`).then( () => {
               // reset the document title to the original value to avoid duplication
               document.title = documentTitle
 

--- a/viewer/latexworkshop.js
+++ b/viewer/latexworkshop.js
@@ -128,12 +128,14 @@ function decodePath(b64url) {
 
 let query = document.location.search.substring(1)
 let parts = query.split('&')
-let file
+let encodedPdfFilePath
+let pdfFilePath
 for (let i = 0, ii = parts.length; i < ii; ++i) {
     let param = parts[i].split('=')
     if (param[0].toLowerCase() === 'file') {
-        file = decodePath(param[1].replace(pdfFilePrefix, ''))
-        documentTitle = file.split(/[\\/]/).pop()
+        encodedPdfFilePath = param[1].replace(pdfFilePrefix, '')
+        pdfFilePath = decodePath(encodedPdfFilePath)
+        documentTitle = pdfFilePath.split(/[\\/]/).pop()
         document.title = documentTitle
     } else if (param[0].toLowerCase() === 'incode' && param[1] === '1') {
         const dom = document.getElementsByClassName('print')
@@ -145,7 +147,7 @@ for (let i = 0, ii = parts.length; i < ii; ++i) {
 let server = `ws://${window.location.hostname}:${window.location.port}`
 
 let socket = new WebSocket(server)
-socket.addEventListener("open", () => socket.send(JSON.stringify({type:"open", path:file, viewer:(embedded ? "tab" : "browser")})))
+socket.addEventListener("open", () => socket.send(JSON.stringify({type:"open", path:pdfFilePath, viewer:(embedded ? "tab" : "browser")})))
 socket.addEventListener("message", (event) => {
     let data = JSON.parse(event.data)
     switch (data.type) {
@@ -171,7 +173,7 @@ socket.addEventListener("message", (event) => {
         case "refresh":
             // Note: without showPreviousViewOnLoad = false restoring the position after the refresh will fail if
             // the user has clicked on any link in the past (pdf.js will automatically navigate to that link).
-            socket.send(JSON.stringify({type:"position", path:file,
+            socket.send(JSON.stringify({type:"position", path:pdfFilePath,
                                         scale:PDFViewerApplication.pdfViewer.currentScaleValue,
                                         scrollMode:PDFViewerApplication.pdfViewer.scrollMode,
                                         spreadMode:PDFViewerApplication.pdfViewer.spreadMode,
@@ -179,7 +181,7 @@ socket.addEventListener("message", (event) => {
                                         scrollLeft:document.getElementById('viewerContainer').scrollLeft,
                                         viewerHistory:{history: viewerHistory._history, currentIndex: viewerHistory._currentIndex}}))
             PDFViewerApplicationOptions.set('showPreviousViewOnLoad', false);
-            PDFViewerApplication.open(`${pdfFilePrefix}${encodePath(file)}`).then( () => {
+            PDFViewerApplication.open(`${pdfFilePrefix}${encodedPdfFilePath}`).then( () => {
               // reset the document title to the original value to avoid duplication
               document.title = documentTitle
 
@@ -239,10 +241,10 @@ socket.onclose = () => { document.title = `[Disconnected] ${document.title}` }
 document.addEventListener('pagesinit', () => {
   // check whether WebSocket is open (readyState === 1).
   if (socket.readyState === 1) {
-    socket.send(JSON.stringify({type:"loaded", path:file}))
+    socket.send(JSON.stringify({type:"loaded", path:pdfFilePath}))
   } else {
     socket.addEventListener("open", () => {
-      socket.send(JSON.stringify({type:"loaded", path:file}))
+      socket.send(JSON.stringify({type:"loaded", path:pdfFilePath}))
     }, {once: true})
   }
 })
@@ -296,7 +298,7 @@ document.addEventListener('pagerendered', (evPageRendered) => {
           left += offsetLeft
         }
         const pos = PDFViewerApplication.pdfViewer._pages[page-1].getPagePoint(left, canvas_dom.offsetHeight - top)
-        socket.send(JSON.stringify({type:"click", path:file, pos:pos, page:page,
+        socket.send(JSON.stringify({type:"click", path:pdfFilePath, pos:pos, page:page,
          textBeforeSelection:textBeforeSelection, textAfterSelection:textAfterSelection}))
     }
 }, true)


### PR DESCRIPTION
We use `encodeURIComponent` to encode the path of a pdf file for the request of `src/components/server.ts`. We also use `/pdf:` as the prefix of the pdf file. They are affected by the change of the behavior of VS Code and pdf.js. For example, #1472 and d68195f5484fd206e21bd507653cb607315025ab.

To solve this issue, we should use base64url to encode the path. See [link](https://en.wikipedia.org/wiki/Base64#URL_applications). Only the characters `a-zA-Z0-9`, `_`, and `-` are used to encode it on the scheme. They are guaranteed not to be converted by `encodeURIComponent`.

In this PR, after calling `encodeURIComponent`, we encode the result with base64url.