### PR TITLE
fix the syntax of verbatim*

### DIFF
--- a/syntax/LaTeX.tmLanguage.json
+++ b/syntax/LaTeX.tmLanguage.json
@@ -481,7 +481,7 @@
       "end": "(\\\\end\\{gnuplot\\}(?:\\s*\\n)?)"
     },
     {
-      "begin": "(?:\\s*)((\\\\)begin)(\\{)((?:fboxv|boxedv|V|v)erbatim)(\\})",
+      "begin": "(?:\\s*)((\\\\)begin)(\\{)((?:fboxv|boxedv|V|v)erbatim\\*?)(\\})",
       "captures": {
         "1": {
           "name": "support.function.be.latex"


### PR DESCRIPTION
The `verbatim` environment has a variant, `verbatim*`.  `Verbatim` and `boxedverbatim` have also variants.  

The `fboxverbatim` does not have its variant. It does not cause problems.

-https://www.overleaf.com/learn/latex/Code_listing
-https://ctan.org/pkg/memoir?lang=en