### PR TITLE
Add option to highlight or comment out duplicate entries in BibTeX

### DIFF
--- a/package.json
+++ b/package.json
@@ -1581,6 +1581,16 @@
           "default": [
             "key"
           ]
+        },
+        "latex-workshop.bibtex-format.handleDuplicates": {
+          "type": "string",
+          "enum": [
+            "Ignore Duplicates",
+            "Highlight Duplicates",
+            "Comment Duplicates"
+          ],
+          "default": "Highlight Duplicates",
+          "markdownDescription": "How to handle duplicates found by the bibtex sorting functions. Duplicates are decided according to the `bibtex-format.sortby` config."
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "onLanguage:doctex",
     "onLanguage:rsweave",
     "onLanguage:pdf",
+    "onLanguage:bibtex",
     "onCommand:latex-workshop.build",
     "onCommand:latex-workshop.recipes",
     "onCommand:latex-workshop.view",

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -1,13 +1,10 @@
 import * as vscode from 'vscode'
 import * as fs from 'fs-extra'
 import * as path from 'path'
-import {bibtexParser} from 'latex-utensils'
 
 import {Extension} from './main'
 import {getLongestBalancedString} from './utils/utils'
-import * as bibtexUtils from './utils/bibtexutils'
 import {TeXDoc} from './components/texdoc'
-import {performance} from 'perf_hooks'
 
 async function quickPickRootFile(rootFile: string, localRootFile: string): Promise<string | undefined> {
     const pickedRootFile = await vscode.window.showQuickPick([{
@@ -669,74 +666,6 @@ export class Commander {
         }
         const ast = await this.extension.pegParser.parseBibtex(vscode.window.activeTextEditor.document.getText())
         vscode.workspace.openTextDocument({content: JSON.stringify(ast, null, 2), language: 'json'}).then(doc => vscode.window.showTextDocument(doc))
-    }
-
-    async bibtexFormat(sort: boolean, align: boolean) {
-        if (vscode.window.activeTextEditor === undefined || vscode.window.activeTextEditor.document.languageId !== 'bibtex') {
-            return
-        }
-        const t0 = performance.now() // Measure performance
-        const ast = await this.extension.pegParser.parseBibtex(vscode.window.activeTextEditor.document.getText())
-
-        const config = vscode.workspace.getConfiguration('latex-workshop')
-        const leftright = config.get('bibtex-format.surround') === 'Curly braces' ? [ '{', '}' ] : [ '"', '"']
-        const tabs = { '2 spaces': '  ', '4 spaces': '    ', 'tab': '\t' }
-        const configuration: bibtexUtils.BibtexFormatConfig = {
-            tab: tabs[config.get('bibtex-format.tab') as ('2 spaces' | '4 spaces' | 'tab')],
-            case: config.get('bibtex-format.case') as ('UPPERCASE' | 'lowercase'),
-            left: leftright[0],
-            right: leftright[1],
-            sort: config.get('bibtex-format.sortby') as string[]
-        }
-
-        const entries: bibtexParser.Entry[] = []
-        const entryLocations: vscode.Range[] = []
-        ast.content.forEach(item => {
-            if (bibtexParser.isEntry(item)) {
-                entries.push(item)
-                // latex-utilities uses 1-based locations whereas VSCode uses 0-based
-                entryLocations.push(new vscode.Range(
-                    item.location.start.line - 1,
-                    item.location.start.column - 1,
-                    item.location.end.line - 1,
-                    item.location.end.column - 1))
-            }
-        })
-
-        let sortedEntryLocations: vscode.Range[] = []
-        if (sort) {
-            entries.sort(bibtexUtils.bibtexSort(configuration.sort)).forEach(entry => {
-                sortedEntryLocations.push((new vscode.Range(
-                    entry.location.start.line - 1,
-                    entry.location.start.column - 1,
-                    entry.location.end.line - 1,
-                    entry.location.end.column - 1)))
-            })
-        } else {
-            sortedEntryLocations = entryLocations
-        }
-
-        // Successively replace the text in the current location from the sorted location
-        const edit = new vscode.WorkspaceEdit()
-        const uri = vscode.window.activeTextEditor.document.uri
-        let text: string
-        for (let i = 0; i < entries.length; i++) {
-            if (align) {
-                text = bibtexUtils.bibtexFormat(entries[i], configuration)
-            } else {
-                text = vscode.window.activeTextEditor.document.getText(sortedEntryLocations[i])
-            }
-            edit.replace(uri, entryLocations[i], text)
-        }
-
-        vscode.workspace.applyEdit(edit).then(success => {
-            if (success) {
-                const t1 = performance.now()
-                this.extension.logger.addLogMessage(`BibTeX action successful. Took ${t1 - t0} ms.`)
-            } else {
-                this.extension.logger.showErrorMessage('Something went wrong while processing the bibliography.')
-            }
-        })
     }
 
     texdoc(pkg?: string) {

--- a/src/components/bibtexformater.ts
+++ b/src/components/bibtexformater.ts
@@ -23,6 +23,7 @@ export class BibtexFormater {
         this.duplicatesDiagnostics.clear()
         const ast = await this.extension.pegParser.parseBibtex(vscode.window.activeTextEditor.document.getText())
 
+        // Get configuration
         const config = vscode.workspace.getConfiguration('latex-workshop')
         const leftright = config.get('bibtex-format.surround') === 'Curly braces' ? [ '{', '}' ] : [ '"', '"']
         const tabs = { '2 spaces': '  ', '4 spaces': '    ', 'tab': '\t' }
@@ -34,6 +35,7 @@ export class BibtexFormater {
             sort: config.get('bibtex-format.sortby') as string[]
         }
 
+        // Create an array of entries and of their starting locations
         const entries: bibtexParser.Entry[] = []
         const entryLocations: vscode.Range[] = []
         ast.content.forEach(item => {
@@ -48,6 +50,7 @@ export class BibtexFormater {
             }
         })
 
+        // Get the sorted locations
         let sortedEntryLocations: vscode.Range[] = []
         const duplicates = new Set<bibtexParser.Entry>()
         if (sort) {

--- a/src/components/bibtexformater.ts
+++ b/src/components/bibtexformater.ts
@@ -1,0 +1,83 @@
+import * as vscode from 'vscode'
+import {bibtexParser} from 'latex-utensils'
+import {performance} from 'perf_hooks'
+
+import * as bibtexUtils from '../utils/bibtexutils'
+import {Extension} from '../main'
+
+export class BibtexFormater {
+
+    extension: Extension
+
+    constructor(extension: Extension) {
+        this.extension = extension
+    }
+
+    async bibtexFormat(sort: boolean, align: boolean) {
+        if (vscode.window.activeTextEditor === undefined || vscode.window.activeTextEditor.document.languageId !== 'bibtex') {
+            return
+        }
+        const t0 = performance.now() // Measure performance
+        const ast = await this.extension.pegParser.parseBibtex(vscode.window.activeTextEditor.document.getText())
+
+        const config = vscode.workspace.getConfiguration('latex-workshop')
+        const leftright = config.get('bibtex-format.surround') === 'Curly braces' ? [ '{', '}' ] : [ '"', '"']
+        const tabs = { '2 spaces': '  ', '4 spaces': '    ', 'tab': '\t' }
+        const configuration: bibtexUtils.BibtexFormatConfig = {
+            tab: tabs[config.get('bibtex-format.tab') as ('2 spaces' | '4 spaces' | 'tab')],
+            case: config.get('bibtex-format.case') as ('UPPERCASE' | 'lowercase'),
+            left: leftright[0],
+            right: leftright[1],
+            sort: config.get('bibtex-format.sortby') as string[]
+        }
+
+        const entries: bibtexParser.Entry[] = []
+        const entryLocations: vscode.Range[] = []
+        ast.content.forEach(item => {
+            if (bibtexParser.isEntry(item)) {
+                entries.push(item)
+                // latex-utilities uses 1-based locations whereas VSCode uses 0-based
+                entryLocations.push(new vscode.Range(
+                    item.location.start.line - 1,
+                    item.location.start.column - 1,
+                    item.location.end.line - 1,
+                    item.location.end.column - 1))
+            }
+        })
+
+        let sortedEntryLocations: vscode.Range[] = []
+        if (sort) {
+            entries.sort(bibtexUtils.bibtexSort(configuration.sort)).forEach(entry => {
+                sortedEntryLocations.push((new vscode.Range(
+                    entry.location.start.line - 1,
+                    entry.location.start.column - 1,
+                    entry.location.end.line - 1,
+                    entry.location.end.column - 1)))
+            })
+        } else {
+            sortedEntryLocations = entryLocations
+        }
+
+        // Successively replace the text in the current location from the sorted location
+        const edit = new vscode.WorkspaceEdit()
+        const uri = vscode.window.activeTextEditor.document.uri
+        let text: string
+        for (let i = 0; i < entries.length; i++) {
+            if (align) {
+                text = bibtexUtils.bibtexFormat(entries[i], configuration)
+            } else {
+                text = vscode.window.activeTextEditor.document.getText(sortedEntryLocations[i])
+            }
+            edit.replace(uri, entryLocations[i], text)
+        }
+
+        vscode.workspace.applyEdit(edit).then(success => {
+            if (success) {
+                const t1 = performance.now()
+                this.extension.logger.addLogMessage(`BibTeX action successful. Took ${t1 - t0} ms.`)
+            } else {
+                this.extension.logger.showErrorMessage('Something went wrong while processing the bibliography.')
+            }
+        })
+    }
+}

--- a/src/components/commander.ts
+++ b/src/components/commander.ts
@@ -55,6 +55,12 @@ export class LaTeXCommander implements vscode.TreeDataProvider<LaTeXCommand> {
 
         const snippetPanelCommand = new LaTeXCommand('Snippet Panel', vscode.TreeItemCollapsibleState.None, {command: 'latex-workshop.showSnippetPanel', title: ''})
         this.commands.push(snippetPanelCommand)
+
+        const bibtexCommand = new LaTeXCommand('BibTeX actions', vscode.TreeItemCollapsibleState.Collapsed)
+        bibtexCommand.children.push(new LaTeXCommand('Align bibliography', vscode.TreeItemCollapsibleState.None, {command: 'latex-workshop.bibalign', title: ''}))
+        bibtexCommand.children.push(new LaTeXCommand('Sort bibliography', vscode.TreeItemCollapsibleState.None, {command: 'latex-workshop.bibsort', title: ''}))
+        bibtexCommand.children.push(new LaTeXCommand('Align and sort bibliography', vscode.TreeItemCollapsibleState.None, {command: 'latex-workshop.bibalignsort', title: ''}))
+        this.commands.push(bibtexCommand)
     }
 
     getTreeItem(element: LaTeXCommand): vscode.TreeItem {

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,6 +29,7 @@ import {DefinitionProvider} from './providers/definition'
 import {LatexFormatterProvider} from './providers/latexformatter'
 import {FoldingProvider} from './providers/folding'
 import { SnippetPanel } from './components/snippetpanel'
+import { BibtexFormater } from './components/bibtexformater'
 
 import {checkDeprecatedFeatures, newVersionMessage, obsoleteConfigCheck} from './config'
 
@@ -117,9 +118,9 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('latex-workshop.showCompilationPanel', () => extension.buildInfo.showPanel())
     vscode.commands.registerCommand('latex-workshop.showSnippetPanel', () => extension.snippetPanel.showPanel())
 
-    vscode.commands.registerCommand('latex-workshop.bibsort', () => extension.commander.bibtexFormat(true, false))
-    vscode.commands.registerCommand('latex-workshop.bibalign', () => extension.commander.bibtexFormat(false, true))
-    vscode.commands.registerCommand('latex-workshop.bibalignsort', () => extension.commander.bibtexFormat(true, true))
+    vscode.commands.registerCommand('latex-workshop.bibsort', () => extension.bibtexFormater.bibtexFormat(true, false))
+    vscode.commands.registerCommand('latex-workshop.bibalign', () => extension.bibtexFormater.bibtexFormat(false, true))
+    vscode.commands.registerCommand('latex-workshop.bibalignsort', () => extension.bibtexFormater.bibtexFormat(true, true))
 
     context.subscriptions.push(vscode.workspace.onDidSaveTextDocument( (e: vscode.TextDocument) => {
         if (extension.manager.hasTexId(e.languageId)) {
@@ -294,6 +295,7 @@ export class Extension {
     snippetPanel: SnippetPanel
     graphicsPreview: GraphicsPreview
     mathPreview: MathPreview
+    bibtexFormater: BibtexFormater
 
     constructor() {
         this.extensionRoot = path.resolve(`${__dirname}/../../`)
@@ -318,6 +320,7 @@ export class Extension {
         this.pegParser = new PEGParser(this)
         this.graphicsPreview = new GraphicsPreview(this)
         this.mathPreview = new MathPreview(this)
+        this.bibtexFormater = new BibtexFormater(this)
         this.logger.addLogMessage('LaTeX Workshop initialized.')
     }
 }

--- a/src/utils/bibtexutils.ts
+++ b/src/utils/bibtexutils.ts
@@ -12,7 +12,7 @@ export interface BibtexFormatConfig {
  * Sorting function for bibtex entries
  * @param keys Array of sorting keys
  */
-export function bibtexSort(keys: string[]): (a: bibtexParser.Entry, b: bibtexParser.Entry) => number {
+export function bibtexSort(keys: string[], duplicates: Set<bibtexParser.Entry>): (a: bibtexParser.Entry, b: bibtexParser.Entry) => number {
     return function (a, b) {
         let r = 0
         for (const key of keys) {
@@ -28,6 +28,10 @@ export function bibtexSort(keys: string[]): (a: bibtexParser.Entry, b: bibtexPar
             if (r !== 0) {
                 break
             }
+        }
+        if (r === 0) {
+            // It seems that items earlier in the list appear as the variable b here, rather than a
+            duplicates.add(a)
         }
         return r
     }


### PR DESCRIPTION
Options are

- ignore
- highlight (default)
- comment out

Also adds the functions to the activity bar.

Resolves #1903 

Note: the second commit (20eb9f6) is essentially just a copy-paste.