### PR TITLE
use workerpool for bibtexParser and parsePreamble

### DIFF
--- a/src/commander.ts
+++ b/src/commander.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode'
 import * as fs from 'fs-extra'
 import * as path from 'path'
-import {latexParser, bibtexParser} from 'latex-utensils'
+import {bibtexParser} from 'latex-utensils'
 
 import {Extension} from './main'
 import {getLongestBalancedString} from './utils/utils'
@@ -654,28 +654,28 @@ export class Commander {
         this.extension.logParser.parse(vscode.window.activeTextEditor.document.getText())
     }
 
-    devParseTeX() {
+    async devParseTeX() {
         if (vscode.window.activeTextEditor === undefined) {
             return
         }
-        const ast = latexParser.parse(vscode.window.activeTextEditor.document.getText())
+        const ast = await this.extension.pegParser.parseLatex(vscode.window.activeTextEditor.document.getText())
         vscode.workspace.openTextDocument({content: JSON.stringify(ast, null, 2), language: 'json'}).then(doc => vscode.window.showTextDocument(doc))
     }
 
-    devParseBib() {
+    async devParseBib() {
         if (vscode.window.activeTextEditor === undefined) {
             return
         }
-        const ast = bibtexParser.parse(vscode.window.activeTextEditor.document.getText())
+        const ast = await this.extension.pegParser.parseBibtex(vscode.window.activeTextEditor.document.getText())
         vscode.workspace.openTextDocument({content: JSON.stringify(ast, null, 2), language: 'json'}).then(doc => vscode.window.showTextDocument(doc))
     }
 
-    bibtexFormat(sort: boolean, align: boolean) {
+    async bibtexFormat(sort: boolean, align: boolean) {
         if (vscode.window.activeTextEditor === undefined || vscode.window.activeTextEditor.document.languageId !== 'bibtex') {
             return
         }
         const t0 = performance.now() // Measure performance
-        const ast = bibtexParser.parse(vscode.window.activeTextEditor.document.getText())
+        const ast = await this.extension.pegParser.parseBibtex(vscode.window.activeTextEditor.document.getText())
 
         const config = vscode.workspace.getConfiguration('latex-workshop')
         const leftright = config.get('bibtex-format.surround') === 'Curly braces' ? [ '{', '}' ] : [ '"', '"']

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -712,14 +712,11 @@ export class Manager {
 
     // This function updates all completers upon tex-file changes, or active file content is changed.
     async updateCompleter(file: string, content: string) {
-        const configuration = vscode.workspace.getConfiguration('latex-workshop')
         this.extension.completer.citation.update(file, content)
         // Here we use this delay config. Otherwise, multiple updates may run
         // concurrently if the actual parsing time is greater than that of
         // the keypress delay.
-        const latexAst = await this.extension.pegParser.parseLatex(content,
-            { timeout: configuration.get('intellisense.update.delay', 1000) }
-        )
+        const latexAst = await this.extension.pegParser.parseLatex(content)
         if (latexAst) {
             const nodes = latexAst.content
             const lines = content.split('\n')

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -639,13 +639,13 @@ export class Manager {
     }
 
     private onWatchedFileChanged(file: string) {
+        this.extension.logger.addLogMessage(`File watcher: responding to change in ${file}`)
         // It is possible for either tex or non-tex files in the watcher.
         if (['.tex', '.bib'].includes(path.extname(file)) &&
             !file.includes('expl3-code.tex')) {
             this.parseFileAndSubs(file, true)
             this.updateCompleterOnChange(file)
         }
-        this.extension.logger.addLogMessage(`File watcher: responding to change in ${file}`)
         this.buildOnFileChanged(file)
     }
 

--- a/src/components/parser/syntax.ts
+++ b/src/components/parser/syntax.ts
@@ -1,6 +1,5 @@
 import {latexParser, bibtexParser} from 'latex-utensils'
 import * as path from 'path'
-import * as vscode from 'vscode'
 import * as workerpool from 'workerpool'
 
 import {Extension} from '../../main'
@@ -17,10 +16,8 @@ export class UtensilsParser {
     }
 
     async parseLatex(s: string, options?: latexParser.ParserOptions): Promise<latexParser.LatexAst | undefined> {
-        const configuration = vscode.workspace.getConfiguration('latex-workshop')
-        const timeout = configuration.get('intellisense.update.delay', 1000)
         try {
-            return await this.pool.exec('parseLatex', [s, options]).timeout(timeout)
+            return await this.pool.exec('parseLatex', [s, options]).timeout(3000)
         } catch(e) {
             return undefined
         }
@@ -31,7 +28,7 @@ export class UtensilsParser {
     }
 
     async parseBibtex(s: string, options?: bibtexParser.ParserOptions): Promise<bibtexParser.BibtexAst> {
-        return await this.pool.exec('parseBibtex', [s, options])
+        return await this.pool.exec('parseBibtex', [s, options]).timeout(30000)
     }
 
 }

--- a/src/components/parser/syntax.ts
+++ b/src/components/parser/syntax.ts
@@ -1,7 +1,9 @@
-import {Extension} from '../../main'
+import {latexParser, bibtexParser} from 'latex-utensils'
 import * as path from 'path'
+import * as vscode from 'vscode'
 import * as workerpool from 'workerpool'
-import {latexParser} from 'latex-utensils'
+
+import {Extension} from '../../main'
 
 export class UtensilsParser {
     extension: Extension
@@ -14,7 +16,18 @@ export class UtensilsParser {
         )
     }
 
-    parseLatex(s: string, options: latexParser.ParserOptions): workerpool.Promise<latexParser.LatexAst | undefined> {
-        return this.pool.exec('parseLatex', [s, options])
+    async parseLatex(s: string, options?: latexParser.ParserOptions): Promise<latexParser.LatexAst | undefined> {
+        const configuration = vscode.workspace.getConfiguration('latex-workshop')
+        const timeout = configuration.get('intellisense.update.delay', 1000)
+        try {
+            return await this.pool.exec('parseLatex', [s, options]).timeout(timeout)
+        } catch(e) {
+            return undefined
+        }
     }
+
+    async parseBibtex(s: string, options?: bibtexParser.ParserOptions): Promise<bibtexParser.BibtexAst> {
+        return await this.pool.exec('parseBibtex', [s, options])
+    }
+
 }

--- a/src/components/parser/syntax.ts
+++ b/src/components/parser/syntax.ts
@@ -26,6 +26,10 @@ export class UtensilsParser {
         }
     }
 
+    async parseLatexPreamble(s: string): Promise<latexParser.AstPreamble> {
+        return await this.pool.exec('parseLatexPreamble', [s]).timeout(500)
+    }
+
     async parseBibtex(s: string, options?: bibtexParser.ParserOptions): Promise<bibtexParser.BibtexAst> {
         return await this.pool.exec('parseBibtex', [s, options])
     }

--- a/src/components/parser/syntax.ts
+++ b/src/components/parser/syntax.ts
@@ -12,7 +12,7 @@ export class UtensilsParser {
         this.extension = extension
         this.pool = workerpool.pool(
             path.join(__dirname, 'syntax_worker.js'),
-            { maxWorkers: 1, workerType: 'process' }
+            { minWorkers: 1, maxWorkers: 1, workerType: 'process' }
         )
     }
 

--- a/src/components/parser/syntax_worker.ts
+++ b/src/components/parser/syntax_worker.ts
@@ -5,11 +5,16 @@ function parseLatex(s: string, options?: latexParser.ParserOptions): latexParser
     return latexParser.parse(s, options)
 }
 
+function parseLatexPreamble(s: string): latexParser.LatexAst {
+    return latexParser.parsePreamble(s)
+}
+
 function parseBibtex(s: string, options?: bibtexParser.ParserOptions): bibtexParser.BibtexAst {
     return bibtexParser.parse(s, options)
 }
 
 workerpool.worker({
     parseLatex,
+    parseLatexPreamble,
     parseBibtex
 })

--- a/src/components/parser/syntax_worker.ts
+++ b/src/components/parser/syntax_worker.ts
@@ -1,14 +1,15 @@
-import {latexParser} from 'latex-utensils'
+import {latexParser, bibtexParser} from 'latex-utensils'
 import * as workerpool from 'workerpool'
 
-function parseLatex(s: string, options: latexParser.ParserOptions) {
-    try {
-        return latexParser.parse(s, options)
-    } catch (e) {
-        return undefined
-    }
+function parseLatex(s: string, options?: latexParser.ParserOptions): latexParser.LatexAst {
+    return latexParser.parse(s, options)
+}
+
+function parseBibtex(s: string, options?: bibtexParser.ParserOptions): bibtexParser.BibtexAst {
+    return bibtexParser.parse(s, options)
 }
 
 workerpool.worker({
-    parseLatex
+    parseLatex,
+    parseBibtex
 })

--- a/src/providers/completer/citation.ts
+++ b/src/providers/completer/citation.ts
@@ -145,7 +145,7 @@ export class Citation {
         return suggestions
     }
 
-    parseBibFile(file: string) {
+    async parseBibFile(file: string) {
         this.extension.logger.addLogMessage(`Parsing .bib entries from ${file}`)
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         if (fs.statSync(file).size >= (configuration.get('intellisense.citation.maxfilesizeMB') as number) * 1024 * 1024) {
@@ -156,7 +156,9 @@ export class Citation {
             return
         }
         this.bibEntries[file] = []
-        bibtexParser.parse(fs.readFileSync(file).toString()).content
+        const bibtex = fs.readFileSync(file).toString()
+        const ast = await this.extension.pegParser.parseBibtex(bibtex)
+        ast.content
             .filter(bibtexParser.isEntry)
             .forEach((entry: bibtexParser.Entry) => {
                 if (entry.internalKey === undefined) {

--- a/src/providers/preview/mathpreview.ts
+++ b/src/providers/preview/mathpreview.ts
@@ -61,17 +61,17 @@ export class MathPreview {
             return commandsInConfigFile
         }
         let commands: string[] = []
-        this.extension.manager.getIncludedTeX().forEach(tex => {
+        for (const tex of this.extension.manager.getIncludedTeX()) {
             const content = this.extension.manager.cachedContent[tex].content
-            commands = commands.concat(this.findNewCommand(content))
-        })
+            commands = commands.concat(await this.findNewCommand(content))
+        }
         return commandsInConfigFile + '\n' + commands.join('')
     }
 
-    private findNewCommand(content: string): string[] {
+    private async findNewCommand(content: string): Promise<string[]> {
         let commands: string[] = []
         try {
-            const ast = latexParser.parsePreamble(content)
+            const ast = await this.extension.pegParser.parseLatexPreamble(content)
             const regex = /((re)?new|provide)command(\\*)?|DeclareMathOperator(\\*)?/
             for (const node of ast.content) {
                 if (latexParser.isCommand(node) && node.name.match(regex)) {

--- a/src/providers/preview/mathpreview.ts
+++ b/src/providers/preview/mathpreview.ts
@@ -61,7 +61,12 @@ export class MathPreview {
             return commandsInConfigFile
         }
         let commands: string[] = []
+        let exceeded = false
+        setTimeout( () => { exceeded = true }, 5000)
         for (const tex of this.extension.manager.getIncludedTeX()) {
+            if (exceeded) {
+                throw new Error('Timeout Error in findProjectNewCommand')
+            }
             const content = this.extension.manager.cachedContent[tex].content
             commands = commands.concat(await this.findNewCommand(content))
         }


### PR DESCRIPTION
use `workerpool` for `bibtexParser` and `parsePreamble`. 

Related to #1788 and #1797. `parsePreamble` also can freeze the extension host. We should use `workerpool` for it.