### PR TITLE
Completer fallback

### DIFF
--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -739,6 +739,8 @@ export class Manager {
         } catch {
             this.extension.logger.addLogMessage(`Cannot parse ${file}. Fall back to regex-based completion.`)
             // Do the update with old style.
+            const contentNoComment = utils.stripComments(content, '%')
+            this.extension.completer.reference.update(file, undefined, undefined, contentNoComment)
         }
     }
 

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -742,6 +742,8 @@ export class Manager {
             const contentNoComment = utils.stripComments(content, '%')
             this.extension.completer.reference.update(file, undefined, undefined, contentNoComment)
             this.extension.completer.environment.update(file, undefined, undefined, contentNoComment)
+            this.extension.completer.command.update(file, undefined, contentNoComment)
+            this.extension.completer.command.updatePkg(file, undefined, contentNoComment)
         }
     }
 

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -728,13 +728,18 @@ export class Manager {
 
     // This function updates all completers upon tex-file changes, or active file content is changed.
     updateCompleter(file: string, content: string) {
-        const nodes = latexParser.parse(content, { timeout: 1000 }).content
-        const lines = content.split('\n')
-        this.extension.completer.reference.update(file, nodes, lines)
-        this.extension.completer.environment.update(file, nodes, lines)
         this.extension.completer.citation.update(file, content)
-        this.extension.completer.command.update(file, nodes)
-        this.extension.completer.command.updatePkg(file, nodes)
+        try {
+            const nodes = latexParser.parse(content, { timeout: 1000 }).content
+            const lines = content.split('\n')
+            this.extension.completer.reference.update(file, nodes, lines)
+            this.extension.completer.environment.update(file, nodes, lines)
+            this.extension.completer.command.update(file, nodes)
+            this.extension.completer.command.updatePkg(file, nodes)
+        } catch {
+            this.extension.logger.addLogMessage(`Cannot parse ${file}. Fall back to regex-based completion.`)
+            // Do the update with old style.
+        }
     }
 
     private resolveBibPath(bib: string, rootDir: string) {

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -741,6 +741,7 @@ export class Manager {
             // Do the update with old style.
             const contentNoComment = utils.stripComments(content, '%')
             this.extension.completer.reference.update(file, undefined, undefined, contentNoComment)
+            this.extension.completer.environment.update(file, undefined, undefined, contentNoComment)
         }
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -301,6 +301,10 @@ export async function activate(context: vscode.ExtensionContext) {
         if (!extension.manager.hasTexId(e.document.languageId)) {
             return
         }
+        extension.linter.lintActiveFileIfEnabledAfterInterval()
+        if (extension.manager.cachedContent[e.document.fileName] === undefined) {
+            return
+        }
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         const content = e.document.getText()
         extension.manager.cachedContent[e.document.fileName].content = content
@@ -311,7 +315,6 @@ export async function activate(context: vscode.ExtensionContext) {
             const file = e.document.uri.fsPath
             extension.manager.updateCompleter(file, content)
         }, configuration.get('intellisense.update.delay', 1000))
-        extension.linter.lintActiveFileIfEnabledAfterInterval()
     }))
 
     let isLaTeXActive = false

