### PR TITLE
load (and cache) PDF preview directly from disk for \includegraphics completion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -319,11 +319,6 @@
       "resolved": "https://registry.npmjs.org/@tamuratak/domstubs/-/domstubs-0.1.1.tgz",
       "integrity": "sha512-UvZYDOp/cpqNttuc6w6RxuoPusA1Alfy3i84dVgy2pPUQ+7fovk09IRuabCATnMZi4phmPFgUlO3z0Y6viSOfw=="
     },
-    "@types/base64-js": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@types/base64-js/-/base64-js-1.2.5.tgz",
-      "integrity": "sha1-WCskdhaabLpGCiFNR2x0REHYc9U="
-    },
     "@types/braces": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/braces/-/braces-3.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -319,6 +319,11 @@
       "resolved": "https://registry.npmjs.org/@tamuratak/domstubs/-/domstubs-0.1.1.tgz",
       "integrity": "sha512-UvZYDOp/cpqNttuc6w6RxuoPusA1Alfy3i84dVgy2pPUQ+7fovk09IRuabCATnMZi4phmPFgUlO3z0Y6viSOfw=="
     },
+    "@types/base64-js": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@types/base64-js/-/base64-js-1.2.5.tgz",
+      "integrity": "sha1-WCskdhaabLpGCiFNR2x0REHYc9U="
+    },
     "@types/braces": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/braces/-/braces-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -1268,11 +1268,11 @@
             "file"
           ],
           "enumDescriptions": [
-            "Use data URL in markdown",
-            "Use cached file in markdown"
+            "Render with data URL",
+            "Render with cached SVGs"
           ],
-          "default": "dataUrl",
-          "markdownDescription": "Render mode for completion preview."
+          "default": "file",
+          "markdownDescription": "Render mode for preview of PDF files."
         },
         "latex-workshop.message.badbox.show": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -1261,6 +1261,19 @@
           "default": true,
           "markdownDescription": "Enable preview for completion."
         },
+        "latex-workshop.intellisense.preview.render": {
+          "type": "string",
+          "enum": [
+            "dataUrl",
+            "file"
+          ],
+          "enumDescriptions": [
+            "Use data URL in markdown",
+            "Use cached file in markdown"
+          ],
+          "default": "dataUrl",
+          "markdownDescription": "Render mode for completion preview."
+        },
         "latex-workshop.message.badbox.show": {
           "type": "boolean",
           "default": true,

--- a/package.json
+++ b/package.json
@@ -1261,19 +1261,6 @@
           "default": true,
           "markdownDescription": "Enable preview for completion."
         },
-        "latex-workshop.intellisense.preview.render": {
-          "type": "string",
-          "enum": [
-            "dataUrl",
-            "file"
-          ],
-          "enumDescriptions": [
-            "Render with data URL",
-            "Render with cached SVGs"
-          ],
-          "default": "file",
-          "markdownDescription": "Render mode for preview of PDF files."
-        },
         "latex-workshop.message.badbox.show": {
           "type": "boolean",
           "default": true,
@@ -1628,7 +1615,6 @@
   },
   "dependencies": {
     "@tamuratak/domstubs": "^0.1.1",
-    "@types/base64-js": "^1.2.5",
     "chokidar": "^3.2.3",
     "fs-extra": "^5.0.0",
     "glob": "^7.1.1",

--- a/package.json
+++ b/package.json
@@ -191,7 +191,7 @@
         "scopeName": "text.tex.latex.rsweave",
         "path": "./syntax/RSweave.tmLanguage.json",
         "embeddedLanguages": {
-            "source.r": "r"
+          "source.r": "r"
         }
       }
     ],
