### PR TITLE
Disallow [ and ] in paths

### DIFF
--- a/src/components/parser.ts
+++ b/src/components/parser.ts
@@ -266,8 +266,8 @@ export class Parser {
         if (result && result.index !== undefined && result.index > -1) {
             line = line.substr(result.index + 1)
             if (result[1] === '(') {
-                const pathResult = line.match(/^"?((?:(?:[a-zA-Z]:|\.|\/)?(?:\/|\\\\?))[ !\u0023-\u0027\u002A-\u00FE\u00a1-\uffff]*)/)
-                const mikTeXPathResult = line.match(/^"?([ !\u0023-\u0027\u002A-\u00FE\u00a1-\uffff]*\.[a-z]{3,})/)
+                const pathResult = line.match(/^"?((?:(?:[a-zA-Z]:|\.|\/)?(?:\/|\\\\?))[^"()[\]]*)/)
+                const mikTeXPathResult = line.match(/^"?([^"()[\]]*\.[a-z]{3,})/)
                 if (pathResult) {
                     fileStack.push(pathResult[1].trim())
                 } else if (mikTeXPathResult) {


### PR DESCRIPTION
Related: #1490 and #1591 

Pdftex outputs some lines like `./1.tex [1{/var/lib/texmf/fonts/map/pdftex/updmap/pdftex.map}])`

Forbidding `[` and `]` is required to correctly pick up `./1.tex`, otherwise it will match all the way to the end and cause errors.

Previously, we allowed everything except non-printable ascii and `()"`. I've changed the regex group to a negative match so it is easier to read. This will allow non-printable ascii again but I don't think that's going to be a problem.

This will fix the issue that uninyhart had in #1566 for xelatex, but not the same issue for pdflatex as I will try to describe shortly.
