### PR TITLE
Don't stop tokenizer at spaces (enables hover on refs with spaces in them)

### DIFF
--- a/src/providers/tokenizer.ts
+++ b/src/providers/tokenizer.ts
@@ -2,8 +2,8 @@ import * as vscode from 'vscode'
 import * as utils from '../utils'
 
 export function tokenizer(document: vscode.TextDocument, position: vscode.Position): string | undefined {
-    const startResult = document.getText(new vscode.Range(new vscode.Position(position.line, 0), position)).match(/[\\{,\s](?=[^\\{,\s]*$)/)
-    const endResult = document.getText(new vscode.Range(position, new vscode.Position(position.line, 65535))).match(/[{}[\],\s]/)
+    const startResult = document.getText(new vscode.Range(new vscode.Position(position.line, 0), position)).match(/[\\{,](?=[^\\{,]*$)/)
+    const endResult = document.getText(new vscode.Range(position, new vscode.Position(position.line, 65535))).match(/[{}[\],]/)
     if (startResult === null || endResult === null ||
         startResult.index === undefined || endResult.index === undefined ||
         startResult.index < 0 || endResult.index < 0) {


### PR DESCRIPTION
Fixes #1653 

I tested this on my own document and everything works normally. However, I don't know if there are edge-cases where this might cause problems.