### PR TITLE
Tikzpreview fixes

### DIFF
--- a/src/components/tikzpictureview.ts
+++ b/src/components/tikzpictureview.ts
@@ -299,7 +299,7 @@ export class TikzPictureView {
         if (!configuration.get('parseTeXFile') as boolean) {
             return commandsString
         }
-        const regex = /(\\usepackage{(?:tikz|pgfplots)}|\\(?:tikzset|pgfplotsset){(?:(?:[^\{\}]|{[^\{\}]+})*)}|\\(?:usetikzlibrary|usepgfplotslibrary){[\w\.,]+}|\\definecolor{\w+}{\w+}{[^}]+}|\\colorlet{\w+}{{[^}]+}})/gm
+        const regex = /(\\usepackage{(?:tikz|pgfplots)}|\\(?:tikzset|pgfplotsset){(?:[^{}]+|{(?:[^{}]+|{(?:[^{}]+|{[^{}]+})+})+})+}|\\(?:usetikzlibrary|usepgfplotslibrary){[\w\.,]+}|\\definecolor{\w+}{\w+}{[^}]+}|\\colorlet{\w+}{{[^}]+}})/gm
         const commands: string[] = []
 
         const content = await fs.readFileSync(fileTikzCollection.location, { encoding: 'utf8' })

--- a/src/components/tikzpictureview.ts
+++ b/src/components/tikzpictureview.ts
@@ -299,7 +299,7 @@ export class TikzPictureView {
         if (!configuration.get('parseTeXFile') as boolean) {
             return commandsString
         }
-        const regex = /(\\usepackage{(?:tikz|pgfplots)}|\\(?:tikzset|pgfplotsset){(?:[^{}]+|{(?:[^{}]+|{(?:[^{}]+|{[^{}]+})+})+})+}|\\(?:usetikzlibrary|usepgfplotslibrary){[\w\.,]+}|\\definecolor{\w+}{\w+}{[^}]+}|\\colorlet{\w+}{{[^}]+}})/gm
+        const regex = /(\\usepackage(?:\[[^\]]*\])?{(?:tikz|pgfplots|xcolor)}|\\(?:tikzset|pgfplotsset){(?:[^{}]+|{(?:[^{}]+|{(?:[^{}]+|{[^{}]+})+})+})+}|\\(?:usetikzlibrary|usepgfplotslibrary){[^}]+}|\\definecolor{[^}]+}{[^}]+}{[^}]+}|\\colorlet{[^}]+}{[^}]+})/gm
         const commands: string[] = []
 
         const content = await fs.readFileSync(fileTikzCollection.location, { encoding: 'utf8' })

--- a/src/providers/tikzcodelense.ts
+++ b/src/providers/tikzcodelense.ts
@@ -13,8 +13,8 @@ export class TikzCodeLense implements vscode.CodeLensProvider {
         return matches.map(
             match =>
                 new vscode.CodeLens(match.range, {
-                    title: 'View TikzPicture',
-                    tooltip: 'Open view of this TikzPicture',
+                    title: 'View TikZ Picture',
+                    tooltip: 'Open view of this TikZ Picture',
                     command: 'latex-workshop.viewtikzpicture',
                     arguments: [match.document, match.range]
                 })
@@ -67,7 +67,7 @@ function findTikzPictures(document: vscode.TextDocument) {
             range: new vscode.Range(i, startColumn, lineNo, endColumn)
         })
 
-        i = lineNo + 1
+        i = lineNo
     }
 
     return matches


### PR DESCRIPTION
This closes #1528, more specifically the points raised at the start. The problems that we moved onto at the end now has it's own issue to track them, #​1540.

Namely:
 - Issue with the code lens (not appearing when it should)
 - Issues with the get-the-important-preamble-bits regex
 - Minor tweak to codelense title