### PR TITLE
Enable keyboard shortcuts of VS Code on the PDF viewer.

### DIFF
--- a/src/components/viewer.ts
+++ b/src/components/viewer.ts
@@ -158,6 +158,12 @@ export class Viewer {
                     iframe.contentWindow.focus();
                 }, 100);
             }
+            // To enable keyboard shortcuts of VS Code when the iframe is focused,
+            // we have to dispatch keyboard events in the parent window.
+            // See https://github.com/microsoft/vscode/issues/65452
+            window.addEventListener('message', (e) => {
+                window.dispatchEvent(new KeyboardEvent('keydown', e.data));
+            }, false);
             </script>
             </body></html>
         `

--- a/src/components/viewer.ts
+++ b/src/components/viewer.ts
@@ -160,7 +160,7 @@ export class Viewer {
             }
             // To enable keyboard shortcuts of VS Code when the iframe is focused,
             // we have to dispatch keyboard events in the parent window.
-            // See https://github.com/microsoft/vscode/issues/65452
+            // See https://github.com/microsoft/vscode/issues/65452#issuecomment-586036474
             window.addEventListener('message', (e) => {
                 window.dispatchEvent(new KeyboardEvent('keydown', e.data));
             }, false);

--- a/viewer/latexworkshop.ts
+++ b/viewer/latexworkshop.ts
@@ -311,6 +311,9 @@ class LateXWorkshopPdfViewer implements ILatexWorkshopPdfViewer {
         }, 30000)
     }
 
+    // To enable keyboard shortcuts of VS Code when the iframe is focused,
+    // we have to dispatch keyboard events in the parent window.
+    // See https://github.com/microsoft/vscode/issues/65452#issuecomment-586036474
     startRebroadcastingKeyboardEvent() {
         if (!this.embedded) {
             return

--- a/viewer/latexworkshop.ts
+++ b/viewer/latexworkshop.ts
@@ -61,6 +61,7 @@ class LateXWorkshopPdfViewer implements ILatexWorkshopPdfViewer {
         this.hidePrintButton()
         this.registerKeybinding()
         this.startConnectionKeeper()
+        this.startRebroadcastingKeyboardEvent()
     }
 
     onWillStartPdfViewer(cb: (e: Event) => any): IDisposable {
@@ -310,6 +311,25 @@ class LateXWorkshopPdfViewer implements ILatexWorkshopPdfViewer {
         }, 30000)
     }
 
+    startRebroadcastingKeyboardEvent() {
+        if (!this.embedded) {
+            return
+        }
+        document.addEventListener('keydown', e => {
+            const obj = {
+                altKey: e.altKey,
+                code: e.code,
+                ctrlKey: e.ctrlKey,
+                isComposing: e.isComposing,
+                key: e.key,
+                location: e.location,
+                metaKey: e.metaKey,
+                repeat: e.repeat,
+                shiftKey: e.shiftKey
+            }
+            window.parent.postMessage(obj, '*')
+        })
+    }
 }
 
 new LateXWorkshopPdfViewer()


### PR DESCRIPTION
To enable keyboard shortcuts of VS Code when the iframe is focused,
we have to dispatch keyboard events in the parent window.
See https://github.com/microsoft/vscode/issues/65452
Close #1406.