### PR TITLE
Refactoring communications between the WebSocket server and PDF viewers

### DIFF
--- a/src/components/locator.ts
+++ b/src/components/locator.ts
@@ -5,6 +5,7 @@ import * as cp from 'child_process'
 import * as synctexjs from './synctex'
 
 import {Extension} from '../main'
+import {ClientRequest} from '../../viewer/components/protocol'
 
 export type SyncTeXRecordForward = {
     page: number,
@@ -261,7 +262,7 @@ export class Locator {
         })
     }
 
-    async locate(data: any, pdfPath: string) {
+    async locate(data: Extract<ClientRequest, {type: 'reverse_synctex'}>, pdfPath: string) {
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         const docker = configuration.get('docker.enabled')
         const useSyncTexJs = configuration.get('synctex.synctexjs.enabled') as boolean

--- a/src/components/viewer.ts
+++ b/src/components/viewer.ts
@@ -11,12 +11,12 @@ import {encodePathWithPrefix} from '../utils/utils'
 import {ClientRequest, ServerResponse} from '../../viewer/components/protocol'
 
 class Client {
-    viewer: 'browser' | 'tab'
-    websocket: ws
+    readonly viewer: 'browser' | 'tab'
+    readonly websocket: ws
 
-    constructor(arg: {viewer: 'browser' | 'tab', websocket: ws}) {
-        this.viewer = arg.viewer
-        this.websocket = arg.websocket
+    constructor(viewer: 'browser' | 'tab', websocket: ws) {
+        this.viewer = viewer
+        this.websocket = websocket
     }
 
     send(message: ServerResponse) {
@@ -27,7 +27,6 @@ class Client {
 export class Viewer {
     extension: Extension
     clients: {[key: string]: Client[]} = {}
-    positions = {}
 
     constructor(extension: Extension) {
         this.extension = extension
@@ -55,7 +54,7 @@ export class Viewer {
                 // Refresh only correct type
                 if (viewer === undefined || client.viewer === viewer) {
                     this.extension.logger.addLogMessage(`Refresh PDF viewer for ${pdfFile}`)
-                    client.websocket.send(JSON.stringify({type: 'refresh'}))
+                    client.send({type: 'refresh'})
                     refreshed = true
                 }
             })
@@ -206,7 +205,7 @@ export class Viewer {
                 if (clients === undefined) {
                     return
                 }
-                clients.push( new Client({ viewer: data.viewer, websocket }) )
+                clients.push( new Client(data.viewer, websocket) )
                 break
             case 'close':
                 for (const key in this.clients) {

--- a/src/components/viewer.ts
+++ b/src/components/viewer.ts
@@ -10,8 +10,7 @@ import {encodePathWithPrefix} from '../utils/utils'
 
 interface Client {
     viewer: 'browser' | 'tab',
-    websocket: ws,
-    position?: {}
+    websocket: ws
 }
 
 export class Viewer {
@@ -216,14 +215,6 @@ export class Viewer {
                     }
                 }
                 break
-            case 'position':
-                clients = this.clients[data.path.toLocaleUpperCase()]
-                for (const client of clients) {
-                    if (client.websocket === websocket) {
-                        client.position = data
-                    }
-                }
-                break
             case 'loaded':
                 clients = this.clients[data.path.toLocaleUpperCase()]
                 for (const client of clients) {
@@ -231,23 +222,19 @@ export class Viewer {
                         continue
                     }
                     const configuration = vscode.workspace.getConfiguration('latex-workshop')
-                    if (client.position !== undefined) {
-                        client.websocket.send(JSON.stringify(client.position))
-                    } else {
-                        client.websocket.send(JSON.stringify({
-                            type: 'params',
-                            scale: configuration.get('view.pdf.zoom'),
-                            trim: configuration.get('view.pdf.trim'),
-                            scrollMode: configuration.get('view.pdf.scrollMode'),
-                            spreadMode: configuration.get('view.pdf.spreadMode'),
-                            hand: configuration.get('view.pdf.hand'),
-                            invert: configuration.get('view.pdf.invert'),
-                            bgColor: configuration.get('view.pdf.backgroundColor'),
-                            keybindings: {
-                                synctex: configuration.get('view.pdf.internal.synctex.keybinding')
-                            }
-                        }))
-                    }
+                    client.websocket.send(JSON.stringify({
+                        type: 'params',
+                        scale: configuration.get('view.pdf.zoom'),
+                        trim: configuration.get('view.pdf.trim'),
+                        scrollMode: configuration.get('view.pdf.scrollMode'),
+                        spreadMode: configuration.get('view.pdf.spreadMode'),
+                        hand: configuration.get('view.pdf.hand'),
+                        invert: configuration.get('view.pdf.invert'),
+                        bgColor: configuration.get('view.pdf.backgroundColor'),
+                        keybindings: {
+                            synctex: configuration.get('view.pdf.internal.synctex.keybinding')
+                        }
+                    }))
                     if (configuration.get('synctex.afterBuild.enabled') as boolean) {
                         this.extension.logger.addLogMessage('SyncTex after build invoked.')
                         this.extension.locator.syncTeX(undefined, undefined, decodeURIComponent(data.path))

--- a/src/components/viewer.ts
+++ b/src/components/viewer.ts
@@ -47,10 +47,6 @@ export class Viewer {
             let refreshed = false
             // Check all viewer clients with the same path
             clients.forEach(client => {
-                // Skip disconnected
-                if (client.websocket === undefined) {
-                    return
-                }
                 // Refresh only correct type
                 if (viewer === undefined || client.viewer === viewer) {
                     this.extension.logger.addLogMessage(`Refresh PDF viewer for ${pdfFile}`)
@@ -200,14 +196,15 @@ export class Viewer {
             this.extension.logger.addLogMessage(`Handle data type: ${data.type}`)
         }
         switch (data.type) {
-            case 'open':
+            case 'open': {
                 clients = this.clients[data.path.toLocaleUpperCase()]
                 if (clients === undefined) {
                     return
                 }
                 clients.push( new Client(data.viewer, websocket) )
                 break
-            case 'close':
+            }
+            case 'close': {
                 for (const key in this.clients) {
                     clients = this.clients[key]
                     let index = -1
@@ -222,7 +219,8 @@ export class Viewer {
                     }
                 }
                 break
-            case 'loaded':
+            }
+            case 'loaded': {
                 clients = this.clients[data.path.toLocaleUpperCase()]
                 for (const client of clients) {
                     if (client.websocket !== websocket) {
@@ -248,18 +246,23 @@ export class Viewer {
                     }
                 }
                 break
-            case 'reverse_synctex':
+            }
+            case 'reverse_synctex': {
                 this.extension.locator.locate(data, data.path)
                 break
-            case 'external_link':
+            }
+            case 'external_link': {
                 vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(data.url))
                 break
-            case 'ping':
+            }
+            case 'ping': {
                 // nothing to do
                 break
-            default:
+            }
+            default: {
                 this.extension.logger.addLogMessage(`Unknown websocket message: ${msg}`)
                 break
+            }
         }
     }
 

--- a/viewer/components/interface.ts
+++ b/viewer/components/interface.ts
@@ -1,4 +1,5 @@
 import {PageTrimmer} from './pagetrimmer.js'
+import {ClientRequest} from './protocol.js'
 import {SyncTex} from './synctex.js'
 import {ViewerHistory} from './viewerhistory.js'
 
@@ -37,7 +38,9 @@ export interface ILatexWorkshopPdfViewer {
     /**
      * `cb` is called after the a PDF document is rendered.
      */
-    onDidRenderPdfFile(cb: (e: Event) => any, option?: {once: boolean}): IDisposable
+    onDidRenderPdfFile(cb: (e: Event) => any, option?: {once: boolean}): IDisposable,
+
+    send(message: ClientRequest): void
 }
 
 export interface IPDFViewerApplication {
@@ -54,7 +57,7 @@ export interface IPDFViewerApplication {
             },
             getPagePoint(x: number, y: number): [number, number]
         }[],
-        currentScaleValue: number,
+        currentScaleValue: string,
         scrollMode: number,
         spreadMode: number
     },

--- a/viewer/components/interface.ts
+++ b/viewer/components/interface.ts
@@ -15,7 +15,6 @@ export interface ILatexWorkshopPdfViewer {
     readonly pageTrimmer: PageTrimmer,
     readonly pdfFilePath: string,
     readonly server: string,
-    readonly socket: WebSocket,
     readonly synctex: SyncTex,
     readonly viewerHistory: ViewerHistory,
 

--- a/viewer/components/protocol.ts
+++ b/viewer/components/protocol.ts
@@ -38,7 +38,7 @@ export type ClientRequest = {
 } | {
     type: 'reverse_synctex',
     path: string,
-    pos: any,
+    pos: [number, number],
     page: number,
     textBeforeSelection: string,
     textAfterSelection: string

--- a/viewer/components/protocol.ts
+++ b/viewer/components/protocol.ts
@@ -1,0 +1,45 @@
+export type ServerResponse = {
+    type: 'refresh'
+} | {
+    type: 'params',
+    scale: string,
+    trim: number,
+    scrollMode: number,
+    spreadMode: number,
+    hand: boolean,
+    invert: number,
+    bgColor: string,
+    keybindings: {
+        synctex: 'ctrl-click' | 'double-click'
+    }
+} | {
+    type: 'synctex',
+    data: {
+        page: number,
+        x: number,
+        y: number
+    }
+}
+
+export type ClientRequest = {
+    type: 'open',
+    path: string,
+    viewer: 'browser' | 'tab'
+} | {
+    type: 'close'
+} | {
+    type: 'loaded',
+    path: string
+} | {
+    type: 'external_link',
+    url: string
+} | {
+    type: 'ping'
+} | {
+    type: 'reverse_synctex',
+    path: string,
+    pos: any,
+    page: number,
+    textBeforeSelection: string,
+    textAfterSelection: string
+}

--- a/viewer/components/synctex.ts
+++ b/viewer/components/synctex.ts
@@ -35,7 +35,7 @@ export class SyncTex {
             left += offsetLeft
         }
         const pos = PDFViewerApplication.pdfViewer._pages[page-1].getPagePoint(left, canvasDom.offsetHeight - top)
-        this.lwApp.socket.send(JSON.stringify({type: 'reverse_synctex', path:this.lwApp.pdfFilePath, pos, page, textBeforeSelection, textAfterSelection}))
+        this.lwApp.send({type: 'reverse_synctex', path:this.lwApp.pdfFilePath, pos, page, textBeforeSelection, textAfterSelection})
     }
 
     registerListenerOnEachPage() {

--- a/viewer/latexworkshop.ts
+++ b/viewer/latexworkshop.ts
@@ -16,9 +16,10 @@ class LateXWorkshopPdfViewer implements ILatexWorkshopPdfViewer {
     readonly pageTrimmer: PageTrimmer
     readonly pdfFilePath: string
     readonly server: string
-    socket: WebSocket
     readonly synctex: SyncTex
     readonly viewerHistory: ViewerHistory
+
+    private socket: WebSocket
 
     constructor() {
         this.embedded = window.parent !== window


### PR DESCRIPTION
- Make messages through WebSocket typed using types defined in ` viewer/components/protocol.ts`
- Since the viewer does not send a message of `type: 'position'` to the server, remove the code.
