### PR TITLE
embed source.r syntax in R code blocks for .Rnw documents

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,19 @@
         "extensions": [
           ".pdf"
         ]
+      },
+      {
+        "id": "rsweave",
+        "aliases": [
+          "R Sweave"
+        ],
+        "extensions": [
+          ".rnw",
+          ".Rnw",
+          ".Rtex",
+          ".rtex"
+        ],
+        "configuration": "./syntax/syntax-rsweave.json"
       }
     ],
     "grammars": [
@@ -138,8 +151,7 @@
           "source.python": "python",
           "source.scala": "scala",
           "text.xtml": "xtml",
-          "source.yaml": "yaml",
-          "source.r": "r"
+          "source.yaml": "yaml"
         }
       },
       {
@@ -168,6 +180,14 @@
         "path": "./syntax/cpp-grammar-bailout.tmLanguage.json",
         "embeddedLanguages": {
           "meta.embedded.assembly.cpp": "asm"
+        }
+      },
+      {
+        "language": "rsweave",
+        "scopeName": "text.tex.latex.rsweave",
+        "path": "./syntax/RSweave.tmLanguage.json",
+        "embeddedLanguages": {
+            "source.r": "r"
         }
       }
     ],

--- a/package.json
+++ b/package.json
@@ -138,7 +138,8 @@
           "source.python": "python",
           "source.scala": "scala",
           "text.xtml": "xtml",
-          "source.yaml": "yaml"
+          "source.yaml": "yaml",
+          "source.r": "r"
         }
       },
       {

--- a/syntax/LaTeX.tmLanguage.json
+++ b/syntax/LaTeX.tmLanguage.json
@@ -1401,25 +1401,6 @@
     },
     {
       "include": "text.tex"
-    },
-    {
-      "begin": "(^(\\s*?)<<.*?>>=(?:\\s*?\\n))",
-      "captures": {
-        "1": {
-          "patterns": [
-            {
-              "include": "#code-env"
-            }
-          ]
-        }
-      },
-      "contentName": "source.r",
-      "patterns": [
-        {
-          "include": "source.r"
-        }
-      ],
-      "end": "(^\\2@(?:\\s*?\\n))"
     }
   ],
   "repository": {

--- a/syntax/LaTeX.tmLanguage.json
+++ b/syntax/LaTeX.tmLanguage.json
@@ -1401,6 +1401,25 @@
     },
     {
       "include": "text.tex"
+    },
+    {
+      "begin": "(^(\\s*?)<<.*?>>=(?:\\s*?\\n))",
+      "captures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#code-env"
+            }
+          ]
+        }
+      },
+      "contentName": "source.r",
+      "patterns": [
+        {
+          "include": "source.r"
+        }
+      ],
+      "end": "(^\\2@(?:\\s*?\\n))"
     }
   ],
   "repository": {

--- a/syntax/RSweave.tmLanguage.json
+++ b/syntax/RSweave.tmLanguage.json
@@ -1,0 +1,50 @@
+{
+    "name": "RSweave",
+    "scopeName": "text.tex.latex.rsweave",
+    "fileTypes": [
+        "rnw",
+        "Rnw"
+    ],
+    "patterns": [
+        {
+            "include": "text.tex.latex"
+        },
+        {
+            "name": "text.tex.latex.rsweave.codeblock",
+            "begin": "^(\\s*?)(<<)(.*?)(>>=)\\s*?(\\S*?)\\s*?\\n",
+            "end": "^\\1(@)\\s*?(\\S*?)\\s*?\\n",
+            "endCaptures": {
+                "1": {
+                    "name": "meta.tag.rsweave"
+                },
+                "2": {
+                    "name": "invalid.illegal.rsweave"
+                }
+            },
+            "beginCaptures": {
+                "2": {
+                    "name": "meta.tag.rsweave"
+                },
+                "4": {
+                    "name": "meta.tag.rsweave"
+                },
+                "5": {
+                    "name": "invalid.illegal.rsweave"
+                },
+                "3": {
+                    "patterns": [
+                        {
+                            "include": "source.r#function-parameters"
+                        }
+                    ]
+                }
+            },
+            "contentName": "source.r",
+            "patterns": [
+                {
+                    "include": "source.r"
+                }
+            ]
+        }
+    ]
+}

--- a/syntax/RSweave.tmLanguage.json
+++ b/syntax/RSweave.tmLanguage.json
@@ -11,8 +11,8 @@
         },
         {
             "name": "text.tex.latex.rsweave.codeblock",
-            "begin": "^(\\s*?)(<<)(.*?)(>>=)\\s*?(\\S*?)\\s*?\\n",
-            "end": "^\\1(@)\\s*?(\\S*?)\\s*?\\n",
+            "begin": "^(\\s*?)(<<)(.*?)(>>=)\\s*(.+)?\\s*\\n",
+            "end": "^\\1(@)\\s*(.+)?\\s*\\n",
             "endCaptures": {
                 "1": {
                     "name": "meta.tag.rsweave"

--- a/syntax/syntax-rsweave.json
+++ b/syntax/syntax-rsweave.json
@@ -1,0 +1,42 @@
+{
+    "fileTypes": [
+        "rsweave"
+    ],
+	"comments": {
+		"lineComment": "%"
+	},
+	"brackets": [
+		["{", "}"],
+		["[", "]"],
+		["(", ")"],
+		["\\left", "\\right"]
+	],
+	"autoClosingPairs": [
+		["{", "}"],
+		["[", "]"],
+		["(", ")"],
+		["`", "'"]
+	],
+	"surroundingPairs": [
+		["{", "}"],
+		["[", "]"],
+		["(", ")"],
+		["\"", "\""],
+		["'", "'"],
+		["`", "'"],
+		["$", "$"]
+	],
+	"indentationRules": {
+		"increaseIndentPattern": "(\\\\begin{(?!document))",
+		"decreaseIndentPattern": "(\\\\end{(?!document))"
+	},
+	"folding": {
+		"markers": {
+			"start": "^((\\s*?)<<.*?>>=(?:\\s*))$",
+			"end": "^(\\2@(?:\\s*))$"
+		}
+	},
+	"autoCloseBefore": ";:.,=}])>\\` \n\t$",
+	"wordPattern": "(__)|(\\*\\*)|(@.)|(\\.\\.\\.)|([^\\s`'\"~_!?|$#@%^&*\\-=+;:,.<>(){}[\\]\\\\\\/]{2,})"
+
+}


### PR DESCRIPTION
Added syntax highlighting for R code blocks in [Rnw documents](https://yihui.name/knitr/demo/minimal/). Tested with Yuki Oeda's [Ikuyadeu.r](https://marketplace.visualstudio.com/items?itemName=Ikuyadeu.r).

This is a screenshot from my editor:
![image](https://user-images.githubusercontent.com/13367887/66529660-254d6c80-eafc-11e9-8b94-2638f6271ccd.png)
