### PR TITLE
Convert viewer/latexworkshop.js to TypeScript

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -10,3 +10,5 @@ __pycache__/
 .pytest_cache/
 .venv/
 .vscode/.ropeproject
+
+viewer/**

--- a/.eslintignore
+++ b/.eslintignore
@@ -10,5 +10,3 @@ __pycache__/
 .pytest_cache/
 .venv/
 .vscode/.ropeproject
-
-viewer/**

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -106,7 +106,7 @@
     },
     "overrides": [
       {
-        "files": ["latexworkshop.ts"],
+        "files": ["viewer/**/*.ts"],
         "parserOptions": {
           "ecmaVersion": 2018,
           "project": "./tsconfig.eslint.viewer.json"

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -106,17 +106,13 @@
     },
     "overrides": [
       {
-        "files": ["latexworkshop.js"],
+        "files": ["latexworkshop.ts"],
+        "parserOptions": {
+          "ecmaVersion": 2018,
+          "project": "./tsconfig.eslint.viewer.json"
+        },
         "rules": {
-          "@typescript-eslint/ban-ts-ignore": "off",
-          "@typescript-eslint/camelcase": "off",
-          "@typescript-eslint/class-name-casing": "off",
-          "@typescript-eslint/type-annotation-spacing": "off",
-          "@typescript-eslint/no-unused-vars": "off",
-          "@typescript-eslint/no-require-imports": "off",
-          "@typescript-eslint/semi": "off",
-          "@typescript-eslint/member-delimiter-style": "off",
-          "no-case-declarations": "off"
+          "@typescript-eslint/no-unnecessary-type-assertion": "off"
         }
       }
     ]

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -6,6 +6,7 @@ test/**
 src/**
 sample/**
 types/**
+viewer/**/*.ts
 **/*.map
 .devcontainer/**
 .github/**

--- a/package-lock.json
+++ b/package-lock.json
@@ -3457,6 +3457,26 @@
         "xtend": "^4.0.0"
       }
     },
+    "load-json-file": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^4.0.0",
+        "pify": "^3.0.0",
+        "strip-bom": "^3.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
+      }
+    },
     "loader-runner": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz",
@@ -3600,6 +3620,12 @@
         "errno": "^0.1.3",
         "readable-stream": "^2.0.1"
       }
+    },
+    "memorystream": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+      "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
+      "dev": true
     },
     "micromatch": {
       "version": "4.0.2",
@@ -3911,6 +3937,36 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+    },
+    "npm-run-all": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.5.tgz",
+      "integrity": "sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "chalk": "^2.4.1",
+        "cross-spawn": "^6.0.5",
+        "memorystream": "^0.3.1",
+        "minimatch": "^3.0.4",
+        "pidtree": "^0.3.0",
+        "read-pkg": "^3.0.0",
+        "shell-quote": "^1.6.1",
+        "string.prototype.padend": "^3.0.0"
+      },
+      "dependencies": {
+        "read-pkg": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
+          }
+        }
+      }
     },
     "npm-run-path": {
       "version": "2.0.2",
@@ -4264,6 +4320,23 @@
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
+    "path-type": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+      "dev": true,
+      "requires": {
+        "pify": "^3.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
+      }
+    },
     "pbkdf2": {
       "version": "3.0.17",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
@@ -4306,6 +4379,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.1.0.tgz",
       "integrity": "sha512-uhnEDzAbrcJ8R3g2fANnSuXZMBtkpSjxTTgn2LeSiQlfmq72enQJWdQllXW24MBLYnA1SBD2vfvx2o0Zw3Ielw=="
+    },
+    "pidtree": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.0.tgz",
+      "integrity": "sha512-9CT4NFlDcosssyg8KVFltgokyKZIFjoBxw8CTGy+5F38Y1eQWrt8tRayiUOXE+zVKQnYu5BR8JjCtvK3BcnBhg==",
+      "dev": true
     },
     "pify": {
       "version": "4.0.1",
@@ -4844,6 +4923,12 @@
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
+    "shell-quote": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
+      "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
+      "dev": true
+    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -5179,6 +5264,17 @@
         }
       }
     },
+    "string.prototype.padend": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.0.0.tgz",
+      "integrity": "sha1-86rvfBcZ8XDF6rHDK/eA2W4h8vA=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.4.3",
+        "function-bind": "^1.0.2"
+      }
+    },
     "string.prototype.trim": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.0.tgz",
@@ -5224,6 +5320,12 @@
       "requires": {
         "ansi-regex": "^4.1.0"
       }
+    },
+    "strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true
     },
     "strip-eof": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1598,11 +1598,13 @@
   },
   "scripts": {
     "clean": "rimraf out/ .eslintcache",
-    "compile": "tsc -p ./",
+    "compile": "tsc -p tsconfig.json && tsc -p viewer/tsconfig.json",
     "lint": "eslint --cache --ext .ts,.js .",
     "lint:fix": "eslint --fix --cache --ext .ts,.js .",
     "release": "npm run clean && npm run lint && npm run compile && vsce package",
-    "watch": "tsc -watch -p ./"
+    "watch": "run-p watch-src watch-viewer",
+    "watch-src": "tsc -watch -p tsconfig.json",
+    "watch-viewer": "tsc -watch -p viewer/tsconfig.json"
   },
   "husky": {
     "hooks": {
@@ -1649,6 +1651,7 @@
     "acorn": "^6.2.1",
     "eslint": "^6.6.0",
     "husky": "^3.0.2",
+    "npm-run-all": "^4.1.5",
     "textmate-bailout": "^1.1.0",
     "rimraf": "^3.0.0",
     "typescript": "~3.6.4",

--- a/src/components/server.ts
+++ b/src/components/server.ts
@@ -73,6 +73,8 @@ export class Server {
             let root: string
             if (request.url.startsWith('/build/') || request.url.startsWith('/cmaps/')) {
                 root = path.resolve(`${this.extension.extensionRoot}/node_modules/pdfjs-dist`)
+            } else if (request.url.startsWith('/out/viewer/')) {
+                root = path.resolve(this.extension.extensionRoot)
             } else {
                 root = path.resolve(`${this.extension.extensionRoot}/viewer`)
             }

--- a/src/components/server.ts
+++ b/src/components/server.ts
@@ -73,7 +73,9 @@ export class Server {
             let root: string
             if (request.url.startsWith('/build/') || request.url.startsWith('/cmaps/')) {
                 root = path.resolve(`${this.extension.extensionRoot}/node_modules/pdfjs-dist`)
-            } else if (request.url.startsWith('/out/viewer/')) {
+            } else if (request.url.startsWith('/out/viewer/') || request.url.startsWith('/viewer/')) {
+                // For requests to /out/viewer/*.js and requests to /viewer/*.ts.
+                // The latter is for debugging with sourcemap.
                 root = path.resolve(this.extension.extensionRoot)
             } else {
                 root = path.resolve(`${this.extension.extensionRoot}/viewer`)

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -3,8 +3,7 @@
     "include": [
       "src/**/*.ts",
       "dev/**/*.ts",
