### PR TITLE
add lualatex to latex-workshop.latex.tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -636,6 +636,7 @@
               "args": [
                 "-synctex=1",
                 "-interaction=nonstopmode",
+                "-file-line-error",
                 "%DOC%"
               ],
               "env": {}

--- a/package.json
+++ b/package.json
@@ -629,6 +629,16 @@
                 "%DOCFILE%"
               ],
               "env": {}
+            },
+            {
+              "name": "lualatex",
+              "command": "lualatex",
+              "args": [
+                "-synctex=1",
+                "-interaction=nonstopmode",
+                "%DOC%"
+              ],
+              "env": {}
             }
           ],
           "markdownDescription": "Define LaTeX compiling tools to be used in recipes.\nEach tool is labeled by its `name`. When invoked, `command` is spawned with arguments defined in `args` and environment variables defined in `env`. Typically no spaces should appear in each argument unless in paths.\nPlaceholders `%DOC%`, `%DOCFILE%`, `%DIR%`, `%TMPDIR%` and `%OUTDIR%` are available. For details, please visit https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#latex-recipe."


### PR DESCRIPTION
This is aimed to allow users to configure lualatex as part of their latex-build-recipe.  Info about `lua{la}tex`: http://www.luatex.org

When this is properly configured in users' recipes, this will allow latex workshop to compile tex that uses luacode (e.g. `\usepackage{luacode}`).  
