### PR TITLE
Tweak section level shift

### DIFF
--- a/package.json
+++ b/package.json
@@ -382,25 +382,25 @@
         "key": "ctrl+l ]",
         "mac": "cmd+l ]",
         "when": "editorTextFocus && !editorReadonly && editorLangId == 'latex' && config.latex-workshop.bind.altKeymap.enabled",
-        "command": "latex-workshop.increment-sectioning"
+        "command": "latex-workshop.promote-sectioning"
       },
       {
         "key": "ctrl+l [",
         "mac": "cmd+l [",
         "when": "editorTextFocus && !editorReadonly && editorLangId == 'latex'&& config.latex-workshop.bind.altKeymap.enabled",
-        "command": "latex-workshop.decrement-sectioning"
+        "command": "latex-workshop.demote-sectioning"
       },
       {
         "key": "ctrl+alt+]",
         "mac": "cmd+alt+]",
         "when": "editorTextFocus && !editorReadonly && editorLangId == 'latex' && !config.latex-workshop.bind.altKeymap.enabled",
-        "command": "latex-workshop.increment-sectioning"
+        "command": "latex-workshop.promote-sectioning"
       },
       {
         "key": "ctrl+alt+[",
         "mac": "cmd+alt+[",
         "when": "editorTextFocus && !editorReadonly && editorLangId == 'latex'&& !config.latex-workshop.bind.altKeymap.enabled",
-        "command": "latex-workshop.decrement-sectioning"
+        "command": "latex-workshop.demote-sectioning"
       },
       {
         "key": "ctrl+l ctrl+enter",

--- a/package.json
+++ b/package.json
@@ -302,6 +302,16 @@
         "category": "LaTeX Workshop"
       },
       {
+        "command": "latex-workshop.promote-sectioning",
+        "title": "Promote all the section levels used in the selection",
+        "category": "LaTeX Workshop"
+      },
+      {
+        "command": "latex-workshop.demote-sectioning",
+        "title": "Demote all the section levels used in the selection",
+        "category": "LaTeX Workshop"
+      },
+      {
         "command": "latex-workshop.showCompilationPanel",
         "title": "Show LaTeX Compilation Info",
         "category": "LaTeX Workshop"

--- a/package.json
+++ b/package.json
@@ -379,27 +379,27 @@
         "when": "!config.latex-workshop.bind.altKeymap.enabled"
       },
       {
-        "key": "ctrl+l ]",
-        "mac": "cmd+l ]",
-        "when": "editorTextFocus && !editorReadonly && editorLangId == 'latex' && config.latex-workshop.bind.altKeymap.enabled",
-        "command": "latex-workshop.promote-sectioning"
-      },
-      {
         "key": "ctrl+l [",
         "mac": "cmd+l [",
         "when": "editorTextFocus && !editorReadonly && editorLangId == 'latex'&& config.latex-workshop.bind.altKeymap.enabled",
-        "command": "latex-workshop.demote-sectioning"
+        "command": "latex-workshop.promote-sectioning"
       },
       {
-        "key": "ctrl+alt+]",
-        "mac": "cmd+alt+]",
-        "when": "editorTextFocus && !editorReadonly && editorLangId == 'latex' && !config.latex-workshop.bind.altKeymap.enabled",
-        "command": "latex-workshop.promote-sectioning"
+        "key": "ctrl+l ]",
+        "mac": "cmd+l ]",
+        "when": "editorTextFocus && !editorReadonly && editorLangId == 'latex' && config.latex-workshop.bind.altKeymap.enabled",
+        "command": "latex-workshop.demote-sectioning"
       },
       {
         "key": "ctrl+alt+[",
         "mac": "cmd+alt+[",
         "when": "editorTextFocus && !editorReadonly && editorLangId == 'latex'&& !config.latex-workshop.bind.altKeymap.enabled",
+        "command": "latex-workshop.promote-sectioning"
+      },
+      {
+        "key": "ctrl+alt+]",
+        "mac": "cmd+alt+]",
+        "when": "editorTextFocus && !editorReadonly && editorLangId == 'latex' && !config.latex-workshop.bind.altKeymap.enabled",
         "command": "latex-workshop.demote-sectioning"
       },
       {

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -544,8 +544,8 @@ export class Commander {
      * Shift the level sectioning in the selection by one (up or down)
      * @param change
      */
-    shiftSectioningLevel(change: 'increment' | 'decrement') {
-        if (change !== 'increment' && change !== 'decrement') {
+    shiftSectioningLevel(change: 'promote' | 'demote') {
+        if (change !== 'promote' && change !== 'demote') {
             throw TypeError(
             `Invalid value of function parameter 'change' (=${change})`
             )
@@ -556,7 +556,7 @@ export class Commander {
             return
         }
 
-        const increments = {
+        const promotes = {
             part: 'part',
             chapter: 'part',
             section: 'chapter',
@@ -565,7 +565,7 @@ export class Commander {
             paragraph: 'subsubsection',
             subparagraph: 'paragraph'
         }
-        const decrements = {
+        const demotes = {
             part: 'chapter',
             chapter: 'section',
             section: 'subsection',
@@ -577,15 +577,15 @@ export class Commander {
 
         function replacer(
             _match: string,
-            sectionName: keyof typeof increments ,
+            sectionName: keyof typeof promotes ,
             options: string,
             contents: string
         ) {
-            if (change === 'increment') {
-                return '\\' + increments[sectionName] + (options ? options : '') + contents
+            if (change === 'promote') {
+                return '\\' + promotes[sectionName] + (options ? options : '') + contents
             } else {
-                // if (change === 'decrement')
-                return '\\' + decrements[sectionName] + (options ? options : '') + contents
+                // if (change === 'demote')
+                return '\\' + demotes[sectionName] + (options ? options : '') + contents
             }
         }
 

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -590,7 +590,7 @@ export class Commander {
         }
 
         // when supported, negative lookbehind at start would be nice --- (?<!\\)
-        const pattern = /\\(part|chapter|section|subsection|subsection|subsubsection|paragraph|subparagraph)(\[.+?\])?(\{.+?\})/g
+        const pattern = /\\(part|chapter|section|subsection|subsection|subsubsection|paragraph|subparagraph)(\[.+?\])?(\{.*\})/g
 
         function getLastLineLength(someText: string) {
             const lines = someText.split(/\n/)

--- a/src/main.ts
+++ b/src/main.ts
@@ -265,8 +265,8 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('latex-workshop.shortcut.mathcal', () => extension.commander.toggleSelectedKeyword('mathcal'))
     vscode.commands.registerCommand('latex-workshop.surround', () => extension.completer.command.surround())
 
-    vscode.commands.registerCommand('latex-workshop.increment-sectioning', () => extension.commander.shiftSectioningLevel('increment'))
-    vscode.commands.registerCommand('latex-workshop.decrement-sectioning', () => extension.commander.shiftSectioningLevel('decrement'))
+    vscode.commands.registerCommand('latex-workshop.promote-sectioning', () => extension.commander.shiftSectioningLevel('promote'))
+    vscode.commands.registerCommand('latex-workshop.demote-sectioning', () => extension.commander.shiftSectioningLevel('demote'))
 
     vscode.commands.registerCommand('latex-workshop.showCompilationPanel', () => extension.buildInfo.showPanel())
     vscode.commands.registerCommand('latex-workshop.showSnippetPanel', () => extension.snippetPanel.showPanel())


### PR DESCRIPTION
This mostly has no effect on functionality, so I'll just go through my reasoning behind the changes.

- Allow for section level shift for blank title
  - I've experienced the scenario where I type `SPG 🡒 \paragraph{}` and then think, actually this should be a sub-section.
  - Can't think of a good reason not to allow this
- Rename section shift increment/decrement to promote/demote
  - To me this naming makes more sense, it's not a counter
- Switch section shift keybindings to follow meaning of default indent/deindent keybindings
  - VScode has 
    - `ctrl`+`[` to indent, increases 'importance'/'priority' of line
    - `ctrl`+`]`to de-indent, decreases 'importance'/'priority' of line
  - I recently reconsidered they default keybindings I set for this (after instictively using these keybindings the wrong way around), and came to the conclusion that I got it the wrong way around
      - keybindings should follow the same 'meaning' as VSCode's indentation keybindings
      - `ctrl`+`alt`+`[` should _increace_ priority of section level
      - `ctrl`+`alt`+`]` should _decreace_ priority of section level
    - For affected users, this change is fairly easy to adjust to
- Add section shift to the command palette
  - I think this is a nice feature, perhaps this may help with discoverability
