### PR TITLE
Treat angle brackets with \left and \right as bracket pair

### DIFF
--- a/syntax/syntax.json
+++ b/syntax/syntax.json
@@ -7,8 +7,9 @@
 		["[", "]"],
 		["(", ")"],
 		["\\left(", "\\right)"],
-        ["\\left[", "\\right]"],
-        ["\\left\\{", "\\right\\}"]
+		["\\left[", "\\right]"],
+		["\\left\\{", "\\right\\}"],
+		["\\left<", "\\right>"]
 	],
 	"autoClosingPairs": [
 		["{", "}"],


### PR DESCRIPTION
Follow-up to 823ece1ceb3cd760cfafaaac243706a9f060bae5 and #1534. I think angle brackets are the last somewhat common bracket combination that should be included; this is a rather minor change. I also updated the indentation to match the rest of the file.