### PR TITLE
add *.syntex(busy) and *.synctex.gz(busy) to files to clean

### DIFF
--- a/package.json
+++ b/package.json
@@ -922,6 +922,8 @@
             "*.log",
             "*.fdb_latexmk",
             "*.snm",
+            "*.synctex(busy)",
+            "*.synctex.gz(busy)",
             "*.nav"
           ],
           "markdownDescription": "Files to clean.\nThis property must be an array of strings. File globs such as *.removeme, something?.aux can be used."


### PR DESCRIPTION
It would be a good idea to add `*.syntex(busy)` and `*.synctex.gz(busy)` to files to clean. Related to #1850. TeXShop [does that](https://pages.uoregon.edu/koch/texshop/changes_3.html). 