### PR TITLE
Add setting for prompting user or not with subfile.

### DIFF
--- a/package.json
+++ b/package.json
@@ -831,7 +831,12 @@
         "latex-workshop.latex.rootFile.useSubFile": {
           "type": "boolean",
           "default": true,
-          "markdownDescription": "When the `subfile` package is used, either the main file or any subfile containing `\\documentclass[main.tex]{subfile}` can be LaTeXing. When set to `true`, the extension uses the subfile as the rootFile for the `autobuild`, `clean` and `synctex` commands. Note that this setting does not affect the `build` and `view` command as they both ask the user's choice first."
+          "markdownDescription": "When the `subfile` package is used, either the main file or any subfile containing `\\documentclass[main.tex]{subfile}` can be LaTeXing. When set to `true`, the extension uses the subfile as the rootFile for the `autobuild`, `clean` and `synctex` commands."
+        },
+        "latex-workshop.latex.rootFile.doNotPrompt": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "When the `subfile` package is used, either the main file or any subfile containing `\\documentclass[main.tex]{subfile}` can be LaTeXing. When set to `false`, the `build` and `view` commands  ask the user's choice first. When set to `true`, the subfile is used when `latex-workshop.latex.rootFile.useSubFile` is also `true`, otherwise the rootFile is used."
         },
         "latex-workshop.latex.watch.usePolling": {
           "type": "boolean",

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -7,6 +7,15 @@ import {getLongestBalancedString} from './utils/utils'
 import {TeXDoc} from './components/texdoc'
 
 async function quickPickRootFile(rootFile: string, localRootFile: string): Promise<string | undefined> {
+    const configuration = vscode.workspace.getConfiguration('latex-workshop')
+    const doNotPrompt = configuration.get('latex.rootFile.doNotPrompt') as boolean
+    if (doNotPrompt) {
+        if (configuration.get('latex.rootFile.useSubFile')) {
+            return localRootFile
+        } else {
+            return rootFile
+        }
+    }
     const pickedRootFile = await vscode.window.showQuickPick([{
         label: 'Default root file',
         description: `Path: ${rootFile}`


### PR DESCRIPTION
Fix #1925. The new setting is `latex-workshop.latex.rootFile.doNotPrompt`.
When set to yes, the file used is decided according to `latex-workshop.latex.rootFile.useSubFile`.

Note that the default value for `latex-workshop.latex.rootFile.doNotPrompt` is false.