### PR TITLE
allow any non '}' in environment name for indent

### DIFF
--- a/syntax/syntax.json
+++ b/syntax/syntax.json
@@ -27,7 +27,7 @@
 		["$", "$"]
 	],
 	"indentationRules": {
-		"increaseIndentPattern": "\\\\begin{(?!document)([a-zA-Z]*)}(?!.*\\\\end{\\1})",
+		"increaseIndentPattern": "\\\\begin{(?!document)([^}]*)}(?!.*\\\\end{\\1})",
 		"decreaseIndentPattern": "^\\s*\\\\end{(?!document)"
 	},
 	"folding": {


### PR DESCRIPTION
Several non-alphabetic characters are allowed in environment names including numbers and '\*', e.g. "equation\*". Re: #2061.