### PR TITLE
Replace placeholders in external build arguments

### DIFF
--- a/src/commander.ts
+++ b/src/commander.ts
@@ -68,13 +68,13 @@ export class Commander {
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         const externalBuildCommand = configuration.get('latex.external.build.command') as string
         const externalBuildArgs = configuration.get('latex.external.build.args') as string[]
+        if (rootFile === undefined && this.extension.manager.hasTexId(vscode.window.activeTextEditor.document.languageId)) {
+            rootFile = await this.extension.manager.findRoot()
+        }
         if (externalBuildCommand) {
             const pwd = path.dirname(rootFile ? rootFile : vscode.window.activeTextEditor.document.fileName)
             await this.extension.builder.buildWithExternalCommand(externalBuildCommand, externalBuildArgs, pwd, rootFile)
             return
-        }
-        if (rootFile === undefined && this.extension.manager.hasTexId(vscode.window.activeTextEditor.document.languageId)) {
-            rootFile = await this.extension.manager.findRoot()
         }
         if (rootFile === undefined) {
             this.extension.logger.addLogMessage('Cannot find LaTeX root file.')

--- a/src/components/builder.ts
+++ b/src/components/builder.ts
@@ -87,7 +87,7 @@ export class Builder {
         }
         this.currentProcess = cp.spawn(command, args, {cwd: wd})
         const pid = this.currentProcess.pid
-        this.extension.logger.addLogMessage(`LaTeX buid process as an external command spawned. PID: ${pid}.`)
+        this.extension.logger.addLogMessage(`External build process spawned. PID: ${pid}.`)
 
         let stdout = ''
         this.currentProcess.stdout.on('data', newStdout => {

--- a/src/components/builder.ts
+++ b/src/components/builder.ts
@@ -79,7 +79,7 @@ export class Builder {
         }
         const releaseBuildMutex = await this.preprocess()
         this.extension.logger.displayStatus('sync~spin', 'statusBar.foreground')
-        this.extension.logger.addLogMessage(`Build using the external command: ${command} ${args ? args.join(' '): ''}`)
+        this.extension.logger.addLogMessage(`Build using the external command: ${command} ${args.length > 0 ? args.join(' '): ''}`)
         let wd = pwd
         const ws = vscode.workspace.workspaceFolders
         if (ws && ws.length > 0) {


### PR DESCRIPTION
Closes #1816.

I've changed `commander.ts` so that `buildWithExternalCommand` can only be called if the `rootFile` is defined. I didn't see a reason to allow calls to `buildWithExternalCommand` with an undefined `rootFile`.