### PR TITLE
Prefer source.cpp.embedded.latex in cpp minted env

### DIFF
--- a/syntax/LaTeX.tmLanguage.json
+++ b/syntax/LaTeX.tmLanguage.json
@@ -138,6 +138,9 @@
           "contentName": "source.cpp",
           "patterns": [
             {
+              "include": "source.cpp.embedded.latex"
+            },
+            {
               "include": "source.cpp"
             }
           ],


### PR DESCRIPTION
C++ side PR: https://github.com/jeff-hykin/cpp-textmate-grammar/pull/351

This should completely fix https://github.com/microsoft/vscode/issues/76603 and #1476.

The grammar for the scope `source.cpp.embedded.latex` is a modified version of `source.cpp` that closes any ranges when a positive lookahead for /\\end\{minted\}/ is matched.