### PR TITLE
Fix tikzpreview bug

### DIFF
--- a/src/providers/tikzcodelense.ts
+++ b/src/providers/tikzcodelense.ts
@@ -53,7 +53,7 @@ function findTikzPictures(document: vscode.TextDocument) {
             line = document.lineAt(++lineNo)
             text = line.text.substr(0, 1000)
             endMatch = text.match(endRegex)
-            if (endMatch && endMatch.index) {
+            if (endMatch && endMatch.index !== undefined) {
                 endColumn = endMatch.index + endMatch[0].length
             }
         } while (!endMatch)


### PR DESCRIPTION
This fixes a bug where `\end{tikzpicture}` is ignored if it starts at column 0. So when the tikzpicture is unindented the code lense doesn't show. Ooops. 