### PR TITLE
Fix pdf viewer shortcut

### DIFF
--- a/src/components/viewer.ts
+++ b/src/components/viewer.ts
@@ -162,8 +162,10 @@ export class Viewer {
             // we have to dispatch keyboard events in the parent window.
             // See https://github.com/microsoft/vscode/issues/65452#issuecomment-586036474
             window.addEventListener('message', (e) => {
-                window.dispatchEvent(new KeyboardEvent('keydown', e.data));
-            }, false);
+                if (e.origin === 'http://localhost:${this.extension.server.port}') {
+                    window.dispatchEvent(new KeyboardEvent('keydown', e.data));
+                }
+            });
             </script>
             </body></html>
         `

--- a/viewer/components/utils.ts
+++ b/viewer/components/utils.ts
@@ -26,3 +26,48 @@ export function callCbOnDidOpenWebSocket(sock: WebSocket, cb: () => any): void {
         }, {once: true})
     }
 }
+
+export function isPdfjsShortcut(e: Pick<KeyboardEvent, 'altKey' | 'ctrlKey' | 'metaKey' | 'shiftKey' | 'code' | 'key'>) {
+    const ctrlKey = e.ctrlKey || e.metaKey
+    if (!ctrlKey && !e.altKey && !e.shiftKey) {
+        if (/^[ njpkrhs]$/.exec(e.key)) {
+            return true
+        }
+        if (/^(Enter|Home|End|PageUp|PageDown|ArrowUp|ArrowLeft|ArrowRight|ArrowDown|F4)$/.exec(e.code)) {
+            return true
+        }
+        return false
+    }
+    // Ctrl
+    if (ctrlKey && !e.altKey && !e.shiftKey) {
+        if (/^[-+=0fp]$/.exec(e.key)) {
+            return true
+        }
+        return false
+    }
+    // Ctrl + Shift
+    if (ctrlKey && !e.altKey && e.shiftKey) {
+        if (/^[g]$/.exec(e.key)) {
+            return true
+        }
+        return false
+    }
+    // Ctrl + Alt
+    if (ctrlKey && e.altKey && !e.shiftKey) {
+        if (/^[g]$/.exec(e.key)) {
+            return true
+        }
+        return false
+    }
+    // Shift
+    if (!ctrlKey && !e.altKey && e.shiftKey) {
+        if (/^[ r]$/.exec(e.key)) {
+            return true
+        }
+        if (e.code === 'Enter') {
+            return true
+        }
+        return false
+    }
+    return false
+}

--- a/viewer/latexworkshop.ts
+++ b/viewer/latexworkshop.ts
@@ -330,8 +330,56 @@ class LateXWorkshopPdfViewer implements ILatexWorkshopPdfViewer {
                 repeat: e.repeat,
                 shiftKey: e.shiftKey
             }
+            if (this.isPdfjsShortcut(obj)) {
+                return
+            }
             window.parent.postMessage(obj, '*')
         })
+    }
+
+    isPdfjsShortcut(e: Pick<KeyboardEvent, 'altKey' | 'ctrlKey' | 'metaKey' | 'shiftKey' | 'code' | 'key'>) {
+        const ctrlKey = e.ctrlKey || e.metaKey
+        if (!ctrlKey && !e.altKey && !e.shiftKey) {
+            if (/^[ njpkrhs]$/.exec(e.key)) {
+                return true
+            }
+            if (/^(Enter|Home|End|PageUp|PageDown|ArrowUp|ArrowLeft|ArrowRight|ArrowDown|F4)$/.exec(e.code)) {
+                return true
+            }
+            return false
+        }
+        // Ctrl
+        if (ctrlKey && !e.altKey && !e.shiftKey) {
+            if (/^[-+=0fp]$/.exec(e.key)) {
+                return true
+            }
+            return false
+        }
+        // Ctrl + Shift
+        if (ctrlKey && !e.altKey && e.shiftKey) {
+            if (/^[g]$/.exec(e.key)) {
+                return true
+            }
+            return false
+        }
+        // Ctrl + Alt
+        if (ctrlKey && e.altKey && !e.shiftKey) {
+            if (/^[g]$/.exec(e.key)) {
+                return true
+            }
+            return false
+        }
+        // Shift
+        if (!ctrlKey && !e.altKey && e.shiftKey) {
+            if (/^[ r]$/.exec(e.key)) {
+                return true
+            }
+            if (e.code === 'Enter') {
+                return true
+            }
+            return false
+        }
+        return false
     }
 }
 

--- a/viewer/latexworkshop.ts
+++ b/viewer/latexworkshop.ts
@@ -336,8 +336,6 @@ class LateXWorkshopPdfViewer implements ILatexWorkshopPdfViewer {
             window.parent.postMessage(obj, '*')
         })
     }
-
-
 }
 
 new LateXWorkshopPdfViewer()

--- a/viewer/latexworkshop.ts
+++ b/viewer/latexworkshop.ts
@@ -330,57 +330,14 @@ class LateXWorkshopPdfViewer implements ILatexWorkshopPdfViewer {
                 repeat: e.repeat,
                 shiftKey: e.shiftKey
             }
-            if (this.isPdfjsShortcut(obj)) {
+            if (utils.isPdfjsShortcut(obj)) {
                 return
             }
             window.parent.postMessage(obj, '*')
         })
     }
 
-    isPdfjsShortcut(e: Pick<KeyboardEvent, 'altKey' | 'ctrlKey' | 'metaKey' | 'shiftKey' | 'code' | 'key'>) {
-        const ctrlKey = e.ctrlKey || e.metaKey
-        if (!ctrlKey && !e.altKey && !e.shiftKey) {
-            if (/^[ njpkrhs]$/.exec(e.key)) {
-                return true
-            }
-            if (/^(Enter|Home|End|PageUp|PageDown|ArrowUp|ArrowLeft|ArrowRight|ArrowDown|F4)$/.exec(e.code)) {
-                return true
-            }
-            return false
-        }
-        // Ctrl
-        if (ctrlKey && !e.altKey && !e.shiftKey) {
-            if (/^[-+=0fp]$/.exec(e.key)) {
-                return true
-            }
-            return false
-        }
-        // Ctrl + Shift
-        if (ctrlKey && !e.altKey && e.shiftKey) {
-            if (/^[g]$/.exec(e.key)) {
-                return true
-            }
-            return false
-        }
-        // Ctrl + Alt
-        if (ctrlKey && e.altKey && !e.shiftKey) {
-            if (/^[g]$/.exec(e.key)) {
-                return true
-            }
-            return false
-        }
-        // Shift
-        if (!ctrlKey && !e.altKey && e.shiftKey) {
-            if (/^[ r]$/.exec(e.key)) {
-                return true
-            }
-            if (e.code === 'Enter') {
-                return true
-            }
-            return false
-        }
-        return false
-    }
+
 }
 
 new LateXWorkshopPdfViewer()


### PR DESCRIPTION
- Check the origin of a message when dispatching keyboard events.
-  Should not rebroadcast keyboard events related to the keyboard shotrcuts of PDF.js.

