### PR TITLE
Configurable reverse synctex keybinding

### DIFF
--- a/package.json
+++ b/package.json
@@ -869,6 +869,15 @@
           "default": "0",
           "markdownDescription": "Define the port to listen on for communicating with the internal viewer. The default value \"0\" means the port is chosen randomly by the application."
         },
+        "latex-workshop.view.pdf.internal.synctex.keybinding": {
+          "type": "string",
+          "default": "ctrl-click",
+          "enum": [
+            "ctrl-click",
+            "double-click"
+          ],
+          "markdownDescription": "Which keybinding to use for the internal viewer for reverse synctex. `ctrl`/`cmd` + click (default) or double click."
+        },
         "latex-workshop.view.pdf.external.viewer.command": {
           "type": "string",
           "default": "",

--- a/src/components/viewer.ts
+++ b/src/components/viewer.ts
@@ -230,7 +230,9 @@ export class Viewer {
                             spreadMode: configuration.get('view.pdf.spreadMode'),
                             hand: configuration.get('view.pdf.hand'),
                             invert: configuration.get('view.pdf.invert'),
-                            keybinding: configuration.get('view.pdf.internal.synctex.keybinding')
+                            keybindings: {
+                                synctex: configuration.get('view.pdf.internal.synctex.keybinding')
+                            }
                         }))
                     }
                     if (configuration.get('synctex.afterBuild.enabled') as boolean) {

--- a/src/components/viewer.ts
+++ b/src/components/viewer.ts
@@ -174,6 +174,7 @@ export class Viewer {
 
     handler(websocket: ws, msg: string) {
         const data = JSON.parse(msg)
+        const reverseSynctexKeyBinding = vscode.workspace.getConfiguration('latex-workshop').get('view.pdf.internal.synctex.keybinding')
         let clients: Client[] | undefined
         if (data.type !== 'ping') {
             this.extension.logger.addLogMessage(`Handle data type: ${data.type}`)
@@ -238,8 +239,19 @@ export class Viewer {
                     }
                 }
                 break
-            case 'click':
-                this.extension.locator.locate(data, data.path)
+            case 'ctrl-click':
+                if(reverseSynctexKeyBinding === 'ctrl-click') {
+                    this.extension.locator.locate(data, data.path)
+                } else {
+                    this.extension.logger.addLogMessage('Reverse SyncTeX keybinding is not set to ctrl+click.')
+                }
+                break
+            case 'double-click':
+                if(reverseSynctexKeyBinding === 'double-click') {
+                    this.extension.locator.locate(data, data.path)
+                } else {
+                    this.extension.logger.addLogMessage('Reverse SyncTeX keybinding is not set to double click.')
+                }
                 break
             case 'external_link':
                 vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(data.url))

--- a/src/components/viewer.ts
+++ b/src/components/viewer.ts
@@ -174,7 +174,6 @@ export class Viewer {
 
     handler(websocket: ws, msg: string) {
         const data = JSON.parse(msg)
-        const reverseSynctexKeyBinding = vscode.workspace.getConfiguration('latex-workshop').get('view.pdf.internal.synctex.keybinding')
         let clients: Client[] | undefined
         if (data.type !== 'ping') {
             this.extension.logger.addLogMessage(`Handle data type: ${data.type}`)
@@ -231,6 +230,7 @@ export class Viewer {
                             spreadMode: configuration.get('view.pdf.spreadMode'),
                             hand: configuration.get('view.pdf.hand'),
                             invert: configuration.get('view.pdf.invert'),
+                            keybinding: configuration.get('view.pdf.internal.synctex.keybinding')
                         }))
                     }
                     if (configuration.get('synctex.afterBuild.enabled') as boolean) {
@@ -239,19 +239,8 @@ export class Viewer {
                     }
                 }
                 break
-            case 'ctrl-click':
-                if(reverseSynctexKeyBinding === 'ctrl-click') {
-                    this.extension.locator.locate(data, data.path)
-                } else {
-                    this.extension.logger.addLogMessage('Reverse SyncTeX keybinding is not set to ctrl+click.')
-                }
-                break
-            case 'double-click':
-                if(reverseSynctexKeyBinding === 'double-click') {
-                    this.extension.locator.locate(data, data.path)
-                } else {
-                    this.extension.logger.addLogMessage('Reverse SyncTeX keybinding is not set to double click.')
-                }
+            case 'reverse_synctex':
+                this.extension.locator.locate(data, data.path)
                 break
             case 'external_link':
                 vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(data.url))

--- a/viewer/latexworkshop.js
+++ b/viewer/latexworkshop.js
@@ -270,35 +270,43 @@ if (embedded) {
   })
 }
 
