### PR TITLE
stop users sending bug reports to the PDF.js dev team.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -20,8 +20,6 @@ You still see this issue?: Yes/No
 
 **If your issue is with compiling a document (not having to do with finding the root file of a project), check first that you can compile manually.**
 
-**If your issue is with the internal pdf viewer not displaying something correctly, take the pdf and open it in Firefox (or any program that uses PDF.js to display PDFs) and check if the same issue exists there. If so, the problem is with PDF.js and not this extension.**
-
 **Describe the bug [Required]**
 A clear and concise description of what the bug is.
 


### PR DESCRIPTION
Because it is difficult for users to distinguish bugs of LaTeX Workshop from the ones of PDF.js, make users report bugs only. We should prevent users from sending false bug reports to the PDF.js dev team and annoying them.