### PR TITLE
Add syntax highlighting for TypeScript in minted

### DIFF
--- a/syntax/LaTeX.tmLanguage.json
+++ b/syntax/LaTeX.tmLanguage.json
@@ -220,6 +220,25 @@
           "end": "(\\\\end\\{minted\\})"
         },
         {
+          "begin": "(\\\\begin\\{minted\\}(?:\\[.*\\])?\\{(?:ts|typescript)\\})",
+          "captures": {
+            "1": {
+              "patterns": [
+                {
+                  "include": "#minted-env"
+                }
+              ]
+            }
+          },
+          "contentName": "source.ts",
+          "patterns": [
+            {
+              "include": "source.ts"
+            }
+          ],
+          "end": "(\\\\end\\{minted\\})"
+        },
+        {
           "begin": "(\\\\begin\\{minted\\}(?:\\[.*\\])?\\{lua\\})",
           "captures": {
             "1": {


### PR DESCRIPTION
This is the same that already happens for JavaScript:

<img width="144" alt="Screen Shot 2020-03-17 at 4 00 59 PM" src="https://user-images.githubusercontent.com/586813/76896591-80804980-6868-11ea-8969-92b63843d959.png">
