### PR TITLE
send packets every 30 sec to prevent the connection closed by timeout

### DIFF
--- a/src/components/viewer.ts
+++ b/src/components/viewer.ts
@@ -172,7 +172,9 @@ export class Viewer {
     handler(websocket: ws, msg: string) {
         const data = JSON.parse(msg)
         let clients: Client[] | undefined
-        this.extension.logger.addLogMessage(`Handle data type: ${data.type}`)
+        if (data.type !== 'ping') {
+            this.extension.logger.addLogMessage(`Handle data type: ${data.type}`)
+        }
         switch (data.type) {
             case 'open':
                 clients = this.clients[data.path.toLocaleUpperCase()]
@@ -238,6 +240,9 @@ export class Viewer {
                 break
             case 'external_link':
                 vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(data.url))
+                break
+            case 'ping':
+                // nothing to do
                 break
             default:
                 this.extension.logger.addLogMessage(`Unknown websocket message: ${msg}`)

--- a/viewer/latexworkshop.js
+++ b/viewer/latexworkshop.js
@@ -249,6 +249,13 @@ document.addEventListener('pagesinit', () => {
   }
 })
 
+// Send packets every 30 sec to prevent the connection closed by timeout.
+setInterval( () => {
+  if (socket.readyState === 1) {
+    socket.send(JSON.stringify({type: 'ping'}))
+  }
+}, 30000)
+
 // if we're embedded we cannot open external links here. So we intercept clicks and forward them to the extension
 if (embedded) {
   document.addEventListener('click', (e) => {


### PR DESCRIPTION
Send packets every 30 sec to prevent the connection closed by timeout. Close #1581. See [link](https://stackoverflow.com/questions/43998283/does-chrome-have-a-timeout-for-connected-web-sockets-that-have-not-sent-a-messag).