### PR TITLE
Add commands to sort and align bibtex files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1446,7 +1446,7 @@
             "left": "{",
             "right": "}",
             "case": "lower",
-            "sort": "key"
+            "sort": ["key"]
           },
           "properties": {
             "tab": {
@@ -1470,9 +1470,9 @@
               "default": "lower"
             },
             "sort": {
-              "description": "What to sort by. Either the entry \"key\", \"author\" or \"title\".",
-              "type": "string",
-              "default": "key"
+              "description": "An array of strings to sort by. Either a bibtex field name (title, author, year, etc.) or \"key\" for the entry key. E.g. [\"author\", \"year\", \"title\"].",
+              "type": "array",
+              "default": ["key"]
             }
           }
         }

--- a/package.json
+++ b/package.json
@@ -1438,6 +1438,43 @@
             "Status Bar",
             "Notification Dialogue"
           ]
+        },
+        "latex-workshop.bibtex-format": {
+          "type": "object",
+          "default": {
+            "tab": "  ",
+            "left": "{",
+            "right": "}",
+            "case": "lower",
+            "sort": "key"
+          },
+          "properties": {
+            "tab": {
+              "description": "Indentation for each field.",
+              "type": "string",
+              "default": "  "
+            },
+            "left": {
+              "description": "Either { or \". Goes before every field value.",
+              "type": "string",
+              "default": "{"
+            },
+            "right": {
+              "description": "Either } or \". Goes after every field value.",
+              "type": "string",
+              "default": "}"
+            },
+            "case": {
+              "description": "Either \"upper\" or \"lower\". Determines if field names should be formatted like 'AUTHOR' or 'author'.",
+              "type": "string",
+              "default": "lower"
+            },
+            "sort": {
+              "description": "What to sort by. Either the entry \"key\", \"author\" or \"title\".",
+              "type": "string",
+              "default": "key"
+            }
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1470,7 +1470,7 @@
               "default": "lower"
             },
             "sort": {
-              "description": "An array of strings to sort by. Either a bibtex field name (title, author, year, etc.) or \"key\" for the entry key. E.g. [\"author\", \"year\", \"title\"].",
+              "description": "An array of strings to sort by. Either a bibtex field name (title, author, year, etc.), or \"year-desc\" to sort by year in descending order, or \"key\" for the entry key. E.g. [\"author\", \"year-desc\", \"title\"].",
               "type": "array",
               "default": ["key"]
             }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "onCommand:latex-workshop.citation",
     "onCommand:latex-workshop.compilerlog",
     "onCommand:latex-workshop.log",
-    "onCommand:latex-workshop.actions"
+    "onCommand:latex-workshop.actions",
+    "onCommand:latex-workshop.bibsort"
   ],
   "main": "./out/src/main.js",
   "contributes": {
@@ -314,6 +315,11 @@
       {
         "command": "latex-workshop.showSnippetPanel",
         "title": "Show Snippet Panel",
+        "category": "LaTeX Workshop"
+      },
+      {
+        "command": "latex-workshop.bibsort",
+        "title": "Sort BibTeX file",
         "category": "LaTeX Workshop"
       }
     ],

--- a/package.json
+++ b/package.json
@@ -40,7 +40,9 @@
     "onCommand:latex-workshop.compilerlog",
     "onCommand:latex-workshop.log",
     "onCommand:latex-workshop.actions",
-    "onCommand:latex-workshop.bibsort"
+    "onCommand:latex-workshop.bibsort",
+    "onCommand:latex-workshop.bibalign",
+    "onCommand:latex-workshop.bibalignsort"
   ],
   "main": "./out/src/main.js",
   "contributes": {
@@ -320,6 +322,16 @@
       {
         "command": "latex-workshop.bibsort",
         "title": "Sort BibTeX file",
+        "category": "LaTeX Workshop"
+      },
+      {
+        "command": "latex-workshop.bibalign",
+        "title": "Align BibTeX file",
+        "category": "LaTeX Workshop"
+      },
+      {
+        "command": "latex-workshop.bibalignsort",
+        "title": "Sort and align BibTeX file",
         "category": "LaTeX Workshop"
       }
     ],