@@ -1628,6 +1628,7 @@
   },
   "dependencies": {
     "@tamuratak/domstubs": "^0.1.1",
+    "@types/base64-js": "^1.2.5",
     "chokidar": "^3.2.3",
     "fs-extra": "^5.0.0",
     "glob": "^7.1.1",

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -108,13 +108,14 @@ export class Completer implements vscode.CompletionItemProvider {
         if (typeof filePath !== 'string') {
             return item
         }
-        const dataUrl = await this.extension.graphicsPreview.renderGraphics(filePath, {height: 190, width: 300})
-        if (dataUrl === undefined) {
+        const rsc = await this.extension.graphicsPreview.renderGraphics(filePath, { height: 190, width: 300 })
+        if (rsc === undefined) {
             return item
         }
+
         // \u{2001} is a unicode character of space with width of one em.
         const spacer = '\n\n\u{2001}  \n\n\u{2001}  \n\n\u{2001}  \n\n\u{2001}  \n\n\u{2001}  \n\n\u{2001}  \n\n'
-        const md = new vscode.MarkdownString(`![graphics](${dataUrl})` + spacer)
+        const md = new vscode.MarkdownString(`![graphics](${rsc})` + spacer)
         const ret = new vscode.CompletionItem(item.label, vscode.CompletionItemKind.File)
         ret.documentation = md
         return ret

--- a/src/providers/preview/graphicspreview.ts
+++ b/src/providers/preview/graphicspreview.ts
@@ -20,7 +20,6 @@ export class GraphicsPreview {
         this.extension = e
         this.pdfRenderer = new PDFRenderer(e)
         this.graphicsScaler = new GraphicsScaler(e)
-        tmpFile.setGracefulCleanup()
         const tmpdir = tmpFile.dirSync({ unsafeCleanup: true })
         this.cacheDir = tmpdir.name
         this.pdfFileInodeMap = new Map<string, number>()

--- a/src/providers/preview/graphicspreview.ts
+++ b/src/providers/preview/graphicspreview.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode'
 import * as fs from 'fs'
 import * as path from 'path'
-import * as tmpfs from 'tmp'
+import * as tmpFile from 'tmp'
 import { Extension } from '../../main'
 import { PDFRenderer } from './pdfrenderer'
 import { GraphicsScaler } from './graphicsscaler'
@@ -10,17 +10,18 @@ import { encodePath } from '../../utils/utils'
 
 export class GraphicsPreview {
     private cacheDir: string
+    private pdfFileInodeMap: Map<string, number>
 
     extension: Extension
     pdfRenderer: PDFRenderer
     graphicsScaler: GraphicsScaler
-    pdfFileInodeMap: Map<string, number>
 
     constructor(e: Extension) {
         this.extension = e
         this.pdfRenderer = new PDFRenderer(e)
         this.graphicsScaler = new GraphicsScaler(e)
-        const tmpdir = tmpfs.dirSync({ unsafeCleanup: true })
+        tmpFile.setGracefulCleanup()
+        const tmpdir = tmpFile.dirSync({ unsafeCleanup: true })
         this.cacheDir = tmpdir.name
         this.pdfFileInodeMap = new Map<string, number>()
     }


### PR DESCRIPTION
### Why:
Currently, when \includegraphics requests completions that involve PDFs, these two things happen:

1. PDF is loaded and rendered to SVG
2. This SVG is converted into a data URL, which is passed into `vscode.CompletionItem.documentation` as a `vscode.MarkdownString`
3. VSCode has to parse and render this data URL, which is super slow and jerky.

The actual rendering of PDF into SVG and then into data URL takes around half a second for a typical PDF on a Macbook. But it takes around several seconds to over 10s for VSCode to render this data URL into an actual image for some reason, which also hangs the editor.

### What:
Added a (default) option to fix that. Users can still fallback to the current implementation.

### How:
Store the generated SVGs in actual files on disk (instead of data URLs) in temp dir. VSCode is able to load on-disk image files pretty quickly.

Each time a preview for a PDF is requested, we compare the mtime between the SVG on disk (if it exists) and the mtime of the PDF. And generate a new preview if the SVG has expired. Pretty straightforward.