### PR TITLE
Allow latexmk uses magic command to select compiler

### DIFF
--- a/src/components/builder.ts
+++ b/src/components/builder.ts
@@ -405,12 +405,21 @@ export class Builder {
                     const candidates = tools.filter(candidate => candidate.name === tool)
                     if (candidates.length < 1) {
                         this.extension.logger.showErrorMessage(`Skipping undefined tool "${tool}" in recipe "${recipe.name}."`)
+                        return
                     } else {
-                        steps.push(candidates[0])
+                        tool = candidates[0]
                     }
-                } else {
-                    steps.push(tool)
                 }
+                if (tool.command === 'latexmk' && magicTex) {
+                    if (!tool.args) {
+                        tool.args = []
+                    }
+                    tool.args.push(`-${magicTex.command}`)
+                    if(magicTex.args) {
+                        tool.args.push(`-${magicTex.command}="${magicTex.args.join(' ').replace('"','\"')}"`)
+                    }
+                }
+                steps.push(tool)
             })
         }
         steps = JSON.parse(JSON.stringify(steps))


### PR DESCRIPTION
<del>#371 was once sovled by commit https://github.com/James-Yu/LaTeX-Workshop/commit/8ee9b525da47b2cf4fda3c313c7b9cfbb892c7f5, but the solution was removed in https://github.com/James-Yu/LaTeX-Workshop/commit/67aa156f1f0e4dec155c7069ef43e36e20aaf7c5#diff-e6eedacc0ab6a25fbf11532210610a31, which makes it difficult for users to work around without hard coding.</del>
Please ignore this and goto https://github.com/James-Yu/LaTeX-Workshop/pull/1840