--- a/package.json
+++ b/package.json
@@ -1439,42 +1439,43 @@
             "Notification Dialogue"
           ]
         },
-        "latex-workshop.bibtex-format": {
-          "type": "object",
-          "default": {
-            "tab": "  ",
-            "left": "{",
-            "right": "}",
-            "case": "lower",
-            "sort": ["key"]
+        "latex-workshop.bibtex-format.tab": {
+          "type": "string",
+          "enum": [
+            "2 spaces",
+            "4 spaces",
+            "tab"
+          ],
+          "default": "2 spaces",
+          "description": "Indentation for each field."
+        },
+        "latex-workshop.bibtex-format.surround": {
+          "type": "string",
+          "enum": [
+            "Curly braces",
+            "Quotation marks"
+          ],
+          "default": "Curly braces",
+          "description": "Surround each field value with either {Curly braces} or \"Quotation marks\"."
+        },
+        "latex-workshop.bibtex-format.case": {
+          "type": "string",
+          "enum": [
+            "UPPERCASE",
+            "lowercase"
+          ],
+          "default": "lowercase",
+          "description": "Determines if field names should be formatted like 'AUTHOR' or 'author'."
+        },
+        "latex-workshop.bibtex-format.sortby": {
+          "type": "array",
+          "items": {
+            "type": "string"
           },
-          "properties": {
-            "tab": {
-              "description": "Indentation for each field.",
-              "type": "string",
-              "default": "  "
-            },
-            "left": {
-              "description": "Either { or \". Goes before every field value.",
-              "type": "string",
-              "default": "{"
-            },
-            "right": {
-              "description": "Either } or \". Goes after every field value.",
-              "type": "string",
-              "default": "}"
-            },
-            "case": {
-              "description": "Either \"upper\" or \"lower\". Determines if field names should be formatted like 'AUTHOR' or 'author'.",
-              "type": "string",
-              "default": "lower"
-            },
-            "sort": {
-              "description": "An array of strings to sort by. Either a bibtex field name (title, author, year, etc.), or \"year-desc\" to sort by year in descending order, or \"key\" for the entry key. E.g. [\"author\", \"year-desc\", \"title\"].",
-              "type": "array",
-              "default": ["key"]
-            }
-          }
+          "markdownDescription": "An array of strings to sort by. Either a bibtex field name (title, author, year, etc.), or `\"year-desc\"` to sort by year in descending order, or `\"key\"` for the entry key. E.g. `[\"author\", \"year-desc\", \"title\"]`.",
+          "default": [
+            "key"
+          ]
         }
       }
     },

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -677,7 +677,16 @@ export class Commander {
         const t0 = performance.now() // Measure performance
         const ast = bibtexParser.parse(vscode.window.activeTextEditor.document.getText())
 
-        const configuration = vscode.workspace.getConfiguration('latex-workshop').get('bibtex-format') as bibtexUtils.BibtexFormatConfig
+        const config = vscode.workspace.getConfiguration('latex-workshop')
+        const leftright = config.get('bibtex-format.surround') === 'Curly braces' ? [ '{', '}' ] : [ '"', '"']
+        const tabs = { '2 spaces': '  ', '4 spaces': '    ', 'tab': '\t' }
+        const configuration: bibtexUtils.BibtexFormatConfig = {
+            tab: tabs[config.get('bibtex-format.tab') as ('2 spaces' | '4 spaces' | 'tab')],
+            case: config.get('bibtex-format.case') as ('UPPERCASE' | 'lowercase'),
+            left: leftright[0],
+            right: leftright[1],
+            sort: config.get('bibtex-format.sortby') as string[]
+        }
 
         const entries: bibtexParser.Entry[] = []
         const entryLocations: vscode.Range[] = []

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -695,7 +695,7 @@ export class Commander {
 
         let sortedEntryLocations: vscode.Range[] = []
         if (sort) {
-            entries.sort(bibtexUtils.bibtexSortBy(configuration.sort)).forEach(entry => {
+            entries.sort(bibtexUtils.bibtexSort(configuration.sort)).forEach(entry => {
                 sortedEntryLocations.push((new vscode.Range(
                     entry.location.start.line - 1,
                     entry.location.start.column - 1,

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -677,6 +677,8 @@ export class Commander {
         const t0 = performance.now() // Measure performance
         const ast = bibtexParser.parse(vscode.window.activeTextEditor.document.getText())
 
+        const configuration = vscode.workspace.getConfiguration('latex-workshop').get('bibtex-format') as bibtexUtils.BibtexFormatConfig
+
         const entries: bibtexParser.Entry[] = []
         const entryLocations: vscode.Range[] = []
         ast.content.forEach(item => {
@@ -693,15 +695,7 @@ export class Commander {
 
         let sortedEntryLocations: vscode.Range[] = []
         if (sort) {
-            entries.sort((a, b) => {
-                if (!a.internalKey) {
-                    return -1 // sort undefined keys first
-                } else if (!b.internalKey) {
-                    return 1
-                } else {
-                    return a.internalKey.localeCompare(b.internalKey)
-                }
-            }).forEach(entry => {
+            entries.sort(bibtexUtils.bibtexSortBy(configuration.sort)).forEach(entry => {
                 sortedEntryLocations.push((new vscode.Range(
                     entry.location.start.line - 1,
                     entry.location.start.column - 1,
@@ -718,7 +712,7 @@ export class Commander {
         let text: string
         for (let i = 0; i < entries.length; i++) {
             if (align) {
-                text = bibtexUtils.bibtexFormat(entries[i])
+                text = bibtexUtils.bibtexFormat(entries[i], configuration)
             } else {
                 text = vscode.window.activeTextEditor.document.getText(sortedEntryLocations[i])
             }

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -668,6 +668,60 @@ export class Commander {
         vscode.workspace.openTextDocument({content: JSON.stringify(ast, null, 2), language: 'json'}).then(doc => vscode.window.showTextDocument(doc))
     }
 
+    bibSort() {
+        if (vscode.window.activeTextEditor === undefined || vscode.window.activeTextEditor.document.languageId !== 'bibtex') {
+            return
+        }
+        const ast = bibtexParser.parse(vscode.window.activeTextEditor.document.getText())
+
+        const entries: bibtexParser.Entry[] = []
+        const entryLocations: vscode.Range[] = []
+        ast.content.forEach(item => {
+            if (bibtexParser.isEntry(item)) {
+                entries.push(item)
+                // latex-utilities uses 1-based locations whereas VSCode uses 0-based
+                entryLocations.push(new vscode.Range(
+                    item.location.start.line - 1,
+                    item.location.start.column - 1,
+                    item.location.end.line - 1,
+                    item.location.end.column - 1))
+            }
+        })
+
+        // Sort entries by key
+        const sortedEntryLocations: vscode.Range[] = []
+        entries.sort((a, b) => {
+            if (!a.internalKey) {
+                return -1 // sort undefined keys first
+            } else if (!b.internalKey) {
+                return 1
+            } else {
+                return a.internalKey.localeCompare(b.internalKey)
+            }
+        }).forEach(entry => {
+            sortedEntryLocations.push((new vscode.Range(
+                entry.location.start.line - 1,
+                entry.location.start.column - 1,
+                entry.location.end.line - 1,
+                entry.location.end.column - 1)))
+        })
+
+        // Successively replace the text in the current location from the sorted location
+        const edit = new vscode.WorkspaceEdit()
+        const uri = vscode.window.activeTextEditor.document.uri
+        for (let i = 0; i < entries.length; i++) {
+            edit.replace(uri, entryLocations[i], vscode.window.activeTextEditor.document.getText(sortedEntryLocations[i]))
+        }
+
+        vscode.workspace.applyEdit(edit).then(success => {
+            if (success) {
+                this.extension.logger.addLogMessage('Successfully sorted bibliography')
+            } else {
+                this.extension.logger.showErrorMessage('Something went wrong while sorting the bibliography')
+            }
+        })
+    }
+
     texdoc(pkg?: string) {
         this._texdoc.texdoc(pkg)
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -280,6 +280,8 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('latex-workshop.showCompilationPanel', () => extension.buildInfo.showPanel())
     vscode.commands.registerCommand('latex-workshop.showSnippetPanel', () => extension.snippetPanel.showPanel())
 
+    vscode.commands.registerCommand('latex-workshop.bibsort', () => extension.commander.bibSort())
+
     context.subscriptions.push(vscode.workspace.onDidSaveTextDocument( (e: vscode.TextDocument) => {
         if (extension.manager.hasTexId(e.languageId)) {
             extension.linter.lintRootFileIfEnabled()

--- a/src/main.ts
+++ b/src/main.ts
@@ -280,7 +280,9 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('latex-workshop.showCompilationPanel', () => extension.buildInfo.showPanel())
     vscode.commands.registerCommand('latex-workshop.showSnippetPanel', () => extension.snippetPanel.showPanel())
 
-    vscode.commands.registerCommand('latex-workshop.bibsort', () => extension.commander.bibSort())
+    vscode.commands.registerCommand('latex-workshop.bibsort', () => extension.commander.bibtexFormat(true, false))
+    vscode.commands.registerCommand('latex-workshop.bibalign', () => extension.commander.bibtexFormat(false, true))
+    vscode.commands.registerCommand('latex-workshop.bibalignsort', () => extension.commander.bibtexFormat(true, true))
 
     context.subscriptions.push(vscode.workspace.onDidSaveTextDocument( (e: vscode.TextDocument) => {
         if (extension.manager.hasTexId(e.languageId)) {

--- a/src/utils/bibtexutils.ts
+++ b/src/utils/bibtexutils.ts
@@ -19,6 +19,8 @@ export function bibtexSort(keys: string[]): (a: bibtexParser.Entry, b: bibtexPar
             // Select the appropriate sort function
             if (key === 'key') {
                 r = bibtexSortByKey(a, b)
+            } else if (key === 'year-desc') {
+                r = -bibtexSortByField('year', a, b)
             } else {
                 r = bibtexSortByField(key, a, b)
             }

--- a/src/utils/bibtexutils.ts
+++ b/src/utils/bibtexutils.ts
@@ -4,7 +4,7 @@ export interface BibtexFormatConfig {
     tab: string,
     left: string,
     right: string,
-    case: 'upper' | 'lower',
+    case: 'UPPERCASE' | 'lowercase',
     sort: string[]
 }
 
@@ -90,7 +90,7 @@ export function bibtexFormat(entry: bibtexParser.Entry, config: BibtexFormatConf
     })
 
     entry.content.forEach(field => {
-        s += ',\n' + config.tab + (config.case === 'lower' ? field.name : field.name.toUpperCase())
+        s += ',\n' + config.tab + (config.case === 'lowercase' ? field.name : field.name.toUpperCase())
         s += ' '.repeat(maxFieldLength - field.name.length) + ' = '
         s += fieldToString(field.value, config.left, config.right)
     })

--- a/src/utils/bibtexutils.ts
+++ b/src/utils/bibtexutils.ts
@@ -1,0 +1,36 @@
+import {bibtexParser} from 'latex-utensils'
+
+export function bibtexFormat(entry: bibtexParser.Entry): string {
+    let s = ''
+    const tab = '  '
+
+    s += '@' + entry.entryType + '{' + (entry.internalKey ? entry.internalKey : '')
+
+    // Find the longest field name in entry
+    let maxFieldLength = 0
+    entry.content.forEach(field => {
+        maxFieldLength = Math.max(maxFieldLength, field.name.length)
+    })
+
+    entry.content.forEach(field => {
+        s += ',\n' + tab + field.name + ' '.repeat(maxFieldLength - field.name.length) + ' = ' + fieldToString(field.value)
+    })
+
+    s += '\n}'
+
+    return s
+}
+
+function fieldToString(field: bibtexParser.FieldValue): string {
+    switch(field.kind) {
+        case 'abbreviation':
+        case 'number':
+            return field.content
+        case 'text_string':
+            return '{' + field.content + '}'
+        case 'concat':
+            return field.content.map(value => fieldToString(value)).reduce((acc, cur) => {return acc + ' # ' + cur})
+        default:
+            return ''
+    }
+}


### PR DESCRIPTION
This was talked about in #1772. This isn't all the features we want yet (I think) but I think it is also helpful to know what the function will look like.

The logical structure is

1. Parse the file using `latex-utilities`
2. Create an array of initial locations
3. Sort the entries and create an array of final locations
4. Successively copy the sorted text to the original positions