### PR TITLE
set noImplicitAny: true

### DIFF
--- a/package.json
+++ b/package.json
@@ -1432,7 +1432,7 @@
     "mathjax-node": "2.1.1",
     "micromatch": "^3.0.0",
     "pdfjs-dist": "2.1.266",
-    "strip-json-comments": "^2.0.1",
+    "strip-json-comments": "^3.0.1",
     "tmp": "^0.0.33",
     "ws": "^5.1.1"
   },

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -257,7 +257,7 @@ export class Commander {
         this.extension.completer.citation.browser()
     }
 
-    log(compiler?) {
+    log(compiler?: string) {
         this.extension.logger.addLogMessage('LOG command invoked.')
         if (compiler) {
             this.extension.logger.showCompilerLog()
@@ -493,7 +493,7 @@ export class Commander {
         const matches = /^(\s*)\\item(\[[^[\]]*\])?\s*(.*)$/.exec(line.text)
         if (matches) {
             let itemString = ''
-            let newCursorPos
+            let newCursorPos: vscode.Position
             // leading indent
             if (matches[1]) {
                 itemString += matches[1]
@@ -662,7 +662,7 @@ export class Commander {
 
         function replacer(
             _match: string,
-            sectionName: string,
+            sectionName: keyof typeof increments ,
             options: string,
             contents: string
         ) {

--- a/src/components/builder.ts
+++ b/src/components/builder.ts
@@ -161,7 +161,7 @@ export class Builder {
         this.extension.logger.addLogMessage(`Build root file ${rootFile}`)
         try {
             this.extension.buildInfo.buildStarted()
-            pdfjsLib.getDocument(this.extension.manager.tex2pdf(rootFile, true)).promise.then(doc => {
+            pdfjsLib.getDocument(this.extension.manager.tex2pdf(rootFile, true)).promise.then((doc: any) => {
                 this.extension.buildInfo.setPageTotal(doc.numPages)
             })
             // Create sub directories of output directory

--- a/src/components/buildinfo.ts
+++ b/src/components/buildinfo.ts
@@ -13,7 +13,7 @@ export class BuildInfo {
         buildStart: number,
         pageTotal?: number | undefined,
         lastStepTime: number,
-        stepTimes: { [runName: string]: { [pageNo: number]: number } },
+        stepTimes: { [runName: string]: { [pageNo: string]: number } },
         stdout: string,
         ruleNumber: number,
         ruleName: string,
@@ -407,9 +407,9 @@ export class BuildInfo {
             }
             return str
         }
-
-        const runIcon: string =
-            enclosedNumbers[this.configuration.get('progress.runIconType') as string][this.currentBuild.ruleNumber]
+        const runIconType = this.configuration.get('progress.runIconType') as keyof typeof enclosedNumbers
+        const index = this.currentBuild.ruleNumber as keyof typeof enclosedNumbers[keyof typeof enclosedNumbers]
+        const runIcon: string = enclosedNumbers[runIconType][index]
         // set generic status text
         this.status.text = `${runIcon} ${this.currentBuild.ruleName}`
 

--- a/src/components/linter.ts
+++ b/src/components/linter.ts
@@ -16,11 +16,13 @@ export class Linter {
     }
 
     get rcPath() {
-        let rcPath
+        let rcPath: string
         // 0. root file folder
         const root = this.extension.manager.rootFile
         if (root) {
             rcPath = path.resolve(path.dirname(root), './.chktexrc')
+        } else {
+            return
         }
         if (fs.existsSync(rcPath)) {
             return rcPath

--- a/src/components/locator.ts
+++ b/src/components/locator.ts
@@ -353,7 +353,7 @@ export class Locator {
     }
 
     private getColumnBySurroundingText(line: string, textBeforeSelectionFull: string, textAfterSelectionFull: string) {
-        let previousColumnMatches = {}
+        let previousColumnMatches: any = {}
 
         for (let length = 5; length <= Math.max(textBeforeSelectionFull.length, textAfterSelectionFull.length); length++) {
             const columns: number[] = []
@@ -369,7 +369,7 @@ export class Locator {
             }
 
             // Get number or occurrences for each column
-            const columnMatches = {}
+            const columnMatches: any = {}
             columns.forEach(column => columnMatches[column] = (columnMatches[column] || 0) + 1)
             const values = Object.values(columnMatches).sort()
 

--- a/src/components/logger.ts
+++ b/src/components/logger.ts
@@ -63,7 +63,7 @@ export class Logger {
         }
     }
 
-    showErrorMessage(message: string, ...args): Thenable<any> | undefined {
+    showErrorMessage(message: string, ...args: string[]): Thenable<any> | undefined {
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         if (configuration.get('message.error.show')) {
             return vscode.window.showErrorMessage(message, ...args)

--- a/src/main.ts
+++ b/src/main.ts
@@ -88,7 +88,7 @@ function splitCommand(extension: Extension, config: string, newCommandConfig: st
     if (!configuration.has(config)) {
         return
     }
-    const originalConfig = configuration.get(config, {})
+    const originalConfig: { [key: string]: any } = configuration.get(config, {})
     if (originalConfig === undefined || Object.keys(originalConfig).indexOf('command') < 0) {
         return
     }
@@ -203,7 +203,6 @@ function newVersionMessage(extensionPath: string, extension: Extension) {
 
 export async function activate(context: vscode.ExtensionContext) {
     const extension = new Extension()
-    global['latex'] = extension
     vscode.commands.executeCommand('setContext', 'latex-workshop:enabled', true)
 
     // let configuration = vscode.workspace.getConfiguration('latex-workshop')
@@ -421,7 +420,7 @@ export async function activate(context: vscode.ExtensionContext) {
 }
 
 export class Extension {
-    packageInfo
+    packageInfo: any
     extensionRoot: string
     logger: Logger
     buildInfo: BuildInfo

--- a/src/providers/completer/citation.ts
+++ b/src/providers/completer/citation.ts
@@ -83,7 +83,7 @@ export class Citation {
 
     getEntryDict(): {[key: string]: Suggestion} {
         const suggestions = this.updateAll()
-        const entries = {}
+        const entries: {[key: string]: Suggestion} = {}
         suggestions.forEach(entry => entries[entry.key] = entry)
         return entries
     }

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -96,7 +96,7 @@ export class Completer implements vscode.CompletionItemProvider {
     completion(type: string, line: string, args: {document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken, context: vscode.CompletionContext}): vscode.CompletionItem[] {
         let reg
         let provider
-        let payload
+        let payload: any
         switch (type) {
             case 'citation':
                 reg = /\\[a-zA-Z]*[Cc]ite[a-zA-Z]*\*?(?:(?:\[[^[\]]*\])*(?:{[^{}]*})?)*{([^}]*)$/

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -15,8 +15,8 @@ type TexMathEnv = { texString: string, range: vscode.Range, envname: string }
 export class HoverProvider implements vscode.HoverProvider {
     extension: Extension
     jaxInitialized = false
-    color
-    mj
+    color: any
+    mj: any
 
     constructor(extension: Extension) {
         this.extension = extension
@@ -333,7 +333,7 @@ export class HoverProvider implements vscode.HoverProvider {
         return b64Start + svg64
     }
 
-    private hexToRgb(hex) {
+    private hexToRgb(hex: string) {
         const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex)
         return result ? {
             r: parseInt(result[1], 16) / 255,
@@ -367,7 +367,7 @@ export class HoverProvider implements vscode.HoverProvider {
             if (extension.packageJSON === undefined || extension.packageJSON.contributes === undefined || extension.packageJSON.contributes.themes === undefined) {
                 continue
             }
-            const candidateThemes = extension.packageJSON.contributes.themes.filter(themePkg => themePkg.label === colorTheme || themePkg.id === colorTheme)
+            const candidateThemes = extension.packageJSON.contributes.themes.filter( (themePkg: any) => themePkg.label === colorTheme || themePkg.id === colorTheme)
             if (candidateThemes.length === 0) {
                 continue
             }

--- a/src/providers/latexformatter.ts
+++ b/src/providers/latexformatter.ts
@@ -6,12 +6,12 @@ import * as os from 'os'
 
 import { Extension } from '../main'
 
-const fullRange = doc => doc.validateRange(new vscode.Range(0, 0, Number.MAX_VALUE, Number.MAX_VALUE))
+const fullRange = (doc: vscode.TextDocument) => doc.validateRange(new vscode.Range(0, 0, Number.MAX_VALUE, Number.MAX_VALUE))
 
 export class OperatingSystem {
-    public name
-    public fileExt
-    public checker
+    public name: string
+    public fileExt: string
+    public checker: string
 
     constructor(name: string, fileExt: string, checker: string) {
         this.name = name

--- a/src/providers/structure.ts
+++ b/src/providers/structure.ts
@@ -11,7 +11,7 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
     private _onDidChangeTreeData: vscode.EventEmitter<Section | undefined> = new vscode.EventEmitter<Section | undefined>()
     readonly onDidChangeTreeData: vscode.Event<Section | undefined>
     private hierarchy: string[]
-    private sectionDepths: { string?: number } = {}
+    private sectionDepths: { [key: string]: number } = {}
     public root: string = ''
 
     // our data source is a set multi-rooted set of trees
@@ -305,7 +305,7 @@ export class StructureTreeView {
         })
     }
 
-    private traverseSectionTree(sections: Section[], fileName: string, lineNumber: number) {
+    private traverseSectionTree(sections: Section[], fileName: string, lineNumber: number): Section | undefined {
         for (const node of sections) {
             if (node.fileName !== fileName) {
                 continue

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "module": "commonjs",
         "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
         "noImplicitReturns": true,
         "noImplicitThis": true,
         "noUnusedLocals": true,
@@ -16,7 +17,13 @@
         "sourceMap": true,
         "strictNullChecks": true,
         "strictPropertyInitialization": true,
-        "target": "es6"
+        "target": "es6",
+        "baseUrl": "./",
+        "paths": {
+            "pdfjs-dist": ["types/pdfjs-dist"],
+            "mathjax-node": ["types/mathjax-node"]
+        },
+        "typeRoots": ["./types", "./node_modules/@types"]
     },
     "exclude": [
         "node_modules",

--- a/types/mathjax-node/index.d.ts
+++ b/types/mathjax-node/index.d.ts
@@ -1,0 +1,2 @@
+export const config: any
+export function start(): any

--- a/types/pdfjs-dist/index.d.ts
+++ b/types/pdfjs-dist/index.d.ts
@@ -1,0 +1,1 @@
+export function getDocument(...args: any): any


### PR DESCRIPTION
- set `noImplicitAny: true`. See [link](https://basarat.gitbooks.io/typescript/docs/options/noImplicitAny.html).
- update `strip-json-comments` to v3 which includes the type definition file of TypeScript.
- remove the line,  `global['latex'] = extension`, at `main.ts`

For the operator, `keyof`, see [Handbook](https://www.typescriptlang.org/docs/handbook/advanced-types.html#index-types) and [Deep Dive](https://basarat.gitbooks.io/typescript/docs/types/literal-types.html#string-based-enums).