### PR TITLE
Texdoc completion

### DIFF
--- a/package.json
+++ b/package.json
@@ -296,6 +296,11 @@
         "category": "LaTeX Workshop"
       },
       {
+        "command": "latex-workshop.texdocUsepackages",
+        "title": "Show package documentation actually used",
+        "category": "LaTeX Workshop"
+      },
+      {
         "command": "latex-workshop.showCompilationPanel",
         "title": "Show LaTeX Compilation Info",
         "category": "LaTeX Workshop"

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -672,6 +672,10 @@ export class Commander {
         this._texdoc.texdoc(pkg)
     }
 
+    texdocUsepackages() {
+        this._texdoc.texdocUsepackages()
+    }
+
     async saveWithoutBuilding() {
         if (vscode.window.activeTextEditor === undefined) {
             return

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -5,7 +5,7 @@ import {latexParser, bibtexParser} from 'latex-utensils'
 
 import {Extension} from './main'
 import {getLongestBalancedString} from './utils'
-import { TeXDoc } from './components/texdoc'
+import {TeXDoc} from './components/texdoc'
 
 async function quickPickRootFile(rootFile: string, localRootFile: string): Promise<string | undefined> {
     const pickedRootFile = await vscode.window.showQuickPick([{

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -1,11 +1,11 @@
 import * as vscode from 'vscode'
 import * as fs from 'fs-extra'
 import * as path from 'path'
-import * as cp from 'child_process'
 import {latexParser, bibtexParser} from 'latex-utensils'
 
 import {Extension} from './main'
 import {getLongestBalancedString} from './utils'
+import { TeXDoc } from './components/texdoc'
 
 async function quickPickRootFile(rootFile: string, localRootFile: string): Promise<string | undefined> {
     const pickedRootFile = await vscode.window.showQuickPick([{
@@ -38,10 +38,12 @@ async function quickPickRootFile(rootFile: string, localRootFile: string): Promi
 
 export class Commander {
     extension: Extension
+    private _texdoc: TeXDoc
     snippets: {[key: string]: vscode.SnippetString} = {}
 
     constructor(extension: Extension) {
         this.extension = extension
+        this._texdoc = new TeXDoc(extension)
         let extensionSnippets: string
         fs.readFile(`${this.extension.extensionRoot}/snippets/latex.json`)
             .then(data => {extensionSnippets = data.toString()})
@@ -666,55 +668,8 @@ export class Commander {
         vscode.workspace.openTextDocument({content: JSON.stringify(ast, null, 2), language: 'json'}).then(doc => vscode.window.showTextDocument(doc))
     }
 
-    runTexdoc(pkg: string) {
-        const configuration = vscode.workspace.getConfiguration('latex-workshop')
-        const texdocPath = configuration.get('texdoc.path') as string
-        const texdocArgs = configuration.get('texdoc.args') as string[]
-        texdocArgs.push(pkg)
-        const proc = cp.spawn(texdocPath, texdocArgs)
-
-        let stdout = ''
-        proc.stdout.on('data', newStdout => {
-            stdout += newStdout
-        })
-
-        let stderr = ''
-        proc.stderr.on('data', newStderr => {
-            stderr += newStderr
-        })
-
-        proc.on('error', err => {
-            this.extension.logger.addLogMessage(`Cannot run texdoc: ${err.message}, ${stderr}`)
-            this.extension.logger.showErrorMessage('Texdoc failed. Please refer to LaTeX Workshop Output for details.')
-        })
-
-        proc.on('exit', exitCode => {
-            if (exitCode !== 0) {
-                this.extension.logger.addLogMessage(`Cannot find documentation for ${pkg}.`)
-                this.extension.logger.showErrorMessage('Texdoc failed. Please refer to LaTeX Workshop Output for details.')
-            } else {
-                const regex = new RegExp(`(no documentation found)|(Documentation for ${pkg} could not be found)`)
-                if (stdout.match(regex) || stderr.match(regex)) {
-                    this.extension.logger.addLogMessage(`Cannot find documentation for ${pkg}.`)
-                    this.extension.logger.showErrorMessage(`Cannot find documentation for ${pkg}.`)
-                } else {
-                    this.extension.logger.addLogMessage(`Opening documentation for ${pkg}.`)
-                }
-            }
-        })
-    }
-
     texdoc(pkg?: string) {
-        if (pkg) {
-            this.runTexdoc(pkg)
-            return
-        }
-        vscode.window.showInputBox({value: '', prompt: 'Package name'}).then(selectedPkg => {
-            if (!selectedPkg) {
-                return
-            }
-            this.runTexdoc(selectedPkg)
-        })
+        this._texdoc.texdoc(pkg)
     }
 
     async saveWithoutBuilding() {

--- a/src/components/texdoc.ts
+++ b/src/components/texdoc.ts
@@ -12,21 +12,21 @@ export class TeXDoc {
 
     constructor(e: Extension) {
         this.extension = e
-        setImmediate( () => this.packageItems = this.readPackages() )
+        setImmediate( () => this.readPackages() )
     }
 
     private readPackages() {
         const json = fs.readFileSync(`${this.extension.extensionRoot}/data/packagenames.json`).toString()
-        const ret: vscode.QuickPickItem[] = []
-        this.pkgs = JSON.parse(json)
-        const pkgs = this.pkgs
+        const items: vscode.QuickPickItem[] = []
+        const pkgs: Packages = JSON.parse(json)
         for ( const pkg of Object.values(pkgs) ) {
             const item = this.quickItemize(pkg)
             if (item) {
-                ret.push(item)
+                items.push(item)
             }
         }
-        return ret
+        this.packageItems = items
+        this.pkgs = pkgs
     }
 
     private quickItemize(pkg: Packages[string]) {

--- a/src/components/texdoc.ts
+++ b/src/components/texdoc.ts
@@ -80,11 +80,11 @@ export class TeXDoc {
             this.runTexdoc(pkg)
             return
         }
-        vscode.window.showQuickPick(this.packageItems).then(selectedPkg => {
+        vscode.window.showInputBox({value: '', prompt: 'Package name'}).then(selectedPkg => {
             if (!selectedPkg) {
                 return
             }
-            this.runTexdoc(selectedPkg.label)
+            this.runTexdoc(selectedPkg)
         })
     }
 
@@ -101,14 +101,12 @@ export class TeXDoc {
         }
         const packagenames = Array.from(new Set(names))
         for (const name of packagenames) {
+            let item: vscode.QuickPickItem | undefined = { label: name }
             const pkg = this.pkgs[name]
-            if (!pkg) {
-                continue
+            if (pkg) {
+                item = this.quickItemize(pkg) || item
             }
-            const item = this.quickItemize(pkg)
-            if (item) {
-                items.push(item)
-            }
+            items.push(item)
         }
         vscode.window.showQuickPick(items).then(selectedPkg => {
             if (!selectedPkg) {

--- a/src/components/texdoc.ts
+++ b/src/components/texdoc.ts
@@ -1,0 +1,62 @@
+import * as vscode from 'vscode'
+import * as cp from 'child_process'
+import {Extension} from 'src/main'
+
+export class TeXDoc {
+    extension: Extension
+    constructor(e: Extension) {
+        this.extension = e
+    }
+
+    runTexdoc(pkg: string) {
+        const configuration = vscode.workspace.getConfiguration('latex-workshop')
+        const texdocPath = configuration.get('texdoc.path') as string
+        const texdocArgs = configuration.get('texdoc.args') as string[]
+        texdocArgs.push(pkg)
+        const proc = cp.spawn(texdocPath, texdocArgs)
+
+        let stdout = ''
+        proc.stdout.on('data', newStdout => {
+            stdout += newStdout
+        })
+
+        let stderr = ''
+        proc.stderr.on('data', newStderr => {
+            stderr += newStderr
+        })
+
+        proc.on('error', err => {
+            this.extension.logger.addLogMessage(`Cannot run texdoc: ${err.message}, ${stderr}`)
+            this.extension.logger.showErrorMessage('Texdoc failed. Please refer to LaTeX Workshop Output for details.')
+        })
+
+        proc.on('exit', exitCode => {
+            if (exitCode !== 0) {
+                this.extension.logger.addLogMessage(`Cannot find documentation for ${pkg}.`)
+                this.extension.logger.showErrorMessage('Texdoc failed. Please refer to LaTeX Workshop Output for details.')
+            } else {
+                const regex = new RegExp(`(no documentation found)|(Documentation for ${pkg} could not be found)`)
+                if (stdout.match(regex) || stderr.match(regex)) {
+                    this.extension.logger.addLogMessage(`Cannot find documentation for ${pkg}.`)
+                    this.extension.logger.showErrorMessage(`Cannot find documentation for ${pkg}.`)
+                } else {
+                    this.extension.logger.addLogMessage(`Opening documentation for ${pkg}.`)
+                }
+            }
+        })
+    }
+
+    texdoc(pkg?: string) {
+        if (pkg) {
+            this.runTexdoc(pkg)
+            return
+        }
+        vscode.window.showInputBox({value: '', prompt: 'Package name'}).then(selectedPkg => {
+            if (!selectedPkg) {
+                return
+            }
+            this.runTexdoc(selectedPkg)
+        })
+    }
+
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -222,6 +222,7 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('latex-workshop.kill', () => extension.commander.kill())
     vscode.commands.registerCommand('latex-workshop.synctex', () => extension.commander.synctex())
     vscode.commands.registerCommand('latex-workshop.texdoc', (pkg) => extension.commander.texdoc(pkg))
+    vscode.commands.registerCommand('latex-workshop.texdocUsepackages', () => extension.commander.texdocUsepackages())
     vscode.commands.registerCommand('latex-workshop.synctexto', (line, filePath) => extension.commander.synctexonref(line, filePath))
     vscode.commands.registerCommand('latex-workshop.clean', () => extension.commander.clean())
     vscode.commands.registerCommand('latex-workshop.actions', () => extension.commander.actions())


### PR DESCRIPTION
Related to #1692.

- use `showQuickPick` for texdoc completion.
- read `data/packagenames.json` for completion items.
- introduce a new command `Show package documentation actually used`