### PR TITLE
Fix 2 small issues in folding.ts

### DIFF
--- a/src/providers/folding.ts
+++ b/src/providers/folding.ts
@@ -9,7 +9,7 @@ export class FoldingProvider implements vscode.FoldingRangeProvider {
     constructor(extension: Extension) {
         this.extension = extension
         const sections = vscode.workspace.getConfiguration('latex-workshop').get('view.outline.sections') as string[]
-        this.sectionRegex = sections.map(section => RegExp(`\\\\${section}(?:\\*)?(?:\\[[^\\[\\]\\{\\}]*\\])?{(.*)}`, 'm'))
+        this.sectionRegex = sections.map(section => RegExp(`\\\\(?:${section})(?:\\*)?(?:\\[[^\\[\\]\\{\\}]*\\])?{(.*)}`, 'm'))
     }
 
     public provideFoldingRanges(

--- a/src/providers/folding.ts
+++ b/src/providers/folding.ts
@@ -26,8 +26,9 @@ export class FoldingProvider implements vscode.FoldingRangeProvider {
         let  documentClassLine = -1
 
         const sections: {level: number, from: number, to: number}[] = []
+        let index = -1
         for (const line of lines) {
-            const index = lines.indexOf(line)
+            index++
             for (const regex of this.sectionRegex) {
                 const result = regex.exec(line)
                 if (!result) {


### PR DESCRIPTION
First, the regex needs to wrap the section in a group so that multiple tags work correctly. https://github.com/James-Yu/LaTeX-Workshop/blob/4ff136dfee567fd1eab15b5955f3c416767f49a1/package.json#L790

Second, we need to use a counter instead of `indexOf` in case there are duplicate lines. E.g. multiple chapters have `\section{Exercises}` or something.