### PR TITLE
latex-workshop.latex.recipe 'pdflatex × 3' added

### DIFF
--- a/package.json
+++ b/package.json
@@ -658,6 +658,14 @@
               ]
             },
             {
+              "name": "pdflatex × 3",
+              "tools": [
+                "pdflatex",
+                "pdflatex",
+                "pdflatex"
+              ]
+            },
+            {
               "name": "Compile Rnw files",
               "tools": [
                 "rnw2pdf"


### PR DESCRIPTION
The 'pdflatex × 3' recipe can be used when no bib-file is present. The existing 'pdflatex ➞ bibtex ➞ pdflatex × 2' receipe is not working without a bib-file.