### PR TITLE
fix parsing \usepackage

### DIFF
--- a/src/providers/completer/command.ts
+++ b/src/providers/completer/command.ts
@@ -208,19 +208,27 @@ export class Command {
     updatePkg(file: string, nodes?: latexParser.Node[], content?: string) {
         if (nodes !== undefined) {
             nodes.forEach(node => {
-                if (latexParser.isCommand(node) && node.name === 'usepackage' && 'args' in node) {
+                if (latexParser.isCommand(node) && node.name === 'usepackage') {
                     node.args.forEach(arg => {
                         if (latexParser.isOptionalArg(arg)) {
                             return
                         }
-                        (arg.content[0] as latexParser.TextString).content.split(',').forEach(pkg => {
-                            const pkgs = this.extension.manager.cachedContent[file].element.package
-                            if (pkgs) {
-                                pkgs.push(pkg)
-                            } else {
-                                this.extension.manager.cachedContent[file].element.package = [pkg]
+                        for (const c of arg.content) {
+                            if (!latexParser.isTextString(c)) {
+                                continue
                             }
-                        })
+                            c.content.split(',').forEach(pkg => {
+                                if (/^\s*$/.exec(pkg)) {
+                                    return
+                                }
+                                const pkgs = this.extension.manager.cachedContent[file].element.package
+                                if (pkgs) {
+                                    pkgs.push(pkg)
+                                } else {
+                                    this.extension.manager.cachedContent[file].element.package = [pkg]
+                                }
+                            })
+                        }
                     })
                 } else {
                     if (latexParser.hasContentArray(node)) {

--- a/src/providers/completer/command.ts
+++ b/src/providers/completer/command.ts
@@ -218,7 +218,8 @@ export class Command {
                                 continue
                             }
                             c.content.split(',').forEach(pkg => {
-                                if (/^\s*$/.exec(pkg)) {
+                                pkg = pkg.trim()
+                                if (pkg === '') {
                                     return
                                 }
                                 const pkgs = this.extension.manager.cachedContent[file].element.package


### PR DESCRIPTION
fix parsing `\usepackage{a, b, c}` where spaces exist between package names.