### PR TITLE
Add config option to modify commands in commands.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1350,6 +1350,14 @@
           "default": true,
           "markdownDescription": "Many snippets use PlaceHolders of the form ${\\d:some_text} for their argument. You may prefer to use TabStops ${\\d} instead, which allows for direct call to intellisense again. Default is true.\nReload vscode to make this configuration effective."
         },
+        "latex-workshop.intellisense.commandsJSON.replace": {
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "array"
+          },
+          "markdownDescription": "Array of pairs `[\"snippet name\", \"snippet action\"]` to replace the default snippets in `data/commands.json`. Snippet actions should not begin with a `\\`. See `data/commands.json` for which snippet names are available. An empty action string gets rid of the snippet. E.g. `[ [\"latexdisplaymath\", \"[ ${1} \\\\]\"], [\"figure\", \"\"] ]`"
+        },
         "latex-workshop.texdoc.path": {
           "type": "string",
           "default": "texdoc",

--- a/src/providers/completer/command.ts
+++ b/src/providers/completer/command.ts
@@ -33,9 +33,30 @@ export class Command {
     }
 
     initialize(defaultCmds: {[key: string]: DataItemEntry}, defaultEnvs: string[]) {
+        const replacementConfig = vscode.workspace.getConfiguration('latex-workshop').get('intellisense.commandsJSON.replace') as string[][]
+        const snippetNames: string[] = []
+        const snippetActions: string[] = []
+        replacementConfig.forEach(item => {
+            if (item.length !== 2) {
+                this.extension.logger.showErrorMessage('Elements of latex-workshop.intellisense.commandsJSON.replace must have length 2')
+            } else {
+                snippetNames.push(item[0])
+                snippetActions.push(item[1])
+            }
+        })
+
         // Initialize default commands and `latex-mathsymbols`
         Object.keys(defaultCmds).forEach(key => {
-            this.defaultCmds.push(this.entryToCompletion(defaultCmds[key]))
+            const index = snippetNames.indexOf(key)
+            if (index >= 0) {
+                const action = snippetActions[index]
+                if (action !== '') {
+                    defaultCmds[key].snippet = action
+                    this.defaultCmds.push(this.entryToCompletion(defaultCmds[key]))
+                }
+            } else {
+                this.defaultCmds.push(this.entryToCompletion(defaultCmds[key]))
+            }
         })
 
         // Initialize default env begin-end pairs, de-duplication


### PR DESCRIPTION
For example, #1755 can now be resolved by setting

```json
"latex-workshop.intellisense.commandsJSON.replace": [
    ["latexinlinemath", "( ${1} \\)"]
]
```

I, myself, want to use this to do the same thing with `latexdisplaymath` (i.e. add spaces to the snippet).

This also allows users to get rid of snippets in `data/commands.json` that they find annoying by simply setting an empty snippet action.
