### PR TITLE
set target: "es2017"

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
         "alwaysStrict": true,
         "forceConsistentCasingInFileNames": true,
         "lib": [
-            "es2017", "dom"
+            "es2017"
         ],
         "module": "commonjs",
         "noFallthroughCasesInSwitch": true,
@@ -17,7 +17,7 @@
         "sourceMap": true,
         "strictNullChecks": true,
         "strictPropertyInitialization": true,
-        "target": "es6",
+        "target": "es2017",
         "baseUrl": "./",
         "paths": {
             "pdfjs-dist": ["types/pdfjs-dist"],


### PR DESCRIPTION
- remove `"dom"` in `lib` in `tsconfig.json`. `"dom"` is added in 42bd3d3a001d70c2e5f1a18a1d3667a4df2b58c8, which is not needed anymore. We can not use native WebSocket in the process of `node.js`.
- set `target: "es2017"`. It is strange setting different versions in `lib` and `target`. In the `tsconfig.json` of VS Code, `es2017` is set. See [link](https://github.com/microsoft/vscode/blob/master/build/tsconfig.json).