-      "dev/generate-bailout.js",
-      "viewer/latexworkshop.js"
+      "dev/generate-bailout.js"
     ],
     "compilerOptions": {
       "allowJs": true,

--- a/tsconfig.eslint.viewer.json
+++ b/tsconfig.eslint.viewer.json
@@ -1,0 +1,14 @@
+{
+    "extends": "./tsconfig.json",
+    "include": [
+      "viewer/**/*.ts"
+    ],
+    "exclude": [
+      "src/**",
+      "dev/**"
+    ],
+    "compilerOptions": {
+      "allowJs": true,
+      "checkJs": true
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,6 +28,7 @@
         "typeRoots": ["./types", "./node_modules/@types"]
     },
     "exclude": [
-        "node_modules"
+        "node_modules",
+        "viewer"
     ]
 }

--- a/viewer/latexworkshop.ts
+++ b/viewer/latexworkshop.ts
@@ -37,7 +37,7 @@ class ViewerHistory {
     return this._history.length
   }
 
-  set(scroll, force = false) {
+  set(scroll: number, force = false) {
     if (this._history.length === 0) {
       this._history.push({scroll, temporary: false})
       this._currentIndex = 0
@@ -129,7 +129,7 @@ function encodePath(path) {
 }
 */
 
-function decodePath(b64url) {
+function decodePath(b64url: string) {
   const tmp = b64url + '='.repeat((4 - b64url.length % 4) % 4)
   const b64 = tmp.replace(/-/g, '+').replace(/_/g, '/')
   const s = window.atob(b64)
@@ -138,8 +138,8 @@ function decodePath(b64url) {
 
 const query = document.location.search.substring(1)
 const parts = query.split('&')
-let encodedPdfFilePath
-let pdfFilePath
+let encodedPdfFilePath: string
+let pdfFilePath: string
 for (let i = 0, ii = parts.length; i < ii; ++i) {
     const param = parts[i].split('=')
     if (param[0].toLowerCase() === 'file') {
@@ -158,7 +158,7 @@ for (let i = 0, ii = parts.length; i < ii; ++i) {
 }
 
 
-function callCbOnDidOpenWebSocket(sock, cb) {
+function callCbOnDidOpenWebSocket(sock: WebSocket, cb: () => void) {
   // check whether WebSocket is already open (readyState === 1).
   if (sock.readyState === 1) {
     cb()
@@ -171,7 +171,7 @@ function callCbOnDidOpenWebSocket(sock, cb) {
 
 const server = `ws://${window.location.hostname}:${window.location.port}`
 
-let reverseSynctexKeybinding
+let reverseSynctexKeybinding: string
 let socket = new WebSocket(server)
 
 function setupWebSocket() {
@@ -324,7 +324,7 @@ if (embedded) {
 }
 
 
-function callSynctex(e, page, pageDom, viewerContainer) {
+function callSynctex(e: MouseEvent, page: number, pageDom: HTMLElement, viewerContainer: HTMLElement) {
   const canvasDom = pageDom.getElementsByTagName('canvas')[0]
   const selection = window.getSelection()
     let textBeforeSelection = ''
@@ -347,10 +347,10 @@ function callSynctex(e, page, pageDom, viewerContainer) {
     socket.send(JSON.stringify({type: 'reverse_synctex', path:pdfFilePath, pos, page, textBeforeSelection, textAfterSelection}))
 }
 
-function registerSynctexKeybinding(keybinding) {
+function registerSynctexKeybinding(keybinding: string) {
   const viewerDom = document.getElementById('viewer')
   for (const pageDom of viewerDom.childNodes as NodeListOf<HTMLElement>) {
-    const page = pageDom.dataset.pageNumber
+    const page = Number(pageDom.dataset.pageNumber)
     const viewerContainer = document.getElementById('viewerContainer')
     switch (keybinding) {
       case 'ctrl-click':
@@ -421,8 +421,8 @@ window.addEventListener('keydown', (evt) => {
   }
 })
 
-let hideToolbarInterval = undefined
-function showToolbar(animate) {
+let hideToolbarInterval: any
+function showToolbar(animate: boolean) {
   if (hideToolbarInterval) {
     clearInterval(hideToolbarInterval)
   }
@@ -446,8 +446,8 @@ document.addEventListener('pagesinit', () => {
   }
 })
 
-let currentUserSelectScale = undefined
-let originalUserSelectIndex = undefined
+let currentUserSelectScale: number | undefined
+let originalUserSelectIndex: number | undefined
 
 const getTrimScale = () => {
   const trimSelect = document.getElementById('trimSelect') as HTMLSelectElement
@@ -498,17 +498,17 @@ document.addEventListener('pagesinit', () => {
     if (originalUserSelectIndex === undefined) {
       originalUserSelectIndex = scaleSelect.selectedIndex
     }
-    o = document.getElementById('trimOption')
-    o.value = currentUserSelectScale * trimScale
+    o = document.getElementById('trimOption') as HTMLOptionElement
+    o.value = (currentUserSelectScale * trimScale).toString()
     o.selected = true
     scaleSelect.dispatchEvent(e)
   })
 })
 
-const trimPage = (page) => {
+const trimPage = (page: HTMLElement) => {
   const trimScale = getTrimScale()
-  const textLayer = page.getElementsByClassName('textLayer')[0]
-  const canvasWrapper = page.getElementsByClassName('canvasWrapper')[0]
+  const textLayer = page.getElementsByClassName('textLayer')[0] as HTMLElement
+  const canvasWrapper = page.getElementsByClassName('canvasWrapper')[0] as HTMLElement
   const canvas = page.getElementsByTagName('canvas')[0]
   if ( !canvasWrapper || !canvas ) {
     if (page.style.width !== '250px') {
@@ -563,7 +563,7 @@ window.addEventListener('pagerendered', () => {
       return
   }
   const viewer = document.getElementById('viewer')
-  for( const page of viewer.getElementsByClassName('page') ){
+  for( const page of viewer.getElementsByClassName('page') as HTMLCollectionOf<HTMLElement> ){
     trimPage(page)
   }
 })
@@ -575,7 +575,7 @@ const setObserverToTrim = () => {
         return
     }
     records.forEach(record => {
-      const page = record.target
+      const page = record.target as HTMLElement
       trimPage(page)
     })
   })

--- a/viewer/latexworkshop.ts
+++ b/viewer/latexworkshop.ts
@@ -272,7 +272,7 @@ function setupWebSocket() {
           document.querySelector('html').style.filter = `invert(${data.invert * 100}%)`
           document.querySelector('html').style.background = 'white'
         }
-        document.querySelector('#viewerContainer').style.background = data.bgColor
+        (document.querySelector('#viewerContainer') as HTMLElement).style.background = data.bgColor
         if (data.keybindings) {
           reverseSynctexKeybinding = data.keybindings['synctex']
           registerSynctexKeybinding(reverseSynctexKeybinding)

--- a/viewer/latexworkshop.ts
+++ b/viewer/latexworkshop.ts
@@ -1,16 +1,16 @@
 const embedded = window.parent !== window
 let documentTitle = ''
 
-let PDFViewerApplication: any
-let PDFViewerApplicationOptions: any
+declare let PDFViewerApplication: any
+declare let PDFViewerApplicationOptions: any
 
 document.addEventListener('webviewerloaded', () => {
   // PDFViewerApplication detects whether it's embedded in an iframe (window.parent !== window)
   // and if so it behaves more "discretely", eg it disables its history mechanism.
   // We dont want that, so we unset the flag here (to keep viewer.js as vanilla as possible)
   //
-  PDFViewerApplication.isViewerEmbedded = false;
-});
+  PDFViewerApplication.isViewerEmbedded = false
+})
 
 class ViewerHistory {
   _history: { scroll: number, temporary: boolean}[]
@@ -77,8 +77,8 @@ class ViewerHistory {
           cur = cur - 1
           prevScroll = this._history[cur].scroll
         } else {
-          const tmp = {scroll: container.scrollTop, temporary: true};
-          this._history.push(tmp);
+          const tmp = {scroll: container.scrollTop, temporary: true}
+          this._history.push(tmp)
         }
       }
     }
@@ -120,12 +120,14 @@ let viewerHistory = new ViewerHistory()
 
 const pdfFilePrefix = 'pdf..'
 
+/*
 function encodePath(path) {
   const s = encodeURIComponent(path)
   const b64 = window.btoa(s)
   const b64url = b64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '')
   return b64url
 }
+*/
 
 function decodePath(b64url) {
   const tmp = b64url + '='.repeat((4 - b64url.length % 4) % 4)
@@ -184,7 +186,7 @@ function setupWebSocket() {
   socket.addEventListener('message', (event) => {
     const data = JSON.parse(event.data)
     switch (data.type) {
-      case 'synctex':
+      case 'synctex': {
         // use the offsetTop of the actual page, much more accurate than multiplying the offsetHeight of the first page
         const container = document.getElementById('viewerContainer')
         const pos = PDFViewerApplication.pdfViewer._pages[data.data.page - 1].viewport.convertToViewportPoint(data.data.x, data.data.y)
@@ -203,7 +205,8 @@ function setupWebSocket() {
         indicator.style.top = `${scrollY}px`
         setTimeout(() => indicator.className = 'hide', 10)
         break
-      case 'refresh':
+      }
+      case 'refresh': {
         // Note: without showPreviousViewOnLoad = false restoring the position after the refresh will fail if
         // the user has clicked on any link in the past (pdf.js will automatically navigate to that link).
         const pack = {
@@ -217,20 +220,21 @@ function setupWebSocket() {
           viewerHistory: { history: viewerHistory._history, currentIndex: viewerHistory._currentIndex }
         }
         socket.send(JSON.stringify(pack))
-        PDFViewerApplicationOptions.set('showPreviousViewOnLoad', false);
+        PDFViewerApplicationOptions.set('showPreviousViewOnLoad', false)
         PDFViewerApplication.open(`${pdfFilePrefix}${encodedPdfFilePath}`).then( () => {
           // reset the document title to the original value to avoid duplication
           document.title = documentTitle
 
           // ensure that trimming is invoked if needed.
           setTimeout(() => {
-            window.dispatchEvent( new Event('pagerendered') );
-          }, 2000);
+            window.dispatchEvent( new Event('pagerendered') )
+          }, 2000)
           setTimeout(() => {
-            window.dispatchEvent( new Event('refreshed') );
-          }, 2000);
-        });
+            window.dispatchEvent( new Event('refreshed') )
+          }, 2000)
+        })
         break
+      }
       case 'position':
         PDFViewerApplication.pdfViewer.currentScaleValue = data.scale
         PDFViewerApplication.pdfViewer.scrollMode = data.scrollMode
@@ -314,7 +318,7 @@ if (embedded) {
       const target = e.target as HTMLAnchorElement
       if (target.nodeName === 'A' && !target.href.startsWith(window.location.href)) { // is external link
         socket.send(JSON.stringify({type:'external_link', url:target.href}))
-        e.preventDefault();
+        e.preventDefault()
       }
   })
 }
@@ -322,14 +326,14 @@ if (embedded) {
 
 function callSynctex(e, page, pageDom, viewerContainer) {
   const canvasDom = pageDom.getElementsByTagName('canvas')[0]
-  const selection = window.getSelection();
+  const selection = window.getSelection()
     let textBeforeSelection = ''
     let textAfterSelection = ''
     // workaround for https://github.com/James-Yu/LaTeX-Workshop/issues/1314
     if(selection && selection.anchorNode && selection.anchorNode.nodeName === '#text'){
-      const text = selection.anchorNode.textContent;
-      textBeforeSelection = text.substring(0, selection.anchorOffset);
-      textAfterSelection = text.substring(selection.anchorOffset);
+      const text = selection.anchorNode.textContent
+      textBeforeSelection = text.substring(0, selection.anchorOffset)
+      textAfterSelection = text.substring(selection.anchorOffset)
     }
     const trimSelect = document.getElementById('trimSelect') as HTMLSelectElement
     let left = e.pageX - pageDom.offsetLeft + viewerContainer.scrollLeft
@@ -356,15 +360,15 @@ function registerSynctexKeybinding(keybinding) {
           }
           callSynctex(e, page, pageDom, viewerContainer)
         }
-        break;
+        break
       case 'double-click':
           pageDom.ondblclick = (e) => {
             callSynctex(e, page, pageDom, viewerContainer)
           }
-          break;
+          break
       default:
         console.log(`Unknown keybinding ${keybinding} (view.pdf.internal.synctex.keybinding)`)
-        break;
+        break
     }
   }
 }
@@ -373,7 +377,7 @@ document.addEventListener('pagesinit', () => {
   if (reverseSynctexKeybinding) {
     registerSynctexKeybinding(reverseSynctexKeybinding)
   }
-});
+})
 
 const setHistory = () => {
   const container = document.getElementById('viewerContainer')
@@ -394,7 +398,7 @@ document.addEventListener('pagesinit', () => {
   document.getElementById('historyForward').addEventListener('click', () => {
     viewerHistory.forward()
   })
-}, { once: true });
+}, { once: true })
 
 // keyboard bindings
 window.addEventListener('keydown', (evt) => {
@@ -410,9 +414,9 @@ window.addEventListener('keydown', (evt) => {
   // Back/Forward don't work in the embedded viewer, so we simulate them.
   if (embedded && (evt.altKey || evt.metaKey)) {
     if (evt.keyCode === 37) {
-      viewerHistory.back();
+      viewerHistory.back()
     } else if(evt.keyCode === 39) {
-      viewerHistory.forward();
+      viewerHistory.forward()
     }
   }
 })
@@ -440,102 +444,102 @@ document.addEventListener('pagesinit', () => {
       showToolbar(true)
     }
   }
-});
+})
 
-let currentUserSelectScale = undefined;
-let originalUserSelectIndex = undefined;
+let currentUserSelectScale = undefined
+let originalUserSelectIndex = undefined
 
 const getTrimScale = () => {
   const trimSelect = document.getElementById('trimSelect') as HTMLSelectElement
   if (trimSelect.selectedIndex <= 0) {
-    return 1.0;
+    return 1.0
   }
-  const trimValue = trimSelect.options[trimSelect.selectedIndex].value;
-  return 1.0/(1 - 2*Number(trimValue));
-};
+  const trimValue = trimSelect.options[trimSelect.selectedIndex].value
+  return 1.0/(1 - 2*Number(trimValue))
+}
 
 document.addEventListener('pagesinit', () => {
   document.getElementById('trimSelect').addEventListener('change', () => {
-    const trimScale = getTrimScale();
+    const trimScale = getTrimScale()
     const trimSelect = document.getElementById('trimSelect') as HTMLSelectElement
-    const scaleSelect = document.getElementById('scaleSelect')  as HTMLSelectElement
-    const e = new Event('change');
-    let o;
+    const scaleSelect = document.getElementById('scaleSelect') as HTMLSelectElement
+    const e = new Event('change')
+    let o
     if (trimSelect.selectedIndex <= 0) {
       for ( o of scaleSelect.options ) {
-        o.disabled = false;
+        o.disabled = false
       }
-      (document.getElementById('trimOption') as HTMLOptionElement).disabled = true;
-      document.getElementById('trimOption').hidden = true;
+      (document.getElementById('trimOption') as HTMLOptionElement).disabled = true
+      document.getElementById('trimOption').hidden = true
       if (originalUserSelectIndex !== undefined) {
-        scaleSelect.selectedIndex = originalUserSelectIndex;
+        scaleSelect.selectedIndex = originalUserSelectIndex
       }
-      scaleSelect.dispatchEvent(e);
-      currentUserSelectScale = undefined;
-      originalUserSelectIndex = undefined;
-      const viewer = document.getElementById('viewer');
+      scaleSelect.dispatchEvent(e)
+      currentUserSelectScale = undefined
+      originalUserSelectIndex = undefined
+      const viewer = document.getElementById('viewer')
       for ( const page of viewer.getElementsByClassName('page') ) {
         for ( const layer of page.getElementsByClassName('annotationLayer') ) {
           for ( const secionOfAnnotation of layer.getElementsByTagName('section') ) {
             if (secionOfAnnotation.dataset.originalLeft !== undefined) {
-              secionOfAnnotation.style.left = secionOfAnnotation.dataset.originalLeft;
+              secionOfAnnotation.style.left = secionOfAnnotation.dataset.originalLeft
             }
           }
         }
       }
-      return;
+      return
     }
     for ( o of scaleSelect.options ) {
-      o.disabled = true;
+      o.disabled = true
     }
     if (currentUserSelectScale === undefined) {
-      currentUserSelectScale = PDFViewerApplication.pdfViewer._currentScale;
+      currentUserSelectScale = PDFViewerApplication.pdfViewer._currentScale
     }
     if (originalUserSelectIndex === undefined) {
-      originalUserSelectIndex = scaleSelect.selectedIndex;
+      originalUserSelectIndex = scaleSelect.selectedIndex
     }
-    o = document.getElementById('trimOption');
-    o.value = currentUserSelectScale * trimScale;
-    o.selected = true;
-    scaleSelect.dispatchEvent(e);
-  });
-});
+    o = document.getElementById('trimOption')
+    o.value = currentUserSelectScale * trimScale
+    o.selected = true
+    scaleSelect.dispatchEvent(e)
+  })
+})
 
 const trimPage = (page) => {
-  const trimScale = getTrimScale();
-  const textLayer = page.getElementsByClassName('textLayer')[0];
-  const canvasWrapper = page.getElementsByClassName('canvasWrapper')[0];
-  const canvas = page.getElementsByTagName('canvas')[0];
+  const trimScale = getTrimScale()
+  const textLayer = page.getElementsByClassName('textLayer')[0]
+  const canvasWrapper = page.getElementsByClassName('canvasWrapper')[0]
+  const canvas = page.getElementsByTagName('canvas')[0]
   if ( !canvasWrapper || !canvas ) {
     if (page.style.width !== '250px') {
-      page.style.width = '250px';
+      page.style.width = '250px'
     }
-    return;
+    return
   }
-  const w = canvas.style.width;
-  const m = w.match(/(\d+)/);
+  const w = canvas.style.width
+  const m = w.match(/(\d+)/)
   if (m) {
     // add -4px to ensure that no horizontal scroll bar appears.
-    const widthNum = Math.floor(Number(m[1])/trimScale) - 4;
-    const width = widthNum + 'px';
-    page.style.width = width;
-    canvasWrapper.style.width = width;
-    const offsetX = - Number(m[1]) * (1 - 1/trimScale) / 2;
-    canvas.style.left = offsetX + 'px';
-    canvas.style.position = 'relative';
-    canvas.setAttribute('data-is-trimmed', 'trimmed');
+    const widthNum = Math.floor(Number(m[1])/trimScale) - 4
+    const width = widthNum + 'px'
+    page.style.width = width
+    canvasWrapper.style.width = width
+    const offsetX = - Number(m[1]) * (1 - 1/trimScale) / 2
+    canvas.style.left = offsetX + 'px'
+    canvas.style.position = 'relative'
+    canvas.setAttribute('data-is-trimmed', 'trimmed')
     if ( textLayer && textLayer.dataset.isTrimmed !== 'trimmed' ) {
-      textLayer.style.width = widthNum - offsetX + 'px';
-      textLayer.style.left = offsetX + 'px';
-      textLayer.setAttribute('data-is-trimmed', 'trimmed');
+      textLayer.style.width = widthNum - offsetX + 'px'
+      textLayer.style.left = offsetX + 'px'
+      textLayer.setAttribute('data-is-trimmed', 'trimmed')
     }
-    const secionOfAnnotationArray = page.getElementsByTagName('section');
+    const secionOfAnnotationArray = page.getElementsByTagName('section')
     for ( const secionOfAnnotation of secionOfAnnotationArray ) {
-      let originalLeft = secionOfAnnotation.style.left;
+      let originalLeft = secionOfAnnotation.style.left
       if (secionOfAnnotation.dataset.originalLeft === undefined) {
-        secionOfAnnotation.setAttribute('data-original-left', secionOfAnnotation.style.left);
+        secionOfAnnotation.setAttribute('data-original-left', secionOfAnnotation.style.left)
       } else {
-        originalLeft = secionOfAnnotation.dataset.originalLeft;
+        originalLeft = secionOfAnnotation.dataset.originalLeft
       }
       const mat = originalLeft.match(/(\d+)/)
       if (mat) {
@@ -546,40 +550,40 @@ const trimPage = (page) => {
 }
 
 window.addEventListener('pagerendered', () => {
-  const container = document.getElementById('trimSelectContainer');
+  const container = document.getElementById('trimSelectContainer')
   const select = document.getElementById('trimSelect') as HTMLSelectElement
-  container.setAttribute('style', 'display: inherit;');
+  container.setAttribute('style', 'display: inherit;')
   if (container.clientWidth > 0) {
-    select.setAttribute('style', 'min-width: inherit;');
-    const width = select.clientWidth + 8;
-    select.setAttribute('style', 'min-width: ' + (width + 22) + 'px;');
-    container.setAttribute('style', 'min-width: ' + width + 'px; ' + 'max-width: ' + width + 'px;');
+    select.setAttribute('style', 'min-width: inherit;')
+    const width = select.clientWidth + 8
+    select.setAttribute('style', 'min-width: ' + (width + 22) + 'px;')
+    container.setAttribute('style', 'min-width: ' + width + 'px; ' + 'max-width: ' + width + 'px;')
   }
   if (select.selectedIndex <= 0) {
-      return;
+      return
   }
-  const viewer = document.getElementById('viewer');
+  const viewer = document.getElementById('viewer')
   for( const page of viewer.getElementsByClassName('page') ){
-    trimPage(page);
+    trimPage(page)
   }
-});
+})
 
 const setObserverToTrim = () => {
   const observer = new MutationObserver(records => {
     const trimSelect = document.getElementById('trimSelect') as HTMLSelectElement
     if (trimSelect.selectedIndex <= 0) {
-        return;
+        return
     }
     records.forEach(record => {
-      const page = record.target;
-      trimPage(page);
+      const page = record.target
+      trimPage(page)
     })
   })
-  const viewer = document.getElementById('viewer');
+  const viewer = document.getElementById('viewer')
   for( const page of viewer.getElementsByClassName('page') as HTMLCollectionOf<HTMLElement> ){
     if (page.dataset.isObserved !== 'observed') {
-      observer.observe(page, {attributes: true, childList: true, attributeFilter: ['style']});
-      page.setAttribute('data-is-observed', 'observed');
+      observer.observe(page, {attributes: true, childList: true, attributeFilter: ['style']})
+      page.setAttribute('data-is-observed', 'observed')
     }
   }
 }
@@ -587,18 +591,18 @@ const setObserverToTrim = () => {
 // We need to recaluculate scale and left offset for trim mode on each resize event.
 window.addEventListener('resize', () =>{
   const trimSelect = document.getElementById('trimSelect') as HTMLSelectElement
-  const ind = trimSelect.selectedIndex;
+  const ind = trimSelect.selectedIndex
   if (!trimSelect || ind <= 0) {
-    return;
+    return
   }
-  trimSelect.selectedIndex = 0;
-  const e = new Event('change');
-  trimSelect.dispatchEvent(e);
-  trimSelect.selectedIndex = ind;
-  trimSelect.dispatchEvent(e);
+  trimSelect.selectedIndex = 0
+  const e = new Event('change')
+  trimSelect.dispatchEvent(e)
+  trimSelect.selectedIndex = ind
+  trimSelect.dispatchEvent(e)
 })
 
 // Set observers after a pdf file is loaded in the first time.
-window.addEventListener('pagerendered', setObserverToTrim, {once: true});
+window.addEventListener('pagerendered', setObserverToTrim, {once: true})
 // Set observers each time a pdf file is refresed.
-window.addEventListener('refreshed', setObserverToTrim);
+window.addEventListener('refreshed', setObserverToTrim)

--- a/viewer/latexworkshop.ts
+++ b/viewer/latexworkshop.ts
@@ -421,7 +421,7 @@ window.addEventListener('keydown', (evt) => {
   }
 })
 
-let hideToolbarInterval: any
+let hideToolbarInterval: number | undefined
 function showToolbar(animate: boolean) {
   if (hideToolbarInterval) {
     clearInterval(hideToolbarInterval)

--- a/viewer/tsconfig.json
+++ b/viewer/tsconfig.json
@@ -4,6 +4,7 @@
             "es2017", "dom", "dom.iterable"
         ],
         "module": "es2015",
+        "noImplicitAny": true,
         "outDir": "../out/viewer",
         "target": "es2017"
     }

--- a/viewer/tsconfig.json
+++ b/viewer/tsconfig.json
@@ -1,11 +1,20 @@
 {
     "compilerOptions": {
+        "alwaysStrict": true,
         "lib": [
             "es2017", "dom", "dom.iterable"
         ],
         "module": "es2015",
+        "noFallthroughCasesInSwitch": true,
         "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "noImplicitThis": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
         "outDir": "../out/viewer",
+        "sourceMap": true,
+        "strictBindCallApply": true,
+        "strictFunctionTypes": true,
         "target": "es2017"
     }
 }

--- a/viewer/tsconfig.json
+++ b/viewer/tsconfig.json
@@ -15,6 +15,7 @@
         "sourceMap": true,
         "strictBindCallApply": true,
         "strictFunctionTypes": true,
-        "target": "es2017"
+        "target": "es2017",
+        "typeRoots": []
     }
 }

--- a/viewer/tsconfig.json
+++ b/viewer/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "compilerOptions": {
+        "lib": [
+            "es2017", "dom", "dom.iterable"
+        ],
+        "module": "es2015",
+        "outDir": "../out/viewer",
+        "target": "es2017"
+    }
+}

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -41,9 +41,9 @@ See https://github.com/adobe-type-tools/cmap-resources
 
 <!-- This snippet is used in production (included from viewer.html) -->
 <link rel="resource" type="application/l10n" href="locale/locale.properties">
-<script src="../build/pdf.js"></script>
-<script src="latexworkshop.js"></script>
-<script src="viewer.js"></script>
+<script src="/build/pdf.js" defer></script>
+<script src="/out/viewer/latexworkshop.js" defer></script>
+<script src="viewer.js" defer></script>
   </head>
 
   <body tabindex="1" class="loadingInProgress">


### PR DESCRIPTION
Convert `viewer/latexworkshop.js` to TypeScript. That would improve the maintainablity.

 `latexworkshop.js` is generated in `out/viewer/`.