### PR TITLE
Add a completion provider for bibtex files

### DIFF
--- a/data/bibtex-entries.json
+++ b/data/bibtex-entries.json
@@ -1,0 +1,86 @@
+{
+    "article": [
+        "author",
+        "title",
+        "journal",
+        "volume",
+        "number",
+        "year"
+    ],
+    "book": [
+        "author",
+        "editor",
+        "title",
+        "publisher",
+        "year"
+    ],
+    "booklet": [
+        "title",
+        "author"
+    ],
+    "inbook": [
+        "author",
+        "editor",
+        "title",
+        "chapter",
+        "pages",
+        "publisher",
+        "year"
+    ],
+    "incollection": [
+        "author",
+        "title",
+        "booktitle",
+        "publisher",
+        "year"
+    ],
+    "inproceedings": [
+        "author",
+        "title",
+        "booktitle",
+        "editor",
+        "year"
+    ],
+    "manual": [
+        "title",
+        "author"
+    ],
+    "masterthesis": [
+        "author",
+        "title",
+        "school",
+        "year"
+    ],
+    "misc": [
+        "author",
+        "title",
+        "howpublished",
+        "year"
+    ],
+    "phdthesis": [
+        "author",
+        "title",
+        "school",
+        "year"
+    ],
+    "proceedings": [
+        "title",
+        "year",
+        "editor",
+        "volume",
+        "series",
+        "published"
+    ],
+    "techreport": [
+        "author",
+        "title",
+        "institution",
+        "year"
+    ],
+    "unpublished": [
+        "author",
+        "title",
+        "note",
+        "year"
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -1512,6 +1512,11 @@
           "default": true,
           "markdownDescription": "Many snippets use PlaceHolders of the form ${\\d:some_text} for their argument. You may prefer to use TabStops ${\\d} instead, which allows for direct call to intellisense again. Default is true.\nReload vscode to make this configuration effective."
         },
+        "latex-workshop.intellisense.bibtexJSON.replace": {
+          "type": "object",
+          "default": {},
+          "markdownDescription": "Dictionary of `\"entry name\": [\"array\", \"of\", \"fields\"]` to replace the default fields used in `data/bibtex-entries.json`. See `data/bibtex-entries.json` for the list of fields for each entry. Reload vscode to make any change in this configuration effective."
+        },
         "latex-workshop.intellisense.commandsJSON.replace": {
           "type": "object",
           "default": {},

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,7 @@ import {Parser as LogParser} from './components/parser/log'
 import {UtensilsParser as PEGParser} from './components/parser/syntax'
 
 import {Completer} from './providers/completion'
+import {BibtexCompleter} from './providers/bibtexcompletion'
 import {CodeActions} from './providers/codeactions'
 import {HoverProvider} from './providers/hover'
 import {GraphicsPreview} from './providers/preview/graphicspreview'
@@ -221,6 +222,7 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(vscode.languages.registerWorkspaceSymbolProvider(new ProjectSymbolProvider(extension)))
     context.subscriptions.push(vscode.languages.registerCompletionItemProvider({ scheme: 'file', language: 'tex'}, extension.completer, '\\', '{'))
     context.subscriptions.push(vscode.languages.registerCompletionItemProvider(latexDoctexSelector, extension.completer, '\\', '{', ',', '(', '['))
+    context.subscriptions.push(vscode.languages.registerCompletionItemProvider({ scheme: 'file', language: 'bibtex'}, new BibtexCompleter(extension), '@'))
     context.subscriptions.push(vscode.languages.registerCodeActionsProvider(latexSelector, extension.codeActions))
     context.subscriptions.push(vscode.languages.registerFoldingRangeProvider(latexSelector, new FoldingProvider(extension)))
 

--- a/src/providers/bibtexcompletion.ts
+++ b/src/providers/bibtexcompletion.ts
@@ -1,0 +1,86 @@
+import * as vscode from 'vscode'
+import * as fs from 'fs-extra'
+
+import * as bibtexUtils from '../utils/bibtexutils'
+import {Extension} from '../main'
+
+export class BibtexCompleter implements vscode.CompletionItemProvider {
+    extension: Extension
+    private entries: vscode.CompletionItem[] = []
+
+    constructor(extension: Extension) {
+        this.extension = extension
+
+        try {
+            this.loadDefaultItems()
+        } catch (err) {
+            this.extension.logger.addLogMessage(`Error reading data: ${err}.`)
+        }
+    }
+
+    loadDefaultItems() {
+        const defaultEntries = fs.readFileSync(`${this.extension.extensionRoot}/data/bibtex-entries.json`, {encoding: 'utf8'})
+        const entriesReplacements = vscode.workspace.getConfiguration('latex-workshop').get('intellisense.bibtexJSON.replace') as {[key: string]: string[]}
+        const config = vscode.workspace.getConfiguration('latex-workshop')
+        const leftright = config.get('bibtex-format.surround') === 'Curly braces' ? [ '{', '}' ] : [ '"', '"']
+        const tabs = { '2 spaces': '  ', '4 spaces': '    ', 'tab': '\t' }
+        const bibtexFormat: bibtexUtils.BibtexFormatConfig = {
+            tab: tabs[config.get('bibtex-format.tab') as ('2 spaces' | '4 spaces' | 'tab')],
+            case: config.get('bibtex-format.case') as ('UPPERCASE' | 'lowercase'),
+            left: leftright[0],
+            right: leftright[1],
+            sort: config.get('bibtex-format.sortby') as string[]
+        }
+
+        const entries = JSON.parse(defaultEntries)
+        const entriesList: string[] = []
+        Object.keys(entries).forEach(entry => {
+            if (entry in entriesList) {
+                return
+            }
+            if (entry in entriesReplacements) {
+                this.entries.push(this.entryToCompletion(entry, entriesReplacements[entry], bibtexFormat))
+            } else {
+                this.entries.push(this.entryToCompletion(entry, entries[entry], bibtexFormat))
+            }
+            entriesList.push(entry)
+        })
+    }
+
+    entryToCompletion(itemName: string, itemFields: string[], config: bibtexUtils.BibtexFormatConfig): vscode.CompletionItem {
+        const suggestion: vscode.CompletionItem = new vscode.CompletionItem(itemName, vscode.CompletionItemKind.Snippet)
+        suggestion.detail = itemName
+        suggestion.documentation = `Add a @${itemName} entry`
+        let count: number = 1
+
+        // The following code is copied from bibtexutils.ts:bibtexFormat
+        // Find the longest field name in entry
+        let maxFieldLength = 0
+        itemFields.forEach(field => {
+            maxFieldLength = Math.max(maxFieldLength, field.length)
+        })
+
+        let s: string = itemName + '{${0:key}'
+        itemFields.forEach(field => {
+            s += ',\n' + config.tab + (config.case === 'lowercase' ? field : field.toUpperCase())
+            s += ' '.repeat(maxFieldLength - field.length) + ' = '
+            s += config.left + `$${count}` + config.right
+            count++
+        })
+        s += '\n}'
+        suggestion.insertText = new vscode.SnippetString(s)
+        return suggestion
+    }
+
+    provideCompletionItems(document: vscode.TextDocument, position: vscode.Position, _token: vscode.CancellationToken, _context: vscode.CompletionContext): Promise<vscode.CompletionItem[]> {
+        return new Promise((resolve, _reject) => {
+            const currentLine = document.lineAt(position.line).text
+            if (currentLine.match(/@[a-zA-Z]*$/)) {
+                resolve(this.entries)
+                return
+            }
+            resolve()
+        })
+    }
+
+}


### PR DESCRIPTION
Close #1339 

While editing a `.bib` file, hitting `@` triggers completion for adding a new entry.

The available completions are described in `data/bibtex-entries.json`. The user can override any entry by redefining it in the variable `latex-workshop.intellisense.bibtexJSON.replace`.
The entries are formatted according to the variables already used for bibtex formatting: 

- `latex-workshop.bibtex-format.tab`
- `latex-workshop.bibtex-format.surround`
- `latex-workshop.bibtex-format.case`

The current content of `data/bibtex-entries.json` is just a proposal, feel free to make other suggestions.