### PR TITLE
Support restoring PDF viewers. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "onCommand:latex-workshop.actions",
     "onCommand:latex-workshop.bibsort",
     "onCommand:latex-workshop.bibalign",
-    "onCommand:latex-workshop.bibalignsort"
+    "onCommand:latex-workshop.bibalignsort",
+    "onWebviewPanel:latex-workshop-pdf"
   ],
   "main": "./out/src/main.js",
   "contributes": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -216,6 +216,8 @@ export function activate(context: vscode.ExtensionContext) {
         extension.structureViewer.showCursorIteme(e)
     }))
 
+    context.subscriptions.push(vscode.window.registerWebviewPanelSerializer('latex-workshop-pdf', extension.viewer.pdfViewerPanelSerializer))
+
     context.subscriptions.push(vscode.languages.registerHoverProvider(latexSelector, new HoverProvider(extension)))
     context.subscriptions.push(vscode.languages.registerDefinitionProvider(latexSelector, new DefinitionProvider(extension)))
     context.subscriptions.push(vscode.languages.registerDocumentSymbolProvider(latexSelector, new DocSymbolProvider(extension)))
@@ -249,7 +251,7 @@ export function activate(context: vscode.ExtensionContext) {
         },
         viewer: {
             clients: extension.viewer.clients,
-            getViewerStatus: process.env['LATEXWORKSHOP_CI'] ? ( (pdfFilePath: string) => extension.viewer.getViewerStatus(pdfFilePath) ) : undefined,
+            getViewerStatus: process.env['LATEXWORKSHOP_CI'] ? ( (pdfFilePath: string) => extension.viewer.getViewerState(pdfFilePath) ) : undefined,
             refreshExistingViewer: (sourceFile?: string, viewer?: string) => extension.viewer.refreshExistingViewer(sourceFile, viewer),
             openTab: (sourceFile: string, respectOutDir: boolean = true, column: string = 'right') => extension.viewer.openTab(sourceFile, respectOutDir, column)
         },

--- a/viewer/components/protocol.ts
+++ b/viewer/components/protocol.ts
@@ -1,7 +1,7 @@
 export type ServerResponse = {
     type: 'refresh'
 } | {
-    type: 'request_status'
+    type: 'request_state'
 } | {
     type: 'params',
     scale: string,
@@ -41,7 +41,7 @@ export type ClientRequest = {
 } | {
     type: 'ping'
 } | {
-    type: 'status',
+    type: 'state',
     path: string,
     scrollTop: number
 } | {
@@ -51,4 +51,29 @@ export type ClientRequest = {
     page: number,
     textBeforeSelection: string,
     textAfterSelection: string
+}
+
+export type PanelManagerResponse = {
+    type: 'restore_state',
+    state: PdfViewerState
+}
+
+export type PanelRequest = {
+    type: 'initialized'
+} | {
+    type: 'keyboard_event',
+    event: any
+} | {
+    type: 'state',
+    state: PdfViewerState
+}
+
+export type PdfViewerState = {
+    path?: string,
+    scale?: string,
+    scrollTop?: number,
+    scrollLeft?: number,
+    trim?: number,
+    scrollMode?: number,
+    spreadMode?: number
 }


### PR DESCRIPTION
Support restoring PDF viewers. Close #2018.

- Support the restoring by implementing the serializer of WebviewPanel.  See https://code.visualstudio.com/api/extension-guides/webview#serialization
- The current state of PDF viewers is sent using `window.parent.postMessage`, not through WebSocket.
- Not support restoring PDF viewers on browsers at the present.


![Apr-29-2020 19-28-31](https://user-images.githubusercontent.com/10665499/80586349-c88db100-8a4f-11ea-850e-75f437597545.gif)