--- a/src/providers/completer/command.ts
+++ b/src/providers/completer/command.ts
@@ -225,13 +225,14 @@ export class Command {
                         if (latexParser.isOptionalArg(arg)) {
                             return
                         }
-                        const pkg: string = (arg.content[0] as latexParser.TextString).content
-                        const pkgs = this.extension.manager.cachedContent[file].element.package
-                        if (pkgs) {
-                            pkgs.push(pkg)
-                        } else {
-                            this.extension.manager.cachedContent[file].element.package = [pkg]
-                        }
+                        (arg.content[0] as latexParser.TextString).content.split(',').forEach(pkg => {
+                            const pkgs = this.extension.manager.cachedContent[file].element.package
+                            if (pkgs) {
+                                pkgs.push(pkg)
+                            } else {
+                                this.extension.manager.cachedContent[file].element.package = [pkg]
+                            }
+                        })
                     })
                 } else {
                     if (latexParser.hasContentArray(node)) {

--- a/src/providers/completer/command.ts
+++ b/src/providers/completer/command.ts
@@ -186,14 +186,18 @@ export class Command {
         return
     }
 
-    update(file: string, nodes: latexParser.Node[]) {
+    update(file: string, nodes?: latexParser.Node[], content?: string) {
         // Remove newcommand cmds, because they will be re-insert in the next step
         Object.keys(this.definedCmds).forEach(cmd => {
             if (this.definedCmds[cmd].file === file) {
                 delete this.definedCmds[cmd]
             }
         })
-        this.extension.manager.cachedContent[file].element.command = this.getCmdFromNodeArray(file, nodes)
+        if (nodes !== undefined) {
+            this.extension.manager.cachedContent[file].element.command = this.getCmdFromNodeArray(file, nodes)
+        } else if (content !== undefined) {
+            this.extension.manager.cachedContent[file].element.command = this.getCmdFromContent(file, content)
+        }
     }
 
     getCmdName(item: Suggestion, removeArgs = false): string {
@@ -213,27 +217,53 @@ export class Command {
         return cmds
     }
 
-    updatePkg(file: string, nodes: latexParser.Node[]){
-        nodes.forEach(node => {
-            if (latexParser.isCommand(node) && node.name === 'usepackage' && 'args' in node) {
-                node.args.forEach(arg => {
-                    if (latexParser.isOptionalArg(arg)) {
+    updatePkg(file: string, nodes?: latexParser.Node[], content?: string) {
+        if (nodes !== undefined) {
+            nodes.forEach(node => {
+                if (latexParser.isCommand(node) && node.name === 'usepackage' && 'args' in node) {
+                    node.args.forEach(arg => {
+                        if (latexParser.isOptionalArg(arg)) {
+                            return
+                        }
+                        const pkg: string = (arg.content[0] as latexParser.TextString).content
+                        const pkgs = this.extension.manager.cachedContent[file].element.package
+                        if (pkgs) {
+                            pkgs.push(pkg)
+                        } else {
+                            this.extension.manager.cachedContent[file].element.package = [pkg]
+                        }
+                    })
+                } else {
+                    if (latexParser.hasContentArray(node)) {
+                        this.updatePkg(file, node.content)
+                    }
+                }
+            })
+        } else if (content !== undefined) {
+            const pkgReg = /\\usepackage(?:\[[^[\]{}]*\])?{(.*)}/g
+            const pkgs: string[] = []
+
+            if (this.extension.manager.cachedContent[file].element.package === undefined) {
+                this.extension.manager.cachedContent[file].element.package = []
+            }
+
+            while (true) {
+                const result = pkgReg.exec(content)
+                if (result === null) {
+                    break
+                }
+                result[1].split(',').forEach(pkg => {
+                    pkg = pkg.trim()
+                    if (pkgs.indexOf(pkg) > -1) {
                         return
                     }
-                    const pkg: string = (arg.content[0] as latexParser.TextString).content
-                    const pkgs = this.extension.manager.cachedContent[file].element.package
-                    if (pkgs) {
-                        pkgs.push(pkg)
-                    } else {
-                        this.extension.manager.cachedContent[file].element.package = [pkg]
+                    const filePkgs = this.extension.manager.cachedContent[file].element.package
+                    if (filePkgs !== undefined) {
+                        filePkgs.push(pkg)
                     }
                 })
-            } else {
-                if (latexParser.hasContentArray(node)) {
-                    this.updatePkg(file, node.content)
-                }
             }
-        })
+        }
     }
 
     private getCmdFromNode(file: string, node: latexParser.Node, cmdList: string[] = []): Suggestion[] {
@@ -305,6 +335,81 @@ export class Command {
             }
         })
         return args
+    }
+
+    private getCmdFromContent(file: string, content: string): Suggestion[] {
+        const cmdReg = /\\([a-zA-Z]+)({[^{}]*})?({[^{}]*})?({[^{}]*})?/g
+        const cmds: Suggestion[] = []
+        const cmdList: string[] = []
+        while (true) {
+            const result = cmdReg.exec(content)
+            if (result === null) {
+                break
+            }
+            if (cmdList.indexOf(result[1]) > -1) {
+                continue
+            }
+
+            const cmd: Suggestion = {
+                label: `\\${result[1]}`,
+                kind: vscode.CompletionItemKind.Function,
+                documentation: '`' + result[1] + '`',
+                insertText: new vscode.SnippetString(this.getArgsFromRegResult(result)),
+                filterText: result[1],
+                package: ''
+            }
+            if (result[1].match(/([a-zA-Z]*(cite|ref)[a-zA-Z]*)|begin/)) {
+                cmd.command = { title: 'Post-Action', command: 'editor.action.triggerSuggest' }
+            }
+            cmds.push(cmd)
+            cmdList.push(result[1])
+        }
+
+        const newCommandReg = /\\(?:re|provide)?(?:new)?command(?:{)?\\(\w+)/g
+        while (true) {
+            const result = newCommandReg.exec(content)
+            if (result === null) {
+                break
+            }
+            if (cmdList.indexOf(result[1]) > -1) {
+                continue
+            }
+
+            const cmd: Suggestion = {
+                label: `\\${result[1]}`,
+                kind: vscode.CompletionItemKind.Function,
+                documentation: '`' + result[1] + '`',
+                insertText: result[1],
+                filterText: result[1],
+                package: 'user-defined'
+            }
+            cmds.push(cmd)
+            cmdList.push(result[1])
+
+            this.definedCmds[result[1]] = {
+                file,
+                location: new vscode.Location(
+                    vscode.Uri.file(file),
+                    new vscode.Position(content.substr(0, result.index).split('\n').length - 1, 0))
+            }
+        }
+
+        return cmds
+    }
+
+    private getArgsFromRegResult(result: RegExpExecArray): string {
+        let text = result[1]
+
+        if (result[2]) {
+            text += '{${1}}'
+        }
+        if (result[3]) {
+            text += '{${2}}'
+        }
+        if (result[4]) {
+            text += '{${3}}'
+        }
+        return text
     }
 
     private entryToCompletion(item: DataItemEntry): Suggestion {

--- a/src/providers/completer/environment.ts
+++ b/src/providers/completer/environment.ts
@@ -125,7 +125,7 @@ export class Environment {
             if (result === null) {
                 break
             }
-            if (result[1] in envList) {
+            if (envList.indexOf(result[1]) > -1) {
                 continue
             }
 

--- a/src/providers/completer/environment.ts
+++ b/src/providers/completer/environment.ts
@@ -67,8 +67,12 @@ export class Environment {
         return suggestions
     }
 
-    update(file: string, nodes: latexParser.Node[], lines: string[]) {
-        this.extension.manager.cachedContent[file].element.environment = this.getEnvFromNodeArray(nodes, lines)
+    update(file: string, nodes?: latexParser.Node[], lines?: string[], content?: string) {
+        if (nodes !== undefined && lines !== undefined) {
+            this.extension.manager.cachedContent[file].element.environment = this.getEnvFromNodeArray(nodes, lines)
+        } else if (content !== undefined) {
+            this.extension.manager.cachedContent[file].element.environment = this.getEnvFromContent(content)
+        }
     }
 
     // This function will return all environments in a node array, including sub-nodes
@@ -110,5 +114,27 @@ export class Environment {
         this.packageEnvs[pkg] = (JSON.parse(fs.readFileSync(filePath).toString()) as string[])
             .map(env => new vscode.CompletionItem(env, vscode.CompletionItemKind.Module))
         return this.packageEnvs[pkg]
+    }
+
+    private getEnvFromContent(content: string): vscode.CompletionItem[] {
+        const envReg = /\\begin\s?{([^{}]*)}/g
+        const envs: vscode.CompletionItem[] = []
+        const envList: string[] = []
+        while (true) {
+            const result = envReg.exec(content)
+            if (result === null) {
+                break
+            }
+            if (result[1] in envList) {
+                continue
+            }
+
+            envs.push({
+                label: result[1],
+                kind: vscode.CompletionItemKind.Module
+            })
+            envList.push(result[1])
+        }
+        return envs
     }
 }

--- a/src/providers/completer/reference.ts
+++ b/src/providers/completer/reference.ts
@@ -123,12 +123,12 @@ export class Reference {
     }
 
     private getRefFromContent(content: string) {
-        const itemReg = /(?:\\label(?:\[[^[\]{}]*\])?|(?:^|[,\s])label=){([^}]*)}/gm
+        const refReg = /(?:\\label(?:\[[^[\]{}]*\])?|(?:^|[,\s])label=){([^}]*)}/gm
         const refs: vscode.CompletionItem[] = []
         const refList: string[] = []
         const contentNoEmpty = content.split('\n').filter(para => para !== '').join('\n')
         while (true) {
-            const result = itemReg.exec(content)
+            const result = refReg.exec(content)
             if (result === null) {
                 break
             }

--- a/src/providers/completer/reference.ts
+++ b/src/providers/completer/reference.ts
@@ -132,7 +132,7 @@ export class Reference {
             if (result === null) {
                 break
             }
-            if (result[1] in refList) {
+            if (refList.indexOf(result[1]) > -1) {
                 continue
             }
             const prevContent = contentNoEmpty.substring(0, contentNoEmpty.substring(0, result.index).lastIndexOf('\n') - 1)


### PR DESCRIPTION
Use the previous regex-based parsing if the extension cannot build AST properly (syntax error, timeout, etc.) The codes are mostly adopted from `7.3.0` with minimal changes to adapt to the new completer logic.