### PR TITLE
Add ability to use custom docker wrapper scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -305,7 +305,7 @@
       },
       {
         "command": "latex-workshop.showSnippetPanel",
-        "title": "Show Snippet Panel", 
+        "title": "Show Snippet Panel",
         "category": "LaTeX Workshop"
       }
     ],
@@ -1130,12 +1130,11 @@
         "latex-workshop.docker.enabled": {
           "type": "boolean",
           "default": false,
-          "markdownDescription": "Enable docker-based LaTeX distribution support.\nDo not set this item to `true` unless you are aware of what it means.\nThis extension will use the images defined in `latex-workshop.docker.image.latex` to execute `latexmk`, `synctex`, `texcount`, and `latexindent`."
+          "markdownDescription": "Enable docker-based LaTeX distribution support.\nDo not set this item to `true` unless you are aware of what it means.\nThis extension will execute `latexmk`, `synctex`, `texcount`, and `latexindent` using `latex-workshop.docker.wrapper`."
         },
-        "latex-workshop.docker.image.latex": {
+        "latex-workshop.docker.wrapper": {
           "type": "string",
-          "default": "tianon/latex",
-          "markdownDescription": "Define the image for `latexmk`, `synctex`, `texcount`, and `latexindent`."
+          "markdownDescription": "Use `docker` to call `latexmk`, `synctex`, `texcount`, and `latexindent`. Leave empty to use the built-in wrapper script."
         },
         "latex-workshop.showContextMenu": {
           "type": "boolean",

--- a/scripts/docker-wrapper
+++ b/scripts/docker-wrapper
@@ -1,0 +1,2 @@
+#!/bin/sh
+docker run --rm -w "$(pwd)" -v "$(pwd):$(pwd)" tianon/latex "$@"

--- a/scripts/docker-wrapper.bat
+++ b/scripts/docker-wrapper.bat
@@ -1,0 +1,1 @@
+docker run -i --rm -w /data -v "%cd%:/data" tianon/latex %*

--- a/scripts/latexindent
+++ b/scripts/latexindent
@@ -1,2 +1,0 @@
-#!/bin/sh
-docker run -i --rm -w "$(pwd)" -v "$(pwd):$(pwd)" $LATEXWORKSHOP_DOCKER_LATEX latexindent "$@"

--- a/scripts/latexindent.bat
+++ b/scripts/latexindent.bat
@@ -1,1 +1,0 @@
-docker run -i --rm -w /data -v "%cd%:/data" %LATEXWORKSHOP_DOCKER_LATEX% latexindent %*

--- a/scripts/latexmk
+++ b/scripts/latexmk
@@ -1,2 +1,0 @@
-#!/bin/sh
-docker run -i --rm -w "$(pwd)" -v "$(pwd):$(pwd)" $LATEXWORKSHOP_DOCKER_LATEX latexmk "$@"

--- a/scripts/latexmk.bat
+++ b/scripts/latexmk.bat
@@ -1,1 +1,0 @@
-docker run -i --rm -w /data -v "%cd%:/data" %LATEXWORKSHOP_DOCKER_LATEX% latexmk %*

--- a/scripts/synctex
+++ b/scripts/synctex
@@ -1,2 +1,0 @@
-#!/bin/sh
-docker run -i --rm -w "$(pwd)" -v "$(pwd):$(pwd)" $LATEXWORKSHOP_DOCKER_LATEX synctex "$@"

--- a/scripts/synctex.bat
+++ b/scripts/synctex.bat
@@ -1,1 +1,0 @@
-docker run -i --rm -w /data -v "%cd%:/data" %LATEXWORKSHOP_DOCKER_LATEX% synctex %*

--- a/scripts/texcount
+++ b/scripts/texcount
@@ -1,2 +1,0 @@
-#!/bin/sh
-docker run -i --rm -w "$(pwd)" -v "$(pwd):$(pwd)" $LATEXWORKSHOP_DOCKER_LATEX texcount "$@"

--- a/scripts/texcount.bat
+++ b/scripts/texcount.bat
@@ -1,1 +1,0 @@
-docker run -i --rm -w /data -v "%cd%:/data" %LATEXWORKSHOP_DOCKER_LATEX% texcount %*

--- a/src/components/locator.ts
+++ b/src/components/locator.ts
@@ -5,6 +5,7 @@ import * as cp from 'child_process'
 import * as synctexjs from './synctex'
 
 import {Extension} from '../main'
+import { getDockerWrapper } from '../utils';
 
 export type SyncTeXRecordForward = {
     page: number;
@@ -164,16 +165,9 @@ export class Locator {
         this.extension.logger.addLogMessage(`Executing synctex with args ${args}`)
 
         let command = configuration.get('synctex.path') as string
-        if (docker) {
-            if (process.platform === 'win32') {
-                command = path.resolve(this.extension.extensionRoot, './scripts/synctex.bat')
-            } else {
-                command = path.resolve(this.extension.extensionRoot, './scripts/synctex')
-                fs.chmodSync(command, 0o755)
-            }
-        }
-        this.extension.manager.setEnvVar()
-        const proc = cp.spawn(command, args, {cwd: path.dirname(pdfFile)})
+        const proc = docker
+            ? cp.spawn(getDockerWrapper(this.extension.extensionRoot), [command, ...args], { cwd: path.dirname(pdfFile) })
+            : cp.spawn(command, args, { cwd: path.dirname(pdfFile) })
         proc.stdout.setEncoding('utf8')
         proc.stderr.setEncoding('utf8')
 
@@ -221,16 +215,9 @@ export class Locator {
         this.extension.logger.addLogMessage(`Executing synctex with args ${args}`)
 
         let command = configuration.get('synctex.path') as string
-        if (docker) {
-            if (process.platform === 'win32') {
-                command = path.resolve(this.extension.extensionRoot, './scripts/synctex.bat')
-            } else {
-                command = path.resolve(this.extension.extensionRoot, './scripts/synctex')
-                fs.chmodSync(command, 0o755)
-            }
-        }
-        this.extension.manager.setEnvVar()
-        const proc = cp.spawn(command, args, {cwd: path.dirname(pdfPath)})
+        const proc = docker
+            ? cp.spawn(getDockerWrapper(this.extension.extensionRoot), [command, ...args], { cwd: path.dirname(pdfPath) })
+            : cp.spawn(command, args, { cwd: path.dirname(pdfPath) })
         proc.stdout.setEncoding('utf8')
         proc.stderr.setEncoding('utf8')
 
@@ -434,7 +421,6 @@ export class Locator {
                                                       .replace(/%LINE%/g, line.toString())
                                                       .replace(/%TEX%/g, texFile))
         }
-        this.extension.manager.setEnvVar()
         cp.spawn(command.command, command.args)
         this.extension.logger.addLogMessage(`Open external viewer for syncTeX from ${pdfFile}`)
     }

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -519,11 +519,6 @@ export class Manager {
         }
     }
 
-    setEnvVar() {
-        const configuration = vscode.workspace.getConfiguration('latex-workshop')
-        process.env['LATEXWORKSHOP_DOCKER_LATEX'] = configuration.get('docker.image.latex') as string
-    }
-
     /**
      * Delete the whole dependency structure from texFileTree for file
      * @param file

--- a/src/components/viewer.ts
+++ b/src/components/viewer.ts
@@ -164,7 +164,6 @@ export class Viewer {
         if (command.args) {
             command.args = command.args.map(arg => arg.replace('%PDF%', pdfFile))
         }
-        this.extension.manager.setEnvVar()
         cp.spawn(command.command, command.args, {cwd: path.dirname(sourceFile), detached: true})
         this.extension.logger.addLogMessage(`Open external viewer for ${pdfFile}`)
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,6 @@
 import * as path from 'path'
 import * as fs from 'fs'
+import * as vscode from 'vscode'
 
 
 export interface ExternalCommand {
@@ -66,4 +67,10 @@ export function resolveFile(dirs: string[], inputFile: string, suffix: string = 
         }
     }
     return null
+}
+
+// Get path to the docker wrapper script
+export function getDockerWrapper(extensionRoot: string) {
+    return vscode.workspace.getConfiguration('latex-workshop').get<string>('docker.wrapper')
+        || path.resolve(extensionRoot, process.platform === 'win32' ? './scripts/docker-wrapper.bat' : './scripts/docker-wrapper')
 }


### PR DESCRIPTION
Rationale behind this functionality:

Currently LaTeX-Workshop only allow users to specify the image file to be used - but in some cases the users might want to pass extra args to `docker` (like volume mount used by [miktex](https://miktex.org/howto/miktex-docker), or use case like https://github.com/James-Yu/LaTeX-Workshop/issues/1512). This PR allows user to specify their own `docker` wrapper script via `latex-workshop.docker.wrapper`.


Todo:
- [ ] should the old option for specifying docker image be remained? If not, this might be a breaking change
- [x] `latexmk`
- [x] `texcount`
- [ ] `latexindent` (not working on my side, seems like its related to the generated temporary file)
- [ ] `synctex` (not working on my side either)
- [ ] some documentation


_I'm very new to both LaTeX and vscode extension development - so I might did some wrong here_ 😅