### PR TITLE
(#1599) Fix handling of periods in multiline warnings

### DIFF
--- a/src/components/parser.ts
+++ b/src/components/parser.ts
@@ -11,7 +11,7 @@ const latexError = /^(?:(.*):(\d+):|!)(?: (.+) Error:)? (.+?)$/
 const latexBox = /^((?:Over|Under)full \\[vh]box \([^)]*\)) in paragraph at lines (\d+)--(\d+)$/
 const latexBoxAlt = /^((?:Over|Under)full \\[vh]box \([^)]*\)) detected at line (\d+)$/
 const latexWarn = /^((?:(?:Class|Package) \S*)|LaTeX) (Warning|Info|Font Warning):\s+(.*?)(?: on input line (\d+))?(\.|\?|)$/
-const latexPackageWarningExtraLines = /^\((.*)\)\s+(.*?)(?: on input line (\d+))?(\.)?$/
+const latexPackageWarningExtraLines = /^\((.*)\)\s+(.*?)(?: +on input line (\d+))?(\.)?$/
 const bibEmpty = /^Empty `thebibliography' environment/
 const biberWarn = /^Biber warning:.*WARN - I didn't find a database entry for '([^']+)'/
 
@@ -165,7 +165,7 @@ export class Parser {
                 } else {
                     const packageExtraLineResult = line.match(latexPackageWarningExtraLines)
                     if (packageExtraLineResult) {
-                        currentResult.text += '\n(' + packageExtraLineResult[1] + ')\t' + packageExtraLineResult[2] + packageExtraLineResult[4]
+                        currentResult.text += '\n(' + packageExtraLineResult[1] + ')\t' + packageExtraLineResult[2] + (packageExtraLineResult[4] ? '.' : '')
                         currentResult.line = parseInt(packageExtraLineResult[3], 10)
                     } else if (insideError) {
                         const subLine = line.replace(messageLine, '$1')


### PR DESCRIPTION
Attempting to print an undefined string will print 'undefined' not ''

Closes #1599 

[Sample error](https://tex.stackexchange.com/a/51871/136270):

```latex
\documentclass{scrartcl}

\usepackage{listings}
\begin{document}
\lstlistoflistings 

\begin{lstlisting}[caption={example}]
 for i=1 by 1 to 10 do
   i++
 od:
\end{lstlisting}
\end{document}
```

```
Class scrartcl Warning: \float@listhead detected!
(scrartcl)              Implementation of \float@listhead became
(scrartcl)              deprecated in KOMA-Script v3.01 2008/11/14 and
(scrartcl)              has been replaced by several more flexible
(scrartcl)              features of package `tocbasic`.
(scrartcl)              Maybe implementation of \float@listhead will
(scrartcl)              be removed from KOMA-Script soon.
(scrartcl)              Loading of package `scrhack' may help to
(scrartcl)              avoid this warning, if you are using a
(scrartcl)              a package that still implements the
(scrartcl)              deprecated \float@listhead interface  on input line 5.
```

Note: there are two spaces before "on input line 5", so I added a `+` to the regex so it appears neater.