### PR TITLE
Add regex for biber to live compilation info.

### DIFF
--- a/src/components/buildinfo.ts
+++ b/src/components/buildinfo.ts
@@ -106,6 +106,7 @@ export class BuildInfo {
         const rules = {
             pdfTeX: [ /This is pdfTeX, Version [\d.-]+[^\n]*$/, true ],
             BibTeX: [ /This is BibTeX[\w.\- ",()]+$/, false ],
+            Biber: [ /This is Biber[\w.\- ",()]+$/, false ],
             Sage: [ /Processing Sage code for [\w.\- "]+\.\.\.$/, false ],
             LuaTeX: [ /This is LuaTeX, Version [\d.]+[^\n]*$/, true ],
             XeTex: [ /This is XeTeX, Version [\d.-]+[^\n]*$/, true ]


### PR DESCRIPTION
This adds Biber to the list of supported tools for the live compilation info.
That seems to work fine already when invoked by latexmk, this PR adds support for invoking biber standalone.