### PR TITLE
Fixes: Wrong File Name When Parsing The LaTeX Log File (issue #1566)

### DIFF
--- a/src/components/parser.ts
+++ b/src/components/parser.ts
@@ -266,8 +266,8 @@ export class Parser {
         if (result && result.index !== undefined && result.index > -1) {
             line = line.substr(result.index + 1)
             if (result[1] === '(') {
-                const pathResult = line.match(/^"?((?:(?:[a-zA-Z]:|\.|\/)?(?:\/|\\\\?))[ !\u0023-\u0027\u002A-\u00FE\u00a1-\uffff]*)/)
-                const mikTeXPathResult = line.match(/^"?([ !\u0023-\u0027\u002A-\u00FE\u00a1-\uffff]*\.[a-z]{3,})/)
+                const pathResult = line.match(/^"?((?:(?:[a-zA-Z]:|\.|\/)?(?:\/|\\\\?))[ !\u0023-\u0027\u002A-\u00FE\u00a1-\uffff]*\.\S{1,})/)
+                const mikTeXPathResult = line.match(/^"?([ !\u0023-\u0027\u002A-\u00FE\u00a1-\uffff]*\.\S{1,})/)
                 if (pathResult) {
                     fileStack.push(pathResult[1].trim())
                 } else if (mikTeXPathResult) {


### PR DESCRIPTION
It is a change in the regular expressions (`pathResult` and `mikTeXPathResult`) to retrieve the correct path to files.
Issue #1566
