### PR TITLE
follow eslint

### DIFF
--- a/src/commander.ts
+++ b/src/commander.ts
@@ -548,8 +548,8 @@ export class Commander {
         const selectionsText = selections.map(selection => document.getText(selection))
 
         const offset: {
-            currentLine: number
-            lineOffset: number
+            currentLine: number,
+            lineOffset: number,
             columnOffset: number
         } = {
             currentLine: 0, lineOffset: 0, columnOffset: 0


### PR DESCRIPTION
Fix errors warned by eslint.

```
$ ./node_modules/.bin/eslint --ext .ts .

/Users/tamura/src/github/LaTeX-Workshop/src/commander.ts
  551:32  error  Expected a comma  @typescript-eslint/member-delimiter-style
  552:31  error  Expected a comma  @typescript-eslint/member-delimiter-style

✖ 2 problems (2 errors, 0 warnings)
  2 errors and 0 warnings potentially fixable with the `--fix` option.
```