### PR TITLE
add acorn to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1480,6 +1480,7 @@
     "@types/ws": "^4.0.2",
     "@typescript-eslint/eslint-plugin": "^2.1.0",
     "@typescript-eslint/parser": "^2.1.0",
+    "acorn": "^6.2.1",
     "eslint": "^6.3.0",
     "husky": "^3.0.2",
     "textmate-bailout": "^1.1.0",


### PR DESCRIPTION
add `acorn` to devDependencies to surpress warnings.

```
npm i

> latex-workshop@8.1.2 postinstall /Users/tamura/src/github/LaTeX-Workshop
> node ./node_modules/vscode/bin/install

Detected VS Code engine version: ^1.34.0
Found minimal version that qualifies engine range: 1.34.0
Fetching vscode.d.ts from: https://raw.githubusercontent.com/Microsoft/vscode/a622c65b2c713c890fcf4fbf07cf34049d5fe758/src/vs/vscode.d.ts
vscode.d.ts successfully installed!

npm WARN acorn-dynamic-import@4.0.0 requires a peer of acorn@^6.0.0 but none is installed. You must install peer dependencies yourself.
npm WARN acorn-jsx@5.0.2 requires a peer of acorn@^6.0.0 || ^7.0.0 but none is installed. You must install peer dependencies yourself.

audited 8342 packages in 7.221s
found 0 vulnerabilities
```