### PR TITLE
remove the snippet of \setminus

### DIFF
--- a/snippets/latex.json
+++ b/snippets/latex.json
@@ -110,11 +110,6 @@
 		"body": "\\Big|",
 		"description": "Insert a Big |"
 	},
-	"setminus": {
-		"prefix": "@\\",
-		"body": "\\setminus",
-		"description": "Insert a minus set"
-	},
 	"bigcup": {
 		"prefix": "@+",
 		"body": "\\bigcup",


### PR DESCRIPTION
remove the snippet of \setminus. Related to #1671. We should not use the triggerCharacter in snippets since the behavior of VS Code has changed.

This PR is just a workaround.  It is more appropreate to provide snippets through `CompletionProvider` by ourselves.