### PR TITLE
Enable esModuleInterop in tsconfig.json

### DIFF
--- a/src/components/cleaner.ts
+++ b/src/components/cleaner.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode'
 import * as path from 'path'
 import * as fs from 'fs-extra'
-import * as glob from 'glob'
+import glob from 'glob'
 
 import {Extension} from '../main'
 

--- a/src/components/server.ts
+++ b/src/components/server.ts
@@ -1,5 +1,5 @@
 import * as http from 'http'
-import * as ws from 'ws'
+import ws from 'ws'
 import * as fs from 'fs'
 import * as path from 'path'
 import * as vscode from 'vscode'

--- a/src/components/viewer.ts
+++ b/src/components/viewer.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode'
 import * as fs from 'fs'
 import * as os from 'os'
-import * as ws from 'ws'
+import ws from 'ws'
 import * as path from 'path'
 import * as cs from 'cross-spawn'
 import {sleep} from '../utils/utils'

--- a/src/providers/preview/graphicsscaler_worker.ts
+++ b/src/providers/preview/graphicsscaler_worker.ts
@@ -1,10 +1,5 @@
 import * as workerpool from 'workerpool'
-
-// workaround to avoid enabling esModuleInterop in tsconfig.json
-// If esModuleInterop enabled, some other packages do not work.
-import JimpT from 'jimp'
-import * as JimpLib0 from 'jimp'
-const JimpLib = JimpLib0 as unknown as JimpT
+import JimpLib from 'jimp'
 
 async function scale(filePath: string, opts: { height: number, width: number }): Promise<string> {
   const image = await JimpLib.read(filePath)

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode'
 import * as fs from 'fs'
 import * as path from 'path'
-import * as stripJsonComments from 'strip-json-comments'
+import stripJsonComments from 'strip-json-comments'
 
 
 const themeColorMap: { [theme: string]: 'light' | 'dark' } = {

--- a/test/build.index.ts
+++ b/test/build.index.ts
@@ -1,6 +1,6 @@
 import * as path from 'path'
-import * as Mocha from 'mocha'
-import * as glob from 'glob'
+import Mocha from 'mocha'
+import glob from 'glob'
 
 export function run(): Promise<void> {
     // Create the mocha test

--- a/test/completion.index.ts
+++ b/test/completion.index.ts
@@ -1,6 +1,6 @@
 import * as path from 'path'
-import * as Mocha from 'mocha'
-import * as glob from 'glob'
+import Mocha from 'mocha'
+import glob from 'glob'
 
 export function run(): Promise<void> {
     // Create the mocha test

--- a/test/viewer.index.ts
+++ b/test/viewer.index.ts
@@ -1,6 +1,6 @@
 import * as path from 'path'
-import * as Mocha from 'mocha'
-import * as glob from 'glob'
+import Mocha from 'mocha'
+import glob from 'glob'
 
 export function run(): Promise<void> {
     // Create the mocha test

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
         "alwaysStrict": true,
+        "esModuleInterop": true,
         "forceConsistentCasingInFileNames": true,
         "lib": [
             "es2017"


### PR DESCRIPTION
Enable `esModuleInterop` in `tsconfig.json`, which necessary to update the `jimp` package.

After this PR merged, if `mod` is callable like `glob`, we have to write
```typescript
import mod from 'mod'
``` 
instead of 
```typescript
import * as mod from 'mod'
```

See 
- https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html#support-for-import-d-from-cjs-from-commonjs-modules-with---esmoduleinterop
- https://stackoverflow.com/questions/56238356/understanding-esmoduleinterop-in-tsconfig-file/56348146#56348146