### PR TITLE
Use a LaTeX parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -1368,6 +1368,7 @@
     "fs-extra": "^5.0.0",
     "glob": "^7.1.1",
     "iconv-lite": "^0.4.24",
+    "latex-utensils": "^0.1.4",
     "mathjax": "^2.7.5",
     "mathjax-node": "2.1.1",
     "micromatch": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1368,7 +1368,7 @@
     "fs-extra": "^5.0.0",
     "glob": "^7.1.1",
     "iconv-lite": "^0.4.24",
-    "latex-utensils": "^0.1.4",
+    "latex-utensils": "^0.1.7",
     "mathjax": "^2.7.5",
     "mathjax-node": "2.1.1",
     "micromatch": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1368,7 +1368,7 @@
     "fs-extra": "^5.0.0",
     "glob": "^7.1.1",
     "iconv-lite": "^0.4.24",
-    "latex-utensils": "^0.1.7",
+    "latex-utensils": "latest",
     "mathjax": "^2.7.5",
     "mathjax-node": "2.1.1",
     "micromatch": "^3.0.0",

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode'
 import * as fs from 'fs-extra'
+import {latexParser} from 'latex-utensils'
 import * as path from 'path'
 import * as stripJsonComments from 'strip-json-comments'
 import * as utils from '../utils'
@@ -130,20 +131,30 @@ export class HoverProvider implements vscode.HoverProvider {
         if (!configuration.get('hover.preview.newcommand.parseTeXFile.enabled') as boolean) {
             return commandsString
         }
-        const regex = /(\\(?:(?:(?:(?:re)?new|provide)command|DeclareMathOperator)(\*)?{\\[a-zA-Z]+}(?:\[[^\[\]\{\}]*\])*{.*})|\\(?:def\\[a-zA-Z]+(?:#[0-9])*{.*}))/gm
+        const ast = latexParser.parse(content, {startRule: 'preamble'})
         const commands: string[] = []
-        const noCommentContent = content.replace(/([^\\]|^)%.*$/gm, '$1') // Strip comments
-        let result
-        do {
-            result = regex.exec(noCommentContent)
-            if (result) {
-                let command = result[1]
-                if (result[2]) {
-                    command = command.replace(/\*/, '')
-                }
-                commands.push(command)
+        const regex = /((re)?new|provide)command(\\*)?/
+        for (const node of ast.content) {
+            if (latexParser.isCommand(node) && node.name.match(regex)) {
+                const s = latexParser.stringify(node)
+                commands.push(s)
             }
-        } while (result)
+        }
+
+        // const regex = /(\\(?:(?:(?:re)?new|provide)command(\*)?{\\[a-zA-Z]+}(?:\[[^\[\]\{\}]*\])*{.*})|\\(?:def\\[a-zA-Z]+(?:#[0-9])*{.*}))/gm
+        // const commands: string[] = []
+        // const noCommentContent = content.replace(/([^\\]|^)%.*$/gm, '$1') // Strip comments
+        // let result
+        // do {
+        //     result = regex.exec(noCommentContent)
+        //     if (result) {
+        //         let command = result[1]
+        //         if (result[2]) {
+        //             command = command.replace(/\*/, '')
+        //         }
+        //         commands.push(command)
+        //     }
+        // } while (result)
         return commandsString + '\n' + commands.join('')
     }
 

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -131,7 +131,7 @@ export class HoverProvider implements vscode.HoverProvider {
         if (!configuration.get('hover.preview.newcommand.parseTeXFile.enabled') as boolean) {
             return commandsString
         }
-        const ast = latexParser.parse(content, {startRule: 'Preamble'})
+        const ast = latexParser.parsePreamble(content)
         const commands: string[] = []
         const regex = /((re)?new|provide)command(\\*)?|DeclareMathOperator(\\*)?/
         for (const node of ast.content) {

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -133,7 +133,7 @@ export class HoverProvider implements vscode.HoverProvider {
         }
         const ast = latexParser.parse(content, {startRule: 'preamble'})
         const commands: string[] = []
-        const regex = /((re)?new|provide)command(\\*)?/
+        const regex = /((re)?new|provide)command(\\*)?|DeclareMathOperator(\\*)?/
         for (const node of ast.content) {
             if (latexParser.isCommand(node) && node.name.match(regex)) {
                 const s = latexParser.stringify(node)

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -143,7 +143,7 @@ export class HoverProvider implements vscode.HoverProvider {
             }
         } catch (e) {
             commands = []
-            const regex = /(\\(?:(?:(?:re)?new|provide)command(\*)?{\\[a-zA-Z]+}(?:\[[^\[\]\{\}]*\])*{.*})|\\(?:def\\[a-zA-Z]+(?:#[0-9])*{.*}))/gm
+            const regex = /(\\(?:(?:(?:(?:re)?new|provide)command|DeclareMathOperator)(\*)?{\\[a-zA-Z]+}(?:\[[^\[\]\{\}]*\])*{.*})|\\(?:def\\[a-zA-Z]+(?:#[0-9])*{.*}))/gm
             const noCommentContent = content.replace(/([^\\]|^)%.*$/gm, '$1') // Strip comments
             let result
             do {

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -131,7 +131,7 @@ export class HoverProvider implements vscode.HoverProvider {
         if (!configuration.get('hover.preview.newcommand.parseTeXFile.enabled') as boolean) {
             return commandsString
         }
-        const ast = latexParser.parse(content, {startRule: 'preamble'})
+        const ast = latexParser.parse(content, {startRule: 'Preamble'})
         const commands: string[] = []
         const regex = /((re)?new|provide)command(\\*)?|DeclareMathOperator(\\*)?/
         for (const node of ast.content) {


### PR DESCRIPTION
I have written a [LaTeX parser](https://github.com/tamuratak/latex-utensils) based on [LaTeX.js](https://github.com/michael-brade/LaTeX.js) and [latex-parser](https://github.com/siefkenj/latex-parser) using [peg.js](https://github.com/pegjs/pegjs). It must be useful for LaTeX Workshop.

As the first step, let's use it to extract commands defined with multi lines in the preamble. Related to #1428.

![スクリーンショット 2019-07-13 0 57 28](https://user-images.githubusercontent.com/10665499/61142181-1f022100-a50a-11e9-8534-11a2e18b6c7e.png)

