### PR TITLE
add embedded language support for minted ruby

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,6 +163,7 @@
           "source.js": "js",
           "source.lua": "lua",
           "source.python": "python",
+          "source.ruby": "ruby",
           "source.scala": "scala",
           "text.xtml": "xtml",
           "source.yaml": "yaml"

--- a/syntax/LaTeX.tmLanguage.json
+++ b/syntax/LaTeX.tmLanguage.json
@@ -258,6 +258,25 @@
           "end": "(\\\\end\\{minted\\})"
         },
         {
+          "begin": "(\\\\begin\\{minted\\}(?:\\[.*\\])?\\{(ruby)\\})",
+          "captures": {
+            "1": {
+              "patterns": [
+                {
+                  "include": "#minted-env"
+                }
+              ]
+            }
+          },
+          "contentName": "source.ruby",
+          "patterns": [
+            {
+              "include": "source.ruby"
+            }
+          ],
+          "end": "(\\\\end\\{minted\\})"
+        },
+        {
           "begin": "(\\\\begin\\{minted\\}(?:\\[.*\\])?\\{xml\\})",
           "captures": {
             "1": {


### PR DESCRIPTION
Add syntax highlighting for ruby code in minted environments, as it currently existing for python, C, and JavaScript:

```latex
\begin{minted}{ruby}
module Test
  def foo
    :bar
  end
end
\end{minted}
```