### PR TITLE
Fix spelling of "auxiliary"

### DIFF
--- a/package.json
+++ b/package.json
@@ -922,7 +922,7 @@
         "latex-workshop.latex.autoBuild.cleanAndRetry.enabled": {
           "type": "boolean",
           "default": true,
-          "markdownDescription": "Delete LaTeX auxillary files when errors occur during build and retry.\nThis property defines whether LaTeX Workshop will try to clean and build the project once again after errors happen in the build toolchain."
+          "markdownDescription": "Delete LaTeX auxiliary files when errors occur during build and retry.\nThis property defines whether LaTeX Workshop will try to clean and build the project once again after errors happen in the build toolchain."
         },
         "latex-workshop.latex.build.clearLog.everyRecipeStep.enabled": {
           "type": "boolean",
@@ -942,12 +942,12 @@
             "Clean after build, be it successful or not"
           ],
           "default": "never",
-          "markdownDescription": "When LaTeX auxillary files should be deleted.\nThe folder to be cleaned is defined in `latex-workshop.latex.outDir`.\n`onFailed` cleans the project when compilation fails. `onBuilt` cleans the project when compilation is terminated, whether successful or failed."
+          "markdownDescription": "When LaTeX auxiliary files should be deleted.\nThe folder to be cleaned is defined in `latex-workshop.latex.outDir`.\n`onFailed` cleans the project when compilation fails. `onBuilt` cleans the project when compilation is terminated, whether successful or failed."
         },
         "latex-workshop.latex.clean.subfolder.enabled": {
           "type": "boolean",
           "default": false,
-          "markdownDescription": "Delete LaTeX auxillary files recursively in sub-folders of `latex-workshop.latex.outDir`."
+          "markdownDescription": "Delete LaTeX auxiliary files recursively in sub-folders of `latex-workshop.latex.outDir`."
         },
         "latex-workshop.latex.clean.fileTypes": {
           "type": "array",

--- a/src/components/builder.ts
+++ b/src/components/builder.ts
@@ -311,7 +311,7 @@ export class Builder {
                     this.disableCleanAndRetry = true
                     if (signal !== 'SIGTERM') {
                         this.extension.logger.displayStatus('x', 'errorForeground', 'Recipe terminated with error. Retry building the project.', 'warning')
-                        this.extension.logger.addLogMessage('Cleaning auxillary files and retrying build after toolchain error.')
+                        this.extension.logger.addLogMessage('Cleaning auxiliary files and retrying build after toolchain error.')
 
                         this.extension.cleaner.clean(rootFile).then(() => {
                             this.buildStep(rootFile, steps, 0, recipeName, releaseBuildMutex)


### PR DESCRIPTION
I was looking for LaTeX Workshop's auxiliary file settings, but VS Code's search did not yield any results due to the word "auxiliary" being misspelled. I've fixed the typos that were present in `package.json` and `builder.ts`.