### PR TITLE
Command completer rework

### DIFF
--- a/package.json
+++ b/package.json
@@ -520,11 +520,11 @@
         "mac": "cmd+l cmd+m",
         "when": "textInputFocus && editorLangId == 'latex'"
       },
-      {	
-        "key": "ctrl+l ctrl+w",	
-        "mac": "cmd+l cmd+w",	
-        "when": "editorTextFocus && !editorReadonly && editorHasSelection && editorLangId == 'latex'",	
-        "command": "latex-workshop.surround"	
+      {
+        "key": "ctrl+l ctrl+w",
+        "mac": "cmd+l cmd+w",
+        "when": "editorTextFocus && !editorReadonly && editorHasSelection && editorLangId == 'latex'",
+        "command": "latex-workshop.surround"
       },
       {
         "command": "latex-workshop.onEnterKey",

--- a/package.json
+++ b/package.json
@@ -520,6 +520,12 @@
         "mac": "cmd+l cmd+m",
         "when": "textInputFocus && editorLangId == 'latex'"
       },
+      {	
+        "key": "ctrl+l ctrl+w",	
+        "mac": "cmd+l cmd+w",	
+        "when": "editorTextFocus && !editorReadonly && editorHasSelection && editorLangId == 'latex'",	
+        "command": "latex-workshop.surround"	
+      },
       {
         "command": "latex-workshop.onEnterKey",
         "key": "enter",

--- a/package.json
+++ b/package.json
@@ -521,12 +521,6 @@
         "when": "textInputFocus && editorLangId == 'latex'"
       },
       {
-        "key": "ctrl+l ctrl+w",
-        "mac": "cmd+l cmd+w",
-        "when": "editorTextFocus && !editorReadonly && editorHasSelection && editorLangId == 'latex'",
-        "command": "latex-workshop.surround"
-      },
-      {
         "command": "latex-workshop.onEnterKey",
         "key": "enter",
         "when": "editorTextFocus && !editorReadonly && editorLangId == 'latex' && !suggestWidgetVisible &&  vim.active && vim.mode == 'Insert'"

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -8,6 +8,7 @@ import {latexParser} from 'latex-utensils'
 
 import {Extension} from '../main'
 import {Suggestion as CiteEntry} from '../providers/completer/citation'
+import {Suggestion as CmdEntry} from '../providers/completer/command'
 
 interface Content {
     [filepath: string]: { // tex file name
@@ -16,7 +17,7 @@ interface Content {
             reference?: vscode.CompletionItem[],
             environment?: vscode.CompletionItem[],
             bibitem?: CiteEntry[],
-            command?: vscode.CompletionItem[],
+            command?: CmdEntry[],
             package?: string[]
         }, // latex elements for completion, e.g., reference defition
         children: { // sub-files, should be tex or plain files

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -15,7 +15,9 @@ interface Content {
         element: {
             reference?: vscode.CompletionItem[],
             environment?: vscode.CompletionItem[],
-            bibitem?: CiteEntry[]
+            bibitem?: CiteEntry[],
+            command?: vscode.CompletionItem[],
+            package?: string[]
         }, // latex elements for completion, e.g., reference defition
         children: { // sub-files, should be tex or plain files
             index: number, // the index of character sub-content is inserted
@@ -554,7 +556,6 @@ export class Manager {
         this.fileWatcher.close()
         this.filesWatched = []
         // We also clean the completions from the old project
-        this.extension.completer.command.reset()
         this.extension.completer.input.reset()
     }
 
@@ -634,9 +635,9 @@ export class Manager {
             this.extension.completer.reference.update(file, nodes, lines)
             this.extension.completer.environment.update(file, nodes, lines)
             this.extension.completer.citation.update(file, content)
+            this.extension.completer.command.update(file, nodes)
+            this.extension.completer.command.updatePkg(file, nodes)
         })
-        this.extension.completer.command.getCommandsTeX(file)
-        this.extension.completer.command.getPackage(file)
         this.extension.completer.input.getGraphicsPath(file)
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -384,11 +384,23 @@ export async function activate(context: vscode.ExtensionContext) {
             findRoot: () => extension.manager.findRoot(),
             rootDir: () => extension.manager.rootDir,
             rootFile: () => extension.manager.rootFile,
-            setEnvVar: () => extension.manager.setEnvVar()
+            setEnvVar: () => extension.manager.setEnvVar(),
+            cachedContent: () => extension.manager.cachedContent
         },
         completer: {
             command: {
-                usedPackages: () => extension.completer.command.usedPackages
+                usedPackages: () => {
+                    console.warn('`completer.command.usedPackages` is deprecated. Consider use `manager.cachedContent`.')
+                    let allPkgs: string[] = []
+                    extension.manager.getIncludedTeX().forEach(tex => {
+                        const pkgs = extension.manager.cachedContent[tex].element.package
+                        if (pkgs === undefined) {
+                            return
+                        }
+                        allPkgs = allPkgs.concat(pkgs)
+                    })
+                    return allPkgs
+                }
             }
         }
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -262,7 +262,6 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('latex-workshop.shortcut.mathsf', () => extension.commander.toggleSelectedKeyword('mathsf'))
     vscode.commands.registerCommand('latex-workshop.shortcut.mathbb', () => extension.commander.toggleSelectedKeyword('mathbb'))
     vscode.commands.registerCommand('latex-workshop.shortcut.mathcal', () => extension.commander.toggleSelectedKeyword('mathcal'))
-    vscode.commands.registerCommand('latex-workshop.surround', () => extension.completer.command.surround())
 
     vscode.commands.registerCommand('latex-workshop.increment-sectioning', () => extension.commander.shiftSectioningLevel('increment'))
     vscode.commands.registerCommand('latex-workshop.decrement-sectioning', () => extension.commander.shiftSectioningLevel('decrement'))

--- a/src/main.ts
+++ b/src/main.ts
@@ -262,6 +262,7 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('latex-workshop.shortcut.mathsf', () => extension.commander.toggleSelectedKeyword('mathsf'))
     vscode.commands.registerCommand('latex-workshop.shortcut.mathbb', () => extension.commander.toggleSelectedKeyword('mathbb'))
     vscode.commands.registerCommand('latex-workshop.shortcut.mathcal', () => extension.commander.toggleSelectedKeyword('mathcal'))
+    vscode.commands.registerCommand('latex-workshop.surround', () => extension.completer.command.surround())
 
     vscode.commands.registerCommand('latex-workshop.increment-sectioning', () => extension.commander.shiftSectioningLevel('increment'))
     vscode.commands.registerCommand('latex-workshop.decrement-sectioning', () => extension.commander.shiftSectioningLevel('decrement'))

--- a/src/providers/completer/command.ts
+++ b/src/providers/completer/command.ts
@@ -11,87 +11,103 @@ export class CommandCompletionItem extends vscode.CompletionItem {
     }
 }
 
+interface DataItemEntry {
+    command: string, // frame
+    snippet: string,
+    package?: string,
+    label?: string, // \\begin{frame} ... \\end{frame}
+    detail?: string,
+    documentation?: string,
+    postAction?: string
+}
+
 export class Command {
     extension: Extension
-    suggestions: CommandCompletionItem[] = []
-    commandInTeX: { [id: string]: {[id: string]: AutocompleteEntry} } = {}
-    refreshTimer: number
-    allCommands: {[key: string]: CommandCompletionItem} = {}
-    defaultCommands: {[key: string]: CommandCompletionItem} = {}
-    defaultSymbols: {[key: string]: CommandCompletionItem} = {}
-    newcommandData: {[id: string]: {position: vscode.Position, file: string}} = {}
-    specialBrackets: {[key: string]: vscode.CompletionItem}
-    usedPackages: string[] = []
-    packageCmds: {[pkg: string]: {[key: string]: CommandCompletionItem}} = {}
+    // suggestions: CommandCompletionItem[] = []
+    // commandInTeX: { [id: string]: {[id: string]: AutocompleteEntry} } = {}
+    // refreshTimer: number
+    // allCommands: {[key: string]: CommandCompletionItem} = {}
+    // defaultCommands: {[key: string]: CommandCompletionItem} = {}
+    // defaultSymbols: {[key: string]: CommandCompletionItem} = {}
+    // newcommandData: {[id: string]: {position: vscode.Position, file: string}} = {}
+    // usedPackages: string[] = []
+    // packageCmds: {[pkg: string]: {[key: string]: CommandCompletionItem}} = {}
+
+    packages: string[] = []
+    bracketCmds: {[key: string]: vscode.CompletionItem} = {}
+    private defaultCmds: vscode.CompletionItem[] = []
+    private defaultSymbols: vscode.CompletionItem[] = []
+    private packageCmds: {[pkg: string]: vscode.CompletionItem[]} = {}
 
     constructor(extension: Extension) {
         this.extension = extension
     }
 
-    reset() {
-        this.suggestions = []
-        this.commandInTeX = {}
-        this.allCommands = {}
-        this.newcommandData = {}
-        this.usedPackages = []
-        this.packageCmds = {}
-    }
-
-    initialize(defaultCommands: {[key: string]: AutocompleteEntry}, defaultEnvs: string[]) {
-        Object.keys(defaultCommands).forEach(key => {
-            const item = defaultCommands[key]
-            this.defaultCommands[key] = this.entryToCompletionItem(item)
+    initialize(defaultCmds: {[key: string]: DataItemEntry}, defaultEnvs: string[]) {
+        // Initialize default commands and `latex-mathsymbols`
+        Object.keys(defaultCmds).forEach(key => {
+            this.defaultCmds.push(this.entryToCompletion(defaultCmds[key]))
+            // } else {
+            //     if (!(item.package in this.packageCmds)) {
+            //         this.packageCmds[item.package] = []
+            //     }
+            //     this.packageCmds[item.package].push(this.entryToCompletion(item))
+            // }
         })
-        const envSnippet: { [id: string]: { command: string, detail: string, snippet: string}} = {}
-        defaultEnvs.forEach(env => {
+
+        // Initialize default env begin-end pairs, de-duplication
+        Array.from(new Set(defaultEnvs)).forEach(env => {
+            const suggestion = new CommandCompletionItem(env, vscode.CompletionItemKind.Snippet)
             // Use 'an' or 'a' depending on the first letter
             const art = ['a', 'e', 'i', 'o', 'u'].indexOf(`${env}`.charAt(0)) >= 0 ? 'an' : 'a'
-            envSnippet[env] = {
-                command: env,
-                detail: `Insert ${art} ${env} environment.`,
-                snippet: `begin{${env}}\n\t$0\n\\\\end{${env}}`
-            }
+            suggestion.detail = `Insert ${art} ${env} environment.`
             if (['enumerate', 'itemize'].indexOf(env) > -1) {
-                envSnippet[env]['snippet'] = `begin{${env}}\n\t\\item $0\n\\\\end{${env}}`
+                suggestion.insertText = new vscode.SnippetString(`begin{${env}}\n\t\\item $0\n\\\\end{${env}}`)
+            } else {
+                suggestion.insertText = new vscode.SnippetString(`begin{${env}}\n\t$0\n\\\\end{${env}}`)
             }
+            suggestion.filterText = env
+            this.defaultCmds.push(suggestion)
         })
-        Object.keys(envSnippet).forEach(key => {
-            const item = envSnippet[key]
-            const command = new CommandCompletionItem(`\\begin{${item.command}} ... \\end{${item.command}}`, vscode.CompletionItemKind.Snippet)
-            command.filterText = item.command
-            command.detail = item.detail
-            command.insertText = new vscode.SnippetString(item.snippet)
-            this.defaultCommands[key] = command
+
+        // Handle special commands with brackets
+        const bracketCmds = ['\\(', '\\[', '\\{', '\\left(', '\\left[', '\\left{']
+        this.defaultCmds.filter(cmd => bracketCmds.indexOf(this.getCommand(cmd)) > -1).forEach(cmd => {
+            this.bracketCmds[cmd.label] = cmd
         })
-        const bracketCommands = {'latexinlinemath': '(', 'latexdisplaymath': '[', 'curlybrackets': '{', 'lrparen': 'left(', 'lrbrack': 'left[', 'lrcurly': 'left\\{'}
-        this.specialBrackets = Object.keys(this.defaultCommands)
-            .filter(key => bracketCommands.hasOwnProperty(key))
-            .reduce((obj, key) => {
-                obj[bracketCommands[key]] = this.defaultCommands[key]
-                return obj
-            }, {})
     }
 
     provide(): vscode.CompletionItem[] {
-        if (Date.now() - this.refreshTimer < 1000) {
-            return this.suggestions
-        }
-        this.refreshTimer = Date.now()
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         const useOptionalArgsEntries = configuration.get('intellisense.optionalArgsEntries.enabled')
-        let suggestions = {}
-        Object.keys(this.defaultCommands).forEach(key => {
-            if (!useOptionalArgsEntries && key.indexOf('[') > -1) {
+
+        const suggestions: vscode.CompletionItem[] = []
+        const cmdList: string[] = []
+
+        // Insert default commands
+        this.defaultCmds.forEach(cmd => {
+            if (!useOptionalArgsEntries && this.getCommand(cmd).indexOf('[') > -1) {
                 return
             }
-            suggestions[key] = this.defaultCommands[key]
+            suggestions.push(cmd)
+            cmdList.push(this.getCommand(cmd))
         })
+
+        // Insert unimathsymbols
         if (configuration.get('intellisense.unimathsymbols.enabled')) {
-            if (Object.keys(this.defaultSymbols).length === 0) {
-                this.loadSymbols()
+            if (this.defaultSymbols.length === 0) {
+                const symbols = JSON.parse(fs.readFileSync(`${this.extension.extensionRoot}/data/unimathsymbols.json`).toString())
+                Object.keys(symbols).forEach(key => {
+                    this.defaultSymbols.push(this.entryToCompletion(symbols[key]))
+                })
             }
-            suggestions = Object.assign(suggestions, this.defaultSymbols)
+            this.defaultSymbols.forEach(symbol => {
+                suggestions.push(symbol)
+                cmdList.push(this.getCommand(symbol))
+            })
         }
+
+        // Insert commands from packages
         const extraPackages = configuration.get('intellisense.package.extra') as string[]
         if (extraPackages) {
             extraPackages.forEach(pkg => {
@@ -144,51 +160,50 @@ export class Command {
         return this.suggestions
     }
 
-    private loadSymbols() {
-        const symbols = JSON.parse(fs.readFileSync(`${this.extension.extensionRoot}/data/unimathsymbols.json`).toString())
-        Object.keys(symbols).forEach(key => {
-            const item = symbols[key]
-            this.defaultSymbols[key] = this.entryToCompletionItem(item)
-        })
+    private getCommand(item: vscode.CompletionItem): string {
+        return item.filterText ? item.filterText : item.label.slice(1)
     }
 
-    private entryToCompletionItem(item: AutocompleteEntry): CommandCompletionItem {
+    private entryToCompletion(item: DataItemEntry): vscode.CompletionItem {
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         const useTabStops = configuration.get('intellisense.useTabStops.enabled')
         const backslash = item.command[0] === ' ' ? '' : '\\'
         const label = item.label ? `${item.label}` : `${backslash}${item.command}`
-        const command = new CommandCompletionItem(label, vscode.CompletionItemKind.Function)
+        const suggestion = new CommandCompletionItem(label, vscode.CompletionItemKind.Function)
+
         if (item.snippet) {
             if (useTabStops) {
                 item.snippet = item.snippet.replace(/\$\{(\d+):[^}]*\}/g, '$${$1}')
             }
-            command.insertText = new vscode.SnippetString(item.snippet)
+            suggestion.insertText = new vscode.SnippetString(item.snippet)
         } else {
-            command.insertText = item.command
+            suggestion.insertText = item.command
         }
-        if (item.label) { command.filterText = item.command }
-        command.detail = item.detail
-        command.documentation = item.documentation ? item.documentation : '`' + item.command + '`'
-        command.packageName = item.package
-        command.sortText = item.command.replace(/^[a-zA-Z]/, c => {
+        if (item.label) {
+            suggestion.filterText = item.command
+        }
+        suggestion.detail = item.detail
+        suggestion.documentation = item.documentation ? item.documentation : '`' + item.command + '`'
+        suggestion.sortText = item.command.replace(/^[a-zA-Z]/, c => {
             const n = c.match(/[a-z]/) ? c.toUpperCase().charCodeAt(0): c.toLowerCase().charCodeAt(0)
             return n !== undefined ? n.toString(16): c
         })
         if (item.postAction) {
-            command.command = { title: 'Post-Action', command: item.postAction }
+            suggestion.command = { title: 'Post-Action', command: item.postAction }
         } else if (/[a-zA-Z]*([Cc]ite|ref|input)[a-zA-Z]*|(sub)?(import|includefrom|inputfrom)/.exec(item.command)) {
             // Automatically trigger completion if the command is for citation, filename or reference
-            command.command = { title: 'Post-Action', command: 'editor.action.triggerSuggest' }
+            suggestion.command = { title: 'Post-Action', command: 'editor.action.triggerSuggest' }
         }
-        return command
+        return suggestion
     }
 
-    private insertPkgCmds(pkg: string, suggestions) {
+    private provideCmdInPkg(pkg: string, suggestions: vscode.CompletionItem[], cmdList: string[]) {
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         if (!(configuration.get('intellisense.package.enabled'))) {
             return
         }
         const useOptionalArgsEntries = configuration.get('intellisense.optionalArgsEntries.enabled')
+        // Load command in pkg
         if (!(pkg in this.packageCmds)) {
             let filePath = `${this.extension.extensionRoot}/data/packages/${pkg}_cmd.json`
             if (!fs.existsSync(filePath)) {
@@ -201,24 +216,26 @@ export class Command {
                 }
             }
             if (fs.existsSync(filePath)) {
-                this.packageCmds[pkg] = {}
-                const cmds = JSON.parse(fs.readFileSync(filePath).toString())
-                Object.keys(cmds).forEach(cmd => {
-                    if (cmd in suggestions) {
-                        return
-                    }
-                    this.packageCmds[pkg][cmd] = this.entryToCompletionItem(cmds[cmd])
-                })
+                const cmds = Object.keys(JSON.parse(fs.readFileSync(filePath).toString()))
+                this.packageCmds[pkg] = cmds.map(key => this.entryToCompletion(cmds[key]))
             }
         }
-        if (pkg in this.packageCmds) {
-            Object.keys(this.packageCmds[pkg]).forEach(cmd => {
-                if (!useOptionalArgsEntries && cmd.indexOf('[') > -1) {
-                    return
-                }
-                suggestions[cmd] = this.packageCmds[pkg][cmd]
-            })
+
+        // No package command defined
+        if (!(pkg in this.packageCmds)) {
+            return
         }
+
+        // Insert commands
+        this.packageCmds[pkg].forEach(cmd => {
+            if (!useOptionalArgsEntries && this.getCommand(cmd).indexOf('[') > -1) {
+                return
+            }
+            if (cmdList.indexOf(this.getCommand(cmd)) < 0) {
+                suggestions.push(cmd)
+                cmdList.push(this.getCommand(cmd))
+            }
+        })
     }
 
     getPackage(filePath: string) {

--- a/src/providers/completer/environment.ts
+++ b/src/providers/completer/environment.ts
@@ -45,13 +45,19 @@ export class Environment {
             return suggestions
         }
         // Insert package environments
-        this.extension.completer.command.usedPackages.map(pkg => {
-            this.getEnvFromPkg(pkg).forEach(env => {
-                if (envList.indexOf(env.label) > -1) {
-                    return
-                }
-                suggestions.push(env)
-                envList.push(env.label)
+        this.extension.manager.getIncludedTeX().forEach(tex => {
+            const pkgs = this.extension.manager.cachedContent[tex].element.package
+            if (pkgs === undefined) {
+                return
+            }
+            pkgs.forEach(pkg => {
+                this.getEnvFromPkg(pkg).forEach(env => {
+                    if (envList.indexOf(env.label) > -1) {
+                        return
+                    }
+                    suggestions.push(env)
+                    envList.push(env.label)
+                })
             })
         })
         return suggestions

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -59,9 +59,9 @@ export class Completer implements vscode.CompletionItemProvider {
                 resolve()
                 return
             }
-            if (this.command.specialBrackets && this.command.specialBrackets.hasOwnProperty(invokeChar)) {
+            if (this.command.bracketCmds && this.command.bracketCmds.hasOwnProperty(invokeChar)) {
                 if (position.character > 1 && currentLine[position.character - 2] === '\\') {
-                    const mathSnippet = Object.assign({}, this.command.specialBrackets[invokeChar])
+                    const mathSnippet = Object.assign({}, this.command.bracketCmds[invokeChar])
                     if (vscode.workspace.getConfiguration('editor', document.uri).get('autoClosingBrackets') &&
                         (currentLine.length > position.character && [')', ']', '}'].indexOf(currentLine[position.character]) > -1)) {
                         mathSnippet.range = new vscode.Range(position.translate(0, -1), position.translate(0, 1))

--- a/src/providers/definition.ts
+++ b/src/providers/definition.ts
@@ -65,11 +65,9 @@ export class DefinitionProvider implements vscode.DefinitionProvider {
                 ))
                 return
             }
-            if (token in this.extension.completer.command.newcommandData) {
-                const command = this.extension.completer.command.newcommandData[token]
-                resolve(new vscode.Location(
-                    vscode.Uri.file(command.file), command.position
-                ))
+            if (token in this.extension.completer.command.definedCmds) {
+                const command = this.extension.completer.command.definedCmds[token]
+                resolve(command.location)
                 return
             }
             if (vscode.window.activeTextEditor && token.indexOf('.') > -1) {

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -162,20 +162,31 @@ export class HoverProvider implements vscode.HoverProvider {
         const signatures: string[] = []
         const pkgs: string[] = []
         const tokenWithoutSlash = token.substring(1)
-        Object.keys(this.extension.completer.command.allCommands).forEach( key => {
-            if (key.startsWith(tokenWithoutSlash) && ((key.length === tokenWithoutSlash.length) || (key.charAt(tokenWithoutSlash.length) === '[') || (key.charAt(tokenWithoutSlash.length) === '{'))) {
-                const command = this.extension.completer.command.allCommands[key]
-                if (command.documentation === undefined) {
-                    return
-                }
-                const doc = command.documentation as string
-                const packageName = command.packageName
-                if (packageName && (pkgs.indexOf(packageName) === -1)) {
-                    pkgs.push(packageName)
-                }
-                signatures.push(doc)
+
+        this.extension.manager.getIncludedTeX().forEach(cachedFile => {
+            const cachedCmds = this.extension.manager.cachedContent[cachedFile].element.command
+            if (cachedCmds === undefined) {
+                return
             }
+            cachedCmds.forEach(cmd => {
+                const key = this.extension.completer.command.getCmdName(cmd)
+                if (key.startsWith(tokenWithoutSlash) &&
+                    ((key.length === tokenWithoutSlash.length) ||
+                     (key.charAt(tokenWithoutSlash.length) === '[') ||
+                     (key.charAt(tokenWithoutSlash.length) === '{'))) {
+                    if (cmd.documentation === undefined) {
+                        return
+                    }
+                    const doc = cmd.documentation as string
+                    const packageName = cmd.package
+                    if (packageName && (pkgs.indexOf(packageName) === -1)) {
+                        pkgs.push(packageName)
+                    }
+                    signatures.push(doc)
+                }
+            })
         })
+
         let pkgLink = ''
         if (pkgs.length > 0) {
             pkgLink = '\n\nView documentation for package(s) '


### PR DESCRIPTION
Similar to #1594, but on command auto-completion. No features are changed, only engineering-side changes to `latex-utensils`.

edit: btw this should be the last PEG-related refactor by me. I plan to make a new release after this one is settled, which might be a new major version.