### PR TITLE
Fix keybinding regression for ctrl+alt+[ and +]

### DIFF
--- a/package.json
+++ b/package.json
@@ -457,13 +457,13 @@
       {
         "key": "ctrl+alt+[",
         "mac": "cmd+alt+[",
-        "when": " config.latex-workshop.bind.altKeymap.enabled && editorTextFocus && !editorReadonly && editorLangId =~ /latex|rsweave/",
+        "when": "!config.latex-workshop.bind.altKeymap.enabled && editorTextFocus && !editorReadonly && editorLangId =~ /latex|rsweave/",
         "command": "latex-workshop.promote-sectioning"
       },
       {
         "key": "ctrl+alt+]",
         "mac": "cmd+alt+]",
-        "when": " config.latex-workshop.bind.altKeymap.enabled && editorTextFocus && !editorReadonly && editorLangId =~ /latex|rsweave/",
+        "when": "!config.latex-workshop.bind.altKeymap.enabled && editorTextFocus && !editorReadonly && editorLangId =~ /latex|rsweave/",
         "command": "latex-workshop.demote-sectioning"
       },
       {


### PR DESCRIPTION
In 6e1c8ea1a3ce83ac4bbf38532620b6263ff8fea2 both the `ctrl+alt+[` and `ctrl+l ctrl+[` were set to `config.latex-workshop.bind.altKeymap.enabled`.