### PR TITLE
Prevent PDF viewer from stealing focus on refresh

### DIFF
--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -1303,7 +1303,7 @@ var PDFViewerApplication = {
                   });
 
                   if (!_this5.isViewerEmbedded) {
-                    pdfViewer.focus();
+                    // pdfViewer.focus();
                   }
 
                   _context8.next = 18;


### PR DESCRIPTION
Does not happen in normal VSCode, but does in [code-server](https://github.com/cdr/code-server).
Shouldn't affect usage, since the `isViewerEmbedded` setting used to be enabled anyway.