### PR TITLE
Improve description of formattedPaste settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1282,17 +1282,17 @@
         "latex-workshop.formattedPaste.tableColumnType": {
           "type": "string",
           "default": "l",
-          "description": "Tabular column type to use, e.g. l/r/c…"
+          "markdownDescription": "Tabular column type to use, e.g. **`l`**/**`r`**/**`c`**…"
         },
         "latex-workshop.formattedPaste.tableBooktabsStyle": {
           "type": "boolean",
           "default": true,
-          "description": "Use the booktabs commands `\\toprule`, `\\midrule`, and `\\bottomrule`"
+          "markdownDescription": "Use the booktabs commands `\\toprule`, `\\midrule`, and `\\bottomrule`"
         },
         "latex-workshop.formattedPaste.tableHeaderRows": {
           "type": "integer",
           "default": 1,
-          "description": "Number of header rows to assume. Set to 0 to disable.`"
+          "markdownDescription": "Number of header rows to assume. Set to **`0`** to disable."
         }
       }
     },


### PR DESCRIPTION
I don't think this needs much of a description. I forgot to use `markdownDescription` originally even though I use markdown bits, this resolves that and tidies up the formatting somewhat.

![image](https://user-images.githubusercontent.com/20903656/61166644-77194180-a563-11e9-8852-00f217276234.png)
