### PR TITLE
Clean up configs related to ref-hover

### DIFF
--- a/package.json
+++ b/package.json
@@ -1151,10 +1151,10 @@
           "default": true,
           "markdownDescription": "Enable Hover on References."
         },
-        "latex-workshop.hover.ref.numberAtLastCompilation.enabled": {
+        "latex-workshop.hover.ref.number.enabled": {
           "type": "boolean",
-          "default": false,
-          "markdownDescription": "Show number given to ref at the last compilation."
+          "default": true,
+          "markdownDescription": "Show number assigned to the reference in the previous compilation."
         },
         "latex-workshop.hover.citation.enabled": {
           "type": "boolean",
@@ -1222,11 +1222,6 @@
             "yellow"
           ],
           "markdownDescription": "The color of cursor in Hover Preview."
-        },
-        "latex-workshop.hover.preview.ref.enabled": {
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Render Hover Preview on \\ref."
         },
         "latex-workshop.intellisense.optionalArgsEntries.enabled": {
           "type": "boolean",

--- a/src/main.ts
+++ b/src/main.ts
@@ -110,6 +110,13 @@ function obsoleteConfigCheck(extension: Extension) {
         'truetrue': 'onFileChange'
     })
     renameValue('latex.autoBuild.run', 'onSave', 'onFileChange')
+    renameConfig('hover.ref.numberAtLastCompilation.enabled', 'hover.ref.number.enabled')
+    combineConfig(extension, 'hover.ref.enabled', 'hover.preview.ref.enabled', 'hover.ref.enabled', {
+        'falsefalse': false,
+        'falsetrue': true,
+        'truefalse': true,
+        'truetrue': true
+    })
 }
 
 function checkDeprecatedFeatures(extension: Extension) {

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -229,7 +229,7 @@ export class HoverProvider implements vscode.HoverProvider {
         const link = vscode.Uri.parse('command:latex-workshop.synctexto').with({ query: JSON.stringify([line, refData.file]) })
         const mdLink = new vscode.MarkdownString(`[View on pdf](${link})`)
         mdLink.isTrusted = true
-        if (configuration.get('hover.preview.ref.enabled') as boolean) {
+        if (configuration.get('hover.ref.enabled') as boolean) {
             const tex = this.findHoverOnRef(document, position, token, refData)
             if (tex) {
                 const newCommands = await this.findNewCommand(document.getText())

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -239,7 +239,7 @@ export class HoverProvider implements vscode.HoverProvider {
         const md = '```latex\n' + refData.label + '\n```\n'
         const refRange = document.getWordRangeAtPosition(position, /\{.*?\}/)
         const refNumberMessage = this.refNumberMessage(refData)
-        if (refNumberMessage !== undefined && configuration.get('hover.ref.numberAtLastCompilation.enabled') as boolean) {
+        if (refNumberMessage !== undefined && configuration.get('hover.ref.number.enabled') as boolean) {
             return new vscode.Hover([md, refNumberMessage, mdLink], refRange)
         }
         return new vscode.Hover([md, mdLink], refRange)
@@ -250,7 +250,7 @@ export class HoverProvider implements vscode.HoverProvider {
         const scale = configuration.get('hover.preview.scale') as number
 
         let tag: string
-        if (refData.prevIndex !== undefined && configuration.get('hover.ref.numberAtLastCompilation.enabled') as boolean) {
+        if (refData.prevIndex !== undefined && configuration.get('hover.ref.number.enabled') as boolean) {
             tag = refData.prevIndex.refNumber
         } else {
             tag = refData.label


### PR DESCRIPTION
1. Merge `latex-workshop.hover.preview.ref.enabled` with `latex-workshop.hover.ref.enabled`. They are identical.
2. Rename `latex-workshop.hover.ref.numberAtLastCompilation.enabled` to `latex-workshop.hover.ref.number.enabled`. We don't need such a long config name. Give the description is sufficient.