### PR TITLE
The default color of backgourd of PDF viewer should be white

### DIFF
--- a/package.json
+++ b/package.json
@@ -1082,7 +1082,7 @@
         },
         "latex-workshop.view.pdf.backgroundColor": {
           "type": "string",
-          "default": "#525659",
+          "default": "#ffffff",
           "markdownDescription": "The background color around the document. The string must represent a color in HTML."
         },
         "latex-workshop.synctex.path": {


### PR DESCRIPTION
With the current default, flickering, white -> black -> white, is much annoying when building.

![Dec-05-2019 07-08-13](https://user-images.githubusercontent.com/10665499/70186178-aa38b900-172e-11ea-8f46-a692d69637a7.gif)

