### PR TITLE
Refactor environments snippets 

### DIFF
--- a/data/commands.json
+++ b/data/commands.json
@@ -1,7 +1,7 @@
 {
   "begin":{
     "command":"begin",
-    "snippet":"begin{$1}\n\t$0\n\\\\end{$1}",
+    "snippet":"begin{",
     "detail":"Begin a new environment",
     "postAction":"editor.action.triggerSuggest"
   },

--- a/data/environments.json
+++ b/data/environments.json
@@ -1,61 +1,131 @@
-[
-  "document",
-  "table",
-  "description",
-  "enumerate",
-  "itemize",
-  "math",
-  "displaymath",
-  "split",
-  "array",
-  "subarray",
-  "eqnarray",
-  "equation",
-  "equation*",
-  "subequations",
-  "subequations*",
-  "multline",
-  "multline*",
-  "gather",
-  "gather*",
-  "gathered",
-  "align",
-  "align*",
-  "alignat",
-  "alignat*",
-  "aligned",
-  "alignedat",
-  "flalign",
-  "flalign*",
-  "xalignat",
-  "xalignat*",
-  "matrix",
-  "bmatrix",
-  "Bmatrix",
-  "pmatrix",
-  "vmatrix",
-  "Vmatrix",
-  "smallmatrix",
-  "definition",
-  "example",
-  "lemma",
-  "theorem",
-  "corollary",
-  "proof",
-  "cases",
-  "center",
-  "flushleft",
-  "flushright",
-  "minipage",
-  "quotation",
-  "quote",
-  "verbatim",
-  "verse",
-  "picture",
-  "tabbing",
-  "tabular",
-  "thebibliography",
-  "titlepage",
-  "columns",
-  "column"
-]
+{
+  "document": {
+    "name": "document"
+  },
+  "table": {
+    "name": "table"
+  },
+  "description": {
+    "name": "description",
+    "snippet": "\n\t\\item[$1] $0"
+  },
+  "enumerate": {
+    "name": "enumerate",
+    "snippet": "\n\t\\item $0"
+  },
+  "itemize": {
+    "name": "itemize",
+    "snippet": "\n\t\\item $0"
+  },
+  "math": {
+    "name": "math"
+  },
+  "displaymath": {
+    "name": "displaymath"
+  },
+  "split": {
+    "name": "split"
+  },
+  "array": {
+    "name": "array"
+  },
+  "subarray": {
+    "name": "subarray"
+  },
+  "eqnarray": {
+    "name": "eqnarray"
+  },
+  "equation": {
+    "name": "equation"
+  },
+  "equation*": {
+    "name": "equation*"
+  },
+  "subequations": {
+    "name": "subequations"
+  },
+  "subequations*": {
+    "name": "subequations*"
+  },
+  "matrix": {
+    "name": "matrix"
+  },
+  "bmatrix": {
+    "name": "bmatrix"
+  },
+  "Bmatrix": {
+    "name": "Bmatrix"
+  },
+  "pmatrix": {
+    "name": "pmatrix"
+  },
+  "vmatrix": {
+    "name": "vmatrix"
+  },
+  "Vmatrix": {
+    "name": "Vmatrix"
+  },
+  "smallmatrix": {
+    "name": "smallmatrix"
+  },
+  "definition": {
+    "name": "definition"
+  },
+  "example": {
+    "name": "example"
+  },
+  "lemma": {
+    "name": "lemma"
+  },
+  "theorem": {
+    "name": "theorem"
+  },
+  "corollary": {
+    "name": "corollary"
+  },
+  "proof": {
+    "name": "proof"
+  },
+  "cases": {
+    "name": "cases"
+  },
+  "center": {
+    "name": "center"
+  },
+  "flushleft": {
+    "name": "flushleft"
+  },
+  "flushright": {
+    "name": "flushright"
+  },
+  "minipage": {
+    "name": "minipage"
+  },
+  "quotation": {
+    "name": "quotation"
+  },
+  "quote": {
+    "name": "quote"
+  },
+  "verbatim": {
+    "name": "verbatim"
+  },
+  "verse": {
+    "name": "verse"
+  },
+  "picture": {
+    "name": "picture"
+  },
+  "tabbing": {
+    "name": "tabbing"
+  },
+  "tabular": {
+    "name": "tabular"
+  },
+  "thebibliography": {
+    "name": "thebibliography"
+  },
+  "titlepage": {
+    "name": "titlepage"
+  }
+}

--- a/data/packages/acronym_env.json
+++ b/data/packages/acronym_env.json
@@ -1,5 +1,5 @@
 {
-  "acronym ": {
+  "acronym": {
     "name": "acronym",
     "detail": "acronym",
     "snippet": "",

--- a/data/packages/acronym_env.json
+++ b/data/packages/acronym_env.json
@@ -1,4 +1,14 @@
-[
-  "acronym",
-  "acronym"
-]
+{
+  "acronym ": {
+    "name": "acronym",
+    "detail": "acronym",
+    "snippet": "",
+    "package": "acronym"
+  },
+  "acronym []": {
+    "name": "acronym",
+    "detail": "acronym[longest]",
+    "snippet": "[${1:longest}]",
+    "package": "acronym"
+  }
+}

--- a/data/packages/algorithm2e_env.json
+++ b/data/packages/algorithm2e_env.json
@@ -1,9 +1,44 @@
-[
-  "algocf",
-  "function",
-  "function*",
-  "procedure",
-  "procedure*",
-  "algorithm",
-  "algorithm*"
-]
+{
+  "algocf ": {
+    "name": "algocf",
+    "detail": "algocf",
+    "snippet": "",
+    "package": "algorithm2e"
+  },
+  "function ": {
+    "name": "function",
+    "detail": "function",
+    "snippet": "",
+    "package": "algorithm2e"
+  },
+  "function* ": {
+    "name": "function*",
+    "detail": "function*",
+    "snippet": "",
+    "package": "algorithm2e"
+  },
+  "procedure ": {
+    "name": "procedure",
+    "detail": "procedure",
+    "snippet": "",
+    "package": "algorithm2e"
+  },
+  "procedure* ": {
+    "name": "procedure*",
+    "detail": "procedure*",
+    "snippet": "",
+    "package": "algorithm2e"
+  },
+  "algorithm ": {
+    "name": "algorithm",
+    "detail": "algorithm",
+    "snippet": "",
+    "package": "algorithm2e"
+  },
+  "algorithm* ": {
+    "name": "algorithm*",
+    "detail": "algorithm*",
+    "snippet": "",
+    "package": "algorithm2e"
+  }
+}

--- a/data/packages/algorithm2e_env.json
+++ b/data/packages/algorithm2e_env.json
@@ -1,41 +1,41 @@
 {
-  "algocf ": {
+  "algocf": {
     "name": "algocf",
     "detail": "algocf",
     "snippet": "",
     "package": "algorithm2e"
   },
-  "function ": {
+  "function": {
     "name": "function",
     "detail": "function",
     "snippet": "",
     "package": "algorithm2e"
   },
-  "function* ": {
+  "function*": {
     "name": "function*",
     "detail": "function*",
     "snippet": "",
     "package": "algorithm2e"
   },
-  "procedure ": {
+  "procedure": {
     "name": "procedure",
     "detail": "procedure",
     "snippet": "",
     "package": "algorithm2e"
   },
-  "procedure* ": {
+  "procedure*": {
     "name": "procedure*",
     "detail": "procedure*",
     "snippet": "",
     "package": "algorithm2e"
   },
-  "algorithm ": {
+  "algorithm": {
     "name": "algorithm",
     "detail": "algorithm",
     "snippet": "",
     "package": "algorithm2e"
   },
-  "algorithm* ": {
+  "algorithm*": {
     "name": "algorithm*",
     "detail": "algorithm*",
     "snippet": "",

--- a/data/packages/amsmath_env.json
+++ b/data/packages/amsmath_env.json
@@ -1,4 +1,122 @@
-[
-  "align",
-  "xxalignat"
-]
+{
+  "align ": {
+    "name": "align",
+    "detail": "align",
+    "snippet": "",
+    "package": "amsmath"
+  },
+  "align* ": {
+    "name": "align*",
+    "detail": "align*",
+    "snippet": "",
+    "package": "amsmath"
+  },
+  "alignat []{}": {
+    "name": "alignat",
+    "detail": "alignat[alignment]{n}",
+    "snippet": "[${2:alignment}]{${1:n}}",
+    "package": "amsmath"
+  },
+  "alignat* []{}": {
+    "name": "alignat*",
+    "detail": "alignat*[alignment]{n}",
+    "snippet": "[${2:alignment}]{${1:n}}",
+    "package": "amsmath"
+  },
+  "alignat {}": {
+    "name": "alignat",
+    "detail": "alignat{n}",
+    "snippet": "{${1:n}}",
+    "package": "amsmath"
+  },
+  "alignat* {}": {
+    "name": "alignat*",
+    "detail": "alignat*{n}",
+    "snippet": "{${1:n}}",
+    "package": "amsmath"
+  },
+  "aligned ": {
+    "name": "aligned",
+    "detail": "aligned",
+    "snippet": "",
+    "package": "amsmath"
+  },
+  "aligned []": {
+    "name": "aligned",
+    "detail": "aligned[alignment]",
+    "snippet": "[${1:alignment}]",
+    "package": "amsmath"
+  },
+  "alignedat ": {
+    "name": "alignedat",
+    "detail": "alignedat",
+    "snippet": "",
+    "package": "amsmath"
+  },
+  "flalign ": {
+    "name": "flalign",
+    "detail": "flalign",
+    "snippet": "",
+    "package": "amsmath"
+  },
+  "flalign* ": {
+    "name": "flalign*",
+    "detail": "flalign*",
+    "snippet": "",
+    "package": "amsmath"
+  },
+  "gather ": {
+    "name": "gather",
+    "detail": "gather",
+    "snippet": "",
+    "package": "amsmath"
+  },
+  "gather* ": {
+    "name": "gather*",
+    "detail": "gather*",
+    "snippet": "",
+    "package": "amsmath"
+  },
+  "gathered ": {
+    "name": "gathered",
+    "detail": "gathered",
+    "snippet": "",
+    "package": "amsmath"
+  },
+  "gathered []": {
+    "name": "gathered",
+    "detail": "gathered[alignment]",
+    "snippet": "[${1:alignment}]",
+    "package": "amsmath"
+  },
+  "multline ": {
+    "name": "multline",
+    "detail": "multline",
+    "snippet": "",
+    "package": "amsmath"
+  },
+  "multline* ": {
+    "name": "multline*",
+    "detail": "multline*",
+    "snippet": "",
+    "package": "amsmath"
+  },
+  "xalignat ": {
+    "name": "xalignat",
+    "detail": "xalignat",
+    "snippet": "",
+    "package": "amsmath"
+  },
+  "xalignat* ": {
+    "name": "xalignat*",
+    "detail": "xalignat*",
+    "snippet": "",
+    "package": "amsmath"
+  },
+  "xxalignat ": {
+    "name": "xxalignat",
+    "detail": "xxalignat",
+    "snippet": "",
+    "package": "amsmath"
+  }
+}

--- a/data/packages/amsmath_env.json
+++ b/data/packages/amsmath_env.json
@@ -1,11 +1,11 @@
 {
-  "align ": {
+  "align": {
     "name": "align",
     "detail": "align",
     "snippet": "",
     "package": "amsmath"
   },
-  "align* ": {
+  "align*": {
     "name": "align*",
     "detail": "align*",
     "snippet": "",
@@ -35,7 +35,7 @@
     "snippet": "{${1:n}}",
     "package": "amsmath"
   },
-  "aligned ": {
+  "aligned": {
     "name": "aligned",
     "detail": "aligned",
     "snippet": "",
@@ -47,37 +47,37 @@
     "snippet": "[${1:alignment}]",
     "package": "amsmath"
   },
-  "alignedat ": {
+  "alignedat": {
     "name": "alignedat",
     "detail": "alignedat",
     "snippet": "",
     "package": "amsmath"
   },
-  "flalign ": {
+  "flalign": {
     "name": "flalign",
     "detail": "flalign",
     "snippet": "",
     "package": "amsmath"
   },
-  "flalign* ": {
+  "flalign*": {
     "name": "flalign*",
     "detail": "flalign*",
     "snippet": "",
     "package": "amsmath"
   },
-  "gather ": {
+  "gather": {
     "name": "gather",
     "detail": "gather",
     "snippet": "",
     "package": "amsmath"
   },
-  "gather* ": {
+  "gather*": {
     "name": "gather*",
     "detail": "gather*",
     "snippet": "",
     "package": "amsmath"
   },
-  "gathered ": {
+  "gathered": {
     "name": "gathered",
     "detail": "gathered",
     "snippet": "",
@@ -89,31 +89,31 @@
     "snippet": "[${1:alignment}]",
     "package": "amsmath"
   },
-  "multline ": {
+  "multline": {
     "name": "multline",
     "detail": "multline",
     "snippet": "",
     "package": "amsmath"
   },
-  "multline* ": {
+  "multline*": {
     "name": "multline*",
     "detail": "multline*",
     "snippet": "",
     "package": "amsmath"
   },
-  "xalignat ": {
+  "xalignat": {
     "name": "xalignat",
     "detail": "xalignat",
     "snippet": "",
     "package": "amsmath"
   },
-  "xalignat* ": {
+  "xalignat*": {
     "name": "xalignat*",
     "detail": "xalignat*",
     "snippet": "",
     "package": "amsmath"
   },
-  "xxalignat ": {
+  "xxalignat": {
     "name": "xxalignat",
     "detail": "xxalignat",
     "snippet": "",

--- a/data/packages/appendix_env.json
+++ b/data/packages/appendix_env.json
@@ -1,4 +1,14 @@
-[
-  "appendices",
-  "subappendices"
-]
+{
+  "appendices ": {
+    "name": "appendices",
+    "detail": "appendices",
+    "snippet": "",
+    "package": "appendix"
+  },
+  "subappendices ": {
+    "name": "subappendices",
+    "detail": "subappendices",
+    "snippet": "",
+    "package": "appendix"
+  }
+}

--- a/data/packages/appendix_env.json
+++ b/data/packages/appendix_env.json
@@ -1,11 +1,11 @@
 {
-  "appendices ": {
+  "appendices": {
     "name": "appendices",
     "detail": "appendices",
     "snippet": "",
     "package": "appendix"
   },
-  "subappendices ": {
+  "subappendices": {
     "name": "subappendices",
     "detail": "subappendices",
     "snippet": "",

--- a/data/packages/babel_env.json
+++ b/data/packages/babel_env.json
@@ -1,5 +1,20 @@
-[
-  "otherlanguage",
-  "otherlanguage*",
-  "hypenrules"
-]
+{
+  "otherlanguage {}": {
+    "name": "otherlanguage",
+    "detail": "otherlanguage{language}",
+    "snippet": "{${1:language}}",
+    "package": "babel"
+  },
+  "otherlanguage* {}": {
+    "name": "otherlanguage*",
+    "detail": "otherlanguage*{language}",
+    "snippet": "{${1:language}}",
+    "package": "babel"
+  },
+  "hypenrules {}": {
+    "name": "hypenrules",
+    "detail": "hypenrules{option}",
+    "snippet": "{${1:option}}",
+    "package": "babel"
+  }
+}

--- a/data/packages/beamerfoils_env.json
+++ b/data/packages/beamerfoils_env.json
@@ -5,7 +5,7 @@
     "snippet": "*",
     "package": "beamerfoils"
   },
-  "boldequation ": {
+  "boldequation": {
     "name": "boldequation",
     "detail": "boldequation",
     "snippet": "",

--- a/data/packages/beamerfoils_env.json
+++ b/data/packages/beamerfoils_env.json
@@ -1,4 +1,14 @@
-[
-  "boldequation",
-  "boldequation"
-]
+{
+  "boldequation *": {
+    "name": "boldequation",
+    "detail": "boldequation*",
+    "snippet": "*",
+    "package": "beamerfoils"
+  },
+  "boldequation ": {
+    "name": "boldequation",
+    "detail": "boldequation",
+    "snippet": "",
+    "package": "beamerfoils"
+  }
+}

--- a/data/packages/beamerprosper_cmd.json
+++ b/data/packages/beamerprosper_cmd.json
@@ -157,11 +157,11 @@
   "onlyInPDF<PDF text>": {
     "command": "onlyInPDF<PDF text>",
     "package": "beamerprosper",
-    "snippet": "onlyInPDF<PDF text>"
+    "snippet": "onlyInPDF<${1:PDF text}>"
   },
   "onlyInPS<PS text>": {
     "command": "onlyInPS<PS text>",
     "package": "beamerprosper",
-    "snippet": "onlyInPS<PS text>"
+    "snippet": "onlyInPS<${1:PS text}>"
   }
 }

--- a/data/packages/beamerprosper_env.json
+++ b/data/packages/beamerprosper_env.json
@@ -1,8 +1,38 @@
-[
-  "slides",
-  "slides",
-  "notes",
-  "Itemize",
-  "itemstep",
-  "enumstep"
-]
+{
+  "slides []{}": {
+    "name": "slides",
+    "detail": "slides[options]{frame title}",
+    "snippet": "[${2:options}]{${1:frame title}}",
+    "package": "beamerprosper"
+  },
+  "slides {}": {
+    "name": "slides",
+    "detail": "slides{frame title}",
+    "snippet": "{${1:frame title}}",
+    "package": "beamerprosper"
+  },
+  "notes {}": {
+    "name": "notes",
+    "detail": "notes{title}",
+    "snippet": "{${1:title}}",
+    "package": "beamerprosper"
+  },
+  "Itemize \\item": {
+    "name": "Itemize",
+    "detail": "Itemize\\item",
+    "snippet": "\\item",
+    "package": "beamerprosper"
+  },
+  "itemstep \\item": {
+    "name": "itemstep",
+    "detail": "itemstep\\item",
+    "snippet": "\\item",
+    "package": "beamerprosper"
+  },
+  "enumstep \\item": {
+    "name": "enumstep",
+    "detail": "enumstep\\item",
+    "snippet": "\\item",
+    "package": "beamerprosper"
+  }
+}

--- a/data/packages/beamerseminar_env.json
+++ b/data/packages/beamerseminar_env.json
@@ -1,4 +1,14 @@
-[
-  "slide",
-  "slide"
-]
+{
+  "slide *": {
+    "name": "slide",
+    "detail": "slide*",
+    "snippet": "*",
+    "package": "beamerseminar"
+  },
+  "slide ": {
+    "name": "slide",
+    "detail": "slide",
+    "snippet": "",
+    "package": "beamerseminar"
+  }
+}

--- a/data/packages/beamerseminar_env.json
+++ b/data/packages/beamerseminar_env.json
@@ -5,7 +5,7 @@
     "snippet": "*",
     "package": "beamerseminar"
   },
-  "slide ": {
+  "slide": {
     "name": "slide",
     "detail": "slide",
     "snippet": "",

--- a/data/packages/beamertexpower_cmd.json
+++ b/data/packages/beamertexpower_cmd.json
@@ -52,12 +52,12 @@
   "reswitch{}<text>": {
     "command": "reswitch{alternate text}<text>",
     "package": "beamertexpower",
-    "snippet": "reswitch{${1:alternate text}}<text>"
+    "snippet": "reswitch{${1:alternate text}}<${2:text}>"
   },
   "rebstep<text>": {
     "command": "rebstep<text>",
     "package": "beamertexpower",
-    "snippet": "rebstep<text>"
+    "snippet": "rebstep<${1:text}>"
   },
   "redstep": {
     "command": "redstep",

--- a/data/packages/beamerthemeFhG_env.json
+++ b/data/packages/beamerthemeFhG_env.json
@@ -1,5 +1,20 @@
-[
-  "splitvv",
-  "splitv",
-  "titleframe"
-]
+{
+  "splitvv ": {
+    "name": "splitvv",
+    "detail": "splitvv",
+    "snippet": "",
+    "package": "beamerthemeFhG"
+  },
+  "splitv ": {
+    "name": "splitv",
+    "detail": "splitv",
+    "snippet": "",
+    "package": "beamerthemeFhG"
+  },
+  "titleframe ": {
+    "name": "titleframe",
+    "detail": "titleframe",
+    "snippet": "",
+    "package": "beamerthemeFhG"
+  }
+}

--- a/data/packages/beamerthemeFhG_env.json
+++ b/data/packages/beamerthemeFhG_env.json
@@ -1,17 +1,17 @@
 {
-  "splitvv ": {
+  "splitvv": {
     "name": "splitvv",
     "detail": "splitvv",
     "snippet": "",
     "package": "beamerthemeFhG"
   },
-  "splitv ": {
+  "splitv": {
     "name": "splitv",
     "detail": "splitv",
     "snippet": "",
     "package": "beamerthemeFhG"
   },
-  "titleframe ": {
+  "titleframe": {
     "name": "titleframe",
     "detail": "titleframe",
     "snippet": "",

--- a/data/packages/biblatex_env.json
+++ b/data/packages/biblatex_env.json
@@ -7,8 +7,8 @@
   },
   "refsection []": {
     "name": "refsection",
-    "detail": "refsection[bib \ufb01les]",
-    "snippet": "[${1:bib \ufb01les}]",
+    "detail": "refsection[bib ﬁles]",
+    "snippet": "[${1:bib ﬁles}]",
     "package": "biblatex"
   },
   "refsegment": {

--- a/data/packages/biblatex_env.json
+++ b/data/packages/biblatex_env.json
@@ -1,5 +1,5 @@
 {
-  "refsection ": {
+  "refsection": {
     "name": "refsection",
     "detail": "refsection",
     "snippet": "",
@@ -11,7 +11,7 @@
     "snippet": "[${1:bib \ufb01les}]",
     "package": "biblatex"
   },
-  "refsegment ": {
+  "refsegment": {
     "name": "refsegment",
     "detail": "refsegment",
     "snippet": "",

--- a/data/packages/biblatex_env.json
+++ b/data/packages/biblatex_env.json
@@ -1,5 +1,20 @@
-[
-  "refsection",
-  "refsection",
-  "refsegment"
-]
+{
+  "refsection ": {
+    "name": "refsection",
+    "detail": "refsection",
+    "snippet": "",
+    "package": "biblatex"
+  },
+  "refsection []": {
+    "name": "refsection",
+    "detail": "refsection[bib \ufb01les]",
+    "snippet": "[${1:bib \ufb01les}]",
+    "package": "biblatex"
+  },
+  "refsegment ": {
+    "name": "refsegment",
+    "detail": "refsegment",
+    "snippet": "",
+    "package": "biblatex"
+  }
+}

--- a/data/packages/bidi_env.json
+++ b/data/packages/bidi_env.json
@@ -1,35 +1,35 @@
 {
-  "LTR ": {
+  "LTR": {
     "name": "LTR",
     "detail": "LTR",
     "snippet": "",
     "package": "bidi"
   },
-  "RTL ": {
+  "RTL": {
     "name": "RTL",
     "detail": "RTL",
     "snippet": "",
     "package": "bidi"
   },
-  "LTRitems ": {
+  "LTRitems": {
     "name": "LTRitems",
     "detail": "LTRitems",
     "snippet": "",
     "package": "bidi"
   },
-  "RTLitems ": {
+  "RTLitems": {
     "name": "RTLitems",
     "detail": "RTLitems",
     "snippet": "",
     "package": "bidi"
   },
-  "LTRbibitems ": {
+  "LTRbibitems": {
     "name": "LTRbibitems",
     "detail": "LTRbibitems",
     "snippet": "",
     "package": "bidi"
   },
-  "RTLbibitems ": {
+  "RTLbibitems": {
     "name": "RTLbibitems",
     "detail": "RTLbibitems",
     "snippet": "",

--- a/data/packages/bidi_env.json
+++ b/data/packages/bidi_env.json
@@ -1,8 +1,38 @@
-[
-  "LTR",
-  "RTL",
-  "LTRitems",
-  "RTLitems",
-  "LTRbibitems",
-  "RTLbibitems"
-]
+{
+  "LTR ": {
+    "name": "LTR",
+    "detail": "LTR",
+    "snippet": "",
+    "package": "bidi"
+  },
+  "RTL ": {
+    "name": "RTL",
+    "detail": "RTL",
+    "snippet": "",
+    "package": "bidi"
+  },
+  "LTRitems ": {
+    "name": "LTRitems",
+    "detail": "LTRitems",
+    "snippet": "",
+    "package": "bidi"
+  },
+  "RTLitems ": {
+    "name": "RTLitems",
+    "detail": "RTLitems",
+    "snippet": "",
+    "package": "bidi"
+  },
+  "LTRbibitems ": {
+    "name": "LTRbibitems",
+    "detail": "LTRbibitems",
+    "snippet": "",
+    "package": "bidi"
+  },
+  "RTLbibitems ": {
+    "name": "RTLbibitems",
+    "detail": "RTLbibitems",
+    "snippet": "",
+    "package": "bidi"
+  }
+}

--- a/data/packages/cases_env.json
+++ b/data/packages/cases_env.json
@@ -1,6 +1,26 @@
-[
-  "numcases",
-  "numcases",
-  "subnumcases",
-  "subnumcases"
-]
+{
+  "numcases ": {
+    "name": "numcases",
+    "detail": "numcases",
+    "snippet": "",
+    "package": "cases"
+  },
+  "numcases {}": {
+    "name": "numcases",
+    "detail": "numcases{left side}",
+    "snippet": "{${1:left side}}",
+    "package": "cases"
+  },
+  "subnumcases ": {
+    "name": "subnumcases",
+    "detail": "subnumcases",
+    "snippet": "",
+    "package": "cases"
+  },
+  "subnumcases {}": {
+    "name": "subnumcases",
+    "detail": "subnumcases{left side}",
+    "snippet": "{${1:left side}}",
+    "package": "cases"
+  }
+}

--- a/data/packages/cases_env.json
+++ b/data/packages/cases_env.json
@@ -1,5 +1,5 @@
 {
-  "numcases ": {
+  "numcases": {
     "name": "numcases",
     "detail": "numcases",
     "snippet": "",
@@ -11,7 +11,7 @@
     "snippet": "{${1:left side}}",
     "package": "cases"
   },
-  "subnumcases ": {
+  "subnumcases": {
     "name": "subnumcases",
     "detail": "subnumcases",
     "snippet": "",

--- a/data/packages/circuitikz_env.json
+++ b/data/packages/circuitikz_env.json
@@ -1,17 +1,17 @@
 {
-  "circuitikz ": {
+  "circuitikz": {
     "name": "circuitikz",
     "detail": "circuitikz",
     "snippet": "",
     "package": "circuitikz"
   },
-  "pgfdecoration ": {
+  "pgfdecoration": {
     "name": "pgfdecoration",
     "detail": "pgfdecoration",
     "snippet": "",
     "package": "circuitikz"
   },
-  "pgfmetadecoration ": {
+  "pgfmetadecoration": {
     "name": "pgfmetadecoration",
     "detail": "pgfmetadecoration",
     "snippet": "",

--- a/data/packages/circuitikz_env.json
+++ b/data/packages/circuitikz_env.json
@@ -1,5 +1,20 @@
-[
-  "circuitikz",
-  "pgfdecoration",
-  "pgfmetadecoration"
-]
+{
+  "circuitikz ": {
+    "name": "circuitikz",
+    "detail": "circuitikz",
+    "snippet": "",
+    "package": "circuitikz"
+  },
+  "pgfdecoration ": {
+    "name": "pgfdecoration",
+    "detail": "pgfdecoration",
+    "snippet": "",
+    "package": "circuitikz"
+  },
+  "pgfmetadecoration ": {
+    "name": "pgfmetadecoration",
+    "detail": "pgfmetadecoration",
+    "snippet": "",
+    "package": "circuitikz"
+  }
+}

--- a/data/packages/class-beamer_cmd.json
+++ b/data/packages/class-beamer_cmd.json
@@ -27,7 +27,7 @@
   "animate<overlay specification>": {
     "command": "animate<overlay specification>",
     "package": "class-beamer",
-    "snippet": "animate<overlay specification>"
+    "snippet": "animate<${1:overlay specification}>"
   },
   "animatevalue<start slide - end slide>{}{}{}": {
     "command": "animatevalue<start slide - end slide>{name}{start value}{end value}",
@@ -82,12 +82,12 @@
   "transblindshorizontal<overlay specification>[]": {
     "command": "transblindshorizontal<overlay specification>[options]",
     "package": "class-beamer",
-    "snippet": "transblindshorizontal<overlay specification>[${1:options}]"
+    "snippet": "transblindshorizontal<${2:overlay specification}>[${1:options}]"
   },
   "transblindshorizontal<overlay specification>": {
     "command": "transblindshorizontal<overlay specification>",
     "package": "class-beamer",
-    "snippet": "transblindshorizontal<overlay specification>"
+    "snippet": "transblindshorizontal<${1:overlay specification}>"
   },
   "transblindshorizontal[]": {
     "command": "transblindshorizontal[options]",
@@ -102,12 +102,12 @@
   "transblindsvertical<overlay specification>[]": {
     "command": "transblindsvertical<overlay specification>[options]",
     "package": "class-beamer",
-    "snippet": "transblindsvertical<overlay specification>[${1:options}]"
+    "snippet": "transblindsvertical<${2:overlay specification}>[${1:options}]"
   },
   "transblindsvertical<overlay specification>": {
     "command": "transblindsvertical<overlay specification>",
     "package": "class-beamer",
-    "snippet": "transblindsvertical<overlay specification>"
+    "snippet": "transblindsvertical<${1:overlay specification}>"
   },
   "transblindsvertical[]": {
     "command": "transblindsvertical[options]",
@@ -122,12 +122,12 @@
   "transboxin<overlay specification>[]": {
     "command": "transboxin<overlay specification>[options]",
     "package": "class-beamer",
-    "snippet": "transboxin<overlay specification>[${1:options}]"
+    "snippet": "transboxin<${2:overlay specification}>[${1:options}]"
   },
   "transboxin<overlay specification>": {
     "command": "transboxin<overlay specification>",
     "package": "class-beamer",
-    "snippet": "transboxin<overlay specification>"
+    "snippet": "transboxin<${1:overlay specification}>"
   },
   "transboxin[]": {
     "command": "transboxin[options]",
@@ -142,12 +142,12 @@
   "transboxout<overlay specification>[]": {
     "command": "transboxout<overlay specification>[options]",
     "package": "class-beamer",
-    "snippet": "transboxout<overlay specification>[${1:options}]"
+    "snippet": "transboxout<${2:overlay specification}>[${1:options}]"
   },
   "transboxout<overlay specification>": {
     "command": "transboxout<overlay specification>",
     "package": "class-beamer",
-    "snippet": "transboxout<overlay specification>"
+    "snippet": "transboxout<${1:overlay specification}>"
   },
   "transboxout[]": {
     "command": "transboxout[options]",
@@ -162,12 +162,12 @@
   "transdissolve<overlay specification>[]": {
     "command": "transdissolve<overlay specification>[options]",
     "package": "class-beamer",
-    "snippet": "transdissolve<overlay specification>[${1:options}]"
+    "snippet": "transdissolve<${2:overlay specification}>[${1:options}]"
   },
   "transdissolve<overlay specification>": {
     "command": "transdissolve<overlay specification>",
     "package": "class-beamer",
-    "snippet": "transdissolve<overlay specification>"
+    "snippet": "transdissolve<${1:overlay specification}>"
   },
   "transdissolve[]": {
     "command": "transdissolve[options]",
@@ -182,12 +182,12 @@
   "transglitter<overlay specification>[]": {
     "command": "transglitter<overlay specification>[options]",
     "package": "class-beamer",
-    "snippet": "transglitter<overlay specification>[${1:options}]"
+    "snippet": "transglitter<${2:overlay specification}>[${1:options}]"
   },
   "transglitter<overlay specification>": {
     "command": "transglitter<overlay specification>",
     "package": "class-beamer",
-    "snippet": "transglitter<overlay specification>"
+    "snippet": "transglitter<${1:overlay specification}>"
   },
   "transglitter[]": {
     "command": "transglitter[options]",
@@ -202,12 +202,12 @@
   "transsplitverticalin<overlay specification>[]": {
     "command": "transsplitverticalin<overlay specification>[options]",
     "package": "class-beamer",
-    "snippet": "transsplitverticalin<overlay specification>[${1:options}]"
+    "snippet": "transsplitverticalin<${2:overlay specification}>[${1:options}]"
   },
   "transsplitverticalin<overlay specification>": {
     "command": "transsplitverticalin<overlay specification>",
     "package": "class-beamer",
-    "snippet": "transsplitverticalin<overlay specification>"
+    "snippet": "transsplitverticalin<${1:overlay specification}>"
   },
   "transsplitverticalin[]": {
     "command": "transsplitverticalin[options]",
@@ -222,12 +222,12 @@
   "transsplitverticalout<overlay specification>[]": {
     "command": "transsplitverticalout<overlay specification>[options]",
     "package": "class-beamer",
-    "snippet": "transsplitverticalout<overlay specification>[${1:options}]"
+    "snippet": "transsplitverticalout<${2:overlay specification}>[${1:options}]"
   },
   "transsplitverticalout<overlay specification>": {
     "command": "transsplitverticalout<overlay specification>",
     "package": "class-beamer",
-    "snippet": "transsplitverticalout<overlay specification>"
+    "snippet": "transsplitverticalout<${1:overlay specification}>"
   },
   "transsplitverticalout[]": {
     "command": "transsplitverticalout[options]",
@@ -242,12 +242,12 @@
   "transsplithorizontalin<overlay specification>[]": {
     "command": "transsplithorizontalin<overlay specification>[options]",
     "package": "class-beamer",
-    "snippet": "transsplithorizontalin<overlay specification>[${1:options}]"
+    "snippet": "transsplithorizontalin<${2:overlay specification}>[${1:options}]"
   },
   "transsplithorizontalin<overlay specification>": {
     "command": "transsplithorizontalin<overlay specification>",
     "package": "class-beamer",
-    "snippet": "transsplithorizontalin<overlay specification>"
+    "snippet": "transsplithorizontalin<${1:overlay specification}>"
   },
   "transsplithorizontalin[]": {
     "command": "transsplithorizontalin[options]",
@@ -262,12 +262,12 @@
   "transsplithorizontalout<overlay specification>[]": {
     "command": "transsplithorizontalout<overlay specification>[options]",
     "package": "class-beamer",
-    "snippet": "transsplithorizontalout<overlay specification>[${1:options}]"
+    "snippet": "transsplithorizontalout<${2:overlay specification}>[${1:options}]"
   },
   "transsplithorizontalout<overlay specification>": {
     "command": "transsplithorizontalout<overlay specification>",
     "package": "class-beamer",
-    "snippet": "transsplithorizontalout<overlay specification>"
+    "snippet": "transsplithorizontalout<${1:overlay specification}>"
   },
   "transsplithorizontalout[]": {
     "command": "transsplithorizontalout[options]",
@@ -282,12 +282,12 @@
   "transwipe<overlay specification>[]": {
     "command": "transwipe<overlay specification>[options]",
     "package": "class-beamer",
-    "snippet": "transwipe<overlay specification>[${1:options}]"
+    "snippet": "transwipe<${2:overlay specification}>[${1:options}]"
   },
   "transwipe<overlay specification>": {
     "command": "transwipe<overlay specification>",
     "package": "class-beamer",
-    "snippet": "transwipe<overlay specification>"
+    "snippet": "transwipe<${1:overlay specification}>"
   },
   "transwipe[]": {
     "command": "transwipe[options]",
@@ -302,7 +302,7 @@
   "transduration<overlay specification>{}": {
     "command": "transduration<overlay specification>{number of seconds}",
     "package": "class-beamer",
-    "snippet": "transduration<overlay specification>{${1:number of seconds}}"
+    "snippet": "transduration<${2:overlay specification}>{${1:number of seconds}}"
   },
   "transduration{}": {
     "command": "transduration{number of seconds}",
@@ -362,7 +362,7 @@
   "opaqueness<overlay specification>{}": {
     "command": "opaqueness<overlay specification>{percentage of opaqueness}",
     "package": "class-beamer",
-    "snippet": "opaqueness<overlay specification>{${1:percentage of opaqueness}}"
+    "snippet": "opaqueness<${2:overlay specification}>{${1:percentage of opaqueness}}"
   },
   "usebeamertemplate{}": {
     "command": "usebeamertemplate{element name}",
@@ -412,32 +412,32 @@
   "defbeamertemplate<mode specification>*{}{}[][]{}[]{}": {
     "command": "defbeamertemplate<mode specification>*{element name}{predefined option}[argument number][default optional argument]{predefined text}[action]{action command}",
     "package": "class-beamer",
-    "snippet": "defbeamertemplate<mode specification>*{${1:element name}}{${2:predefined option}}[${3:argument number}][${4:default optional argument}]{${5:predefined text}}[${6:action}]{${7:action command}}"
+    "snippet": "defbeamertemplate<${8:mode specification}>*{${1:element name}}{${2:predefined option}}[${3:argument number}][${4:default optional argument}]{${5:predefined text}}[${6:action}]{${7:action command}}"
   },
   "defbeamertemplate<mode specification>*{}{}[]{}[]{}": {
     "command": "defbeamertemplate<mode specification>*{element name}{predefined option}[default optional argument]{predefined text}[action]{action command}",
     "package": "class-beamer",
-    "snippet": "defbeamertemplate<mode specification>*{${1:element name}}{${2:predefined option}}[${3:default optional argument}]{${4:predefined text}}[${5:action}]{${6:action command}}"
+    "snippet": "defbeamertemplate<${7:mode specification}>*{${1:element name}}{${2:predefined option}}[${3:default optional argument}]{${4:predefined text}}[${5:action}]{${6:action command}}"
   },
   "defbeamertemplate<mode specification>*{}{}{}[]{}": {
     "command": "defbeamertemplate<mode specification>*{element name}{predefined option}{predefined text}[action]{action command}",
     "package": "class-beamer",
-    "snippet": "defbeamertemplate<mode specification>*{${1:element name}}{${2:predefined option}}{${3:predefined text}}[${4:action}]{${5:action command}}"
+    "snippet": "defbeamertemplate<${6:mode specification}>*{${1:element name}}{${2:predefined option}}{${3:predefined text}}[${4:action}]{${5:action command}}"
   },
   "defbeamertemplate<mode specification>*{}{}[][]{}": {
     "command": "defbeamertemplate<mode specification>*{element name}{predefined option}[argument number][default optional argument]{predefined text}",
     "package": "class-beamer",
-    "snippet": "defbeamertemplate<mode specification>*{${1:element name}}{${2:predefined option}}[${3:argument number}][${4:default optional argument}]{${5:predefined text}}"
+    "snippet": "defbeamertemplate<${6:mode specification}>*{${1:element name}}{${2:predefined option}}[${3:argument number}][${4:default optional argument}]{${5:predefined text}}"
   },
   "defbeamertemplate<mode specification>*{}{}[]{}": {
     "command": "defbeamertemplate<mode specification>*{element name}{predefined option}[argument number]{predefined text}",
     "package": "class-beamer",
-    "snippet": "defbeamertemplate<mode specification>*{${1:element name}}{${2:predefined option}}[${3:argument number}]{${4:predefined text}}"
+    "snippet": "defbeamertemplate<${5:mode specification}>*{${1:element name}}{${2:predefined option}}[${3:argument number}]{${4:predefined text}}"
   },
   "defbeamertemplate<mode specification>*{}{}{}": {
     "command": "defbeamertemplate<mode specification>*{element name}{predefined option}{predefined text}",
     "package": "class-beamer",
-    "snippet": "defbeamertemplate<mode specification>*{${1:element name}}{${2:predefined option}}{${3:predefined text}}"
+    "snippet": "defbeamertemplate<${4:mode specification}>*{${1:element name}}{${2:predefined option}}{${3:predefined text}}"
   },
   "defbeamertemplate{}{}[][]{}[]{}": {
     "command": "defbeamertemplate{element name}{predefined option}[argument number][default optional argument]{predefined text}[action]{action command}",
@@ -817,12 +817,12 @@
   "frametitle<overlay specification>[]{}": {
     "command": "frametitle<overlay specification>[short frame title]{frame title text}",
     "package": "class-beamer",
-    "snippet": "frametitle<overlay specification>[${2:short frame title}]{${1:frame title text}}"
+    "snippet": "frametitle<${3:overlay specification}>[${2:short frame title}]{${1:frame title text}}"
   },
   "frametitle<overlay specification>{}": {
     "command": "frametitle<overlay specification>{frame title text}",
     "package": "class-beamer",
-    "snippet": "frametitle<overlay specification>{${1:frame title text}}"
+    "snippet": "frametitle<${2:overlay specification}>{${1:frame title text}}"
   },
   "frametitle[]{}": {
     "command": "frametitle[short frame title]{frame title text}",
@@ -837,7 +837,7 @@
   "framesubtitle<overlay specification>{}": {
     "command": "framesubtitle<overlay specification>{frame subtitle text}",
     "package": "class-beamer",
-    "snippet": "framesubtitle<overlay specification>{${1:frame subtitle text}}"
+    "snippet": "framesubtitle<${2:overlay specification}>{${1:frame subtitle text}}"
   },
   "framesubtitle{}": {
     "command": "framesubtitle{frame subtitle text}",
@@ -917,12 +917,12 @@
   "section<mode specification>[]{}": {
     "command": "section<mode specification>[short section name]{section name}",
     "package": "class-beamer",
-    "snippet": "section<mode specification>[${2:short section name}]{${1:section name}}"
+    "snippet": "section<${3:mode specification}>[${2:short section name}]{${1:section name}}"
   },
   "section<mode specification>{}": {
     "command": "section<mode specification>{section name}",
     "package": "class-beamer",
-    "snippet": "section<mode specification>{${1:section name}}"
+    "snippet": "section<${2:mode specification}>{${1:section name}}"
   },
   "section{}": {
     "command": "section{section name}",
@@ -932,12 +932,12 @@
   "section<mode specification>*[]{}": {
     "command": "section<mode specification>*[short section name]{section name}",
     "package": "class-beamer",
-    "snippet": "section<mode specification>*[${2:short section name}]{${1:section name}}"
+    "snippet": "section<${3:mode specification}>*[${2:short section name}]{${1:section name}}"
   },
   "section<mode specification>*{}": {
     "command": "section<mode specification>*{section name}",
     "package": "class-beamer",
-    "snippet": "section<mode specification>*{${1:section name}}"
+    "snippet": "section<${2:mode specification}>*{${1:section name}}"
   },
   "section*[]{}": {
     "command": "section*[short section name]{section name}",
@@ -952,12 +952,12 @@
   "subsection<mode specification>[]{}": {
     "command": "subsection<mode specification>[short section name]{section name}",
     "package": "class-beamer",
-    "snippet": "subsection<mode specification>[${2:short section name}]{${1:section name}}"
+    "snippet": "subsection<${3:mode specification}>[${2:short section name}]{${1:section name}}"
   },
   "subsection<mode specification>{}": {
     "command": "subsection<mode specification>{section name}",
     "package": "class-beamer",
-    "snippet": "subsection<mode specification>{${1:section name}}"
+    "snippet": "subsection<${2:mode specification}>{${1:section name}}"
   },
   "subsection{}": {
     "command": "subsection{section name}",
@@ -967,12 +967,12 @@
   "subsection<mode specification>*[]{}": {
     "command": "subsection<mode specification>*[short section name]{section name}",
     "package": "class-beamer",
-    "snippet": "subsection<mode specification>*[${2:short section name}]{${1:section name}}"
+    "snippet": "subsection<${3:mode specification}>*[${2:short section name}]{${1:section name}}"
   },
   "subsection<mode specification>*{}": {
     "command": "subsection<mode specification>*{section name}",
     "package": "class-beamer",
-    "snippet": "subsection<mode specification>*{${1:section name}}"
+    "snippet": "subsection<${2:mode specification}>*{${1:section name}}"
   },
   "subsection*[]{}": {
     "command": "subsection*[short section name]{section name}",
@@ -987,12 +987,12 @@
   "subsubsection<mode specification>[]{}": {
     "command": "subsubsection<mode specification>[short section name]{section name}",
     "package": "class-beamer",
-    "snippet": "subsubsection<mode specification>[${2:short section name}]{${1:section name}}"
+    "snippet": "subsubsection<${3:mode specification}>[${2:short section name}]{${1:section name}}"
   },
   "subsubsection<mode specification>{}": {
     "command": "subsubsection<mode specification>{section name}",
     "package": "class-beamer",
-    "snippet": "subsubsection<mode specification>{${1:section name}}"
+    "snippet": "subsubsection<${2:mode specification}>{${1:section name}}"
   },
   "subsubsection{}": {
     "command": "subsubsection{section name}",
@@ -1002,12 +1002,12 @@
   "subsubsection<mode specification>*[]{}": {
     "command": "subsubsection<mode specification>*[short section name]{section name}",
     "package": "class-beamer",
-    "snippet": "subsubsection<mode specification>*[${2:short section name}]{${1:section name}}"
+    "snippet": "subsubsection<${3:mode specification}>*[${2:short section name}]{${1:section name}}"
   },
   "subsubsection<mode specification>*{}": {
     "command": "subsubsection<mode specification>*{section name}",
     "package": "class-beamer",
-    "snippet": "subsubsection<mode specification>*{${1:section name}}"
+    "snippet": "subsubsection<${2:mode specification}>*{${1:section name}}"
   },
   "subsubsection*[]{}": {
     "command": "subsubsection*[short section name]{section name}",
@@ -1052,12 +1052,12 @@
   "part<mode specification>[]{}": {
     "command": "part<mode specification>[short part name]{part name}",
     "package": "class-beamer",
-    "snippet": "part<mode specification>[${2:short part name}]{${1:part name}}"
+    "snippet": "part<${3:mode specification}>[${2:short part name}]{${1:part name}}"
   },
   "part<mode specification>{}": {
     "command": "part<mode specification>{part name}",
     "package": "class-beamer",
-    "snippet": "part<mode specification>{${1:part name}}"
+    "snippet": "part<${2:mode specification}>{${1:part name}}"
   },
   "part{}": {
     "command": "part{part name}",
@@ -1102,12 +1102,12 @@
   "bibitem<overlay specification>[]{}": {
     "command": "bibitem<overlay specification>[citation text]{label name}",
     "package": "class-beamer",
-    "snippet": "bibitem<overlay specification>[${2:citation text}]{${1:label name}}"
+    "snippet": "bibitem<${3:overlay specification}>[${2:citation text}]{${1:label name}}"
   },
   "bibitem<overlay specification>{}": {
     "command": "bibitem<overlay specification>{label name}",
     "package": "class-beamer",
-    "snippet": "bibitem<overlay specification>{${1:label name}}"
+    "snippet": "bibitem<${2:overlay specification}>{${1:label name}}"
   },
   "bibitem{}": {
     "command": "bibitem{label name}",
@@ -1117,12 +1117,12 @@
   "appendix<mode specification>": {
     "command": "appendix<mode specification>",
     "package": "class-beamer",
-    "snippet": "appendix<mode specification>"
+    "snippet": "appendix<${1:mode specification}>"
   },
   "hypertarget<overlay specification>{}{}": {
     "command": "hypertarget<overlay specification>{target name}{text}",
     "package": "class-beamer",
-    "snippet": "hypertarget<overlay specification>{${1:target name}}{${2:text}}"
+    "snippet": "hypertarget<${3:overlay specification}>{${1:target name}}{${2:text}}"
   },
   "hypertarget{}{}": {
     "command": "hypertarget{target name}{text}",
@@ -1152,12 +1152,12 @@
   "hyperlink<overlay specification>{}{}<overlay specification>": {
     "command": "hyperlink<overlay specification>{target name}{link text}<overlay specification>",
     "package": "class-beamer",
-    "snippet": "hyperlink<overlay specification>{${1:target name}}{${2:link text}}<overlay specification>"
+    "snippet": "hyperlink<${3:overlay specification}>{${1:target name}}{${2:link text}}<${4:overlay specification}>"
   },
   "hyperlink{}{}<overlay specification>": {
     "command": "hyperlink{target name}{link text}<overlay specification>",
     "package": "class-beamer",
-    "snippet": "hyperlink{${1:target name}}{${2:link text}}<overlay specification>"
+    "snippet": "hyperlink{${1:target name}}{${2:link text}}<${3:overlay specification}>"
   },
   "hyperlink{}{}": {
     "command": "hyperlink{target name}{link text}",
@@ -1167,7 +1167,7 @@
   "hyperlinkslideprev<overlay specification>{}": {
     "command": "hyperlinkslideprev<overlay specification>{link text}",
     "package": "class-beamer",
-    "snippet": "hyperlinkslideprev<overlay specification>{${1:link text}}"
+    "snippet": "hyperlinkslideprev<${2:overlay specification}>{${1:link text}}"
   },
   "hyperlinkslideprev{}": {
     "command": "hyperlinkslideprev{link text}",
@@ -1177,7 +1177,7 @@
   "hyperlinkslidenext<overlay specification>{}": {
     "command": "hyperlinkslidenext<overlay specification>{link text}",
     "package": "class-beamer",
-    "snippet": "hyperlinkslidenext<overlay specification>{${1:link text}}"
+    "snippet": "hyperlinkslidenext<${2:overlay specification}>{${1:link text}}"
   },
   "hyperlinkslidenext{}": {
     "command": "hyperlinkslidenext{link text}",
@@ -1187,7 +1187,7 @@
   "hyperlinkframestart<overlay specification>{}": {
     "command": "hyperlinkframestart<overlay specification>{link text}",
     "package": "class-beamer",
-    "snippet": "hyperlinkframestart<overlay specification>{${1:link text}}"
+    "snippet": "hyperlinkframestart<${2:overlay specification}>{${1:link text}}"
   },
   "hyperlinkframestart{}": {
     "command": "hyperlinkframestart{link text}",
@@ -1197,7 +1197,7 @@
   "hyperlinkframeend<overlay specification>{}": {
     "command": "hyperlinkframeend<overlay specification>{link text}",
     "package": "class-beamer",
-    "snippet": "hyperlinkframeend<overlay specification>{${1:link text}}"
+    "snippet": "hyperlinkframeend<${2:overlay specification}>{${1:link text}}"
   },
   "hyperlinkframeend{}": {
     "command": "hyperlinkframeend{link text}",
@@ -1207,7 +1207,7 @@
   "hyperlinkframestartnext<overlay specification>{}": {
     "command": "hyperlinkframestartnext<overlay specification>{link text}",
     "package": "class-beamer",
-    "snippet": "hyperlinkframestartnext<overlay specification>{${1:link text}}"
+    "snippet": "hyperlinkframestartnext<${2:overlay specification}>{${1:link text}}"
   },
   "hyperlinkframestartnext{}": {
     "command": "hyperlinkframestartnext{link text}",
@@ -1217,7 +1217,7 @@
   "hyperlinkframeendprev<overlay specification>{}": {
     "command": "hyperlinkframeendprev<overlay specification>{link text}",
     "package": "class-beamer",
-    "snippet": "hyperlinkframeendprev<overlay specification>{${1:link text}}"
+    "snippet": "hyperlinkframeendprev<${2:overlay specification}>{${1:link text}}"
   },
   "hyperlinkframeendprev{}": {
     "command": "hyperlinkframeendprev{link text}",
@@ -1227,7 +1227,7 @@
   "hyperlinkpresentationstart<overlay specification>{}": {
     "command": "hyperlinkpresentationstart<overlay specification>{link text}",
     "package": "class-beamer",
-    "snippet": "hyperlinkpresentationstart<overlay specification>{${1:link text}}"
+    "snippet": "hyperlinkpresentationstart<${2:overlay specification}>{${1:link text}}"
   },
   "hyperlinkpresentationstart{}": {
     "command": "hyperlinkpresentationstart{link text}",
@@ -1237,7 +1237,7 @@
   "hyperlinkpresentationend<overlay specification>{}": {
     "command": "hyperlinkpresentationend<overlay specification>{link text}",
     "package": "class-beamer",
-    "snippet": "hyperlinkpresentationend<overlay specification>{${1:link text}}"
+    "snippet": "hyperlinkpresentationend<${2:overlay specification}>{${1:link text}}"
   },
   "hyperlinkpresentationend{}": {
     "command": "hyperlinkpresentationend{link text}",
@@ -1247,7 +1247,7 @@
   "hyperlinkappendixstart<overlay specification>{}": {
     "command": "hyperlinkappendixstart<overlay specification>{link text}",
     "package": "class-beamer",
-    "snippet": "hyperlinkappendixstart<overlay specification>{${1:link text}}"
+    "snippet": "hyperlinkappendixstart<${2:overlay specification}>{${1:link text}}"
   },
   "hyperlinkappendixstart{}": {
     "command": "hyperlinkappendixstart{link text}",
@@ -1257,7 +1257,7 @@
   "hyperlinkappendixend<overlay specification>{}": {
     "command": "hyperlinkappendixend<overlay specification>{link text}",
     "package": "class-beamer",
-    "snippet": "hyperlinkappendixend<overlay specification>{${1:link text}}"
+    "snippet": "hyperlinkappendixend<${2:overlay specification}>{${1:link text}}"
   },
   "hyperlinkappendixend{}": {
     "command": "hyperlinkappendixend{link text}",
@@ -1267,7 +1267,7 @@
   "hyperlinkdocumentstart<overlay specification>{}": {
     "command": "hyperlinkdocumentstart<overlay specification>{link text}",
     "package": "class-beamer",
-    "snippet": "hyperlinkdocumentstart<overlay specification>{${1:link text}}"
+    "snippet": "hyperlinkdocumentstart<${2:overlay specification}>{${1:link text}}"
   },
   "hyperlinkdocumentstart{}": {
     "command": "hyperlinkdocumentstart{link text}",
@@ -1277,7 +1277,7 @@
   "hyperlinkdocumentend<overlay specification>{}": {
     "command": "hyperlinkdocumentend<overlay specification>{link text}",
     "package": "class-beamer",
-    "snippet": "hyperlinkdocumentend<overlay specification>{${1:link text}}"
+    "snippet": "hyperlinkdocumentend<${2:overlay specification}>{${1:link text}}"
   },
   "hyperlinkdocumentend{}": {
     "command": "hyperlinkdocumentend{link text}",
@@ -1287,17 +1287,17 @@
   "againframe<overlay specification>[][]{}": {
     "command": "againframe<overlay specification>[<default overlay specification>][options]{name}",
     "package": "class-beamer",
-    "snippet": "againframe<overlay specification>[${2:<default overlay specification>}][${3:options}]{${1:name}}"
+    "snippet": "againframe<${4:overlay specification}>[${2:<default overlay specification>}][${3:options}]{${1:name}}"
   },
   "againframe<overlay specification>[]{}": {
     "command": "againframe<overlay specification>[options]{name}",
     "package": "class-beamer",
-    "snippet": "againframe<overlay specification>[${2:options}]{${1:name}}"
+    "snippet": "againframe<${3:overlay specification}>[${2:options}]{${1:name}}"
   },
   "againframe<overlay specification>{}": {
     "command": "againframe<overlay specification>{name}",
     "package": "class-beamer",
-    "snippet": "againframe<overlay specification>{${1:name}}"
+    "snippet": "againframe<${2:overlay specification}>{${1:name}}"
   },
   "againframe[][]{}": {
     "command": "againframe[<default overlay specification>][options]{name}",
@@ -1317,17 +1317,17 @@
   "framezoom<button overlay specification><zoomed overlay specification>[](upper left x,upper left y)(zoom area width,zoom area depth)": {
     "command": "framezoom<button overlay specification><zoomed overlay specification>[options](upper left x,upper left y)(zoom area width,zoom area depth)",
     "package": "class-beamer",
-    "snippet": "framezoom<button overlay specification><zoomed overlay specification>[${1:options}](upper left x,upper left y)(zoom area width,zoom area depth)"
+    "snippet": "framezoom<${2:button overlay specification}><${3:zoomed overlay specification}>[${1:options}](upper left x,upper left y)(zoom area width,zoom area depth)"
   },
   "framezoom<button overlay specification><zoomed overlay specification>(upper left x,upper left y)(zoom area width,zoom area depth)": {
     "command": "framezoom<button overlay specification><zoomed overlay specification>(upper left x,upper left y)(zoom area width,zoom area depth)",
     "package": "class-beamer",
-    "snippet": "framezoom<button overlay specification><zoomed overlay specification>(upper left x,upper left y)(zoom area width,zoom area depth)"
+    "snippet": "framezoom<${1:button overlay specification}><${2:zoomed overlay specification}>(upper left x,upper left y)(zoom area width,zoom area depth)"
   },
   "structure<overlay specification>{}": {
     "command": "structure<overlay specification>{text}",
     "package": "class-beamer",
-    "snippet": "structure<overlay specification>{${1:text}}"
+    "snippet": "structure<${2:overlay specification}>{${1:text}}"
   },
   "structure{}": {
     "command": "structure{text}",
@@ -1337,7 +1337,7 @@
   "alert<overlay specification>{}": {
     "command": "alert<overlay specification>{highlighted text}",
     "package": "class-beamer",
-    "snippet": "alert<overlay specification>{${1:highlighted text}}"
+    "snippet": "alert<${2:overlay specification}>{${1:highlighted text}}"
   },
   "alert{}": {
     "command": "alert{highlighted text}",
@@ -1372,12 +1372,12 @@
   "footnote<overlay specification>[]{}": {
     "command": "footnote<overlay specification>[options]{text}",
     "package": "class-beamer",
-    "snippet": "footnote<overlay specification>[${2:options}]{${1:text}}"
+    "snippet": "footnote<${3:overlay specification}>[${2:options}]{${1:text}}"
   },
   "footnote<overlay specification>{}": {
     "command": "footnote<overlay specification>{text}",
     "package": "class-beamer",
-    "snippet": "footnote<overlay specification>{${1:text}}"
+    "snippet": "footnote<${2:overlay specification}>{${1:text}}"
   },
   "footnote{}": {
     "command": "footnote{text}",
@@ -1402,7 +1402,7 @@
   "mode<mode specification>{}": {
     "command": "mode<mode specification>{text}",
     "package": "class-beamer",
-    "snippet": "mode<mode specification>{${1:text}}"
+    "snippet": "mode<${2:mode specification}>{${1:text}}"
   },
   "mode{}": {
     "command": "mode{text}",
@@ -1412,7 +1412,7 @@
   "mode<mode specification>": {
     "command": "mode<mode specification>",
     "package": "class-beamer",
-    "snippet": "mode<mode specification>"
+    "snippet": "mode<${1:mode specification}>"
   },
   "mode*": {
     "command": "mode*",
@@ -1427,12 +1427,12 @@
   "note<overlay specification>[]{}": {
     "command": "note<overlay specification>[options]{note text}",
     "package": "class-beamer",
-    "snippet": "note<overlay specification>[${2:options}]{${1:note text}}"
+    "snippet": "note<${3:overlay specification}>[${2:options}]{${1:note text}}"
   },
   "note<overlay specification>{}": {
     "command": "note<overlay specification>{note text}",
     "package": "class-beamer",
-    "snippet": "note<overlay specification>{${1:note text}}"
+    "snippet": "note<${2:overlay specification}>{${1:note text}}"
   },
   "note[]{}": {
     "command": "note[options]{note text}",
@@ -1467,22 +1467,22 @@
   "onslide<overlay specification>{}": {
     "command": "onslide<overlay specification>{text}",
     "package": "class-beamer",
-    "snippet": "onslide<overlay specification>{${1:text}}"
+    "snippet": "onslide<${2:overlay specification}>{${1:text}}"
   },
   "onslide+<overlay specification>{}": {
     "command": "onslide+<overlay specification>{text}",
     "package": "class-beamer",
-    "snippet": "onslide+<overlay specification>{${1:text}}"
+    "snippet": "onslide+<${2:overlay specification}>{${1:text}}"
   },
   "onslide*<overlay specification>{}": {
     "command": "onslide*<overlay specification>{text}",
     "package": "class-beamer",
-    "snippet": "onslide*<overlay specification>{${1:text}}"
+    "snippet": "onslide*<${2:overlay specification}>{${1:text}}"
   },
   "onslide<overlay specification>": {
     "command": "onslide<overlay specification>",
     "package": "class-beamer",
-    "snippet": "onslide<overlay specification>"
+    "snippet": "onslide<${1:overlay specification}>"
   },
   "onslide": {
     "command": "onslide",
@@ -1492,12 +1492,12 @@
   "only<overlay specification>{}<overlay specification>": {
     "command": "only<overlay specification>{text}<overlay specification>",
     "package": "class-beamer",
-    "snippet": "only<overlay specification>{${1:text}}<overlay specification>"
+    "snippet": "only<${2:overlay specification}>{${1:text}}<${3:overlay specification}>"
   },
   "only{}<overlay specification>": {
     "command": "only{text}<overlay specification>",
     "package": "class-beamer",
-    "snippet": "only{${1:text}}<overlay specification>"
+    "snippet": "only{${1:text}}<${2:overlay specification}>"
   },
   "only{}": {
     "command": "only{text}",
@@ -1507,7 +1507,7 @@
   "uncover<overlay specification>{}": {
     "command": "uncover<overlay specification>{text}",
     "package": "class-beamer",
-    "snippet": "uncover<overlay specification>{${1:text}}"
+    "snippet": "uncover<${2:overlay specification}>{${1:text}}"
   },
   "uncover{}": {
     "command": "uncover{text}",
@@ -1517,7 +1517,7 @@
   "visible<overlay specification>{}": {
     "command": "visible<overlay specification>{text}",
     "package": "class-beamer",
-    "snippet": "visible<overlay specification>{${1:text}}"
+    "snippet": "visible<${2:overlay specification}>{${1:text}}"
   },
   "visible{}": {
     "command": "visible{text}",
@@ -1527,7 +1527,7 @@
   "invisible<overlay specification>{}": {
     "command": "invisible<overlay specification>{text}",
     "package": "class-beamer",
-    "snippet": "invisible<overlay specification>{${1:text}}"
+    "snippet": "invisible<${2:overlay specification}>{${1:text}}"
   },
   "invisible{}": {
     "command": "invisible{text}",
@@ -1537,12 +1537,12 @@
   "alt<overlay specification>{}{}<overlay specification>": {
     "command": "alt<overlay specification>{default text}{alternative text}<overlay specification>",
     "package": "class-beamer",
-    "snippet": "alt<overlay specification>{${1:default text}}{${2:alternative text}}<overlay specification>"
+    "snippet": "alt<${3:overlay specification}>{${1:default text}}{${2:alternative text}}<${4:overlay specification}>"
   },
   "alt{}{}<overlay specification>": {
     "command": "alt{default text}{alternative text}<overlay specification>",
     "package": "class-beamer",
-    "snippet": "alt{${1:default text}}{${2:alternative text}}<overlay specification>"
+    "snippet": "alt{${1:default text}}{${2:alternative text}}<${3:overlay specification}>"
   },
   "alt{}{}": {
     "command": "alt{default text}{alternative text}",
@@ -1557,27 +1557,27 @@
   "temporal<overlay specification>{}{}{}": {
     "command": "temporal<overlay specification>{before slide text}{default text}{after slide text}",
     "package": "class-beamer",
-    "snippet": "temporal<overlay specification>{${1:before slide text}}{${2:default text}}{${3:after slide text}}"
+    "snippet": "temporal<${4:overlay specification}>{${1:before slide text}}{${2:default text}}{${3:after slide text}}"
   },
   "item<alert specification>[]<alert specification>": {
     "command": "item<alert specification>[item label]<alert specification>",
     "package": "class-beamer",
-    "snippet": "item<alert specification>[${1:item label}]<alert specification>"
+    "snippet": "item<${2:alert specification}>[${1:item label}]<${3:alert specification}>"
   },
   "item<alert specification><alert specification>": {
     "command": "item<alert specification><alert specification>",
     "package": "class-beamer",
-    "snippet": "item<alert specification><alert specification>"
+    "snippet": "item<${1:alert specification}><${2:alert specification}>"
   },
   "item[]<alert specification>": {
     "command": "item[item label]<alert specification>",
     "package": "class-beamer",
-    "snippet": "item[${1:item label}]<alert specification>"
+    "snippet": "item[${1:item label}]<${2:alert specification}>"
   },
   "label<overlay specification>{}": {
     "command": "label<overlay specification>{label name}",
     "package": "class-beamer",
-    "snippet": "label<overlay specification>{${1:label name}}"
+    "snippet": "label<${2:overlay specification}>{${1:label name}}"
   },
   "label{}": {
     "command": "label{label name}",
@@ -1597,7 +1597,7 @@
   "action<action specification>{}": {
     "command": "action<action specification>{text}",
     "package": "class-beamer",
-    "snippet": "action<action specification>{${1:text}}"
+    "snippet": "action<${2:action specification}>{${1:text}}"
   },
   "action{}": {
     "command": "action{text}",

--- a/data/packages/class-beamer_env.json
+++ b/data/packages/class-beamer_env.json
@@ -1,5 +1,5 @@
 {
-  "frame ": {
+  "frame": {
     "name": "frame",
     "detail": "frame",
     "snippet": "",
@@ -83,7 +83,7 @@
     "snippet": "<${1:overlay specification}>",
     "package": "class-beamer"
   },
-  "structureenv ": {
+  "structureenv": {
     "name": "structureenv",
     "detail": "structureenv",
     "snippet": "",
@@ -95,7 +95,7 @@
     "snippet": "<${1:overlay specification}>",
     "package": "class-beamer"
   },
-  "alertenv ": {
+  "alertenv": {
     "name": "alertenv",
     "detail": "alertenv",
     "snippet": "",
@@ -149,7 +149,7 @@
     "snippet": "[${1:options}]",
     "package": "class-beamer"
   },
-  "columns ": {
+  "columns": {
     "name": "columns",
     "detail": "columns",
     "snippet": "",
@@ -167,7 +167,7 @@
     "snippet": "{${1:column width}}",
     "package": "class-beamer"
   },
-  "semiverbatim ": {
+  "semiverbatim": {
     "name": "semiverbatim",
     "detail": "semiverbatim",
     "snippet": "",
@@ -185,7 +185,7 @@
     "snippet": "<${1:overlay specification}>",
     "package": "class-beamer"
   },
-  "onlyenv ": {
+  "onlyenv": {
     "name": "onlyenv",
     "detail": "onlyenv",
     "snippet": "",
@@ -215,7 +215,7 @@
     "snippet": "[${1:area width}]",
     "package": "class-beamer"
   },
-  "overprint ": {
+  "overprint": {
     "name": "overprint",
     "detail": "overprint",
     "snippet": "",

--- a/data/packages/class-beamer_env.json
+++ b/data/packages/class-beamer_env.json
@@ -1,40 +1,230 @@
-[
-  "frame",
-  "frame",
-  "frame",
-  "frame",
-  "frame",
-  "frame",
-  "frame",
-  "frame",
-  "frame",
-  "frame",
-  "frame",
-  "frame",
-  "frame",
-  "frame",
-  "frame",
-  "frame",
-  "frame",
-  "structureenv",
-  "structureenv",
-  "alertenv",
-  "alertenv",
-  "block",
-  "alertblock",
-  "exampleblock",
-  "beamercolorbox",
-  "beamercolorbox",
-  "beamerboxesrounded",
-  "beamerboxesrounded",
-  "semiverbatim",
-  "abstract",
-  "onlyenv",
-  "onlyenv",
-  "altenv",
-  "altenv",
-  "overlayarea",
-  "overprint",
-  "overprint",
-  "actionenv"
-]
+{
+  "frame ": {
+    "name": "frame",
+    "detail": "frame",
+    "snippet": "",
+    "package": "class-beamer"
+  },
+  "frame <>": {
+    "name": "frame",
+    "detail": "frame<overlay specification>",
+    "snippet": "<${1:overlay specification}>",
+    "package": "class-beamer"
+  },
+  "frame <>[]": {
+    "name": "frame",
+    "detail": "frame<overlay specification>[<default overlay specification>]",
+    "snippet": "<${2:overlay specification}>[${1:<default overlay specification>}]",
+    "package": "class-beamer"
+  },
+  "frame <>[][]": {
+    "name": "frame",
+    "detail": "frame<overlay specification>[<default overlay specification>][options]",
+    "snippet": "<${3:overlay specification}>[${1:<default overlay specification>}][${2:options}]",
+    "package": "class-beamer"
+  },
+  "frame <>[][]{}": {
+    "name": "frame",
+    "detail": "frame<overlay specification>[<default overlay specification>][options]{title}",
+    "snippet": "<${4:overlay specification}>[${2:<default overlay specification>}][${3:options}]{${1:title}}",
+    "package": "class-beamer"
+  },
+  "frame <>[][]{}{}": {
+    "name": "frame",
+    "detail": "frame<overlay specification>[<default overlay specification>][options]{title}{subtitle}",
+    "snippet": "<${5:overlay specification}>[${3:<default overlay specification>}][${4:options}]{${1:title}}{${2:subtitle}}",
+    "package": "class-beamer"
+  },
+  "frame []": {
+    "name": "frame",
+    "detail": "frame[options]",
+    "snippet": "[${1:options}]",
+    "package": "class-beamer"
+  },
+  "frame [][]": {
+    "name": "frame",
+    "detail": "frame[<default overlay specification>][options]",
+    "snippet": "[${1:<default overlay specification>}][${2:options}]",
+    "package": "class-beamer"
+  },
+  "frame [][]{}": {
+    "name": "frame",
+    "detail": "frame[<default overlay specification>][options]{title}",
+    "snippet": "[${2:<default overlay specification>}][${3:options}]{${1:title}}",
+    "package": "class-beamer"
+  },
+  "frame [][]{}{}": {
+    "name": "frame",
+    "detail": "frame[<default overlay specification>][options]{title}{subtitle}",
+    "snippet": "[${3:<default overlay specification>}][${4:options}]{${1:title}}{${2:subtitle}}",
+    "package": "class-beamer"
+  },
+  "frame []{}": {
+    "name": "frame",
+    "detail": "frame[options]{title}",
+    "snippet": "[${2:options}]{${1:title}}",
+    "package": "class-beamer"
+  },
+  "frame []{}{}": {
+    "name": "frame",
+    "detail": "frame[options]{title}{subtitle}",
+    "snippet": "[${3:options}]{${1:title}}{${2:subtitle}}",
+    "package": "class-beamer"
+  },
+  "frame {}": {
+    "name": "frame",
+    "detail": "frame{subtitle}",
+    "snippet": "{${1:subtitle}}",
+    "package": "class-beamer"
+  },
+  "structureenv <>": {
+    "name": "structureenv",
+    "detail": "structureenv<overlay specification>",
+    "snippet": "<${1:overlay specification}>",
+    "package": "class-beamer"
+  },
+  "structureenv ": {
+    "name": "structureenv",
+    "detail": "structureenv",
+    "snippet": "",
+    "package": "class-beamer"
+  },
+  "alertenv <>": {
+    "name": "alertenv",
+    "detail": "alertenv<overlay specification>",
+    "snippet": "<${1:overlay specification}>",
+    "package": "class-beamer"
+  },
+  "alertenv ": {
+    "name": "alertenv",
+    "detail": "alertenv",
+    "snippet": "",
+    "package": "class-beamer"
+  },
+  "block <>{}<>": {
+    "name": "block",
+    "detail": "block<action specification>{block title}<action specification>",
+    "snippet": "<${2:action specification}>{${1:block title}}<${3:action specification}>",
+    "package": "class-beamer"
+  },
+  "alertblock <>{}<>": {
+    "name": "alertblock",
+    "detail": "alertblock<action specification>{block title}<action specification>",
+    "snippet": "<${2:action specification}>{${1:block title}}<${3:action specification}>",
+    "package": "class-beamer"
+  },
+  "exampleblock <>{}<>": {
+    "name": "exampleblock",
+    "detail": "exampleblock<action specification>{block title}<overlay specification>",
+    "snippet": "<${2:action specification}>{${1:block title}}<${3:overlay specification}>",
+    "package": "class-beamer"
+  },
+  "beamercolorbox []{}": {
+    "name": "beamercolorbox",
+    "detail": "beamercolorbox[options]{beamer color}",
+    "snippet": "[${2:options}]{${1:beamer color}}",
+    "package": "class-beamer"
+  },
+  "beamercolorbox {}": {
+    "name": "beamercolorbox",
+    "detail": "beamercolorbox{beamer color}",
+    "snippet": "{${1:beamer color}}",
+    "package": "class-beamer"
+  },
+  "beamerboxesrounded []{}": {
+    "name": "beamerboxesrounded",
+    "detail": "beamerboxesrounded[options]{head}",
+    "snippet": "[${2:options}]{${1:head}}",
+    "package": "class-beamer"
+  },
+  "beamerboxesrounded {}": {
+    "name": "beamerboxesrounded",
+    "detail": "beamerboxesrounded{head}",
+    "snippet": "{${1:head}}",
+    "package": "class-beamer"
+  },
+  "columns []": {
+    "name": "columns",
+    "detail": "columns[options]",
+    "snippet": "[${1:options}]",
+    "package": "class-beamer"
+  },
+  "columns ": {
+    "name": "columns",
+    "detail": "columns",
+    "snippet": "",
+    "package": "class-beamer"
+  },
+  "column []{}": {
+    "name": "column",
+    "detail": "column[placement]{column width}",
+    "snippet": "[${2:placement}]{${1:column width}}",
+    "package": "class-beamer"
+  },
+  "column {}": {
+    "name": "column",
+    "detail": "column{column width}",
+    "snippet": "{${1:column width}}",
+    "package": "class-beamer"
+  },
+  "semiverbatim ": {
+    "name": "semiverbatim",
+    "detail": "semiverbatim",
+    "snippet": "",
+    "package": "class-beamer"
+  },
+  "abstract <>": {
+    "name": "abstract",
+    "detail": "abstract<action specification>",
+    "snippet": "<${1:action specification}>",
+    "package": "class-beamer"
+  },
+  "onlyenv <>": {
+    "name": "onlyenv",
+    "detail": "onlyenv<overlay specification>",
+    "snippet": "<${1:overlay specification}>",
+    "package": "class-beamer"
+  },
+  "onlyenv ": {
+    "name": "onlyenv",
+    "detail": "onlyenv",
+    "snippet": "",
+    "package": "class-beamer"
+  },
+  "altenv <>{}{}{}{}<>": {
+    "name": "altenv",
+    "detail": "altenv<overlay specification>{begin text}{end text}{alternate begin text}{alternate end text}<overlay specification>",
+    "snippet": "<${5:overlay specification}>{${1:begin text}}{${2:end text}}{${3:alternate begin text}}{${4:alternate end text}}<${6:overlay specification}>",
+    "package": "class-beamer"
+  },
+  "altenv {}{}{}{}<>": {
+    "name": "altenv",
+    "detail": "altenv{begin text}{end text}{alternate begin text}{alternate end text}<overlay specification>",
+    "snippet": "{${1:begin text}}{${2:end text}}{${3:alternate begin text}}{${4:alternate end text}}<${5:overlay specification}>",
+    "package": "class-beamer"
+  },
+  "overlayarea {}{}": {
+    "name": "overlayarea",
+    "detail": "overlayarea{area width}{area height}",
+    "snippet": "{${1:area width}}{${2:area height}}",
+    "package": "class-beamer"
+  },
+  "overprint []": {
+    "name": "overprint",
+    "detail": "overprint[area width]",
+    "snippet": "[${1:area width}]",
+    "package": "class-beamer"
+  },
+  "overprint ": {
+    "name": "overprint",
+    "detail": "overprint",
+    "snippet": "",
+    "package": "class-beamer"
+  },
+  "actionenv <>": {
+    "name": "actionenv",
+    "detail": "actionenv<action specification>",
+    "snippet": "<${1:action specification}>",
+    "package": "class-beamer"
+  }
+}

--- a/data/packages/class-exam_env.json
+++ b/data/packages/class-exam_env.json
@@ -1,24 +1,134 @@
-[
-  "questions",
-  "parts",
-  "subparts",
-  "subsubparts",
-  "choices",
-  "oneparchoices",
-  "checkboxes",
-  "oneparcheckboxes",
-  "EnvUplevel",
-  "EnvFullwidth",
-  "solution",
-  "solution",
-  "solutionorbox",
-  "solutionorbox",
-  "solutionorlines",
-  "solutionorlines",
-  "solutionordottedlines",
-  "solutionordottedlines",
-  "solutionorgrid",
-  "solutionorgrid",
-  "solutionbox",
-  "coverpages"
-]
+{
+  "questions ": {
+    "name": "questions",
+    "detail": "questions",
+    "snippet": "",
+    "package": "class-exam"
+  },
+  "parts ": {
+    "name": "parts",
+    "detail": "parts",
+    "snippet": "",
+    "package": "class-exam"
+  },
+  "subparts ": {
+    "name": "subparts",
+    "detail": "subparts",
+    "snippet": "",
+    "package": "class-exam"
+  },
+  "subsubparts ": {
+    "name": "subsubparts",
+    "detail": "subsubparts",
+    "snippet": "",
+    "package": "class-exam"
+  },
+  "choices ": {
+    "name": "choices",
+    "detail": "choices",
+    "snippet": "",
+    "package": "class-exam"
+  },
+  "oneparchoices ": {
+    "name": "oneparchoices",
+    "detail": "oneparchoices",
+    "snippet": "",
+    "package": "class-exam"
+  },
+  "checkboxes ": {
+    "name": "checkboxes",
+    "detail": "checkboxes",
+    "snippet": "",
+    "package": "class-exam"
+  },
+  "oneparcheckboxes ": {
+    "name": "oneparcheckboxes",
+    "detail": "oneparcheckboxes",
+    "snippet": "",
+    "package": "class-exam"
+  },
+  "EnvUplevel ": {
+    "name": "EnvUplevel",
+    "detail": "EnvUplevel",
+    "snippet": "",
+    "package": "class-exam"
+  },
+  "EnvFullwidth ": {
+    "name": "EnvFullwidth",
+    "detail": "EnvFullwidth",
+    "snippet": "",
+    "package": "class-exam"
+  },
+  "solution ": {
+    "name": "solution",
+    "detail": "solution",
+    "snippet": "",
+    "package": "class-exam"
+  },
+  "solution []": {
+    "name": "solution",
+    "detail": "solution[height]",
+    "snippet": "[${1:height}]",
+    "package": "class-exam"
+  },
+  "solutionorbox ": {
+    "name": "solutionorbox",
+    "detail": "solutionorbox",
+    "snippet": "",
+    "package": "class-exam"
+  },
+  "solutionorbox []": {
+    "name": "solutionorbox",
+    "detail": "solutionorbox[height]",
+    "snippet": "[${1:height}]",
+    "package": "class-exam"
+  },
+  "solutionorlines ": {
+    "name": "solutionorlines",
+    "detail": "solutionorlines",
+    "snippet": "",
+    "package": "class-exam"
+  },
+  "solutionorlines []": {
+    "name": "solutionorlines",
+    "detail": "solutionorlines[height]",
+    "snippet": "[${1:height}]",
+    "package": "class-exam"
+  },
+  "solutionordottedlines ": {
+    "name": "solutionordottedlines",
+    "detail": "solutionordottedlines",
+    "snippet": "",
+    "package": "class-exam"
+  },
+  "solutionordottedlines []": {
+    "name": "solutionordottedlines",
+    "detail": "solutionordottedlines[height]",
+    "snippet": "[${1:height}]",
+    "package": "class-exam"
+  },
+  "solutionorgrid ": {
+    "name": "solutionorgrid",
+    "detail": "solutionorgrid",
+    "snippet": "",
+    "package": "class-exam"
+  },
+  "solutionorgrid []": {
+    "name": "solutionorgrid",
+    "detail": "solutionorgrid[height]",
+    "snippet": "[${1:height}]",
+    "package": "class-exam"
+  },
+  "solutionbox {}": {
+    "name": "solutionbox",
+    "detail": "solutionbox{height}",
+    "snippet": "{${1:height}}",
+    "package": "class-exam"
+  },
+  "coverpages ": {
+    "name": "coverpages",
+    "detail": "coverpages",
+    "snippet": "",
+    "package": "class-exam"
+  }
+}

--- a/data/packages/class-exam_env.json
+++ b/data/packages/class-exam_env.json
@@ -1,65 +1,65 @@
 {
-  "questions ": {
+  "questions": {
     "name": "questions",
     "detail": "questions",
     "snippet": "",
     "package": "class-exam"
   },
-  "parts ": {
+  "parts": {
     "name": "parts",
     "detail": "parts",
     "snippet": "",
     "package": "class-exam"
   },
-  "subparts ": {
+  "subparts": {
     "name": "subparts",
     "detail": "subparts",
     "snippet": "",
     "package": "class-exam"
   },
-  "subsubparts ": {
+  "subsubparts": {
     "name": "subsubparts",
     "detail": "subsubparts",
     "snippet": "",
     "package": "class-exam"
   },
-  "choices ": {
+  "choices": {
     "name": "choices",
     "detail": "choices",
     "snippet": "",
     "package": "class-exam"
   },
-  "oneparchoices ": {
+  "oneparchoices": {
     "name": "oneparchoices",
     "detail": "oneparchoices",
     "snippet": "",
     "package": "class-exam"
   },
-  "checkboxes ": {
+  "checkboxes": {
     "name": "checkboxes",
     "detail": "checkboxes",
     "snippet": "",
     "package": "class-exam"
   },
-  "oneparcheckboxes ": {
+  "oneparcheckboxes": {
     "name": "oneparcheckboxes",
     "detail": "oneparcheckboxes",
     "snippet": "",
     "package": "class-exam"
   },
-  "EnvUplevel ": {
+  "EnvUplevel": {
     "name": "EnvUplevel",
     "detail": "EnvUplevel",
     "snippet": "",
     "package": "class-exam"
   },
-  "EnvFullwidth ": {
+  "EnvFullwidth": {
     "name": "EnvFullwidth",
     "detail": "EnvFullwidth",
     "snippet": "",
     "package": "class-exam"
   },
-  "solution ": {
+  "solution": {
     "name": "solution",
     "detail": "solution",
     "snippet": "",
@@ -71,7 +71,7 @@
     "snippet": "[${1:height}]",
     "package": "class-exam"
   },
-  "solutionorbox ": {
+  "solutionorbox": {
     "name": "solutionorbox",
     "detail": "solutionorbox",
     "snippet": "",
@@ -83,7 +83,7 @@
     "snippet": "[${1:height}]",
     "package": "class-exam"
   },
-  "solutionorlines ": {
+  "solutionorlines": {
     "name": "solutionorlines",
     "detail": "solutionorlines",
     "snippet": "",
@@ -95,7 +95,7 @@
     "snippet": "[${1:height}]",
     "package": "class-exam"
   },
-  "solutionordottedlines ": {
+  "solutionordottedlines": {
     "name": "solutionordottedlines",
     "detail": "solutionordottedlines",
     "snippet": "",
@@ -107,7 +107,7 @@
     "snippet": "[${1:height}]",
     "package": "class-exam"
   },
-  "solutionorgrid ": {
+  "solutionorgrid": {
     "name": "solutionorgrid",
     "detail": "solutionorgrid",
     "snippet": "",
@@ -125,7 +125,7 @@
     "snippet": "{${1:height}}",
     "package": "class-exam"
   },
-  "coverpages ": {
+  "coverpages": {
     "name": "coverpages",
     "detail": "coverpages",
     "snippet": "",

--- a/data/packages/class-letter_env.json
+++ b/data/packages/class-letter_env.json
@@ -1,3 +1,8 @@
-[
-  "letter"
-]
+{
+  "letter {}": {
+    "name": "letter",
+    "detail": "letter{name}",
+    "snippet": "{${1:name}}",
+    "package": "class-letter"
+  }
+}

--- a/data/packages/class-memoir_env.json
+++ b/data/packages/class-memoir_env.json
@@ -1,29 +1,29 @@
 {
-  "DoubleSpace ": {
+  "DoubleSpace": {
     "name": "DoubleSpace",
     "detail": "DoubleSpace",
     "snippet": "",
     "package": "class-memoir"
   },
-  "OnehalfSpace ": {
+  "OnehalfSpace": {
     "name": "OnehalfSpace",
     "detail": "OnehalfSpace",
     "snippet": "",
     "package": "class-memoir"
   },
-  "DoubleSpace* ": {
+  "DoubleSpace*": {
     "name": "DoubleSpace*",
     "detail": "DoubleSpace*",
     "snippet": "",
     "package": "class-memoir"
   },
-  "OnehalfSpace* ": {
+  "OnehalfSpace*": {
     "name": "OnehalfSpace*",
     "detail": "OnehalfSpace*",
     "snippet": "",
     "package": "class-memoir"
   },
-  "SingleSpace ": {
+  "SingleSpace": {
     "name": "SingleSpace",
     "detail": "SingleSpace",
     "snippet": "",
@@ -35,175 +35,175 @@
     "snippet": "{${1:factor}}",
     "package": "class-memoir"
   },
-  "adjustwidth ": {
+  "adjustwidth": {
     "name": "adjustwidth",
     "detail": "adjustwidth",
     "snippet": "",
     "package": "class-memoir"
   },
-  "altverse ": {
+  "altverse": {
     "name": "altverse",
     "detail": "altverse",
     "snippet": "",
     "package": "class-memoir"
   },
-  "appendices ": {
+  "appendices": {
     "name": "appendices",
     "detail": "appendices",
     "snippet": "",
     "package": "class-memoir"
   },
-  "bibitemlist ": {
+  "bibitemlist": {
     "name": "bibitemlist",
     "detail": "bibitemlist",
     "snippet": "",
     "package": "class-memoir"
   },
-  "blockdescription ": {
+  "blockdescription": {
     "name": "blockdescription",
     "detail": "blockdescription",
     "snippet": "",
     "package": "class-memoir"
   },
-  "epigraphs ": {
+  "epigraphs": {
     "name": "epigraphs",
     "detail": "epigraphs",
     "snippet": "",
     "package": "class-memoir"
   },
-  "flexlabelled ": {
+  "flexlabelled": {
     "name": "flexlabelled",
     "detail": "flexlabelled",
     "snippet": "",
     "package": "class-memoir"
   },
-  "framed ": {
+  "framed": {
     "name": "framed",
     "detail": "framed",
     "snippet": "",
     "package": "class-memoir"
   },
-  "hangparas ": {
+  "hangparas": {
     "name": "hangparas",
     "detail": "hangparas",
     "snippet": "",
     "package": "class-memoir"
   },
-  "labelled ": {
+  "labelled": {
     "name": "labelled",
     "detail": "labelled",
     "snippet": "",
     "package": "class-memoir"
   },
-  "leftbar ": {
+  "leftbar": {
     "name": "leftbar",
     "detail": "leftbar",
     "snippet": "",
     "package": "class-memoir"
   },
-  "marginfigure ": {
+  "marginfigure": {
     "name": "marginfigure",
     "detail": "marginfigure",
     "snippet": "",
     "package": "class-memoir"
   },
-  "margintable ": {
+  "margintable": {
     "name": "margintable",
     "detail": "margintable",
     "snippet": "",
     "package": "class-memoir"
   },
-  "midsloppypar ": {
+  "midsloppypar": {
     "name": "midsloppypar",
     "detail": "midsloppypar",
     "snippet": "",
     "package": "class-memoir"
   },
-  "onecolabstract ": {
+  "onecolabstract": {
     "name": "onecolabstract",
     "detail": "onecolabstract",
     "snippet": "",
     "package": "class-memoir"
   },
-  "patverse ": {
+  "patverse": {
     "name": "patverse",
     "detail": "patverse",
     "snippet": "",
     "package": "class-memoir"
   },
-  "qframe ": {
+  "qframe": {
     "name": "qframe",
     "detail": "qframe",
     "snippet": "",
     "package": "class-memoir"
   },
-  "qshade ": {
+  "qshade": {
     "name": "qshade",
     "detail": "qshade",
     "snippet": "",
     "package": "class-memoir"
   },
-  "shaded ": {
+  "shaded": {
     "name": "shaded",
     "detail": "shaded",
     "snippet": "",
     "package": "class-memoir"
   },
-  "snugshade ": {
+  "snugshade": {
     "name": "snugshade",
     "detail": "snugshade",
     "snippet": "",
     "package": "class-memoir"
   },
-  "subappendices ": {
+  "subappendices": {
     "name": "subappendices",
     "detail": "subappendices",
     "snippet": "",
     "package": "class-memoir"
   },
-  "subfloat ": {
+  "subfloat": {
     "name": "subfloat",
     "detail": "subfloat",
     "snippet": "",
     "package": "class-memoir"
   },
-  "symbols ": {
+  "symbols": {
     "name": "symbols",
     "detail": "symbols",
     "snippet": "",
     "package": "class-memoir"
   },
-  "theglossary ": {
+  "theglossary": {
     "name": "theglossary",
     "detail": "theglossary",
     "snippet": "",
     "package": "class-memoir"
   },
-  "theindex ": {
+  "theindex": {
     "name": "theindex",
     "detail": "theindex",
     "snippet": "",
     "package": "class-memoir"
   },
-  "titlingpage ": {
+  "titlingpage": {
     "name": "titlingpage",
     "detail": "titlingpage",
     "snippet": "",
     "package": "class-memoir"
   },
-  "titlingpage* ": {
+  "titlingpage*": {
     "name": "titlingpage*",
     "detail": "titlingpage*",
     "snippet": "",
     "package": "class-memoir"
   },
-  "vminipage ": {
+  "vminipage": {
     "name": "vminipage",
     "detail": "vminipage",
     "snippet": "",
     "package": "class-memoir"
   },
-  "vplace ": {
+  "vplace": {
     "name": "vplace",
     "detail": "vplace",
     "snippet": "",

--- a/data/packages/class-memoir_env.json
+++ b/data/packages/class-memoir_env.json
@@ -1,37 +1,212 @@
-[
-  "DoubleSpace",
-  "OnehalfSpace",
-  "DoubleSpace*",
-  "OnehalfSpace*",
-  "SingleSpace",
-  "Spacing",
-  "adjustwidth",
-  "altverse",
-  "appendices",
-  "bibitemlist",
-  "blockdescription",
-  "epigraphs",
-  "flexlabelled",
-  "framed",
-  "hangparas",
-  "labelled",
-  "leftbar",
-  "marginfigure",
-  "margintable",
-  "midsloppypar",
-  "onecolabstract",
-  "patverse",
-  "qframe",
-  "qshade",
-  "shaded",
-  "snugshade",
-  "subappendices",
-  "subfloat",
-  "symbols",
-  "theglossary",
-  "theindex",
-  "titlingpage",
-  "titlingpage*",
-  "vminipage",
-  "vplace"
-]
+{
+  "DoubleSpace ": {
+    "name": "DoubleSpace",
+    "detail": "DoubleSpace",
+    "snippet": "",
+    "package": "class-memoir"
+  },
+  "OnehalfSpace ": {
+    "name": "OnehalfSpace",
+    "detail": "OnehalfSpace",
+    "snippet": "",
+    "package": "class-memoir"
+  },
+  "DoubleSpace* ": {
+    "name": "DoubleSpace*",
+    "detail": "DoubleSpace*",
+    "snippet": "",
+    "package": "class-memoir"
+  },
+  "OnehalfSpace* ": {
+    "name": "OnehalfSpace*",
+    "detail": "OnehalfSpace*",
+    "snippet": "",
+    "package": "class-memoir"
+  },
+  "SingleSpace ": {
+    "name": "SingleSpace",
+    "detail": "SingleSpace",
+    "snippet": "",
+    "package": "class-memoir"
+  },
+  "Spacing {}": {
+    "name": "Spacing",
+    "detail": "Spacing{factor}",
+    "snippet": "{${1:factor}}",
+    "package": "class-memoir"
+  },
+  "adjustwidth ": {
+    "name": "adjustwidth",
+    "detail": "adjustwidth",
+    "snippet": "",
+    "package": "class-memoir"
+  },
+  "altverse ": {
+    "name": "altverse",
+    "detail": "altverse",
+    "snippet": "",
+    "package": "class-memoir"
+  },
+  "appendices ": {
+    "name": "appendices",
+    "detail": "appendices",
+    "snippet": "",
+    "package": "class-memoir"
+  },
+  "bibitemlist ": {
+    "name": "bibitemlist",
+    "detail": "bibitemlist",
+    "snippet": "",
+    "package": "class-memoir"
+  },
+  "blockdescription ": {
+    "name": "blockdescription",
+    "detail": "blockdescription",
+    "snippet": "",
+    "package": "class-memoir"
+  },
+  "epigraphs ": {
+    "name": "epigraphs",
+    "detail": "epigraphs",
+    "snippet": "",
+    "package": "class-memoir"
+  },
+  "flexlabelled ": {
+    "name": "flexlabelled",
+    "detail": "flexlabelled",
+    "snippet": "",
+    "package": "class-memoir"
+  },
+  "framed ": {
+    "name": "framed",
+    "detail": "framed",
+    "snippet": "",
+    "package": "class-memoir"
+  },
+  "hangparas ": {
+    "name": "hangparas",
+    "detail": "hangparas",
+    "snippet": "",
+    "package": "class-memoir"
+  },
+  "labelled ": {
+    "name": "labelled",
+    "detail": "labelled",
+    "snippet": "",
+    "package": "class-memoir"
+  },
+  "leftbar ": {
+    "name": "leftbar",
+    "detail": "leftbar",
+    "snippet": "",
+    "package": "class-memoir"
+  },
+  "marginfigure ": {
+    "name": "marginfigure",
+    "detail": "marginfigure",
+    "snippet": "",
+    "package": "class-memoir"
+  },
+  "margintable ": {
+    "name": "margintable",
+    "detail": "margintable",
+    "snippet": "",
+    "package": "class-memoir"
+  },
+  "midsloppypar ": {
+    "name": "midsloppypar",
+    "detail": "midsloppypar",
+    "snippet": "",
+    "package": "class-memoir"
+  },
+  "onecolabstract ": {
+    "name": "onecolabstract",
+    "detail": "onecolabstract",
+    "snippet": "",
+    "package": "class-memoir"
+  },
+  "patverse ": {
+    "name": "patverse",
+    "detail": "patverse",
+    "snippet": "",
+    "package": "class-memoir"
+  },
+  "qframe ": {
+    "name": "qframe",
+    "detail": "qframe",
+    "snippet": "",
+    "package": "class-memoir"
+  },
+  "qshade ": {
+    "name": "qshade",
+    "detail": "qshade",
+    "snippet": "",
+    "package": "class-memoir"
+  },
+  "shaded ": {
+    "name": "shaded",
+    "detail": "shaded",
+    "snippet": "",
+    "package": "class-memoir"
+  },
+  "snugshade ": {
+    "name": "snugshade",
+    "detail": "snugshade",
+    "snippet": "",
+    "package": "class-memoir"
+  },
+  "subappendices ": {
+    "name": "subappendices",
+    "detail": "subappendices",
+    "snippet": "",
+    "package": "class-memoir"
+  },
+  "subfloat ": {
+    "name": "subfloat",
+    "detail": "subfloat",
+    "snippet": "",
+    "package": "class-memoir"
+  },
+  "symbols ": {
+    "name": "symbols",
+    "detail": "symbols",
+    "snippet": "",
+    "package": "class-memoir"
+  },
+  "theglossary ": {
+    "name": "theglossary",
+    "detail": "theglossary",
+    "snippet": "",
+    "package": "class-memoir"
+  },
+  "theindex ": {
+    "name": "theindex",
+    "detail": "theindex",
+    "snippet": "",
+    "package": "class-memoir"
+  },
+  "titlingpage ": {
+    "name": "titlingpage",
+    "detail": "titlingpage",
+    "snippet": "",
+    "package": "class-memoir"
+  },
+  "titlingpage* ": {
+    "name": "titlingpage*",
+    "detail": "titlingpage*",
+    "snippet": "",
+    "package": "class-memoir"
+  },
+  "vminipage ": {
+    "name": "vminipage",
+    "detail": "vminipage",
+    "snippet": "",
+    "package": "class-memoir"
+  },
+  "vplace ": {
+    "name": "vplace",
+    "detail": "vplace",
+    "snippet": "",
+    "package": "class-memoir"
+  }
+}

--- a/data/packages/class-moderncv_cmd.json
+++ b/data/packages/class-moderncv_cmd.json
@@ -22,7 +22,7 @@
   "familyname{}": {
     "command": "familyname{%<family name>}",
     "package": "class-moderncv",
-    "snippet": "familyname{${1:%<family name>}}"
+    "snippet": "familyname{${1:%<${2:family name}>}}"
   },
   "title{}": {
     "command": "title{%<title%>}",
@@ -127,7 +127,7 @@
   "closing{}": {
     "command": "closing{%<closing>}",
     "package": "class-moderncv",
-    "snippet": "closing{${1:%<closing>}}"
+    "snippet": "closing{${1:%<${2:closing}>}}"
   },
   "enclosure{}": {
     "command": "enclosure{%<enclosure%>}",

--- a/data/packages/class-moderncv_env.json
+++ b/data/packages/class-moderncv_env.json
@@ -1,3 +1,8 @@
-[
-  "cvcolumns"
-]
+{
+  "cvcolumns ": {
+    "name": "cvcolumns",
+    "detail": "cvcolumns",
+    "snippet": "",
+    "package": "class-moderncv"
+  }
+}

--- a/data/packages/class-moderncv_env.json
+++ b/data/packages/class-moderncv_env.json
@@ -1,5 +1,5 @@
 {
-  "cvcolumns ": {
+  "cvcolumns": {
     "name": "cvcolumns",
     "detail": "cvcolumns",
     "snippet": "",

--- a/data/packages/class-scrartcl,scrreprt,scrbook_env.json
+++ b/data/packages/class-scrartcl,scrreprt,scrbook_env.json
@@ -1,15 +1,80 @@
-[
-  "addmargin",
-  "addmargin*",
-  "addmargin",
-  "addmargin*",
-  "captionbeside",
-  "captionbeside",
-  "captionbeside",
-  "captionbeside",
-  "captionbeside",
-  "captionbeside",
-  "captionbeside",
-  "labeling",
-  "labeling"
-]
+{
+  "addmargin {}": {
+    "name": "addmargin",
+    "detail": "addmargin{indent}",
+    "snippet": "{${1:indent}}",
+    "package": "class-scrartcl,scrreprt,scrbook"
+  },
+  "addmargin* {}": {
+    "name": "addmargin*",
+    "detail": "addmargin*{indent}",
+    "snippet": "{${1:indent}}",
+    "package": "class-scrartcl,scrreprt,scrbook"
+  },
+  "addmargin []{}": {
+    "name": "addmargin",
+    "detail": "addmargin[leftindent]{indent}",
+    "snippet": "[${2:leftindent}]{${1:indent}}",
+    "package": "class-scrartcl,scrreprt,scrbook"
+  },
+  "addmargin* []{}": {
+    "name": "addmargin*",
+    "detail": "addmargin*[middleindent]{indent}",
+    "snippet": "[${2:middleindent}]{${1:indent}}",
+    "package": "class-scrartcl,scrreprt,scrbook"
+  },
+  "captionbeside []{}": {
+    "name": "captionbeside",
+    "detail": "captionbeside[short]{title}",
+    "snippet": "[${2:short}]{${1:title}}",
+    "package": "class-scrartcl,scrreprt,scrbook"
+  },
+  "captionbeside []{}[]": {
+    "name": "captionbeside",
+    "detail": "captionbeside[short]{title}[pos]",
+    "snippet": "[${2:short}]{${1:title}}[${3:pos}]",
+    "package": "class-scrartcl,scrreprt,scrbook"
+  },
+  "captionbeside []{}[][]": {
+    "name": "captionbeside",
+    "detail": "captionbeside[short]{title}[pos][width]",
+    "snippet": "[${2:short}]{${1:title}}[${3:pos}][${4:width}]",
+    "package": "class-scrartcl,scrreprt,scrbook"
+  },
+  "captionbeside {}": {
+    "name": "captionbeside",
+    "detail": "captionbeside{title}",
+    "snippet": "{${1:title}}",
+    "package": "class-scrartcl,scrreprt,scrbook"
+  },
+  "captionbeside {}[]": {
+    "name": "captionbeside",
+    "detail": "captionbeside{title}[pos]",
+    "snippet": "{${1:title}}[${2:pos}]",
+    "package": "class-scrartcl,scrreprt,scrbook"
+  },
+  "captionbeside {}[][]": {
+    "name": "captionbeside",
+    "detail": "captionbeside{title}[pos][width]",
+    "snippet": "{${1:title}}[${2:pos}][${3:width}]",
+    "package": "class-scrartcl,scrreprt,scrbook"
+  },
+  "captionbeside {}[][][]": {
+    "name": "captionbeside",
+    "detail": "captionbeside{title}[pos][width][offset]",
+    "snippet": "{${1:title}}[${2:pos}][${3:width}][${4:offset}]",
+    "package": "class-scrartcl,scrreprt,scrbook"
+  },
+  "labeling []{}\\item": {
+    "name": "labeling",
+    "detail": "labeling[div]{template}\\item",
+    "snippet": "[${2:div}]{${1:template}}\\item",
+    "package": "class-scrartcl,scrreprt,scrbook"
+  },
+  "labeling {}\\item": {
+    "name": "labeling",
+    "detail": "labeling{template}\\item",
+    "snippet": "{${1:template}}\\item",
+    "package": "class-scrartcl,scrreprt,scrbook"
+  }
+}

--- a/data/packages/class-scrartcl_env.json
+++ b/data/packages/class-scrartcl_env.json
@@ -1,15 +1,80 @@
-[
-  "addmargin",
-  "addmargin*",
-  "addmargin",
-  "addmargin*",
-  "captionbeside",
-  "captionbeside",
-  "captionbeside",
-  "captionbeside",
-  "captionbeside",
-  "captionbeside",
-  "captionbeside",
-  "labeling",
-  "labeling"
-]
+{
+  "addmargin {}": {
+    "name": "addmargin",
+    "detail": "addmargin{indent}",
+    "snippet": "{${1:indent}}",
+    "package": "class-scrartcl,scrreprt,scrbook"
+  },
+  "addmargin* {}": {
+    "name": "addmargin*",
+    "detail": "addmargin*{indent}",
+    "snippet": "{${1:indent}}",
+    "package": "class-scrartcl,scrreprt,scrbook"
+  },
+  "addmargin []{}": {
+    "name": "addmargin",
+    "detail": "addmargin[leftindent]{indent}",
+    "snippet": "[${2:leftindent}]{${1:indent}}",
+    "package": "class-scrartcl,scrreprt,scrbook"
+  },
+  "addmargin* []{}": {
+    "name": "addmargin*",
+    "detail": "addmargin*[middleindent]{indent}",
+    "snippet": "[${2:middleindent}]{${1:indent}}",
+    "package": "class-scrartcl,scrreprt,scrbook"
+  },
+  "captionbeside []{}": {
+    "name": "captionbeside",
+    "detail": "captionbeside[short]{title}",
+    "snippet": "[${2:short}]{${1:title}}",
+    "package": "class-scrartcl,scrreprt,scrbook"
+  },
+  "captionbeside []{}[]": {
+    "name": "captionbeside",
+    "detail": "captionbeside[short]{title}[pos]",
+    "snippet": "[${2:short}]{${1:title}}[${3:pos}]",
+    "package": "class-scrartcl,scrreprt,scrbook"
+  },
+  "captionbeside []{}[][]": {
+    "name": "captionbeside",
+    "detail": "captionbeside[short]{title}[pos][width]",
+    "snippet": "[${2:short}]{${1:title}}[${3:pos}][${4:width}]",
+    "package": "class-scrartcl,scrreprt,scrbook"
+  },
+  "captionbeside {}": {
+    "name": "captionbeside",
+    "detail": "captionbeside{title}",
+    "snippet": "{${1:title}}",
+    "package": "class-scrartcl,scrreprt,scrbook"
+  },
+  "captionbeside {}[]": {
+    "name": "captionbeside",
+    "detail": "captionbeside{title}[pos]",
+    "snippet": "{${1:title}}[${2:pos}]",
+    "package": "class-scrartcl,scrreprt,scrbook"
+  },
+  "captionbeside {}[][]": {
+    "name": "captionbeside",
+    "detail": "captionbeside{title}[pos][width]",
+    "snippet": "{${1:title}}[${2:pos}][${3:width}]",
+    "package": "class-scrartcl,scrreprt,scrbook"
+  },
+  "captionbeside {}[][][]": {
+    "name": "captionbeside",
+    "detail": "captionbeside{title}[pos][width][offset]",
+    "snippet": "{${1:title}}[${2:pos}][${3:width}][${4:offset}]",
+    "package": "class-scrartcl,scrreprt,scrbook"
+  },
+  "labeling []{}\\item": {
+    "name": "labeling",
+    "detail": "labeling[div]{template}\\item",
+    "snippet": "[${2:div}]{${1:template}}\\item",
+    "package": "class-scrartcl,scrreprt,scrbook"
+  },
+  "labeling {}\\item": {
+    "name": "labeling",
+    "detail": "labeling{template}\\item",
+    "snippet": "{${1:template}}\\item",
+    "package": "class-scrartcl,scrreprt,scrbook"
+  }
+}

--- a/data/packages/class-scrbook_env.json
+++ b/data/packages/class-scrbook_env.json
@@ -1,15 +1,80 @@
-[
-  "addmargin",
-  "addmargin*",
-  "addmargin",
-  "addmargin*",
-  "captionbeside",
-  "captionbeside",
-  "captionbeside",
-  "captionbeside",
-  "captionbeside",
-  "captionbeside",
-  "captionbeside",
-  "labeling",
-  "labeling"
-]
+{
+  "addmargin {}": {
+    "name": "addmargin",
+    "detail": "addmargin{indent}",
+    "snippet": "{${1:indent}}",
+    "package": "class-scrartcl,scrreprt,scrbook"
+  },
+  "addmargin* {}": {
+    "name": "addmargin*",
+    "detail": "addmargin*{indent}",
+    "snippet": "{${1:indent}}",
+    "package": "class-scrartcl,scrreprt,scrbook"
+  },
+  "addmargin []{}": {
+    "name": "addmargin",
+    "detail": "addmargin[leftindent]{indent}",
+    "snippet": "[${2:leftindent}]{${1:indent}}",
+    "package": "class-scrartcl,scrreprt,scrbook"
+  },
+  "addmargin* []{}": {
+    "name": "addmargin*",
+    "detail": "addmargin*[middleindent]{indent}",
+    "snippet": "[${2:middleindent}]{${1:indent}}",
+    "package": "class-scrartcl,scrreprt,scrbook"
+  },
+  "captionbeside []{}": {
+    "name": "captionbeside",
+    "detail": "captionbeside[short]{title}",
+    "snippet": "[${2:short}]{${1:title}}",
+    "package": "class-scrartcl,scrreprt,scrbook"
+  },
+  "captionbeside []{}[]": {
+    "name": "captionbeside",
+    "detail": "captionbeside[short]{title}[pos]",
+    "snippet": "[${2:short}]{${1:title}}[${3:pos}]",
+    "package": "class-scrartcl,scrreprt,scrbook"
+  },
+  "captionbeside []{}[][]": {
+    "name": "captionbeside",
+    "detail": "captionbeside[short]{title}[pos][width]",
+    "snippet": "[${2:short}]{${1:title}}[${3:pos}][${4:width}]",
+    "package": "class-scrartcl,scrreprt,scrbook"
+  },
+  "captionbeside {}": {
+    "name": "captionbeside",
+    "detail": "captionbeside{title}",
+    "snippet": "{${1:title}}",
+    "package": "class-scrartcl,scrreprt,scrbook"
+  },
+  "captionbeside {}[]": {
+    "name": "captionbeside",
+    "detail": "captionbeside{title}[pos]",
+    "snippet": "{${1:title}}[${2:pos}]",
+    "package": "class-scrartcl,scrreprt,scrbook"
+  },
+  "captionbeside {}[][]": {
+    "name": "captionbeside",
+    "detail": "captionbeside{title}[pos][width]",
+    "snippet": "{${1:title}}[${2:pos}][${3:width}]",
+    "package": "class-scrartcl,scrreprt,scrbook"
+  },
+  "captionbeside {}[][][]": {
+    "name": "captionbeside",
+    "detail": "captionbeside{title}[pos][width][offset]",
+    "snippet": "{${1:title}}[${2:pos}][${3:width}][${4:offset}]",
+    "package": "class-scrartcl,scrreprt,scrbook"
+  },
+  "labeling []{}\\item": {
+    "name": "labeling",
+    "detail": "labeling[div]{template}\\item",
+    "snippet": "[${2:div}]{${1:template}}\\item",
+    "package": "class-scrartcl,scrreprt,scrbook"
+  },
+  "labeling {}\\item": {
+    "name": "labeling",
+    "detail": "labeling{template}\\item",
+    "snippet": "{${1:template}}\\item",
+    "package": "class-scrartcl,scrreprt,scrbook"
+  }
+}

--- a/data/packages/class-scrlttr2_env.json
+++ b/data/packages/class-scrlttr2_env.json
@@ -1,3 +1,8 @@
-[
-  "letter"
-]
+{
+  "letter {}": {
+    "name": "letter",
+    "detail": "letter{name}",
+    "snippet": "{${1:name}}",
+    "package": "class-scrlttr2"
+  }
+}

--- a/data/packages/class-scrreprt_env.json
+++ b/data/packages/class-scrreprt_env.json
@@ -1,15 +1,80 @@
-[
-  "addmargin",
-  "addmargin*",
-  "addmargin",
-  "addmargin*",
-  "captionbeside",
-  "captionbeside",
-  "captionbeside",
-  "captionbeside",
-  "captionbeside",
-  "captionbeside",
-  "captionbeside",
-  "labeling",
-  "labeling"
-]
+{
+  "addmargin {}": {
+    "name": "addmargin",
+    "detail": "addmargin{indent}",
+    "snippet": "{${1:indent}}",
+    "package": "class-scrartcl,scrreprt,scrbook"
+  },
+  "addmargin* {}": {
+    "name": "addmargin*",
+    "detail": "addmargin*{indent}",
+    "snippet": "{${1:indent}}",
+    "package": "class-scrartcl,scrreprt,scrbook"
+  },
+  "addmargin []{}": {
+    "name": "addmargin",
+    "detail": "addmargin[leftindent]{indent}",
+    "snippet": "[${2:leftindent}]{${1:indent}}",
+    "package": "class-scrartcl,scrreprt,scrbook"
+  },
+  "addmargin* []{}": {
+    "name": "addmargin*",
+    "detail": "addmargin*[middleindent]{indent}",
+    "snippet": "[${2:middleindent}]{${1:indent}}",
+    "package": "class-scrartcl,scrreprt,scrbook"
+  },
+  "captionbeside []{}": {
+    "name": "captionbeside",
+    "detail": "captionbeside[short]{title}",
+    "snippet": "[${2:short}]{${1:title}}",
+    "package": "class-scrartcl,scrreprt,scrbook"
+  },
+  "captionbeside []{}[]": {
+    "name": "captionbeside",
+    "detail": "captionbeside[short]{title}[pos]",
+    "snippet": "[${2:short}]{${1:title}}[${3:pos}]",
+    "package": "class-scrartcl,scrreprt,scrbook"
+  },
+  "captionbeside []{}[][]": {
+    "name": "captionbeside",
+    "detail": "captionbeside[short]{title}[pos][width]",
+    "snippet": "[${2:short}]{${1:title}}[${3:pos}][${4:width}]",
+    "package": "class-scrartcl,scrreprt,scrbook"
+  },
+  "captionbeside {}": {
+    "name": "captionbeside",
+    "detail": "captionbeside{title}",
+    "snippet": "{${1:title}}",
+    "package": "class-scrartcl,scrreprt,scrbook"
+  },
+  "captionbeside {}[]": {
+    "name": "captionbeside",
+    "detail": "captionbeside{title}[pos]",
+    "snippet": "{${1:title}}[${2:pos}]",
+    "package": "class-scrartcl,scrreprt,scrbook"
+  },
+  "captionbeside {}[][]": {
+    "name": "captionbeside",
+    "detail": "captionbeside{title}[pos][width]",
+    "snippet": "{${1:title}}[${2:pos}][${3:width}]",
+    "package": "class-scrartcl,scrreprt,scrbook"
+  },
+  "captionbeside {}[][][]": {
+    "name": "captionbeside",
+    "detail": "captionbeside{title}[pos][width][offset]",
+    "snippet": "{${1:title}}[${2:pos}][${3:width}][${4:offset}]",
+    "package": "class-scrartcl,scrreprt,scrbook"
+  },
+  "labeling []{}\\item": {
+    "name": "labeling",
+    "detail": "labeling[div]{template}\\item",
+    "snippet": "[${2:div}]{${1:template}}\\item",
+    "package": "class-scrartcl,scrreprt,scrbook"
+  },
+  "labeling {}\\item": {
+    "name": "labeling",
+    "detail": "labeling{template}\\item",
+    "snippet": "{${1:template}}\\item",
+    "package": "class-scrartcl,scrreprt,scrbook"
+  }
+}

--- a/data/packages/comment_env.json
+++ b/data/packages/comment_env.json
@@ -1,5 +1,5 @@
 {
-  "comment ": {
+  "comment": {
     "name": "comment",
     "detail": "comment",
     "snippet": "",

--- a/data/packages/comment_env.json
+++ b/data/packages/comment_env.json
@@ -1,3 +1,8 @@
-[
-  "comment"
-]
+{
+  "comment ": {
+    "name": "comment",
+    "detail": "comment",
+    "snippet": "",
+    "package": "comment"
+  }
+}

--- a/data/packages/cquthesis_env.json
+++ b/data/packages/cquthesis_env.json
@@ -1,71 +1,71 @@
 {
-  "cabstract ": {
+  "cabstract": {
     "name": "cabstract",
     "detail": "cabstract",
     "snippet": "",
     "package": "cquthesis"
   },
-  "denotation ": {
+  "denotation": {
     "name": "denotation",
     "detail": "denotation",
     "snippet": "",
     "package": "cquthesis"
   },
-  "eabstract ": {
+  "eabstract": {
     "name": "eabstract",
     "detail": "eabstract",
     "snippet": "",
     "package": "cquthesis"
   },
-  "Cplus ": {
+  "Cplus": {
     "name": "Cplus",
     "detail": "Cplus",
     "snippet": "",
     "package": "cquthesis"
   },
-  "Python ": {
+  "Python": {
     "name": "Python",
     "detail": "Python",
     "snippet": "",
     "package": "cquthesis"
   },
-  "axiom ": {
+  "axiom": {
     "name": "axiom",
     "detail": "axiom",
     "snippet": "",
     "package": "cquthesis"
   },
-  "proposition ": {
+  "proposition": {
     "name": "proposition",
     "detail": "proposition",
     "snippet": "",
     "package": "cquthesis"
   },
-  "conjecture ": {
+  "conjecture": {
     "name": "conjecture",
     "detail": "conjecture",
     "snippet": "",
     "package": "cquthesis"
   },
-  "exercise ": {
+  "exercise": {
     "name": "exercise",
     "detail": "exercise",
     "snippet": "",
     "package": "cquthesis"
   },
-  "assumption ": {
+  "assumption": {
     "name": "assumption",
     "detail": "assumption",
     "snippet": "",
     "package": "cquthesis"
   },
-  "remark ": {
+  "remark": {
     "name": "remark",
     "detail": "remark",
     "snippet": "",
     "package": "cquthesis"
   },
-  "problem ": {
+  "problem": {
     "name": "problem",
     "detail": "problem",
     "snippet": "",

--- a/data/packages/cquthesis_env.json
+++ b/data/packages/cquthesis_env.json
@@ -1,14 +1,74 @@
-[
-  "cabstract",
-  "denotation",
-  "eabstract",
-  "Cplus",
-  "Python",
-  "axiom",
-  "proposition",
-  "conjecture",
-  "exercise",
-  "assumption",
-  "remark",
-  "problem"
-]
+{
+  "cabstract ": {
+    "name": "cabstract",
+    "detail": "cabstract",
+    "snippet": "",
+    "package": "cquthesis"
+  },
+  "denotation ": {
+    "name": "denotation",
+    "detail": "denotation",
+    "snippet": "",
+    "package": "cquthesis"
+  },
+  "eabstract ": {
+    "name": "eabstract",
+    "detail": "eabstract",
+    "snippet": "",
+    "package": "cquthesis"
+  },
+  "Cplus ": {
+    "name": "Cplus",
+    "detail": "Cplus",
+    "snippet": "",
+    "package": "cquthesis"
+  },
+  "Python ": {
+    "name": "Python",
+    "detail": "Python",
+    "snippet": "",
+    "package": "cquthesis"
+  },
+  "axiom ": {
+    "name": "axiom",
+    "detail": "axiom",
+    "snippet": "",
+    "package": "cquthesis"
+  },
+  "proposition ": {
+    "name": "proposition",
+    "detail": "proposition",
+    "snippet": "",
+    "package": "cquthesis"
+  },
+  "conjecture ": {
+    "name": "conjecture",
+    "detail": "conjecture",
+    "snippet": "",
+    "package": "cquthesis"
+  },
+  "exercise ": {
+    "name": "exercise",
+    "detail": "exercise",
+    "snippet": "",
+    "package": "cquthesis"
+  },
+  "assumption ": {
+    "name": "assumption",
+    "detail": "assumption",
+    "snippet": "",
+    "package": "cquthesis"
+  },
+  "remark ": {
+    "name": "remark",
+    "detail": "remark",
+    "snippet": "",
+    "package": "cquthesis"
+  },
+  "problem ": {
+    "name": "problem",
+    "detail": "problem",
+    "snippet": "",
+    "package": "cquthesis"
+  }
+}

--- a/data/packages/csquotes_env.json
+++ b/data/packages/csquotes_env.json
@@ -1,8 +1,38 @@
-[
-  "displayquote",
-  "foreigndisplayquote",
-  "hyphendisplayquote",
-  "displaycquote",
-  "foreigndisplaycquote",
-  "hyphendisplaycquote"
-]
+{
+  "displayquote [][]": {
+    "name": "displayquote",
+    "detail": "displayquote[cite][punct]",
+    "snippet": "[${1:cite}][${2:punct}]",
+    "package": "csquotes"
+  },
+  "foreigndisplayquote {}[][]": {
+    "name": "foreigndisplayquote",
+    "detail": "foreigndisplayquote{lang}[cite][punct]",
+    "snippet": "{${1:lang}}[${2:cite}][${3:punct}]",
+    "package": "csquotes"
+  },
+  "hyphendisplayquote {}[][]": {
+    "name": "hyphendisplayquote",
+    "detail": "hyphendisplayquote{lang}[cite][punct]",
+    "snippet": "{${1:lang}}[${2:cite}][${3:punct}]",
+    "package": "csquotes"
+  },
+  "displaycquote [][]{}[]": {
+    "name": "displaycquote",
+    "detail": "displaycquote[prenote][postnote]{key}[punct]",
+    "snippet": "[${2:prenote}][${3:postnote}]{${1:key}}[${4:punct}]",
+    "package": "csquotes"
+  },
+  "foreigndisplaycquote {}[][]{}[]": {
+    "name": "foreigndisplaycquote",
+    "detail": "foreigndisplaycquote{lang}[prenote][postnote]{key}[punct]",
+    "snippet": "{${1:lang}}[${2:prenote}][${3:postnote}]{${4:key}}[${5:punct}]",
+    "package": "csquotes"
+  },
+  "hyphendisplaycquote {}[][]{}[]": {
+    "name": "hyphendisplaycquote",
+    "detail": "hyphendisplaycquote{lang}[prenote][postnote]{key}[punct]",
+    "snippet": "{${1:lang}}[${2:prenote}][${3:postnote}]{${4:key}}[${5:punct}]",
+    "package": "csquotes"
+  }
+}

--- a/data/packages/currvita_env.json
+++ b/data/packages/currvita_env.json
@@ -1,4 +1,14 @@
-[
-  "cv",
-  "cvlist"
-]
+{
+  "cv {}": {
+    "name": "cv",
+    "detail": "cv{heading of the curriculum vitae}",
+    "snippet": "{${1:heading of the curriculum vitae}}",
+    "package": "currvita"
+  },
+  "cvlist {}\\item": {
+    "name": "cvlist",
+    "detail": "cvlist{heading of the list}\\item",
+    "snippet": "{${1:heading of the list}}\\item",
+    "package": "currvita"
+  }
+}

--- a/data/packages/datatool-base_env.json
+++ b/data/packages/datatool-base_env.json
@@ -1,3 +1,8 @@
-[
-  "dtlenvgforint"
-]
+{
+  "dtlenvgforint ": {
+    "name": "dtlenvgforint",
+    "detail": "dtlenvgforint",
+    "snippet": "",
+    "package": "datatool-base"
+  }
+}

--- a/data/packages/datatool-base_env.json
+++ b/data/packages/datatool-base_env.json
@@ -1,5 +1,5 @@
 {
-  "dtlenvgforint ": {
+  "dtlenvgforint": {
     "name": "dtlenvgforint",
     "detail": "dtlenvgforint",
     "snippet": "",

--- a/data/packages/datatool_env.json
+++ b/data/packages/datatool_env.json
@@ -1,4 +1,14 @@
-[
-  "DTLenvforeach",
-  "DTLenvforeach*"
-]
+{
+  "DTLenvforeach []{}{}": {
+    "name": "DTLenvforeach",
+    "detail": "DTLenvforeach[condition]{db%special}{assign list}",
+    "snippet": "[${3:condition}]{${1:db%special}}{${2:assign list}}",
+    "package": "datatool"
+  },
+  "DTLenvforeach* []{}{}": {
+    "name": "DTLenvforeach*",
+    "detail": "DTLenvforeach*[condition]{db%special}{assign list}",
+    "snippet": "[${3:condition}]{${1:db%special}}{${2:assign list}}",
+    "package": "datatool"
+  }
+}

--- a/data/packages/empheq_env.json
+++ b/data/packages/empheq_env.json
@@ -1,5 +1,5 @@
 {
-  "empheq ": {
+  "empheq": {
     "name": "empheq",
     "detail": "empheq",
     "snippet": "",

--- a/data/packages/empheq_env.json
+++ b/data/packages/empheq_env.json
@@ -1,5 +1,20 @@
-[
-  "empheq",
-  "empheq",
-  "empheq"
-]
+{
+  "empheq ": {
+    "name": "empheq",
+    "detail": "empheq",
+    "snippet": "",
+    "package": "empheq"
+  },
+  "empheq {}": {
+    "name": "empheq",
+    "detail": "empheq{AMS env name}",
+    "snippet": "{${1:AMS env name}}",
+    "package": "empheq"
+  },
+  "empheq []{}": {
+    "name": "empheq",
+    "detail": "empheq[markup instructions]{AMS env name}",
+    "snippet": "[${2:markup instructions}]{${1:AMS env name}}",
+    "package": "empheq"
+  }
+}

--- a/data/packages/epigraph_env.json
+++ b/data/packages/epigraph_env.json
@@ -1,3 +1,8 @@
-[
-  "epigraphs"
-]
+{
+  "epigraphs ": {
+    "name": "epigraphs",
+    "detail": "epigraphs",
+    "snippet": "",
+    "package": "epigraph"
+  }
+}

--- a/data/packages/epigraph_env.json
+++ b/data/packages/epigraph_env.json
@@ -1,5 +1,5 @@
 {
-  "epigraphs ": {
+  "epigraphs": {
     "name": "epigraphs",
     "detail": "epigraphs",
     "snippet": "",

--- a/data/packages/fancybox_env.json
+++ b/data/packages/fancybox_env.json
@@ -1,21 +1,116 @@
-[
-  "Bcenter",
-  "Bdescription",
-  "Bdescription",
-  "Benumerate",
-  "Benumerate",
-  "Beqnarray",
-  "Beqnarray*",
-  "Bflushleft",
-  "Bflushright",
-  "Bitemize",
-  "Bitemize",
-  "BVerbatim",
-  "BVerbatim",
-  "landfloat",
-  "Landscape",
-  "LandScape",
-  "LVerbatim",
-  "Sbox",
-  "Verbatim"
-]
+{
+  "Bcenter ": {
+    "name": "Bcenter",
+    "detail": "Bcenter",
+    "snippet": "",
+    "package": "fancybox"
+  },
+  "Bdescription \\item": {
+    "name": "Bdescription",
+    "detail": "Bdescription\\item",
+    "snippet": "\\item",
+    "package": "fancybox"
+  },
+  "Bdescription []\\item": {
+    "name": "Bdescription",
+    "detail": "Bdescription[valign]\\item",
+    "snippet": "[${1:valign}]\\item",
+    "package": "fancybox"
+  },
+  "Benumerate \\item": {
+    "name": "Benumerate",
+    "detail": "Benumerate\\item",
+    "snippet": "\\item",
+    "package": "fancybox"
+  },
+  "Benumerate []\\item": {
+    "name": "Benumerate",
+    "detail": "Benumerate[valign]\\item",
+    "snippet": "[${1:valign}]\\item",
+    "package": "fancybox"
+  },
+  "Beqnarray ": {
+    "name": "Beqnarray",
+    "detail": "Beqnarray",
+    "snippet": "",
+    "package": "fancybox"
+  },
+  "Beqnarray* ": {
+    "name": "Beqnarray*",
+    "detail": "Beqnarray*",
+    "snippet": "",
+    "package": "fancybox"
+  },
+  "Bflushleft ": {
+    "name": "Bflushleft",
+    "detail": "Bflushleft",
+    "snippet": "",
+    "package": "fancybox"
+  },
+  "Bflushright ": {
+    "name": "Bflushright",
+    "detail": "Bflushright",
+    "snippet": "",
+    "package": "fancybox"
+  },
+  "Bitemize \\item": {
+    "name": "Bitemize",
+    "detail": "Bitemize\\item",
+    "snippet": "\\item",
+    "package": "fancybox"
+  },
+  "Bitemize []\\item": {
+    "name": "Bitemize",
+    "detail": "Bitemize[valign]\\item",
+    "snippet": "[${1:valign}]\\item",
+    "package": "fancybox"
+  },
+  "BVerbatim ": {
+    "name": "BVerbatim",
+    "detail": "BVerbatim",
+    "snippet": "",
+    "package": "fancybox"
+  },
+  "BVerbatim []": {
+    "name": "BVerbatim",
+    "detail": "BVerbatim[pos]",
+    "snippet": "[${1:pos}]",
+    "package": "fancybox"
+  },
+  "landfloat {}{}": {
+    "name": "landfloat",
+    "detail": "landfloat{float}{rotation command}",
+    "snippet": "{${1:float}}{${2:rotation command}}",
+    "package": "fancybox"
+  },
+  "Landscape {}{}{}": {
+    "name": "Landscape",
+    "detail": "Landscape{paperwidth}{paperheight}{rotation command}",
+    "snippet": "{${1:paperwidth}}{${2:paperheight}}{${3:rotation command}}",
+    "package": "fancybox"
+  },
+  "LandScape {}": {
+    "name": "LandScape",
+    "detail": "LandScape{rotation command}",
+    "snippet": "{${1:rotation command}}",
+    "package": "fancybox"
+  },
+  "LVerbatim ": {
+    "name": "LVerbatim",
+    "detail": "LVerbatim",
+    "snippet": "",
+    "package": "fancybox"
+  },
+  "Sbox ": {
+    "name": "Sbox",
+    "detail": "Sbox",
+    "snippet": "",
+    "package": "fancybox"
+  },
+  "Verbatim ": {
+    "name": "Verbatim",
+    "detail": "Verbatim",
+    "snippet": "",
+    "package": "fancybox"
+  }
+}

--- a/data/packages/fancybox_env.json
+++ b/data/packages/fancybox_env.json
@@ -1,5 +1,5 @@
 {
-  "Bcenter ": {
+  "Bcenter": {
     "name": "Bcenter",
     "detail": "Bcenter",
     "snippet": "",
@@ -29,25 +29,25 @@
     "snippet": "[${1:valign}]\\item",
     "package": "fancybox"
   },
-  "Beqnarray ": {
+  "Beqnarray": {
     "name": "Beqnarray",
     "detail": "Beqnarray",
     "snippet": "",
     "package": "fancybox"
   },
-  "Beqnarray* ": {
+  "Beqnarray*": {
     "name": "Beqnarray*",
     "detail": "Beqnarray*",
     "snippet": "",
     "package": "fancybox"
   },
-  "Bflushleft ": {
+  "Bflushleft": {
     "name": "Bflushleft",
     "detail": "Bflushleft",
     "snippet": "",
     "package": "fancybox"
   },
-  "Bflushright ": {
+  "Bflushright": {
     "name": "Bflushright",
     "detail": "Bflushright",
     "snippet": "",
@@ -65,7 +65,7 @@
     "snippet": "[${1:valign}]\\item",
     "package": "fancybox"
   },
-  "BVerbatim ": {
+  "BVerbatim": {
     "name": "BVerbatim",
     "detail": "BVerbatim",
     "snippet": "",
@@ -95,19 +95,19 @@
     "snippet": "{${1:rotation command}}",
     "package": "fancybox"
   },
-  "LVerbatim ": {
+  "LVerbatim": {
     "name": "LVerbatim",
     "detail": "LVerbatim",
     "snippet": "",
     "package": "fancybox"
   },
-  "Sbox ": {
+  "Sbox": {
     "name": "Sbox",
     "detail": "Sbox",
     "snippet": "",
     "package": "fancybox"
   },
-  "Verbatim ": {
+  "Verbatim": {
     "name": "Verbatim",
     "detail": "Verbatim",
     "snippet": "",

--- a/data/packages/fancyvrb_env.json
+++ b/data/packages/fancyvrb_env.json
@@ -1,6 +1,26 @@
-[
-  "Verbatim",
-  "Verbatim",
-  "Verbatim*",
-  "BVerbatim*"
-]
+{
+  "Verbatim ": {
+    "name": "Verbatim",
+    "detail": "Verbatim",
+    "snippet": "",
+    "package": "fancyvrb"
+  },
+  "Verbatim []": {
+    "name": "Verbatim",
+    "detail": "Verbatim[key=value]",
+    "snippet": "[${1:key=value}]",
+    "package": "fancyvrb"
+  },
+  "Verbatim* ": {
+    "name": "Verbatim*",
+    "detail": "Verbatim*",
+    "snippet": "",
+    "package": "fancyvrb"
+  },
+  "BVerbatim* ": {
+    "name": "BVerbatim*",
+    "detail": "BVerbatim*",
+    "snippet": "",
+    "package": "fancyvrb"
+  }
+}

--- a/data/packages/fancyvrb_env.json
+++ b/data/packages/fancyvrb_env.json
@@ -1,5 +1,5 @@
 {
-  "Verbatim ": {
+  "Verbatim": {
     "name": "Verbatim",
     "detail": "Verbatim",
     "snippet": "",
@@ -11,13 +11,13 @@
     "snippet": "[${1:key=value}]",
     "package": "fancyvrb"
   },
-  "Verbatim* ": {
+  "Verbatim*": {
     "name": "Verbatim*",
     "detail": "Verbatim*",
     "snippet": "",
     "package": "fancyvrb"
   },
-  "BVerbatim* ": {
+  "BVerbatim*": {
     "name": "BVerbatim*",
     "detail": "BVerbatim*",
     "snippet": "",

--- a/data/packages/fhgtechdoku_additional_env.json
+++ b/data/packages/fhgtechdoku_additional_env.json
@@ -1,11 +1,11 @@
 {
-  "fullwidth ": {
+  "fullwidth": {
     "name": "fullwidth",
     "detail": "fullwidth",
     "snippet": "",
     "package": "fhgtechdoku_additional"
   },
-  "innertitlepage ": {
+  "innertitlepage": {
     "name": "innertitlepage",
     "detail": "innertitlepage",
     "snippet": "",

--- a/data/packages/fhgtechdoku_additional_env.json
+++ b/data/packages/fhgtechdoku_additional_env.json
@@ -1,4 +1,14 @@
-[
-  "fullwidth",
-  "innertitlepage"
-]
+{
+  "fullwidth ": {
+    "name": "fullwidth",
+    "detail": "fullwidth",
+    "snippet": "",
+    "package": "fhgtechdoku_additional"
+  },
+  "innertitlepage ": {
+    "name": "innertitlepage",
+    "detail": "innertitlepage",
+    "snippet": "",
+    "package": "fhgtechdoku_additional"
+  }
+}

--- a/data/packages/fixme_env.json
+++ b/data/packages/fixme_env.json
@@ -1,10 +1,50 @@
-[
-  "anfxerror*",
-  "anfxerror",
-  "anfxfatal*",
-  "anfxfatal",
-  "anfxnote*",
-  "anfxnote",
-  "anfxwarning*",
-  "anfxwarning"
-]
+{
+  "anfxerror* {}": {
+    "name": "anfxerror*",
+    "detail": "anfxerror*{summary}",
+    "snippet": "{${1:summary}}",
+    "package": "fixme"
+  },
+  "anfxerror {}": {
+    "name": "anfxerror",
+    "detail": "anfxerror{summary}",
+    "snippet": "{${1:summary}}",
+    "package": "fixme"
+  },
+  "anfxfatal* {}": {
+    "name": "anfxfatal*",
+    "detail": "anfxfatal*{summary}",
+    "snippet": "{${1:summary}}",
+    "package": "fixme"
+  },
+  "anfxfatal {}": {
+    "name": "anfxfatal",
+    "detail": "anfxfatal{summary}",
+    "snippet": "{${1:summary}}",
+    "package": "fixme"
+  },
+  "anfxnote* {}": {
+    "name": "anfxnote*",
+    "detail": "anfxnote*{summary}",
+    "snippet": "{${1:summary}}",
+    "package": "fixme"
+  },
+  "anfxnote {}": {
+    "name": "anfxnote",
+    "detail": "anfxnote{summary}",
+    "snippet": "{${1:summary}}",
+    "package": "fixme"
+  },
+  "anfxwarning* {}": {
+    "name": "anfxwarning*",
+    "detail": "anfxwarning*{summary}",
+    "snippet": "{${1:summary}}",
+    "package": "fixme"
+  },
+  "anfxwarning {}": {
+    "name": "anfxwarning",
+    "detail": "anfxwarning{summary}",
+    "snippet": "{${1:summary}}",
+    "package": "fixme"
+  }
+}

--- a/data/packages/fontspec_cmd.json
+++ b/data/packages/fontspec_cmd.json
@@ -42,17 +42,17 @@
   "newfontfamily<fontinstance>{}": {
     "command": "newfontfamily<fontinstance>{fontname}",
     "package": "fontspec",
-    "snippet": "newfontfamily<fontinstance>{${1:fontname}}"
+    "snippet": "newfontfamily<${2:fontinstance}>{${1:fontname}}"
   },
   "newfontface<fontface>{}": {
     "command": "newfontface<fontface>{fontname}",
     "package": "fontspec",
-    "snippet": "newfontface<fontface>{${1:fontname}}"
+    "snippet": "newfontface<${2:fontface}>{${1:fontname}}"
   },
   "newfontface<fontface>[]{}": {
     "command": "newfontface<fontface>[fontfeature=option,fontfeature=option]{fontname}",
     "package": "fontspec",
-    "snippet": "newfontface<fontface>[${2:fontfeature=option,fontfeature=option}]{${1:fontname}}"
+    "snippet": "newfontface<${3:fontface}>[${2:fontfeature=option,fontfeature=option}]{${1:fontname}}"
   },
   "setmathrm": {
     "command": "setmathrm",

--- a/data/packages/gauss_env.json
+++ b/data/packages/gauss_env.json
@@ -1,5 +1,5 @@
 {
-  "gmatrix ": {
+  "gmatrix": {
     "name": "gmatrix",
     "detail": "gmatrix",
     "snippet": "",

--- a/data/packages/gauss_env.json
+++ b/data/packages/gauss_env.json
@@ -1,8 +1,14 @@
-[
-  "gmatrix",
-  "gmatrix",
-  "gmatrix",
-  "gmatrix",
-  "gmatrix",
-  "gmatrix"
-]
+{
+  "gmatrix ": {
+    "name": "gmatrix",
+    "detail": "gmatrix",
+    "snippet": "",
+    "package": "gauss"
+  },
+  "gmatrix []": {
+    "name": "gmatrix",
+    "detail": "gmatrix[V]",
+    "snippet": "[${1:V}]",
+    "package": "gauss"
+  }
+}

--- a/data/packages/glossaries_env.json
+++ b/data/packages/glossaries_env.json
@@ -1,5 +1,5 @@
 {
-  "theglossary ": {
+  "theglossary": {
     "name": "theglossary",
     "detail": "theglossary",
     "snippet": "",

--- a/data/packages/glossaries_env.json
+++ b/data/packages/glossaries_env.json
@@ -1,3 +1,8 @@
-[
-  "theglossary"
-]
+{
+  "theglossary ": {
+    "name": "theglossary",
+    "detail": "theglossary",
+    "snippet": "",
+    "package": "glossaries"
+  }
+}

--- a/data/packages/glosstex_cmd.json
+++ b/data/packages/glosstex_cmd.json
@@ -137,12 +137,12 @@
   "ac<form>(list)[]{}": {
     "command": "ac<form>(list)[pageref-mode]{label}",
     "package": "glosstex",
-    "snippet": "ac<form>(list)[${2:pageref-mode}]{${1:label}}"
+    "snippet": "ac<${3:form}>(list)[${2:pageref-mode}]{${1:label}}"
   },
   "ac[]<form>(list)[]{}": {
     "command": "ac[, lparen , rparen ,]<form>(list)[pageref-mode]{label}",
     "package": "glosstex",
-    "snippet": "ac[${2:, lparen , rparen ,}]<form>(list)[${3:pageref-mode}]{${1:label}}"
+    "snippet": "ac[${2:, lparen , rparen ,}]<${4:form}>(list)[${3:pageref-mode}]{${1:label}}"
   },
   "ac*{}": {
     "command": "ac*{label}",
@@ -162,12 +162,12 @@
   "ac*<form>(list)[]{}": {
     "command": "ac*<form>(list)[pageref-mode]{label}",
     "package": "glosstex",
-    "snippet": "ac*<form>(list)[${2:pageref-mode}]{${1:label}}"
+    "snippet": "ac*<${3:form}>(list)[${2:pageref-mode}]{${1:label}}"
   },
   "ac*[]<form>(list)[]{}": {
     "command": "ac*[, lparen , rparen ,]<form>(list)[pageref-mode]{label}",
     "package": "glosstex",
-    "snippet": "ac*[${2:, lparen , rparen ,}]<form>(list)[${3:pageref-mode}]{${1:label}}"
+    "snippet": "ac*[${2:, lparen , rparen ,}]<${4:form}>(list)[${3:pageref-mode}]{${1:label}}"
   },
   "acs{}": {
     "command": "acs{label}",
@@ -187,12 +187,12 @@
   "acs<form>(list)[]{}": {
     "command": "acs<form>(list)[pageref-mode]{label}",
     "package": "glosstex",
-    "snippet": "acs<form>(list)[${2:pageref-mode}]{${1:label}}"
+    "snippet": "acs<${3:form}>(list)[${2:pageref-mode}]{${1:label}}"
   },
   "acs[]<form>(list)[]{}": {
     "command": "acs[, lparen , rparen ,]<form>(list)[pageref-mode]{label}",
     "package": "glosstex",
-    "snippet": "acs[${2:, lparen , rparen ,}]<form>(list)[${3:pageref-mode}]{${1:label}}"
+    "snippet": "acs[${2:, lparen , rparen ,}]<${4:form}>(list)[${3:pageref-mode}]{${1:label}}"
   },
   "acs*{}": {
     "command": "acs*{label}",
@@ -212,12 +212,12 @@
   "acs*<form>(list)[]{}": {
     "command": "acs*<form>(list)[pageref-mode]{label}",
     "package": "glosstex",
-    "snippet": "acs*<form>(list)[${2:pageref-mode}]{${1:label}}"
+    "snippet": "acs*<${3:form}>(list)[${2:pageref-mode}]{${1:label}}"
   },
   "acs*[]<form>(list)[]{}": {
     "command": "acs*[, lparen , rparen ,]<form>(list)[pageref-mode]{label}",
     "package": "glosstex",
-    "snippet": "acs*[${2:, lparen , rparen ,}]<form>(list)[${3:pageref-mode}]{${1:label}}"
+    "snippet": "acs*[${2:, lparen , rparen ,}]<${4:form}>(list)[${3:pageref-mode}]{${1:label}}"
   },
   "acl{}": {
     "command": "acl{label}",
@@ -237,12 +237,12 @@
   "acl<form>(list)[]{}": {
     "command": "acl<form>(list)[pageref-mode]{label}",
     "package": "glosstex",
-    "snippet": "acl<form>(list)[${2:pageref-mode}]{${1:label}}"
+    "snippet": "acl<${3:form}>(list)[${2:pageref-mode}]{${1:label}}"
   },
   "acl[]<form>(list)[]{}": {
     "command": "acl[, lparen , rparen ,]<form>(list)[pageref-mode]{label}",
     "package": "glosstex",
-    "snippet": "acl[${2:, lparen , rparen ,}]<form>(list)[${3:pageref-mode}]{${1:label}}"
+    "snippet": "acl[${2:, lparen , rparen ,}]<${4:form}>(list)[${3:pageref-mode}]{${1:label}}"
   },
   "acl*{}": {
     "command": "acl*{label}",
@@ -262,12 +262,12 @@
   "acl*<form>(list)[]{}": {
     "command": "acl*<form>(list)[pageref-mode]{label}",
     "package": "glosstex",
-    "snippet": "acl*<form>(list)[${2:pageref-mode}]{${1:label}}"
+    "snippet": "acl*<${3:form}>(list)[${2:pageref-mode}]{${1:label}}"
   },
   "acl*[]<form>(list)[]{}": {
     "command": "acl*[, lparen , rparen ,]<form>(list)[pageref-mode]{label}",
     "package": "glosstex",
-    "snippet": "acl*[${2:, lparen , rparen ,}]<form>(list)[${3:pageref-mode}]{${1:label}}"
+    "snippet": "acl*[${2:, lparen , rparen ,}]<${4:form}>(list)[${3:pageref-mode}]{${1:label}}"
   },
   "acf{}": {
     "command": "acf{label}",
@@ -287,12 +287,12 @@
   "acf<form>(list)[]{}": {
     "command": "acf<form>(list)[pageref-mode]{label}",
     "package": "glosstex",
-    "snippet": "acf<form>(list)[${2:pageref-mode}]{${1:label}}"
+    "snippet": "acf<${3:form}>(list)[${2:pageref-mode}]{${1:label}}"
   },
   "acf[]<form>(list)[]{}": {
     "command": "acf[, lparen , rparen ,]<form>(list)[pageref-mode]{label}",
     "package": "glosstex",
-    "snippet": "acf[${2:, lparen , rparen ,}]<form>(list)[${3:pageref-mode}]{${1:label}}"
+    "snippet": "acf[${2:, lparen , rparen ,}]<${4:form}>(list)[${3:pageref-mode}]{${1:label}}"
   },
   "acf*{}": {
     "command": "acf*{label}",
@@ -312,12 +312,12 @@
   "acf*<form>(list)[]{}": {
     "command": "acf*<form>(list)[pageref-mode]{label}",
     "package": "glosstex",
-    "snippet": "acf*<form>(list)[${2:pageref-mode}]{${1:label}}"
+    "snippet": "acf*<${3:form}>(list)[${2:pageref-mode}]{${1:label}}"
   },
   "acf*[]<form>(list)[]{}": {
     "command": "acf*[, lparen , rparen ,]<form>(list)[pageref-mode]{label}",
     "package": "glosstex",
-    "snippet": "acf*[${2:, lparen , rparen ,}]<form>(list)[${3:pageref-mode}]{${1:label}}"
+    "snippet": "acf*[${2:, lparen , rparen ,}]<${4:form}>(list)[${3:pageref-mode}]{${1:label}}"
   },
   "printglosstex(list)": {
     "command": "printglosstex(list)",

--- a/data/packages/latex-document_env.json
+++ b/data/packages/latex-document_env.json
@@ -1,20 +1,104 @@
-[
-  "",
-  "abstract",
-  "alltt",
-  "equation",
-  "figure",
-  "figure",
-  "figure*",
-  "figure*",
-  "filecontents",
-  "list",
-  "lrbox",
-  "table*",
-  "table*",
-  "tabular*",
-  "tabular*",
-  "theindex",
-  "trivlist",
-  "verbatim*"
-]
+{
+  " ": {
+    "name": "",
+    "detail": "",
+    "snippet": "",
+    "package": "latex-document"
+  },
+  "abstract ": {
+    "name": "abstract",
+    "detail": "abstract",
+    "snippet": "",
+    "package": "latex-document"
+  },
+  "alltt ": {
+    "name": "alltt",
+    "detail": "alltt",
+    "snippet": "",
+    "package": "latex-document"
+  },
+  "figure ": {
+    "name": "figure",
+    "detail": "figure",
+    "snippet": "",
+    "package": "latex-document"
+  },
+  "figure []": {
+    "name": "figure",
+    "detail": "figure[placement]",
+    "snippet": "[${1:placement}]",
+    "package": "latex-document"
+  },
+  "figure* ": {
+    "name": "figure*",
+    "detail": "figure*",
+    "snippet": "",
+    "package": "latex-document"
+  },
+  "figure* []": {
+    "name": "figure*",
+    "detail": "figure*[placement]",
+    "snippet": "[${1:placement}]",
+    "package": "latex-document"
+  },
+  "filecontents ": {
+    "name": "filecontents",
+    "detail": "filecontents",
+    "snippet": "",
+    "package": "latex-document"
+  },
+  "list {}{}": {
+    "name": "list",
+    "detail": "list{label}{spacing}",
+    "snippet": "{${1:label}}{${2:spacing}}",
+    "package": "latex-document"
+  },
+  "lrbox ": {
+    "name": "lrbox",
+    "detail": "lrbox",
+    "snippet": "",
+    "package": "latex-document"
+  },
+  "table* ": {
+    "name": "table*",
+    "detail": "table*",
+    "snippet": "",
+    "package": "latex-document"
+  },
+  "table* []": {
+    "name": "table*",
+    "detail": "table*[placement]",
+    "snippet": "[${1:placement}]",
+    "package": "latex-document"
+  },
+  "tabular* {}[]{}": {
+    "name": "tabular*",
+    "detail": "tabular*{width}[pos]{cols}",
+    "snippet": "{${1:width}}[${2:pos}]{${3:cols}}",
+    "package": "latex-document"
+  },
+  "tabular* {}{}": {
+    "name": "tabular*",
+    "detail": "tabular*{width}{cols}",
+    "snippet": "{${1:width}}{${2:cols}}",
+    "package": "latex-document"
+  },
+  "theindex ": {
+    "name": "theindex",
+    "detail": "theindex",
+    "snippet": "",
+    "package": "latex-document"
+  },
+  "trivlist ": {
+    "name": "trivlist",
+    "detail": "trivlist",
+    "snippet": "",
+    "package": "latex-document"
+  },
+  "verbatim* ": {
+    "name": "verbatim*",
+    "detail": "verbatim*",
+    "snippet": "",
+    "package": "latex-document"
+  }
+}

--- a/data/packages/latex-document_env.json
+++ b/data/packages/latex-document_env.json
@@ -1,23 +1,23 @@
 {
-  " ": {
+  "": {
     "name": "",
     "detail": "",
     "snippet": "",
     "package": "latex-document"
   },
-  "abstract ": {
+  "abstract": {
     "name": "abstract",
     "detail": "abstract",
     "snippet": "",
     "package": "latex-document"
   },
-  "alltt ": {
+  "alltt": {
     "name": "alltt",
     "detail": "alltt",
     "snippet": "",
     "package": "latex-document"
   },
-  "figure ": {
+  "figure": {
     "name": "figure",
     "detail": "figure",
     "snippet": "",
@@ -29,7 +29,7 @@
     "snippet": "[${1:placement}]",
     "package": "latex-document"
   },
-  "figure* ": {
+  "figure*": {
     "name": "figure*",
     "detail": "figure*",
     "snippet": "",
@@ -41,7 +41,7 @@
     "snippet": "[${1:placement}]",
     "package": "latex-document"
   },
-  "filecontents ": {
+  "filecontents": {
     "name": "filecontents",
     "detail": "filecontents",
     "snippet": "",
@@ -53,13 +53,13 @@
     "snippet": "{${1:label}}{${2:spacing}}",
     "package": "latex-document"
   },
-  "lrbox ": {
+  "lrbox": {
     "name": "lrbox",
     "detail": "lrbox",
     "snippet": "",
     "package": "latex-document"
   },
-  "table* ": {
+  "table*": {
     "name": "table*",
     "detail": "table*",
     "snippet": "",
@@ -83,19 +83,19 @@
     "snippet": "{${1:width}}{${2:cols}}",
     "package": "latex-document"
   },
-  "theindex ": {
+  "theindex": {
     "name": "theindex",
     "detail": "theindex",
     "snippet": "",
     "package": "latex-document"
   },
-  "trivlist ": {
+  "trivlist": {
     "name": "trivlist",
     "detail": "trivlist",
     "snippet": "",
     "package": "latex-document"
   },
-  "verbatim* ": {
+  "verbatim*": {
     "name": "verbatim*",
     "detail": "verbatim*",
     "snippet": "",

--- a/data/packages/latex-l2tabu_env.json
+++ b/data/packages/latex-l2tabu_env.json
@@ -1,6 +1,26 @@
-[
-  "appendix",
-  "eqnarray*",
-  "fussypar",
-  "sloppypar"
-]
+{
+  "appendix ": {
+    "name": "appendix",
+    "detail": "appendix",
+    "snippet": "",
+    "package": "latex-l2tabu"
+  },
+  "eqnarray* ": {
+    "name": "eqnarray*",
+    "detail": "eqnarray*",
+    "snippet": "",
+    "package": "latex-l2tabu"
+  },
+  "fussypar ": {
+    "name": "fussypar",
+    "detail": "fussypar",
+    "snippet": "",
+    "package": "latex-l2tabu"
+  },
+  "sloppypar ": {
+    "name": "sloppypar",
+    "detail": "sloppypar",
+    "snippet": "",
+    "package": "latex-l2tabu"
+  }
+}

--- a/data/packages/latex-l2tabu_env.json
+++ b/data/packages/latex-l2tabu_env.json
@@ -1,23 +1,23 @@
 {
-  "appendix ": {
+  "appendix": {
     "name": "appendix",
     "detail": "appendix",
     "snippet": "",
     "package": "latex-l2tabu"
   },
-  "eqnarray* ": {
+  "eqnarray*": {
     "name": "eqnarray*",
     "detail": "eqnarray*",
     "snippet": "",
     "package": "latex-l2tabu"
   },
-  "fussypar ": {
+  "fussypar": {
     "name": "fussypar",
     "detail": "fussypar",
     "snippet": "",
     "package": "latex-l2tabu"
   },
-  "sloppypar ": {
+  "sloppypar": {
     "name": "sloppypar",
     "detail": "sloppypar",
     "snippet": "",

--- a/data/packages/listings_env.json
+++ b/data/packages/listings_env.json
@@ -1,5 +1,5 @@
 {
-  "lstlisting ": {
+  "lstlisting": {
     "name": "lstlisting",
     "detail": "lstlisting",
     "snippet": "",

--- a/data/packages/listings_env.json
+++ b/data/packages/listings_env.json
@@ -1,4 +1,14 @@
-[
-  "lstlisting",
-  "lstlisting"
-]
+{
+  "lstlisting ": {
+    "name": "lstlisting",
+    "detail": "lstlisting",
+    "snippet": "",
+    "package": "listings"
+  },
+  "lstlisting []": {
+    "name": "lstlisting",
+    "detail": "lstlisting[kv-list]",
+    "snippet": "[${1:kv-list}]",
+    "package": "listings"
+  }
+}

--- a/data/packages/longtable_env.json
+++ b/data/packages/longtable_env.json
@@ -1,4 +1,14 @@
-[
-  "longtable",
-  "longtable"
-]
+{
+  "longtable []{}": {
+    "name": "longtable",
+    "detail": "longtable[alignment]{preamble}",
+    "snippet": "[${2:alignment}]{${1:preamble}}",
+    "package": "longtable"
+  },
+  "longtable {}": {
+    "name": "longtable",
+    "detail": "longtable{preamble}",
+    "snippet": "{${1:preamble}}",
+    "package": "longtable"
+  }
+}

--- a/data/packages/lscape_env.json
+++ b/data/packages/lscape_env.json
@@ -1,5 +1,5 @@
 {
-  "landscape ": {
+  "landscape": {
     "name": "landscape",
     "detail": "landscape",
     "snippet": "",

--- a/data/packages/lscape_env.json
+++ b/data/packages/lscape_env.json
@@ -1,3 +1,8 @@
-[
-  "landscape"
-]
+{
+  "landscape ": {
+    "name": "landscape",
+    "detail": "landscape",
+    "snippet": "",
+    "package": "lscape"
+  }
+}

--- a/data/packages/mathtools_env.json
+++ b/data/packages/mathtools_env.json
@@ -1,11 +1,11 @@
 {
-  "bmatrix* ": {
+  "bmatrix*": {
     "name": "bmatrix*",
     "detail": "bmatrix*",
     "snippet": "",
     "package": "mathtools"
   },
-  "Bmatrix* ": {
+  "Bmatrix*": {
     "name": "Bmatrix*",
     "detail": "Bmatrix*",
     "snippet": "",
@@ -23,19 +23,19 @@
     "snippet": "[${1:col}]",
     "package": "mathtools"
   },
-  "dcases ": {
+  "dcases": {
     "name": "dcases",
     "detail": "dcases",
     "snippet": "",
     "package": "mathtools"
   },
-  "dcases* ": {
+  "dcases*": {
     "name": "dcases*",
     "detail": "dcases*",
     "snippet": "",
     "package": "mathtools"
   },
-  "lgathered ": {
+  "lgathered": {
     "name": "lgathered",
     "detail": "lgathered",
     "snippet": "",
@@ -47,7 +47,7 @@
     "snippet": "[${1:pos}]",
     "package": "mathtools"
   },
-  "matrix* ": {
+  "matrix*": {
     "name": "matrix*",
     "detail": "matrix*",
     "snippet": "",
@@ -59,7 +59,7 @@
     "snippet": "[${1:col}]",
     "package": "mathtools"
   },
-  "multlined ": {
+  "multlined": {
     "name": "multlined",
     "detail": "multlined",
     "snippet": "",
@@ -77,7 +77,7 @@
     "snippet": "[${1:pos}][${2:width}]",
     "package": "mathtools"
   },
-  "pmatrix* ": {
+  "pmatrix*": {
     "name": "pmatrix*",
     "detail": "pmatrix*",
     "snippet": "",
@@ -89,7 +89,7 @@
     "snippet": "[${1:col}]",
     "package": "mathtools"
   },
-  "rgathered ": {
+  "rgathered": {
     "name": "rgathered",
     "detail": "rgathered",
     "snippet": "",
@@ -107,13 +107,13 @@
     "snippet": "{${1:dimen}}",
     "package": "mathtools"
   },
-  "vmatrix* ": {
+  "vmatrix*": {
     "name": "vmatrix*",
     "detail": "vmatrix*",
     "snippet": "",
     "package": "mathtools"
   },
-  "Vmatrix* ": {
+  "Vmatrix*": {
     "name": "Vmatrix*",
     "detail": "Vmatrix*",
     "snippet": "",

--- a/data/packages/mathtools_env.json
+++ b/data/packages/mathtools_env.json
@@ -1,24 +1,134 @@
-[
-  "bmatrix*",
-  "Bmatrix*",
-  "bmatrix*",
-  "Bmatrix*",
-  "dcases",
-  "dcases*",
-  "lgathered",
-  "lgathered",
-  "matrix*",
-  "matrix*",
-  "multlined",
-  "multlined",
-  "multlined",
-  "pmatrix*",
-  "pmatrix*",
-  "rgathered",
-  "rgathered",
-  "spreadlines",
-  "vmatrix*",
-  "Vmatrix*",
-  "vmatrix*",
-  "Vmatrix*"
-]
+{
+  "bmatrix* ": {
+    "name": "bmatrix*",
+    "detail": "bmatrix*",
+    "snippet": "",
+    "package": "mathtools"
+  },
+  "Bmatrix* ": {
+    "name": "Bmatrix*",
+    "detail": "Bmatrix*",
+    "snippet": "",
+    "package": "mathtools"
+  },
+  "bmatrix* []": {
+    "name": "bmatrix*",
+    "detail": "bmatrix*[col]",
+    "snippet": "[${1:col}]",
+    "package": "mathtools"
+  },
+  "Bmatrix* []": {
+    "name": "Bmatrix*",
+    "detail": "Bmatrix*[col]",
+    "snippet": "[${1:col}]",
+    "package": "mathtools"
+  },
+  "dcases ": {
+    "name": "dcases",
+    "detail": "dcases",
+    "snippet": "",
+    "package": "mathtools"
+  },
+  "dcases* ": {
+    "name": "dcases*",
+    "detail": "dcases*",
+    "snippet": "",
+    "package": "mathtools"
+  },
+  "lgathered ": {
+    "name": "lgathered",
+    "detail": "lgathered",
+    "snippet": "",
+    "package": "mathtools"
+  },
+  "lgathered []": {
+    "name": "lgathered",
+    "detail": "lgathered[pos]",
+    "snippet": "[${1:pos}]",
+    "package": "mathtools"
+  },
+  "matrix* ": {
+    "name": "matrix*",
+    "detail": "matrix*",
+    "snippet": "",
+    "package": "mathtools"
+  },
+  "matrix* []": {
+    "name": "matrix*",
+    "detail": "matrix*[col]",
+    "snippet": "[${1:col}]",
+    "package": "mathtools"
+  },
+  "multlined ": {
+    "name": "multlined",
+    "detail": "multlined",
+    "snippet": "",
+    "package": "mathtools"
+  },
+  "multlined []": {
+    "name": "multlined",
+    "detail": "multlined[pos]",
+    "snippet": "[${1:pos}]",
+    "package": "mathtools"
+  },
+  "multlined [][]": {
+    "name": "multlined",
+    "detail": "multlined[pos][width]",
+    "snippet": "[${1:pos}][${2:width}]",
+    "package": "mathtools"
+  },
+  "pmatrix* ": {
+    "name": "pmatrix*",
+    "detail": "pmatrix*",
+    "snippet": "",
+    "package": "mathtools"
+  },
+  "pmatrix* []": {
+    "name": "pmatrix*",
+    "detail": "pmatrix*[col]",
+    "snippet": "[${1:col}]",
+    "package": "mathtools"
+  },
+  "rgathered ": {
+    "name": "rgathered",
+    "detail": "rgathered",
+    "snippet": "",
+    "package": "mathtools"
+  },
+  "rgathered []": {
+    "name": "rgathered",
+    "detail": "rgathered[pos]",
+    "snippet": "[${1:pos}]",
+    "package": "mathtools"
+  },
+  "spreadlines {}": {
+    "name": "spreadlines",
+    "detail": "spreadlines{dimen}",
+    "snippet": "{${1:dimen}}",
+    "package": "mathtools"
+  },
+  "vmatrix* ": {
+    "name": "vmatrix*",
+    "detail": "vmatrix*",
+    "snippet": "",
+    "package": "mathtools"
+  },
+  "Vmatrix* ": {
+    "name": "Vmatrix*",
+    "detail": "Vmatrix*",
+    "snippet": "",
+    "package": "mathtools"
+  },
+  "vmatrix* []": {
+    "name": "vmatrix*",
+    "detail": "vmatrix*[col]",
+    "snippet": "[${1:col}]",
+    "package": "mathtools"
+  },
+  "Vmatrix* []": {
+    "name": "Vmatrix*",
+    "detail": "Vmatrix*[col]",
+    "snippet": "[${1:col}]",
+    "package": "mathtools"
+  }
+}

--- a/data/packages/mdframed_env.json
+++ b/data/packages/mdframed_env.json
@@ -1,3 +1,8 @@
-[
-  "mdframed"
-]
+{
+  "mdframed []": {
+    "name": "mdframed",
+    "detail": "mdframed[options]",
+    "snippet": "[${1:options}]",
+    "package": "mdframed"
+  }
+}

--- a/data/packages/mdwlist_env.json
+++ b/data/packages/mdwlist_env.json
@@ -1,17 +1,17 @@
 {
-  "description* ": {
+  "description*": {
     "name": "description*",
     "detail": "description*",
     "snippet": "",
     "package": "mdwlist"
   },
-  "enumerate* ": {
+  "enumerate*": {
     "name": "enumerate*",
     "detail": "enumerate*",
     "snippet": "",
     "package": "mdwlist"
   },
-  "itemize* ": {
+  "itemize*": {
     "name": "itemize*",
     "detail": "itemize*",
     "snippet": "",

--- a/data/packages/mdwlist_env.json
+++ b/data/packages/mdwlist_env.json
@@ -1,5 +1,20 @@
-[
-  "description*",
-  "enumerate*",
-  "itemize*"
-]
+{
+  "description* ": {
+    "name": "description*",
+    "detail": "description*",
+    "snippet": "",
+    "package": "mdwlist"
+  },
+  "enumerate* ": {
+    "name": "enumerate*",
+    "detail": "enumerate*",
+    "snippet": "",
+    "package": "mdwlist"
+  },
+  "itemize* ": {
+    "name": "itemize*",
+    "detail": "itemize*",
+    "snippet": "",
+    "package": "mdwlist"
+  }
+}

--- a/data/packages/metrix_env.json
+++ b/data/packages/metrix_env.json
@@ -1,4 +1,14 @@
-[
-  "symbolline",
-  "metricverses"
-]
+{
+  "symbolline ": {
+    "name": "symbolline",
+    "detail": "symbolline",
+    "snippet": "",
+    "package": "metrix"
+  },
+  "metricverses ": {
+    "name": "metricverses",
+    "detail": "metricverses",
+    "snippet": "",
+    "package": "metrix"
+  }
+}

--- a/data/packages/metrix_env.json
+++ b/data/packages/metrix_env.json
@@ -1,11 +1,11 @@
 {
-  "symbolline ": {
+  "symbolline": {
     "name": "symbolline",
     "detail": "symbolline",
     "snippet": "",
     "package": "metrix"
   },
-  "metricverses ": {
+  "metricverses": {
     "name": "metricverses",
     "detail": "metricverses",
     "snippet": "",

--- a/data/packages/microtype_env.json
+++ b/data/packages/microtype_env.json
@@ -1,5 +1,5 @@
 {
-  "microtypecontext ": {
+  "microtypecontext": {
     "name": "microtypecontext",
     "detail": "microtypecontext",
     "snippet": "",

--- a/data/packages/microtype_env.json
+++ b/data/packages/microtype_env.json
@@ -1,3 +1,8 @@
-[
-  "microtypecontext"
-]
+{
+  "microtypecontext ": {
+    "name": "microtypecontext",
+    "detail": "microtypecontext",
+    "snippet": "",
+    "package": "microtype"
+  }
+}

--- a/data/packages/minted_env.json
+++ b/data/packages/minted_env.json
@@ -11,7 +11,7 @@
     "snippet": "[${2:options}]{${1:language}}",
     "package": "minted"
   },
-  "listing ": {
+  "listing": {
     "name": "listing",
     "detail": "listing",
     "snippet": "",

--- a/data/packages/minted_env.json
+++ b/data/packages/minted_env.json
@@ -1,5 +1,20 @@
-[
-  "minted",
-  "minted",
-  "listing"
-]
+{
+  "minted {}": {
+    "name": "minted",
+    "detail": "minted{language}",
+    "snippet": "{${1:language}}",
+    "package": "minted"
+  },
+  "minted []{}": {
+    "name": "minted",
+    "detail": "minted[options]{language}",
+    "snippet": "[${2:options}]{${1:language}}",
+    "package": "minted"
+  },
+  "listing ": {
+    "name": "listing",
+    "detail": "listing",
+    "snippet": "",
+    "package": "minted"
+  }
+}

--- a/data/packages/multicol_env.json
+++ b/data/packages/multicol_env.json
@@ -1,8 +1,38 @@
-[
-  "multicols",
-  "multicols*",
-  "multicols",
-  "multicols*",
-  "multicols",
-  "multicols*"
-]
+{
+  "multicols {}": {
+    "name": "multicols",
+    "detail": "multicols{n}",
+    "snippet": "{${1:n}}",
+    "package": "multicol"
+  },
+  "multicols* {}": {
+    "name": "multicols*",
+    "detail": "multicols*{n}",
+    "snippet": "{${1:n}}",
+    "package": "multicol"
+  },
+  "multicols {}[]": {
+    "name": "multicols",
+    "detail": "multicols{n}[preface]",
+    "snippet": "{${1:n}}[${2:preface}]",
+    "package": "multicol"
+  },
+  "multicols* {}[]": {
+    "name": "multicols*",
+    "detail": "multicols*{n}[preface]",
+    "snippet": "{${1:n}}[${2:preface}]",
+    "package": "multicol"
+  },
+  "multicols {}[][]": {
+    "name": "multicols",
+    "detail": "multicols{n}[preface][skip]",
+    "snippet": "{${1:n}}[${2:preface}][${3:skip}]",
+    "package": "multicol"
+  },
+  "multicols* {}[][]": {
+    "name": "multicols*",
+    "detail": "multicols*{n}[preface][skip]",
+    "snippet": "{${1:n}}[${2:preface}][${3:skip}]",
+    "package": "multicol"
+  }
+}

--- a/data/packages/paracol_env.json
+++ b/data/packages/paracol_env.json
@@ -1,15 +1,86 @@
-[
-  "paracol",
-  "paracol",
-  "column*",
-  "column*",
-  "nthcolumn",
-  "nthcolumn*",
-  "nthcolumn*",
-  "leftcolumn",
-  "leftcolumn*",
-  "leftcolumn*",
-  "rightcolumn",
-  "rightcolumn*",
-  "rightcolumn*"
-]
+{
+  "paracol {}": {
+    "name": "paracol",
+    "detail": "paracol{number}",
+    "snippet": "{${1:number}}",
+    "package": "paracol"
+  },
+  "paracol {}[]": {
+    "name": "paracol",
+    "detail": "paracol{number}[text]",
+    "snippet": "{${1:number}}[${2:text}]",
+    "package": "paracol"
+  },
+  "column ": {
+    "name": "column",
+    "detail": "column",
+    "snippet": "",
+    "package": "paracol"
+  },
+  "column* ": {
+    "name": "column*",
+    "detail": "column*",
+    "snippet": "",
+    "package": "paracol"
+  },
+  "column* []": {
+    "name": "column*",
+    "detail": "column*[text]",
+    "snippet": "[${1:text}]",
+    "package": "paracol"
+  },
+  "nthcolumn {}": {
+    "name": "nthcolumn",
+    "detail": "nthcolumn{column}",
+    "snippet": "{${1:column}}",
+    "package": "paracol"
+  },
+  "nthcolumn* {}": {
+    "name": "nthcolumn*",
+    "detail": "nthcolumn*{column}",
+    "snippet": "{${1:column}}",
+    "package": "paracol"
+  },
+  "nthcolumn* {}[]": {
+    "name": "nthcolumn*",
+    "detail": "nthcolumn*{column}[text]",
+    "snippet": "{${1:column}}[${2:text}]",
+    "package": "paracol"
+  },
+  "leftcolumn ": {
+    "name": "leftcolumn",
+    "detail": "leftcolumn",
+    "snippet": "",
+    "package": "paracol"
+  },
+  "leftcolumn* ": {
+    "name": "leftcolumn*",
+    "detail": "leftcolumn*",
+    "snippet": "",
+    "package": "paracol"
+  },
+  "leftcolumn* []": {
+    "name": "leftcolumn*",
+    "detail": "leftcolumn*[text]",
+    "snippet": "[${1:text}]",
+    "package": "paracol"
+  },
+  "rightcolumn ": {
+    "name": "rightcolumn",
+    "detail": "rightcolumn",
+    "snippet": "",
+    "package": "paracol"
+  },
+  "rightcolumn* ": {
+    "name": "rightcolumn*",
+    "detail": "rightcolumn*",
+    "snippet": "",
+    "package": "paracol"
+  },
+  "rightcolumn* []": {
+    "name": "rightcolumn*",
+    "detail": "rightcolumn*[text]",
+    "snippet": "[${1:text}]",
+    "package": "paracol"
+  }
+}

--- a/data/packages/paracol_env.json
+++ b/data/packages/paracol_env.json
@@ -11,13 +11,13 @@
     "snippet": "{${1:number}}[${2:text}]",
     "package": "paracol"
   },
-  "column ": {
+  "column": {
     "name": "column",
     "detail": "column",
     "snippet": "",
     "package": "paracol"
   },
-  "column* ": {
+  "column*": {
     "name": "column*",
     "detail": "column*",
     "snippet": "",
@@ -47,13 +47,13 @@
     "snippet": "{${1:column}}[${2:text}]",
     "package": "paracol"
   },
-  "leftcolumn ": {
+  "leftcolumn": {
     "name": "leftcolumn",
     "detail": "leftcolumn",
     "snippet": "",
     "package": "paracol"
   },
-  "leftcolumn* ": {
+  "leftcolumn*": {
     "name": "leftcolumn*",
     "detail": "leftcolumn*",
     "snippet": "",
@@ -65,13 +65,13 @@
     "snippet": "[${1:text}]",
     "package": "paracol"
   },
-  "rightcolumn ": {
+  "rightcolumn": {
     "name": "rightcolumn",
     "detail": "rightcolumn",
     "snippet": "",
     "package": "paracol"
   },
-  "rightcolumn* ": {
+  "rightcolumn*": {
     "name": "rightcolumn*",
     "detail": "rightcolumn*",
     "snippet": "",

--- a/data/packages/pgfcore_env.json
+++ b/data/packages/pgfcore_env.json
@@ -1,5 +1,5 @@
 {
-  "pgfonlayer ": {
+  "pgfonlayer": {
     "name": "pgfonlayer",
     "detail": "pgfonlayer",
     "snippet": "",

--- a/data/packages/pgfcore_env.json
+++ b/data/packages/pgfcore_env.json
@@ -1,3 +1,8 @@
-[
-  "pgfonlayer"
-]
+{
+  "pgfonlayer ": {
+    "name": "pgfonlayer",
+    "detail": "pgfonlayer",
+    "snippet": "",
+    "package": "pgfcore"
+  }
+}

--- a/data/packages/pgfplots_env.json
+++ b/data/packages/pgfplots_env.json
@@ -1,16 +1,86 @@
-[
-  "tikzpicture",
-  "tikzpicture",
-  "tikzpicture",
-  "tikzpicture",
-  "tikzpicture",
-  "axis",
-  "axis",
-  "axis",
-  "axis",
-  "axis",
-  "axis",
-  "semilogxaxis",
-  "semilogyaxis",
-  "loglogaxis"
-]
+{
+  "tikzpicture % function%\\\\begin{}[]%\\\\addplot {};%\\\\end{}%\\\\end{}": {
+    "name": "tikzpicture",
+    "detail": "tikzpicture% function%\\\\begin{axis}[xlabel=%<x axis label%>,ylabel=%<y axis label%>]%\\\\addplot {%|};%\\\\end{axis}%\\\\end{tikzpicture}",
+    "snippet": "% function%\\\\begin{${1:axis}}[${2:xlabel=%<x axis label%>,ylabel=%<y axis label%>}]%\\\\addplot {${3:%|}};%\\\\end{${4:axis}}%\\\\end{${5:tikzpicture}}",
+    "package": "pgfplots"
+  },
+  "tikzpicture % table%\\\\begin{}[]%\\\\addplot table[] {};%\\\\end{}%\\\\end{}": {
+    "name": "tikzpicture",
+    "detail": "tikzpicture% table%\\\\begin{axis}[xlabel=%<x axis label%>,ylabel=%<y axis label%>]%\\\\addplot table[x=%<column header%>,y=%<column header%>] {%<file%>};%\\\\end{axis}%\\\\end{tikzpicture}",
+    "snippet": "% table%\\\\begin{${1:axis}}[${2:xlabel=%<x axis label%>,ylabel=%<y axis label%>}]%\\\\addplot table[${3:x=%<column header%>,y=%<column header%>}] {${4:%<file%>}};%\\\\end{${5:axis}}%\\\\end{${6:tikzpicture}}",
+    "package": "pgfplots"
+  },
+  "tikzpicture % coordinates%\\\\begin{}[]%\\\\addplot coordinates {};%\\\\end{}%\\\\end{}": {
+    "name": "tikzpicture",
+    "detail": "tikzpicture% coordinates%\\\\begin{axis}[xlabel=%<x axis label%>,ylabel=%<y axis label%>]%\\\\addplot coordinates {%|};%\\\\end{axis}%\\\\end{tikzpicture}",
+    "snippet": "% coordinates%\\\\begin{${1:axis}}[${2:xlabel=%<x axis label%>,ylabel=%<y axis label%>}]%\\\\addplot coordinates {${3:%|}};%\\\\end{${4:axis}}%\\\\end{${5:tikzpicture}}",
+    "package": "pgfplots"
+  },
+  "tikzpicture % file%\\\\begin{}[]%\\\\addplot file {};%\\\\end{}%\\\\end{}": {
+    "name": "tikzpicture",
+    "detail": "tikzpicture% file%\\\\begin{axis}[xlabel=%<x axis label%>,ylabel=%<y axis label%>]%\\\\addplot file {%<file%>};%\\\\end{axis}%\\\\end{tikzpicture}",
+    "snippet": "% file%\\\\begin{${1:axis}}[${2:xlabel=%<x axis label%>,ylabel=%<y axis label%>}]%\\\\addplot file {${3:%<file%>}};%\\\\end{${4:axis}}%\\\\end{${5:tikzpicture}}",
+    "package": "pgfplots"
+  },
+  "tikzpicture % gnuplot%\\\\begin{}[]%\\\\addplot gnuplot {};%\\\\end{}%\\\\end{}": {
+    "name": "tikzpicture",
+    "detail": "tikzpicture% gnuplot%\\\\begin{axis}[xlabel=%<x axis label%>,ylabel=%<y axis label%>]%\\\\addplot gnuplot {%<gnuplot code%>};%\\\\end{axis}%\\\\end{tikzpicture}",
+    "snippet": "% gnuplot%\\\\begin{${1:axis}}[${2:xlabel=%<x axis label%>,ylabel=%<y axis label%>}]%\\\\addplot gnuplot {${3:%<gnuplot code%>}};%\\\\end{${4:axis}}%\\\\end{${5:tikzpicture}}",
+    "package": "pgfplots"
+  },
+  "axis ": {
+    "name": "axis",
+    "detail": "axis",
+    "snippet": "",
+    "package": "pgfplots"
+  },
+  "axis []% function%\\\\addplot {};%\\\\end{}": {
+    "name": "axis",
+    "detail": "axis[xlabel=%<x axis label%>,ylabel=%<y axis label%>]% function%\\\\addplot {%|};%\\\\end{axis}",
+    "snippet": "[${3:xlabel=%<x axis label%>,ylabel=%<y axis label%>}]% function%\\\\addplot {${1:%|}};%\\\\end{${2:axis}}",
+    "package": "pgfplots"
+  },
+  "axis []% table%\\\\addplot table[] {};%\\\\end{}": {
+    "name": "axis",
+    "detail": "axis[xlabel=%<x axis label%>,ylabel=%<y axis label%>]% table%\\\\addplot table[x=%<column header%>,y=%<column header%>] {%<file%>};%\\\\end{axis}",
+    "snippet": "[${3:xlabel=%<x axis label%>,ylabel=%<y axis label%>}]% table%\\\\addplot table[${4:x=%<column header%>,y=%<column header%>}] {${1:%<file%>}};%\\\\end{${2:axis}}",
+    "package": "pgfplots"
+  },
+  "axis []% coordinates%\\\\addplot coordinates {};%\\\\end{}": {
+    "name": "axis",
+    "detail": "axis[xlabel=%<x axis label%>,ylabel=%<y axis label%>]% coordinates%\\\\addplot coordinates {%|};%\\\\end{axis}",
+    "snippet": "[${3:xlabel=%<x axis label%>,ylabel=%<y axis label%>}]% coordinates%\\\\addplot coordinates {${1:%|}};%\\\\end{${2:axis}}",
+    "package": "pgfplots"
+  },
+  "axis []% file%\\\\addplot file {};%\\\\end{}": {
+    "name": "axis",
+    "detail": "axis[xlabel=%<x axis label%>,ylabel=%<y axis label%>]% file%\\\\addplot file {%<file%>};%\\\\end{axis}",
+    "snippet": "[${3:xlabel=%<x axis label%>,ylabel=%<y axis label%>}]% file%\\\\addplot file {${1:%<file%>}};%\\\\end{${2:axis}}",
+    "package": "pgfplots"
+  },
+  "axis []% gnuplot%\\\\addplot gnuplot {};%\\\\end{}": {
+    "name": "axis",
+    "detail": "axis[xlabel=%<x axis label%>,ylabel=%<y axis label%>]% gnuplot%\\\\addplot gnuplot {%<gnuplot code%>};%\\\\end{axis}",
+    "snippet": "[${3:xlabel=%<x axis label%>,ylabel=%<y axis label%>}]% gnuplot%\\\\addplot gnuplot {${1:%<gnuplot code%>}};%\\\\end{${2:axis}}",
+    "package": "pgfplots"
+  },
+  "semilogxaxis ": {
+    "name": "semilogxaxis",
+    "detail": "semilogxaxis",
+    "snippet": "",
+    "package": "pgfplots"
+  },
+  "semilogyaxis ": {
+    "name": "semilogyaxis",
+    "detail": "semilogyaxis",
+    "snippet": "",
+    "package": "pgfplots"
+  },
+  "loglogaxis ": {
+    "name": "loglogaxis",
+    "detail": "loglogaxis",
+    "snippet": "",
+    "package": "pgfplots"
+  }
+}

--- a/data/packages/pgfplots_env.json
+++ b/data/packages/pgfplots_env.json
@@ -29,7 +29,7 @@
     "snippet": "% gnuplot%\\\\begin{${1:axis}}[${2:xlabel=%<x axis label%>,ylabel=%<y axis label%>}]%\\\\addplot gnuplot {${3:%<gnuplot code%>}};%\\\\end{${4:axis}}%\\\\end{${5:tikzpicture}}",
     "package": "pgfplots"
   },
-  "axis ": {
+  "axis": {
     "name": "axis",
     "detail": "axis",
     "snippet": "",
@@ -65,19 +65,19 @@
     "snippet": "[${3:xlabel=%<x axis label%>,ylabel=%<y axis label%>}]% gnuplot%\\\\addplot gnuplot {${1:%<gnuplot code%>}};%\\\\end{${2:axis}}",
     "package": "pgfplots"
   },
-  "semilogxaxis ": {
+  "semilogxaxis": {
     "name": "semilogxaxis",
     "detail": "semilogxaxis",
     "snippet": "",
     "package": "pgfplots"
   },
-  "semilogyaxis ": {
+  "semilogyaxis": {
     "name": "semilogyaxis",
     "detail": "semilogyaxis",
     "snippet": "",
     "package": "pgfplots"
   },
-  "loglogaxis ": {
+  "loglogaxis": {
     "name": "loglogaxis",
     "detail": "loglogaxis",
     "snippet": "",

--- a/data/packages/pifont_env.json
+++ b/data/packages/pifont_env.json
@@ -1,6 +1,26 @@
-[
-  "dinglist",
-  "dingautolist",
-  "Pilist",
-  "Piautolist"
-]
+{
+  "dinglist {}": {
+    "name": "dinglist",
+    "detail": "dinglist{number}",
+    "snippet": "{${1:number}}",
+    "package": "pifont"
+  },
+  "dingautolist {}": {
+    "name": "dingautolist",
+    "detail": "dingautolist{number}",
+    "snippet": "{${1:number}}",
+    "package": "pifont"
+  },
+  "Pilist {}{}": {
+    "name": "Pilist",
+    "detail": "Pilist{family}{number}",
+    "snippet": "{${1:family}}{${2:number}}",
+    "package": "pifont"
+  },
+  "Piautolist {}{}": {
+    "name": "Piautolist",
+    "detail": "Piautolist{family}{number}",
+    "snippet": "{${1:family}}{${2:number}}",
+    "package": "pifont"
+  }
+}

--- a/data/packages/psfrag_env.json
+++ b/data/packages/psfrag_env.json
@@ -1,5 +1,5 @@
 {
-  "psfrags ": {
+  "psfrags": {
     "name": "psfrags",
     "detail": "psfrags",
     "snippet": "",

--- a/data/packages/psfrag_env.json
+++ b/data/packages/psfrag_env.json
@@ -1,3 +1,8 @@
-[
-  "psfrags"
-]
+{
+  "psfrags ": {
+    "name": "psfrags",
+    "detail": "psfrags",
+    "snippet": "",
+    "package": "psfrag"
+  }
+}

--- a/data/packages/pst-char_env.json
+++ b/data/packages/pst-char_env.json
@@ -1,6 +1,26 @@
-[
-  "charclip",
-  "charclip*",
-  "charclip",
-  "charclip*"
-]
+{
+  "charclip []{}": {
+    "name": "charclip",
+    "detail": "charclip[par]{text}",
+    "snippet": "[${2:par}]{${1:text}}",
+    "package": "pst-char"
+  },
+  "charclip* []{}": {
+    "name": "charclip*",
+    "detail": "charclip*[par]{text}",
+    "snippet": "[${2:par}]{${1:text}}",
+    "package": "pst-char"
+  },
+  "charclip {}": {
+    "name": "charclip",
+    "detail": "charclip{text}",
+    "snippet": "{${1:text}}",
+    "package": "pst-char"
+  },
+  "charclip* {}": {
+    "name": "charclip*",
+    "detail": "charclip*{text}",
+    "snippet": "{${1:text}}",
+    "package": "pst-char"
+  }
+}

--- a/data/packages/pst-eps_env.json
+++ b/data/packages/pst-eps_env.json
@@ -1,5 +1,5 @@
 {
-  "TeXtoEPS ": {
+  "TeXtoEPS": {
     "name": "TeXtoEPS",
     "detail": "TeXtoEPS",
     "snippet": "",

--- a/data/packages/pst-eps_env.json
+++ b/data/packages/pst-eps_env.json
@@ -1,3 +1,8 @@
-[
-  "TeXtoEPS"
-]
+{
+  "TeXtoEPS ": {
+    "name": "TeXtoEPS",
+    "detail": "TeXtoEPS",
+    "snippet": "",
+    "package": "pst-eps"
+  }
+}

--- a/data/packages/pst-tree_env.json
+++ b/data/packages/pst-tree_env.json
@@ -1,3 +1,8 @@
-[
-  "psTree"
-]
+{
+  "psTree {}": {
+    "name": "psTree",
+    "detail": "psTree{node}",
+    "snippet": "{${1:node}}",
+    "package": "pst-tree"
+  }
+}

--- a/data/packages/pstricks_env.json
+++ b/data/packages/pstricks_env.json
@@ -1,6 +1,26 @@
-[
-  "pspicture",
-  "pspicture*",
-  "pspicture",
-  "pspicture*"
-]
+{
+  "pspicture [](x0,y0)(x1,y1)": {
+    "name": "pspicture",
+    "detail": "pspicture[par](x0,y0)(x1,y1)",
+    "snippet": "[${1:par}](x0,y0)(x1,y1)",
+    "package": "pstricks"
+  },
+  "pspicture* [](x0,y0)(x1,y1)": {
+    "name": "pspicture*",
+    "detail": "pspicture*[par](x0,y0)(x1,y1)",
+    "snippet": "[${1:par}](x0,y0)(x1,y1)",
+    "package": "pstricks"
+  },
+  "pspicture (x0,y0)(x1,y1)": {
+    "name": "pspicture",
+    "detail": "pspicture(x0,y0)(x1,y1)",
+    "snippet": "(x0,y0)(x1,y1)",
+    "package": "pstricks"
+  },
+  "pspicture* (x0,y0)(x1,y1)": {
+    "name": "pspicture*",
+    "detail": "pspicture*(x0,y0)(x1,y1)",
+    "snippet": "(x0,y0)(x1,y1)",
+    "package": "pstricks"
+  }
+}

--- a/data/packages/rotating_env.json
+++ b/data/packages/rotating_env.json
@@ -1,4 +1,14 @@
-[
-  "sidewaystable",
-  "sidewaysfigure"
-]
+{
+  "sidewaystable ": {
+    "name": "sidewaystable",
+    "detail": "sidewaystable",
+    "snippet": "",
+    "package": "rotating"
+  },
+  "sidewaysfigure ": {
+    "name": "sidewaysfigure",
+    "detail": "sidewaysfigure",
+    "snippet": "",
+    "package": "rotating"
+  }
+}

--- a/data/packages/rotating_env.json
+++ b/data/packages/rotating_env.json
@@ -1,11 +1,11 @@
 {
-  "sidewaystable ": {
+  "sidewaystable": {
     "name": "sidewaystable",
     "detail": "sidewaystable",
     "snippet": "",
     "package": "rotating"
   },
-  "sidewaysfigure ": {
+  "sidewaysfigure": {
     "name": "sidewaysfigure",
     "detail": "sidewaysfigure",
     "snippet": "",

--- a/data/packages/setspace_env.json
+++ b/data/packages/setspace_env.json
@@ -1,6 +1,26 @@
-[
-  "singlespace",
-  "doublespace",
-  "onehalfspace",
-  "spacing"
-]
+{
+  "singlespace ": {
+    "name": "singlespace",
+    "detail": "singlespace",
+    "snippet": "",
+    "package": "setspace"
+  },
+  "doublespace ": {
+    "name": "doublespace",
+    "detail": "doublespace",
+    "snippet": "",
+    "package": "setspace"
+  },
+  "onehalfspace ": {
+    "name": "onehalfspace",
+    "detail": "onehalfspace",
+    "snippet": "",
+    "package": "setspace"
+  },
+  "spacing {}": {
+    "name": "spacing",
+    "detail": "spacing{factor}",
+    "snippet": "{${1:factor}}",
+    "package": "setspace"
+  }
+}

--- a/data/packages/setspace_env.json
+++ b/data/packages/setspace_env.json
@@ -1,17 +1,17 @@
 {
-  "singlespace ": {
+  "singlespace": {
     "name": "singlespace",
     "detail": "singlespace",
     "snippet": "",
     "package": "setspace"
   },
-  "doublespace ": {
+  "doublespace": {
     "name": "doublespace",
     "detail": "doublespace",
     "snippet": "",
     "package": "setspace"
   },
-  "onehalfspace ": {
+  "onehalfspace": {
     "name": "onehalfspace",
     "detail": "onehalfspace",
     "snippet": "",

--- a/data/packages/subcaption_env.json
+++ b/data/packages/subcaption_env.json
@@ -1,6 +1,26 @@
-[
-  "subfigure",
-  "subfigure",
-  "subtable",
-  "subtable"
-]
+{
+  "subfigure {}": {
+    "name": "subfigure",
+    "detail": "subfigure{width}",
+    "snippet": "{${1:width}}",
+    "package": "subcaption"
+  },
+  "subfigure []{}": {
+    "name": "subfigure",
+    "detail": "subfigure[pos]{width}",
+    "snippet": "[${2:pos}]{${1:width}}",
+    "package": "subcaption"
+  },
+  "subtable {}": {
+    "name": "subtable",
+    "detail": "subtable{width}",
+    "snippet": "{${1:width}}",
+    "package": "subcaption"
+  },
+  "subtable []{}": {
+    "name": "subtable",
+    "detail": "subtable[pos]{width}",
+    "snippet": "[${2:pos}]{${1:width}}",
+    "package": "subcaption"
+  }
+}

--- a/data/packages/supertabular_env.json
+++ b/data/packages/supertabular_env.json
@@ -1,6 +1,26 @@
-[
-  "mpsupertabular",
-  "mpsupertabular*",
-  "supertabular",
-  "supertabular*"
-]
+{
+  "mpsupertabular {}": {
+    "name": "mpsupertabular",
+    "detail": "mpsupertabular{preamble}",
+    "snippet": "{${1:preamble}}",
+    "package": "supertabular"
+  },
+  "mpsupertabular* {}": {
+    "name": "mpsupertabular*",
+    "detail": "mpsupertabular*{preamble}",
+    "snippet": "{${1:preamble}}",
+    "package": "supertabular"
+  },
+  "supertabular {}": {
+    "name": "supertabular",
+    "detail": "supertabular{preamble}",
+    "snippet": "{${1:preamble}}",
+    "package": "supertabular"
+  },
+  "supertabular* {}": {
+    "name": "supertabular*",
+    "detail": "supertabular*{preamble}",
+    "snippet": "{${1:preamble}}",
+    "package": "supertabular"
+  }
+}

--- a/data/packages/tabu_cmd.json
+++ b/data/packages/tabu_cmd.json
@@ -37,7 +37,7 @@
   "tabulinesep = %<dimen%>": {
     "command": "tabulinesep = %<dimen%>",
     "package": "tabu",
-    "snippet": "tabulinesep = %<dimen%>"
+    "snippet": "tabulinesep = ${1:dimen}"
   },
   "abovetabulinesep": {
     "command": "abovetabulinesep",
@@ -57,17 +57,17 @@
   "extrarowsep =^%<dimen%>": {
     "command": "extrarowsep =^%<dimen%>",
     "package": "tabu",
-    "snippet": "extrarowsep =^%<dimen%>"
+    "snippet": "extrarowsep =^${1:dimen}"
   },
   "extrarowsep =_%<dimen%>": {
     "command": "extrarowsep =_%<dimen%>",
     "package": "tabu",
-    "snippet": "extrarowsep =_%<dimen%>"
+    "snippet": "extrarowsep =_${1:dimen}"
   },
   "extrarowsep =_%<dimen%>^%<dimen%>": {
     "command": "extrarowsep =_%<dimen%>^%<dimen%>",
     "package": "tabu",
-    "snippet": "extrarowsep =_%<dimen%>^%<dimen%>"
+    "snippet": "extrarowsep =_${1:dimen}^${2:dimen}"
   },
   "taburulecolor{}": {
     "command": "taburulecolor{color}",
@@ -97,12 +97,12 @@
   "taburowcolors [] %<number%> {}": {
     "command": "taburowcolors [<%first line%>] %<number%> {%<first%> .. %<last%>}",
     "package": "tabu",
-    "snippet": "taburowcolors [${2:<%first line%>}] %<number%> {${1:%<first%> .. %<last%>}}"
+    "snippet": "taburowcolors [${2:<%first line%>}] ${3:number} {${1:%<first%> .. %<last%>}}"
   },
   "taburowcolors %<number%> {}": {
     "command": "taburowcolors %<number%> {%<first%> .. %<last%>}",
     "package": "tabu",
-    "snippet": "taburowcolors %<number%> {${1:%<first%> .. %<last%>}}"
+    "snippet": "taburowcolors ${2:number} {${1:%<first%> .. %<last%>}}"
   },
   "rowfont[]{}": {
     "command": "rowfont[alignment]{fontSpec}",

--- a/data/packages/tabu_env.json
+++ b/data/packages/tabu_env.json
@@ -8,13 +8,13 @@
   "tabu  to %<width%> {}": {
     "name": "tabu",
     "detail": "tabu to %<width%> {%<preamble%>}",
-    "snippet": " to %<width%> {${1:%<preamble%>}}",
+    "snippet": " to ${2:width} {${1:%<preamble%>}}",
     "package": "tabu"
   },
   "tabu  spread %<width%> {}": {
     "name": "tabu",
     "detail": "tabu spread %<width%> {%<preamble%>}",
-    "snippet": " spread %<width%> {${1:%<preamble%>}}",
+    "snippet": " spread ${2:width} {${1:%<preamble%>}}",
     "package": "tabu"
   },
   "longtabu {}": {
@@ -26,13 +26,13 @@
   "longtabu  to %<width%> {}": {
     "name": "longtabu",
     "detail": "longtabu to %<width%> {%<preamble%>}",
-    "snippet": " to %<width%> {${1:%<preamble%>}}",
+    "snippet": " to ${2:width} {${1:%<preamble%>}}",
     "package": "tabu"
   },
   "longtabu  spread %<width%> {}": {
     "name": "longtabu",
     "detail": "longtabu spread %<width%> {%<preamble%>}",
-    "snippet": " spread %<width%> {${1:%<preamble%>}}",
+    "snippet": " spread ${2:width} {${1:%<preamble%>}}",
     "package": "tabu"
   }
 }

--- a/data/packages/tabu_env.json
+++ b/data/packages/tabu_env.json
@@ -1,8 +1,38 @@
-[
-  "tabu",
-  "tabu",
-  "tabu",
-  "longtabu",
-  "longtabu",
-  "longtabu"
-]
+{
+  "tabu {}": {
+    "name": "tabu",
+    "detail": "tabu{preamble}",
+    "snippet": "{${1:preamble}}",
+    "package": "tabu"
+  },
+  "tabu  to %<width%> {}": {
+    "name": "tabu",
+    "detail": "tabu to %<width%> {%<preamble%>}",
+    "snippet": " to %<width%> {${1:%<preamble%>}}",
+    "package": "tabu"
+  },
+  "tabu  spread %<width%> {}": {
+    "name": "tabu",
+    "detail": "tabu spread %<width%> {%<preamble%>}",
+    "snippet": " spread %<width%> {${1:%<preamble%>}}",
+    "package": "tabu"
+  },
+  "longtabu {}": {
+    "name": "longtabu",
+    "detail": "longtabu{preamble}",
+    "snippet": "{${1:preamble}}",
+    "package": "tabu"
+  },
+  "longtabu  to %<width%> {}": {
+    "name": "longtabu",
+    "detail": "longtabu to %<width%> {%<preamble%>}",
+    "snippet": " to %<width%> {${1:%<preamble%>}}",
+    "package": "tabu"
+  },
+  "longtabu  spread %<width%> {}": {
+    "name": "longtabu",
+    "detail": "longtabu spread %<width%> {%<preamble%>}",
+    "snippet": " spread %<width%> {${1:%<preamble%>}}",
+    "package": "tabu"
+  }
+}

--- a/data/packages/tabularx_env.json
+++ b/data/packages/tabularx_env.json
@@ -1,3 +1,8 @@
-[
-  "tabularx"
-]
+{
+  "tabularx {}{}": {
+    "name": "tabularx",
+    "detail": "tabularx{width}{preamble}",
+    "snippet": "{${1:width}}{${2:preamble}}",
+    "package": "tabularx"
+  }
+}

--- a/data/packages/tabulary_env.json
+++ b/data/packages/tabulary_env.json
@@ -1,3 +1,8 @@
-[
-  "tabulary"
-]
+{
+  "tabulary {}{}": {
+    "name": "tabulary",
+    "detail": "tabulary{width}{preamble}",
+    "snippet": "{${1:width}}{${2:preamble}}",
+    "package": "tabulary"
+  }
+}

--- a/data/packages/tcolorbox_env.json
+++ b/data/packages/tcolorbox_env.json
@@ -1,47 +1,272 @@
-[
-  "tcolorbox",
-  "tcolorbox",
-  "tcbverbatimwrite",
-  "tcbwritetemp",
-  "tcbclipframe",
-  "tcbinvclipframe",
-  "tcbclipinterior",
-  "tcbcliptitle",
-  "tcbraster",
-  "tcbraster",
-  "tcbitemize",
-  "tcbitemize",
-  "tcboxedraster",
-  "tcboxedraster",
-  "tcboxeditemize",
-  "tcboxeditemize",
-  "tcblisting",
-  "tcboutputlisting",
-  "boxarraystore",
-  "tcbposter",
-  "tcbposter",
-  "posterboxenv",
-  "posterboxenv",
-  "tcbexternal",
-  "tcbexternal",
-  "extcolorbox",
-  "extcolorbox",
-  "extikzpicture",
-  "extikzpicture",
-  "docCommand",
-  "docCommand",
-  "docCommand*",
-  "docCommand*",
-  "docEnvironment",
-  "docEnvironment",
-  "docEnvironment*",
-  "docEnvironment*",
-  "docKey",
-  "docKey",
-  "docKey*",
-  "docKey*",
-  "dispExample",
-  "dispExample*",
-  "dispListing",
-  "absquote"
-]
+{
+  "tcolorbox ": {
+    "name": "tcolorbox",
+    "detail": "tcolorbox",
+    "snippet": "",
+    "package": "tcolorbox"
+  },
+  "tcolorbox []": {
+    "name": "tcolorbox",
+    "detail": "tcolorbox[%<options%>]",
+    "snippet": "[${1:%<options%>}]",
+    "package": "tcolorbox"
+  },
+  "tcbverbatimwrite {}": {
+    "name": "tcbverbatimwrite",
+    "detail": "tcbverbatimwrite{%<file%>}",
+    "snippet": "{${1:%<file%>}}",
+    "package": "tcolorbox"
+  },
+  "tcbwritetemp ": {
+    "name": "tcbwritetemp",
+    "detail": "tcbwritetemp",
+    "snippet": "",
+    "package": "tcolorbox"
+  },
+  "tcbclipframe ": {
+    "name": "tcbclipframe",
+    "detail": "tcbclipframe",
+    "snippet": "",
+    "package": "tcolorbox"
+  },
+  "tcbinvclipframe ": {
+    "name": "tcbinvclipframe",
+    "detail": "tcbinvclipframe",
+    "snippet": "",
+    "package": "tcolorbox"
+  },
+  "tcbclipinterior ": {
+    "name": "tcbclipinterior",
+    "detail": "tcbclipinterior",
+    "snippet": "",
+    "package": "tcolorbox"
+  },
+  "tcbcliptitle ": {
+    "name": "tcbcliptitle",
+    "detail": "tcbcliptitle",
+    "snippet": "",
+    "package": "tcolorbox"
+  },
+  "tcbraster ": {
+    "name": "tcbraster",
+    "detail": "tcbraster",
+    "snippet": "",
+    "package": "tcolorbox"
+  },
+  "tcbraster []": {
+    "name": "tcbraster",
+    "detail": "tcbraster[options%keyvals]",
+    "snippet": "[${1:options%keyvals}]",
+    "package": "tcolorbox"
+  },
+  "tcbitemize ": {
+    "name": "tcbitemize",
+    "detail": "tcbitemize",
+    "snippet": "",
+    "package": "tcolorbox"
+  },
+  "tcbitemize []": {
+    "name": "tcbitemize",
+    "detail": "tcbitemize[options%keyvals]",
+    "snippet": "[${1:options%keyvals}]",
+    "package": "tcolorbox"
+  },
+  "tcboxedraster {}": {
+    "name": "tcboxedraster",
+    "detail": "tcboxedraster{box options}",
+    "snippet": "{${1:box options}}",
+    "package": "tcolorbox"
+  },
+  "tcboxedraster []{}": {
+    "name": "tcboxedraster",
+    "detail": "tcboxedraster[raster options]{box options}",
+    "snippet": "[${2:raster options}]{${1:box options}}",
+    "package": "tcolorbox"
+  },
+  "tcboxeditemize {}": {
+    "name": "tcboxeditemize",
+    "detail": "tcboxeditemize{box options}",
+    "snippet": "{${1:box options}}",
+    "package": "tcolorbox"
+  },
+  "tcboxeditemize []{}": {
+    "name": "tcboxeditemize",
+    "detail": "tcboxeditemize[raster options]{box options}",
+    "snippet": "[${2:raster options}]{${1:box options}}",
+    "package": "tcolorbox"
+  },
+  "tcblisting {}": {
+    "name": "tcblisting",
+    "detail": "tcblisting{options%keyvals}",
+    "snippet": "{${1:options%keyvals}}",
+    "package": "tcolorbox"
+  },
+  "tcboutputlisting ": {
+    "name": "tcboutputlisting",
+    "detail": "tcboutputlisting",
+    "snippet": "",
+    "package": "tcolorbox"
+  },
+  "boxarraystore {}": {
+    "name": "boxarraystore",
+    "detail": "boxarraystore{%<name%>}",
+    "snippet": "{${1:%<name%>}}",
+    "package": "tcolorbox"
+  },
+  "tcbposter ": {
+    "name": "tcbposter",
+    "detail": "tcbposter",
+    "snippet": "",
+    "package": "tcolorbox"
+  },
+  "tcbposter []": {
+    "name": "tcbposter",
+    "detail": "tcbposter[options%keyvals]",
+    "snippet": "[${1:options%keyvals}]",
+    "package": "tcolorbox"
+  },
+  "posterboxenv {}": {
+    "name": "posterboxenv",
+    "detail": "posterboxenv{placement}",
+    "snippet": "{${1:placement}}",
+    "package": "tcolorbox"
+  },
+  "posterboxenv []{}": {
+    "name": "posterboxenv",
+    "detail": "posterboxenv[options%keyvals]{placement}",
+    "snippet": "[${2:options%keyvals}]{${1:placement}}",
+    "package": "tcolorbox"
+  },
+  "tcbexternal {}": {
+    "name": "tcbexternal",
+    "detail": "tcbexternal{name}",
+    "snippet": "{${1:name}}",
+    "package": "tcolorbox"
+  },
+  "tcbexternal []{}": {
+    "name": "tcbexternal",
+    "detail": "tcbexternal[options%keyvals]{name}",
+    "snippet": "[${2:options%keyvals}]{${1:name}}",
+    "package": "tcolorbox"
+  },
+  "extcolorbox {}": {
+    "name": "extcolorbox",
+    "detail": "extcolorbox{name}",
+    "snippet": "{${1:name}}",
+    "package": "tcolorbox"
+  },
+  "extcolorbox []{}[]": {
+    "name": "extcolorbox",
+    "detail": "extcolorbox[options%keyvals]{name}[tcolorbox options%keyvals]",
+    "snippet": "[${2:options%keyvals}]{${1:name}}[${3:tcolorbox options%keyvals}]",
+    "package": "tcolorbox"
+  },
+  "extikzpicture {}": {
+    "name": "extikzpicture",
+    "detail": "extikzpicture{name}",
+    "snippet": "{${1:name}}",
+    "package": "tcolorbox"
+  },
+  "extikzpicture []{}[]": {
+    "name": "extikzpicture",
+    "detail": "extikzpicture[options%keyvals]{name}[tikz options%keyvals]",
+    "snippet": "[${2:options%keyvals}]{${1:name}}[${3:tikz options%keyvals}]",
+    "package": "tcolorbox"
+  },
+  "docCommand {}{}": {
+    "name": "docCommand",
+    "detail": "docCommand{name}{parameters}",
+    "snippet": "{${1:name}}{${2:parameters}}",
+    "package": "tcolorbox"
+  },
+  "docCommand []{}{}": {
+    "name": "docCommand",
+    "detail": "docCommand[options%keyvals]{name}{parameters}",
+    "snippet": "[${3:options%keyvals}]{${1:name}}{${2:parameters}}",
+    "package": "tcolorbox"
+  },
+  "docCommand* {}{}": {
+    "name": "docCommand*",
+    "detail": "docCommand*{name}{parameters}",
+    "snippet": "{${1:name}}{${2:parameters}}",
+    "package": "tcolorbox"
+  },
+  "docCommand* []{}{}": {
+    "name": "docCommand*",
+    "detail": "docCommand*[options%keyvals]{name}{parameters}",
+    "snippet": "[${3:options%keyvals}]{${1:name}}{${2:parameters}}",
+    "package": "tcolorbox"
+  },
+  "docEnvironment {}{}": {
+    "name": "docEnvironment",
+    "detail": "docEnvironment{name}{parameters}",
+    "snippet": "{${1:name}}{${2:parameters}}",
+    "package": "tcolorbox"
+  },
+  "docEnvironment []{}{}": {
+    "name": "docEnvironment",
+    "detail": "docEnvironment[options%keyvals]{name}{parameters}",
+    "snippet": "[${3:options%keyvals}]{${1:name}}{${2:parameters}}",
+    "package": "tcolorbox"
+  },
+  "docEnvironment* {}{}": {
+    "name": "docEnvironment*",
+    "detail": "docEnvironment*{name}{parameters}",
+    "snippet": "{${1:name}}{${2:parameters}}",
+    "package": "tcolorbox"
+  },
+  "docEnvironment* []{}{}": {
+    "name": "docEnvironment*",
+    "detail": "docEnvironment*[options%keyvals]{name}{parameters}",
+    "snippet": "[${3:options%keyvals}]{${1:name}}{${2:parameters}}",
+    "package": "tcolorbox"
+  },
+  "docKey {}{}{}{}": {
+    "name": "docKey",
+    "detail": "docKey{name}{parameters}{description}{key description}",
+    "snippet": "{${1:name}}{${2:parameters}}{${3:description}}{${4:key description}}",
+    "package": "tcolorbox"
+  },
+  "docKey [][]{}{}{}{}": {
+    "name": "docKey",
+    "detail": "docKey[key path][options%keyvals]{name}{parameters}{description}{key description}",
+    "snippet": "[${5:key path}][${6:options%keyvals}]{${1:name}}{${2:parameters}}{${3:description}}{${4:key description}}",
+    "package": "tcolorbox"
+  },
+  "docKey* {}{}{}{}": {
+    "name": "docKey*",
+    "detail": "docKey*{name}{parameters}{description}{key description}",
+    "snippet": "{${1:name}}{${2:parameters}}{${3:description}}{${4:key description}}",
+    "package": "tcolorbox"
+  },
+  "docKey* [][]{}{}{}{}": {
+    "name": "docKey*",
+    "detail": "docKey*[key path][options%keyvals]{name}{parameters}{description}{key description}",
+    "snippet": "[${5:key path}][${6:options%keyvals}]{${1:name}}{${2:parameters}}{${3:description}}{${4:key description}}",
+    "package": "tcolorbox"
+  },
+  "dispExample ": {
+    "name": "dispExample",
+    "detail": "dispExample",
+    "snippet": "",
+    "package": "tcolorbox"
+  },
+  "dispExample* {}": {
+    "name": "dispExample*",
+    "detail": "dispExample*{options%keyvals}",
+    "snippet": "{${1:options%keyvals}}",
+    "package": "tcolorbox"
+  },
+  "dispListing ": {
+    "name": "dispListing",
+    "detail": "dispListing",
+    "snippet": "",
+    "package": "tcolorbox"
+  },
+  "absquote ": {
+    "name": "absquote",
+    "detail": "absquote",
+    "snippet": "",
+    "package": "tcolorbox"
+  }
+}

--- a/data/packages/tcolorbox_env.json
+++ b/data/packages/tcolorbox_env.json
@@ -1,5 +1,5 @@
 {
-  "tcolorbox ": {
+  "tcolorbox": {
     "name": "tcolorbox",
     "detail": "tcolorbox",
     "snippet": "",
@@ -17,37 +17,37 @@
     "snippet": "{${1:%<file%>}}",
     "package": "tcolorbox"
   },
-  "tcbwritetemp ": {
+  "tcbwritetemp": {
     "name": "tcbwritetemp",
     "detail": "tcbwritetemp",
     "snippet": "",
     "package": "tcolorbox"
   },
-  "tcbclipframe ": {
+  "tcbclipframe": {
     "name": "tcbclipframe",
     "detail": "tcbclipframe",
     "snippet": "",
     "package": "tcolorbox"
   },
-  "tcbinvclipframe ": {
+  "tcbinvclipframe": {
     "name": "tcbinvclipframe",
     "detail": "tcbinvclipframe",
     "snippet": "",
     "package": "tcolorbox"
   },
-  "tcbclipinterior ": {
+  "tcbclipinterior": {
     "name": "tcbclipinterior",
     "detail": "tcbclipinterior",
     "snippet": "",
     "package": "tcolorbox"
   },
-  "tcbcliptitle ": {
+  "tcbcliptitle": {
     "name": "tcbcliptitle",
     "detail": "tcbcliptitle",
     "snippet": "",
     "package": "tcolorbox"
   },
-  "tcbraster ": {
+  "tcbraster": {
     "name": "tcbraster",
     "detail": "tcbraster",
     "snippet": "",
@@ -59,7 +59,7 @@
     "snippet": "[${1:options%keyvals}]",
     "package": "tcolorbox"
   },
-  "tcbitemize ": {
+  "tcbitemize": {
     "name": "tcbitemize",
     "detail": "tcbitemize",
     "snippet": "",
@@ -101,7 +101,7 @@
     "snippet": "{${1:options%keyvals}}",
     "package": "tcolorbox"
   },
-  "tcboutputlisting ": {
+  "tcboutputlisting": {
     "name": "tcboutputlisting",
     "detail": "tcboutputlisting",
     "snippet": "",
@@ -113,7 +113,7 @@
     "snippet": "{${1:%<name%>}}",
     "package": "tcolorbox"
   },
-  "tcbposter ": {
+  "tcbposter": {
     "name": "tcbposter",
     "detail": "tcbposter",
     "snippet": "",
@@ -245,7 +245,7 @@
     "snippet": "[${5:key path}][${6:options%keyvals}]{${1:name}}{${2:parameters}}{${3:description}}{${4:key description}}",
     "package": "tcolorbox"
   },
-  "dispExample ": {
+  "dispExample": {
     "name": "dispExample",
     "detail": "dispExample",
     "snippet": "",
@@ -257,13 +257,13 @@
     "snippet": "{${1:options%keyvals}}",
     "package": "tcolorbox"
   },
-  "dispListing ": {
+  "dispListing": {
     "name": "dispListing",
     "detail": "dispListing",
     "snippet": "",
     "package": "tcolorbox"
   },
-  "absquote ": {
+  "absquote": {
     "name": "absquote",
     "detail": "absquote",
     "snippet": "",

--- a/data/packages/tikz-cd_env.json
+++ b/data/packages/tikz-cd_env.json
@@ -1,3 +1,8 @@
-[
-  "tikzcd"
-]
+{
+  "tikzcd ": {
+    "name": "tikzcd",
+    "detail": "tikzcd",
+    "snippet": "",
+    "package": "tikz-cd"
+  }
+}

--- a/data/packages/tikz-cd_env.json
+++ b/data/packages/tikz-cd_env.json
@@ -1,5 +1,5 @@
 {
-  "tikzcd ": {
+  "tikzcd": {
     "name": "tikzcd",
     "detail": "tikzcd",
     "snippet": "",

--- a/data/packages/tikz-timing_env.json
+++ b/data/packages/tikz-timing_env.json
@@ -1,11 +1,11 @@
 {
-  "tikztimingtable ": {
+  "tikztimingtable": {
     "name": "tikztimingtable",
     "detail": "tikztimingtable",
     "snippet": "",
     "package": "tikz-timing"
   },
-  "pgfonlayer ": {
+  "pgfonlayer": {
     "name": "pgfonlayer",
     "detail": "pgfonlayer",
     "snippet": "",

--- a/data/packages/tikz-timing_env.json
+++ b/data/packages/tikz-timing_env.json
@@ -1,4 +1,14 @@
-[
-  "tikztimingtable",
-  "pgfonlayer"
-]
+{
+  "tikztimingtable ": {
+    "name": "tikztimingtable",
+    "detail": "tikztimingtable",
+    "snippet": "",
+    "package": "tikz-timing"
+  },
+  "pgfonlayer ": {
+    "name": "pgfonlayer",
+    "detail": "pgfonlayer",
+    "snippet": "",
+    "package": "tikz-timing"
+  }
+}

--- a/data/packages/tikz_env.json
+++ b/data/packages/tikz_env.json
@@ -1,11 +1,11 @@
 {
-  "scope ": {
+  "scope": {
     "name": "scope",
     "detail": "scope",
     "snippet": "",
     "package": "tikz"
   },
-  "tikzpicture ": {
+  "tikzpicture": {
     "name": "tikzpicture",
     "detail": "tikzpicture",
     "snippet": "",

--- a/data/packages/tikz_env.json
+++ b/data/packages/tikz_env.json
@@ -1,4 +1,14 @@
-[
-  "scope",
-  "tikzpicture"
-]
+{
+  "scope ": {
+    "name": "scope",
+    "detail": "scope",
+    "snippet": "",
+    "package": "tikz"
+  },
+  "tikzpicture ": {
+    "name": "tikzpicture",
+    "detail": "tikzpicture",
+    "snippet": "",
+    "package": "tikz"
+  }
+}

--- a/data/packages/verse_env.json
+++ b/data/packages/verse_env.json
@@ -1,5 +1,20 @@
-[
-  "altverse",
-  "patverse",
-  "patverse*"
-]
+{
+  "altverse ": {
+    "name": "altverse",
+    "detail": "altverse",
+    "snippet": "",
+    "package": "verse"
+  },
+  "patverse ": {
+    "name": "patverse",
+    "detail": "patverse",
+    "snippet": "",
+    "package": "verse"
+  },
+  "patverse* ": {
+    "name": "patverse*",
+    "detail": "patverse*",
+    "snippet": "",
+    "package": "verse"
+  }
+}

--- a/data/packages/verse_env.json
+++ b/data/packages/verse_env.json
@@ -1,17 +1,17 @@
 {
-  "altverse ": {
+  "altverse": {
     "name": "altverse",
     "detail": "altverse",
     "snippet": "",
     "package": "verse"
   },
-  "patverse ": {
+  "patverse": {
     "name": "patverse",
     "detail": "patverse",
     "snippet": "",
     "package": "verse"
   },
-  "patverse* ": {
+  "patverse*": {
     "name": "patverse*",
     "detail": "patverse*",
     "snippet": "",

--- a/data/packages/xepersian_env.json
+++ b/data/packages/xepersian_env.json
@@ -1,23 +1,23 @@
 {
-  "latin ": {
+  "latin": {
     "name": "latin",
     "detail": "latin",
     "snippet": "",
     "package": "xepersian"
   },
-  "persian ": {
+  "persian": {
     "name": "persian",
     "detail": "persian",
     "snippet": "",
     "package": "xepersian"
   },
-  "latinitems ": {
+  "latinitems": {
     "name": "latinitems",
     "detail": "latinitems",
     "snippet": "",
     "package": "xepersian"
   },
-  "parsiitems ": {
+  "parsiitems": {
     "name": "parsiitems",
     "detail": "parsiitems",
     "snippet": "",

--- a/data/packages/xepersian_env.json
+++ b/data/packages/xepersian_env.json
@@ -1,6 +1,26 @@
-[
-  "latin",
-  "persian",
-  "latinitems",
-  "parsiitems"
-]
+{
+  "latin ": {
+    "name": "latin",
+    "detail": "latin",
+    "snippet": "",
+    "package": "xepersian"
+  },
+  "persian ": {
+    "name": "persian",
+    "detail": "persian",
+    "snippet": "",
+    "package": "xepersian"
+  },
+  "latinitems ": {
+    "name": "latinitems",
+    "detail": "latinitems",
+    "snippet": "",
+    "package": "xepersian"
+  },
+  "parsiitems ": {
+    "name": "parsiitems",
+    "detail": "parsiitems",
+    "snippet": "",
+    "package": "xepersian"
+  }
+}

--- a/data/packages/xifthen_cmd.json
+++ b/data/packages/xifthen_cmd.json
@@ -82,12 +82,12 @@
   "cnttest{}<comparison>{}": {
     "command": "cnttest{counter expression}<comparison>{counter expression}",
     "package": "xifthen",
-    "snippet": "cnttest{${1:counter expression}}<comparison>{${2:counter expression}}"
+    "snippet": "cnttest{${1:counter expression}}<${3:comparison}>{${2:counter expression}}"
   },
   "dimtest{}<comparison>{}": {
     "command": "dimtest{dimen expression}<comparison>{dimen expression}",
     "package": "xifthen",
-    "snippet": "dimtest{${1:dimen expression}}<comparison>{${2:dimen expression}}"
+    "snippet": "dimtest{${1:dimen expression}}<${3:comparison}>{${2:dimen expression}}"
   },
   "newtest{}[]{}": {
     "command": "newtest{command}[n]{testexpression}",

--- a/data/packages/xtab_env.json
+++ b/data/packages/xtab_env.json
@@ -1,6 +1,26 @@
-[
-  "mpxtabular",
-  "mpxtabular*",
-  "xtabular",
-  "xtabular*"
-]
+{
+  "mpxtabular {}": {
+    "name": "mpxtabular",
+    "detail": "mpxtabular{preamble}",
+    "snippet": "{${1:preamble}}",
+    "package": "xtab"
+  },
+  "mpxtabular* {}": {
+    "name": "mpxtabular*",
+    "detail": "mpxtabular*{preamble}",
+    "snippet": "{${1:preamble}}",
+    "package": "xtab"
+  },
+  "xtabular {}": {
+    "name": "xtabular",
+    "detail": "xtabular{preamble}",
+    "snippet": "{${1:preamble}}",
+    "package": "xtab"
+  },
+  "xtabular* {}": {
+    "name": "xtabular*",
+    "detail": "xtabular*{preamble}",
+    "snippet": "{${1:preamble}}",
+    "package": "xtab"
+  }
+}

--- a/data/packages/yathesis_env.json
+++ b/data/packages/yathesis_env.json
@@ -1,5 +1,5 @@
 {
-  "abstract ": {
+  "abstract": {
     "name": "abstract",
     "detail": "abstract",
     "snippet": "",

--- a/data/packages/yathesis_env.json
+++ b/data/packages/yathesis_env.json
@@ -7,8 +7,8 @@
   },
   "abstract []": {
     "name": "abstract",
-    "detail": "abstract[intitul\u00e9 alternatif%text]",
-    "snippet": "[${1:intitul\u00e9 alternatif%text}]",
+    "detail": "abstract[intitulé alternatif%text]",
+    "snippet": "[${1:intitulé alternatif%text}]",
     "package": "yathesis"
   }
 }

--- a/data/packages/yathesis_env.json
+++ b/data/packages/yathesis_env.json
@@ -1,4 +1,14 @@
-[
-  "abstract",
-  "abstract"
-]
+{
+  "abstract ": {
+    "name": "abstract",
+    "detail": "abstract",
+    "snippet": "",
+    "package": "yathesis"
+  },
+  "abstract []": {
+    "name": "abstract",
+    "detail": "abstract[intitul\u00e9 alternatif%text]",
+    "snippet": "[${1:intitul\u00e9 alternatif%text}]",
+    "package": "yathesis"
+  }
+}

--- a/dev/pkgcommand.py
+++ b/dev/pkgcommand.py
@@ -25,20 +25,28 @@ class TabStop:
 class PlaceHolder:
     count: int
     usePlaceHolders: bool
+    keepDelimiters: bool
 
     def __init__(self):
         self.count = 0
         self.usePlaceHolders = True
+        self.keepDelimiters = True
 
     def setUsePlaceHolders(self, trueOrFalse):
         self.usePlaceHolders = trueOrFalse
+
+    def setKeepDelimiters(self, trueOrFalse):
+        self.keepDelimiters = trueOrFalse
 
     def sub(self, matchObject) -> str:
         self.count += 1
         name = ''
         if self.usePlaceHolders:
             name = ':' + matchObject.group(2)
-        return matchObject.group(1) + '${' + str(self.count) + name + '}' + matchObject.group(3)
+        if self.keepDelimiters:
+            return matchObject.group(1) + '${' + str(self.count) + name + '}' + matchObject.group(3)
+        else:
+            return '${' + str(self.count) + name + '}'
 
 
 def get_unimathsymbols_file():
@@ -103,6 +111,8 @@ def create_snippet(line: str) -> str:
     else:
         snippet = re.sub(r'(\{|\[)([^\{\[\$]*)(\}|\])', p.sub, snippet)
     snippet = re.sub(r'(?<![\{\s:\[])(\<)([a-zA-Z\s]*)(\>)', p.sub, snippet)
+    p.setKeepDelimiters(False)
+    snippet = re.sub(r'(?<![\{:\[=-])(%\<)([a-zA-Z\s]*)(%\>)(?!})', p.sub, snippet)
 
     t = TabStop()
     snippet = re.sub(r'(?<![\. ])\.\.(?![\. ])', t.sub, snippet)

--- a/dev/pkgcommand.py
+++ b/dev/pkgcommand.py
@@ -165,7 +165,7 @@ for cwl_file in cwl_files:
     if pkgEnvs:
         json.dump(pkgEnvs,
                   open(f'../data/packages/{cwl_file[:-4]}_env.json', 'w', encoding='utf8'),
-                  indent=2)
+                  indent=2, ensure_ascii=False)
     if pkgCmds != {}:
         json.dump(pkgCmds,
                   open(f'../data/packages/{cwl_file[:-4]}_cmd.json', 'w', encoding='utf8'),

--- a/dev/pkgcommand.py
+++ b/dev/pkgcommand.py
@@ -135,7 +135,7 @@ def parse_cwl_file(
             snippet_name = env + ' ' + re.sub(r'(\{|\[)[^\{\[\$]*(\}|\])', r'\1\2', args)
             snippet_name = re.sub(r'\<[a-zA-Z\s]*\>', '<>', snippet_name)
             snippet = create_snippet(args)
-            pkgenvs[snippet_name] = {'name': env, 'detail': env + args, 'snippet': snippet, 'package': package}
+            pkgenvs[snippet_name.rstrip()] = {'name': env, 'detail': env + args, 'snippet': snippet, 'package': package}
             continue
         if line[:5] == '\\end{':
             continue

--- a/package.json
+++ b/package.json
@@ -1334,6 +1334,11 @@
           "default": [],
           "markdownDescription": "List of extra packages to always add to the auto-completion mechanism.\nWhen `latex-workshop.intellisense.package.enabled` is set to `true`, the commands and environments defined in these extra packages will be added to the intellisense suggestions."
         },
+        "latex-workshop.intellisense.package.env.enabled": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "If true, every environment provided by an included package is available by a snippet `\\envname`. Only applies when `latex-workshop.intellisense.package.enable` is true. "
+        },
         "latex-workshop.intellisense.includegraphics.preview.enabled": {
           "type": "boolean",
           "default": true,

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -9,13 +9,14 @@ import * as utils from '../utils/utils'
 import {Extension} from '../main'
 import {Suggestion as CiteEntry} from '../providers/completer/citation'
 import {Suggestion as CmdEntry} from '../providers/completer/command'
+import {Suggestion as EnvEntry} from '../providers/completer/environment'
 
 interface Content {
     [filepath: string]: { // tex file name
         content: string, // the dirty (under editing) contents
         element: {
             reference?: vscode.CompletionItem[],
-            environment?: vscode.CompletionItem[],
+            environment?: EnvEntry[],
             bibitem?: CiteEntry[],
             command?: CmdEntry[],
             package?: string[]

--- a/src/providers/completer/command.ts
+++ b/src/providers/completer/command.ts
@@ -95,32 +95,32 @@ export class Command {
         }
 
         // Insert commands from packages
-        const extraPackages = configuration.get('intellisense.package.extra') as string[]
-        if (extraPackages) {
-            extraPackages.forEach(pkg => {
-                this.provideCmdInPkg(pkg, suggestions, cmdList)
+        if ((configuration.get('intellisense.package.enabled'))) {
+            const extraPackages = configuration.get('intellisense.package.extra') as string[]
+            if (extraPackages) {
+                extraPackages.forEach(pkg => {
+                    this.provideCmdInPkg(pkg, suggestions, cmdList)
+                })
+            }
+            this.extension.manager.getIncludedTeX().forEach(tex => {
+                const pkgs = this.extension.manager.cachedContent[tex].element.package
+                if (pkgs !== undefined) {
+                    pkgs.forEach(pkg => this.provideCmdInPkg(pkg, suggestions, cmdList))
+                }
             })
         }
-        this.extension.manager.getIncludedTeX().forEach(tex => {
-            const pkgs = this.extension.manager.cachedContent[tex].element.package
-            if (pkgs === undefined) {
-                return
-            }
-            pkgs.forEach(pkg => this.provideCmdInPkg(pkg, suggestions, cmdList))
-        })
 
         // Start working on commands in tex
         this.extension.manager.getIncludedTeX().forEach(tex => {
             const cmds = this.extension.manager.cachedContent[tex].element.command
-            if (cmds === undefined) {
-                return
+            if (cmds !== undefined) {
+                cmds.forEach(cmd => {
+                    if (!cmdList.includes(this.getCmdName(cmd, true))) {
+                        suggestions.push(cmd)
+                        cmdList.push(this.getCmdName(cmd, true))
+                    }
+                })
             }
-            cmds.forEach(cmd => {
-                if (!cmdList.includes(this.getCmdName(cmd, true))) {
-                    suggestions.push(cmd)
-                    cmdList.push(this.getCmdName(cmd, true))
-                }
-            })
         })
 
         return suggestions
@@ -485,9 +485,6 @@ export class Command {
 
     private provideCmdInPkg(pkg: string, suggestions: vscode.CompletionItem[], cmdList: string[]) {
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
-        if (!(configuration.get('intellisense.package.enabled'))) {
-            return
-        }
         const useOptionalArgsEntries = configuration.get('intellisense.optionalArgsEntries.enabled')
         // Load command in pkg
         if (!(pkg in this.packageCmds)) {

--- a/src/providers/completer/command.ts
+++ b/src/providers/completer/command.ts
@@ -98,7 +98,7 @@ export class Command {
             if (extraPackages) {
                 extraPackages.forEach(pkg => {
                     this.provideCmdInPkg(pkg, suggestions, cmdList)
-                    this.environment.provideEnvSnippetInPkg(pkg, suggestions, cmdList)
+                    this.environment.provideEnvsAsCommandInPkg(pkg, suggestions, cmdList)
                 })
             }
             this.extension.manager.getIncludedTeX().forEach(tex => {
@@ -106,7 +106,7 @@ export class Command {
                 if (pkgs !== undefined) {
                     pkgs.forEach(pkg => {
                         this.provideCmdInPkg(pkg, suggestions, cmdList)
-                        this.environment.provideEnvSnippetInPkg(pkg, suggestions, cmdList)
+                        this.environment.provideEnvsAsCommandInPkg(pkg, suggestions, cmdList)
                     })
                 }
             })

--- a/src/providers/completer/command.ts
+++ b/src/providers/completer/command.ts
@@ -55,7 +55,7 @@ export class Command {
 
         // Initialize default env begin-end pairs, de-duplication
         Object.keys(defaultEnvs).forEach(key => {
-            this.defaultCmds.push(this.environment.entryEnvToCompletion(defaultEnvs[key]))
+            this.defaultCmds.push(this.environment.entryEnvToCompletion(defaultEnvs[key], 'begin{'))
         })
 
         // Handle special commands with brackets

--- a/src/providers/completer/command.ts
+++ b/src/providers/completer/command.ts
@@ -100,12 +100,16 @@ export class Command {
             if (extraPackages) {
                 extraPackages.forEach(pkg => {
                     this.provideCmdInPkg(pkg, suggestions, cmdList)
+                    this.environment.provideEnvSnippetInPkg(pkg, suggestions, cmdList)
                 })
             }
             this.extension.manager.getIncludedTeX().forEach(tex => {
                 const pkgs = this.extension.manager.cachedContent[tex].element.package
                 if (pkgs !== undefined) {
-                    pkgs.forEach(pkg => this.provideCmdInPkg(pkg, suggestions, cmdList))
+                    pkgs.forEach(pkg => {
+                        this.provideCmdInPkg(pkg, suggestions, cmdList)
+                        this.environment.provideEnvSnippetInPkg(pkg, suggestions, cmdList)
+                    })
                 }
             })
         }

--- a/src/providers/completer/command.ts
+++ b/src/providers/completer/command.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs-extra'
 import {latexParser} from 'latex-utensils'
 
 import {Extension} from '../../main'
-import {EnvItemEntry, Environment} from './environment'
+import {Environment, EnvSnippetType} from './environment'
 
 interface CmdItemEntry {
     command: string, // frame
@@ -35,9 +35,7 @@ export class Command {
         this.environment = environment
     }
 
-    initialize(defaultCmds: {[key: string]: CmdItemEntry}, defaultEnvs: {[key: string]: EnvItemEntry}) {
-        // Make sure to initialize Environment first
-        this.environment.initialize(defaultEnvs)
+    initialize(defaultCmds: {[key: string]: CmdItemEntry}) {
         const snippetReplacements = vscode.workspace.getConfiguration('latex-workshop').get('intellisense.commandsJSON.replace') as {[key: string]: string}
 
         // Initialize default commands and `latex-mathsymbols`
@@ -53,9 +51,9 @@ export class Command {
             }
         })
 
-        // Initialize default env begin-end pairs, de-duplication
-        Object.keys(defaultEnvs).forEach(key => {
-            this.defaultCmds.push(this.environment.entryEnvToCompletion(defaultEnvs[key], 'begin{'))
+        // Initialize default env begin-end pairs
+        this.environment.getDefaultEnvs(EnvSnippetType.AsCommand).forEach(cmd => {
+            this.defaultCmds.push(cmd)
         })
 
         // Handle special commands with brackets

--- a/src/providers/completer/environment.ts
+++ b/src/providers/completer/environment.ts
@@ -78,6 +78,10 @@ export class Environment {
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         const useOptionalArgsEntries = configuration.get('intellisense.optionalArgsEntries.enabled')
 
+        if (! configuration.get('intellisense.package.env.enabled')) {
+            return
+        }
+
         // Load environments from the package if not already done
         if (!(pkg in this.packageEnvSnippets)) {
             this.packageEnvSnippets[pkg] = []
@@ -91,7 +95,6 @@ export class Environment {
         if (!(pkg in this.packageEnvSnippets) || this.packageEnvSnippets[pkg].length === 0) {
             return
         }
-
 
         // Insert env snippets
         this.packageEnvSnippets[pkg].forEach(env => {
@@ -205,6 +208,9 @@ export class Environment {
         const art = ['a', 'e', 'i', 'o', 'u'].includes(`${item.name}`.charAt(0)) ? 'an' : 'a'
         suggestion.detail = `Insert ${art} ${item.name} environment.`
         suggestion.documentation = label
+        if (item.package) {
+            suggestion.documentation += '\n' + `Package: ${item.package}`
+        }
         suggestion.sortText = label.replace(/^[a-zA-Z]/, c => {
             const n = c.match(/[a-z]/) ? c.toUpperCase().charCodeAt(0): c.toLowerCase().charCodeAt(0)
             return n !== undefined ? n.toString(16): c

--- a/src/providers/completer/environment.ts
+++ b/src/providers/completer/environment.ts
@@ -43,16 +43,14 @@ export class Environment {
         const envList: string[] = this.defaultEnvs.map(env => env.label)
         this.extension.manager.getIncludedTeX().forEach(cachedFile => {
             const cachedEnvs = this.extension.manager.cachedContent[cachedFile].element.environment
-            if (cachedEnvs === undefined) {
-                return
+            if (cachedEnvs !== undefined) {
+                cachedEnvs.forEach(env => {
+                    if (! envList.includes(env.label)) {
+                        suggestions.push(env)
+                        envList.push(env.label)
+                    }
+                })
             }
-            cachedEnvs.forEach(env => {
-                if (envList.includes(env.label)) {
-                    return
-                }
-                suggestions.push(env)
-                envList.push(env.label)
-            })
         })
         // If no insert package-defined environments
         if (!(vscode.workspace.getConfiguration('latex-workshop').get('intellisense.package.enabled'))) {
@@ -61,18 +59,16 @@ export class Environment {
         // Insert package environments
         this.extension.manager.getIncludedTeX().forEach(tex => {
             const pkgs = this.extension.manager.cachedContent[tex].element.package
-            if (pkgs === undefined) {
-                return
-            }
-            pkgs.forEach(pkg => {
-                this.getEnvFromPkg(pkg).forEach(env => {
-                    if (envList.includes(env.label)) {
-                        return
-                    }
-                    suggestions.push(env)
-                    envList.push(env.label)
+            if (pkgs !== undefined) {
+                pkgs.forEach(pkg => {
+                    this.getEnvFromPkg(pkg).forEach(env => {
+                        if (!envList.includes(env.label)) {
+                            suggestions.push(env)
+                            envList.push(env.label)
+                        }
+                    })
                 })
-            })
+            }
         })
         return suggestions
     }

--- a/src/providers/completer/environment.ts
+++ b/src/providers/completer/environment.ts
@@ -31,9 +31,8 @@ export class Environment {
             return
         }
         this.defaultEnvs = []
-        const envList: string[] = Object.keys(envs).map(key => envs[key].name)
-        Array.from(new Set(envList)).forEach(env => {
-           this.defaultEnvs.push(new vscode.CompletionItem(env, vscode.CompletionItemKind.Module))
+        Object.keys(envs).forEach(env => {
+           this.defaultEnvs.push(this.entryEnvToCompletion(envs[env]))
         })
         this.isInitialized = true
     }
@@ -64,6 +63,7 @@ export class Environment {
                 pkgs.forEach(pkg => {
                     this.getEnvFromPkg(pkg).forEach(env => {
                         if (!envList.includes(env.label)) {
+                            // env.kind = vscode.CompletionItemKind.Snippet
                             suggestions.push(env)
                             envList.push(env.label)
                         }
@@ -87,7 +87,7 @@ export class Environment {
             this.packageEnvSnippets[pkg] = []
             const envs: {[key: string]: EnvItemEntry} = this.getEnvItemsFromPkg(pkg)
             Object.keys(envs).forEach(env => {
-                this.packageEnvSnippets[pkg].push(this.entryEnvToCompletion(envs[env]))
+                this.packageEnvSnippets[pkg].push(this.entryEnvToCompletion(envs[env], 'begin'))
             })
         }
 
@@ -157,8 +157,8 @@ export class Environment {
         }
         this.packageEnvs[pkg] = []
         const envs: {[key: string]: EnvItemEntry} = this.getEnvItemsFromPkg(pkg)
-        Array.from(new Set(Object.keys(envs).map(e => envs[e].name))).forEach(env => {
-            this.packageEnvs[pkg].push(new vscode.CompletionItem(env, vscode.CompletionItemKind.Module))
+        Object.keys(envs).forEach(env => {
+            this.packageEnvs[pkg].push(this.entryEnvToCompletion(envs[env]))
         })
         return this.packageEnvs[pkg]
     }
@@ -182,8 +182,7 @@ export class Environment {
         return envs
     }
 
-
-    entryEnvToCompletion(item: EnvItemEntry): Suggestion {
+    entryEnvToCompletion(item: EnvItemEntry, prefix: string = ''): Suggestion {
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         const useTabStops = configuration.get('intellisense.useTabStops.enabled')
         const label = item.detail ? item.detail : item.name
@@ -204,7 +203,7 @@ export class Environment {
         } else {
             snippet += '\n\t$0\n'
         }
-        suggestion.insertText = new vscode.SnippetString(`begin{${item.name}}${snippet}\\end{${item.name}}`)
+        suggestion.insertText = new vscode.SnippetString(`${prefix}${item.name}}${snippet}\\end{${item.name}}`)
         const art = ['a', 'e', 'i', 'o', 'u'].includes(`${item.name}`.charAt(0)) ? 'an' : 'a'
         suggestion.detail = `Insert ${art} ${item.name} environment.`
         suggestion.documentation = label
@@ -217,6 +216,5 @@ export class Environment {
         })
         return suggestion
     }
-
 
 }

--- a/src/providers/completer/environment.ts
+++ b/src/providers/completer/environment.ts
@@ -39,7 +39,7 @@ export class Environment {
             sortText: ' ',
             insertText: new vscode.SnippetString('$1}\n\t$0\n\\end{$1}'),
             command: { title: 'Post-Action', command: 'editor.action.triggerSuggest' },
-            kind: vscode.CompletionItemKind.Function,
+            kind: vscode.CompletionItemKind.Module,
             package: ''
         }
         this.defaultEnvsForBegin.push(endCompletion)
@@ -258,7 +258,7 @@ export class Environment {
         const label = item.detail ? item.detail : item.name
         const suggestion: Suggestion = {
             label: item.name,
-            kind: vscode.CompletionItemKind.Function,
+            kind: vscode.CompletionItemKind.Module,
             package: 'latex',
             detail: `Insert environment ${item.name}.`,
             documentation: item.name
@@ -274,6 +274,9 @@ export class Environment {
         if (type === EnvSnippetType.AsName) {
             return suggestion
         } else {
+            if (type === EnvSnippetType.AsCommand) {
+                suggestion.kind = vscode.CompletionItemKind.Snippet
+            }
             const configuration = vscode.workspace.getConfiguration('latex-workshop')
             const useTabStops = configuration.get('intellisense.useTabStops.enabled')
             const prefix = (type === EnvSnippetType.ForBegin) ? '' : 'begin{'

--- a/src/providers/completer/environment.ts
+++ b/src/providers/completer/environment.ts
@@ -32,6 +32,16 @@ export class Environment {
     initialize(envs: {[key: string]: EnvItemEntry}) {
         this.defaultEnvsAsCommand = []
         this.defaultEnvsForBegin = []
+        this.defaultEnvsAsName = []
+        const endCompletion: Suggestion = {
+            label: 'Complete with \\end',
+            sortText: ' ',
+            insertText: new vscode.SnippetString('$1}\n\t$0\n\\end{$1}'),
+            command: { title: 'Post-Action', command: 'editor.action.triggerSuggest' },
+            kind: vscode.CompletionItemKind.Function,
+            package: ''
+        }
+        this.defaultEnvsForBegin.push(endCompletion)
         Object.keys(envs).forEach(env => {
            this.defaultEnvsAsCommand.push(this.entryEnvToCompletion(envs[env], 'begin{'))
            this.defaultEnvsForBegin.push(this.entryEnvToCompletion(envs[env]))

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -39,8 +39,7 @@ export class Completer implements vscode.CompletionItemProvider {
     loadDefaultItems() {
         const defaultEnvs = fs.readFileSync(`${this.extension.extensionRoot}/data/environments.json`, {encoding: 'utf8'})
         const defaultCommands = fs.readFileSync(`${this.extension.extensionRoot}/data/commands.json`, {encoding: 'utf8'})
-        const defaultLaTeXMathSymbols = fs.readFileSync(`${this.extension.extensionRoot}/data/packages/latex-mathsymbols_cmd.json`,
-                                                        {encoding: 'utf8'})
+        const defaultLaTeXMathSymbols = fs.readFileSync(`${this.extension.extensionRoot}/data/packages/latex-mathsymbols_cmd.json`, {encoding: 'utf8'})
         const env = JSON.parse(defaultEnvs)
         const cmds = JSON.parse(defaultCommands)
         const maths = JSON.parse(defaultLaTeXMathSymbols)

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -23,9 +23,9 @@ export class Completer implements vscode.CompletionItemProvider {
     constructor(extension: Extension) {
         this.extension = extension
         this.citation = new Citation(extension)
-        this.command = new Command(extension)
+        this.environment = new Environment(extension) // Must be created before command
+        this.command = new Command(extension, this.environment)
         this.documentClass = new DocumentClass(extension)
-        this.environment = new Environment(extension)
         this.reference = new Reference(extension)
         this.package = new Package(extension)
         this.input = new Input(extension)

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -52,8 +52,9 @@ export class Completer implements vscode.CompletionItemProvider {
             }
         }
         Object.assign(maths, cmds)
-        this.command.initialize(maths, env)
+        // Make sure to initialize environment first
         this.environment.initialize(env)
+        this.command.initialize(maths)
     }
 
     provideCompletionItems(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken, context: vscode.CompletionContext): Promise<vscode.CompletionItem[]> {


### PR DESCRIPTION
Close #2006
This PR contributes the following features

- [x] Create snippets for environments with extra arguments like

    ```
   \begin{env}<some extra args which can even split on several lines>
      Some starting text
   \end{env}
    ```

- [x] Insert any environments (the default ones + those contributed by the used packages) by using the `\envname` snippet, which gets expanded into

    ```
   \begin{env}<some extra args which can even split on several lines>
      Some starting text
   \end{env}
    ```
   and takes care of the extra arguments. Only when `latex-workshopintellisense.package.env.enabled` is true (its default value).

- [x] Handling extra arguments with the `\begin{...} / \end{...}` snippet -- ie when there is a multi-cursor selection -- is not possible. So we simply provide the list of environments names in this case without taking care of the extra arguments.

