### PR TITLE
Refresh viewer after successful build

### DIFF
--- a/src/commander.ts
+++ b/src/commander.ts
@@ -68,7 +68,7 @@ export class Commander {
         const externalBuildArgs = configuration.get('latex.external.build.args') as string[]
         if (externalBuildCommand) {
             const pwd = path.dirname(rootFile ? rootFile : vscode.window.activeTextEditor.document.fileName)
-            await this.extension.builder.buildWithExternalCommand(externalBuildCommand, externalBuildArgs, pwd)
+            await this.extension.builder.buildWithExternalCommand(externalBuildCommand, externalBuildArgs, pwd, rootFile)
             return
         }
         if (rootFile === undefined && this.extension.manager.hasTexId(vscode.window.activeTextEditor.document.languageId)) {

--- a/src/components/builder.ts
+++ b/src/components/builder.ts
@@ -70,7 +70,7 @@ export class Builder {
         return releaseBuildMutex
     }
 
-    async buildWithExternalCommand(command: string, args: string[], pwd: string) {
+    async buildWithExternalCommand(command: string, args: string[], pwd: string, rootFile: string | undefined = undefined) {
         if (this.isWaitingForBuildToFinish()) {
             return
         }
@@ -125,6 +125,16 @@ export class Builder {
             } else {
                 this.extension.logger.addLogMessage(`Successfully built. PID: ${pid}`)
                 this.extension.logger.displayStatus('check', 'statusBar.foreground', 'Build succeeded.')
+                try {
+                    if (rootFile === undefined) {
+                        this.extension.viewer.refreshExistingViewer()
+                    } else {
+                        this.buildFinished(rootFile)
+                    }
+                } finally {
+                    this.currentProcess = undefined
+                    releaseBuildMutex()
+                }
             }
             this.currentProcess = undefined
             releaseBuildMutex()


### PR DESCRIPTION
Refresh viewer after successful build with an external build command.

Closes #1625