+
+function callSynctex(e, page, pageDom, viewerContainer) {
+  const canvasDom = pageDom.getElementsByTagName('canvas')[0]
+  const selection = window.getSelection();
+    let textBeforeSelection = ''
+    let textAfterSelection = ''
+    // workaround for https://github.com/James-Yu/LaTeX-Workshop/issues/1314
+    if(selection && selection.anchorNode && selection.anchorNode.nodeName === '#text'){
+      const text = selection.anchorNode.textContent;
+      textBeforeSelection = text.substring(0, selection.anchorOffset);
+      textAfterSelection = text.substring(selection.anchorOffset);
+    }
+    const trimSelect = document.getElementById('trimSelect')
+    let left = e.pageX - pageDom.offsetLeft + viewerContainer.scrollLeft
+    const top = e.pageY - pageDom.offsetTop + viewerContainer.scrollTop
+    if (trimSelect.selectedIndex > 0) {
+      const m = canvasDom.style.left.match(/-(.*)px/)
+      const offsetLeft = m ? Number(m[1]) : 0
+      left += offsetLeft
+    }
+    const pos = PDFViewerApplication.pdfViewer._pages[page-1].getPagePoint(left, canvasDom.offsetHeight - top)
+    socket.send(JSON.stringify({type:'click', path:pdfFilePath, pos, page, textBeforeSelection, textAfterSelection}))
+}
+
 document.addEventListener('pagesinit', () => {
   const viewerDom = document.getElementById('viewer')
   for (const pageDom of viewerDom.childNodes) {
     const page = pageDom.dataset.pageNumber
     const viewerContainer = document.getElementById('viewerContainer')
     pageDom.onclick = (e) => {
-      const canvasDom = pageDom.getElementsByTagName('canvas')[0]
       if (!(e.ctrlKey || e.metaKey)) {
         return
       }
-      const selection = window.getSelection();
-      let textBeforeSelection = ''
-      let textAfterSelection = ''
-      // workaround for https://github.com/James-Yu/LaTeX-Workshop/issues/1314
-      if(selection && selection.anchorNode && selection.anchorNode.nodeName === '#text'){
-        const text = selection.anchorNode.textContent;
-        textBeforeSelection = text.substring(0, selection.anchorOffset);
-        textAfterSelection = text.substring(selection.anchorOffset);
-      }
-      const trimSelect = document.getElementById('trimSelect')
-      let left = e.pageX - pageDom.offsetLeft + viewerContainer.scrollLeft
-      const top = e.pageY - pageDom.offsetTop + viewerContainer.scrollTop
-      if (trimSelect.selectedIndex > 0) {
-        const m = canvasDom.style.left.match(/-(.*)px/)
-        const offsetLeft = m ? Number(m[1]) : 0
-        left += offsetLeft
-      }
-      const pos = PDFViewerApplication.pdfViewer._pages[page-1].getPagePoint(left, canvasDom.offsetHeight - top)
-      socket.send(JSON.stringify({type:'click', path:pdfFilePath, pos, page, textBeforeSelection, textAfterSelection}))
+      callSynctex(e, page, pageDom, viewerContainer)
+    }
+    pageDom.ondblclick = (e) => {
+      callSynctex(e, page, pageDom, viewerContainer)
     }
   }
 });

--- a/viewer/latexworkshop.js
+++ b/viewer/latexworkshop.js
@@ -271,7 +271,7 @@ if (embedded) {
 }
 
 
-function callSynctex(e, page, pageDom, viewerContainer) {
+function callSynctex(clickType, e, page, pageDom, viewerContainer) {
   const canvasDom = pageDom.getElementsByTagName('canvas')[0]
   const selection = window.getSelection();
     let textBeforeSelection = ''
@@ -291,7 +291,7 @@ function callSynctex(e, page, pageDom, viewerContainer) {
       left += offsetLeft
     }
     const pos = PDFViewerApplication.pdfViewer._pages[page-1].getPagePoint(left, canvasDom.offsetHeight - top)
-    socket.send(JSON.stringify({type:'click', path:pdfFilePath, pos, page, textBeforeSelection, textAfterSelection}))
+    socket.send(JSON.stringify({type: clickType, path:pdfFilePath, pos, page, textBeforeSelection, textAfterSelection}))
 }
 
 document.addEventListener('pagesinit', () => {
@@ -303,10 +303,10 @@ document.addEventListener('pagesinit', () => {
       if (!(e.ctrlKey || e.metaKey)) {
         return
       }
-      callSynctex(e, page, pageDom, viewerContainer)
+      callSynctex('ctrl-click', e, page, pageDom, viewerContainer)
     }
     pageDom.ondblclick = (e) => {
-      callSynctex(e, page, pageDom, viewerContainer)
+      callSynctex('double-click', e, page, pageDom, viewerContainer)
     }
   }
 });

--- a/viewer/latexworkshop.js
+++ b/viewer/latexworkshop.js
@@ -235,8 +235,8 @@ socket.addEventListener('message', (event) => {
               document.querySelector('#viewer').style.filter = `invert(${data.invert * 100}%)`
               document.querySelector('#viewer').style.background = 'white'
             }
-            if (data.keybinding) {
-              registerSynctexKeybinding(data.keybinding)
+            if (data.keybindings) {
+              registerSynctexKeybinding(data.keybindings['synctex'])
             }
             break
         default:


### PR DESCRIPTION
This has come up in several issues now:

#1596 
#1464 
#662
#106

With double clicking being the default on Overleaf and other online editors, I think it is worth having an option to have double clicking as a keybind.

Closes #1596 