### PR TITLE
use workerpool for MathPreview. Related to #1788

### DIFF
--- a/src/providers/preview/mathjaxpool.ts
+++ b/src/providers/preview/mathjaxpool.ts
@@ -1,0 +1,29 @@
+import {Extension} from '../../main'
+import * as path from 'path'
+import * as workerpool from 'workerpool'
+
+type TypesetArg = {
+    width?: number,
+    equationNumbers?: string,
+    math: string,
+    format: string,
+    svgNode: boolean,
+    state?: any
+}
+
+export class MathJaxPool {
+    extension: Extension
+    pool: workerpool.WorkerPool
+    constructor(extension: Extension) {
+        this.extension = extension
+        this.pool = workerpool.pool(
+            path.join(__dirname, 'mathjaxpool_worker.js'),
+            { minWorkers: 1, maxWorkers: 1, workerType: 'process' }
+        )
+    }
+
+    async typeset(arg: TypesetArg, opts: { scale: number, color: string }): Promise<string> {
+        return await this.pool.exec('typeset', [arg, opts]).timeout(3000)
+    }
+
+}

--- a/src/providers/preview/mathjaxpool_worker.ts
+++ b/src/providers/preview/mathjaxpool_worker.ts
@@ -1,0 +1,50 @@
+import * as workerpool from 'workerpool'
+import * as mj from 'mathjax-node'
+
+mj.config({
+    MathJax: {
+        jax: ['input/TeX', 'output/SVG'],
+        extensions: ['tex2jax.js', 'MathZoom.js'],
+        showMathMenu: false,
+        showProcessingMessages: false,
+        messageStyle: 'none',
+        SVG: {
+            useGlobalCache: false
+        },
+        TeX: {
+            extensions: ['AMSmath.js', 'AMSsymbols.js', 'autoload-all.js', 'color.js', 'noUndefined.js']
+        }
+    }
+})
+mj.start()
+
+function scaleSVG(data: any, scale: number) {
+    const svgelm = data.svgNode
+    // w0[2] and h0[2] are units, i.e., pt, ex, em, ...
+    const w0 = svgelm.getAttribute('width').match(/([.\d]+)(\w*)/)
+    const h0 = svgelm.getAttribute('height').match(/([.\d]+)(\w*)/)
+    const w = scale * Number(w0[1])
+    const h = scale * Number(h0[1])
+    svgelm.setAttribute('width', w + w0[2])
+    svgelm.setAttribute('height', h + h0[2])
+}
+
+function colorSVG(svg: string, color: string): string {
+    const ret = svg.replace('</title>', `</title><style> * { color: ${color} }</style>`)
+    return ret
+}
+
+export async function typeset(arg: any, opts: { scale: number, color: string }) {
+    try {
+        const data = await mj.typeset(arg)
+        scaleSVG(data, opts.scale)
+        const xml = colorSVG(data.svgNode.outerHTML, opts.color)
+        return xml
+    } catch(e) {
+        return e.stack
+    }
+}
+
+workerpool.worker({
+    typeset
+})

--- a/src/providers/preview/mathjaxpool_worker.ts
+++ b/src/providers/preview/mathjaxpool_worker.ts
@@ -34,15 +34,11 @@ function colorSVG(svg: string, color: string): string {
     return ret
 }
 
-export async function typeset(arg: any, opts: { scale: number, color: string }) {
-    try {
-        const data = await mj.typeset(arg)
-        scaleSVG(data, opts.scale)
-        const xml = colorSVG(data.svgNode.outerHTML, opts.color)
-        return xml
-    } catch(e) {
-        return e.stack
-    }
+export async function typeset(arg: any, opts: { scale: number, color: string }): Promise<string> {
+    const data = await mj.typeset(arg)
+    scaleSVG(data, opts.scale)
+    const xml = colorSVG(data.svgNode.outerHTML, opts.color)
+    return xml
 }
 
 workerpool.worker({

--- a/types/mathjax-node/index.d.ts
+++ b/types/mathjax-node/index.d.ts
@@ -1,2 +1,3 @@
 export const config: any
 export function start(): any
+export function typeset(arg: any): Promise<any>


### PR DESCRIPTION
Use workerpool for MathPreview. Related to #1788 and #1795.

I guess that the cause of #1788  and #1795 is MathJax takes a long time to render math preview. The following is the detail:

1. Lots of files in a fls file are parsed.
2. All the commands, `\newcommand` and others,  in these files are appended to a TeX equation MathJax tries to render. This feature has been merged in #1729.
3. MathJax takes a long time to render the equation, or it ends with an error. An error message is mentioned as `TeX parse error: MathJax internal buffer size exceeded; is there a recursive macro call?` in #1795.

#1729 has been merged between v8.2.0 and v.8.3.0. This explains why this problem [does not occur in v8.2.0](https://github.com/James-Yu/LaTeX-Workshop/issues/1788#issuecomment-552146668).

This PR makes MathJax run in a child process and terminate it if it does not end a rendering task in 3 seconds.