### PR TITLE
Add properties to define the types of values of recipes and tools.

### DIFF
--- a/package.json
+++ b/package.json
@@ -632,6 +632,20 @@
       "properties": {
         "latex-workshop.latex.recipes": {
           "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "tools": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          },
           "default": [
             {
               "name": "latexmk 🔃",
@@ -685,6 +699,26 @@
         },
         "latex-workshop.latex.tools": {
           "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "command": {
+                "type": "string"
+              },
+              "args": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "env": {
+                "type": "object"
+              }
+            }
+          },
           "default": [
             {
               "name": "latexmk",

--- a/package.json
+++ b/package.json
@@ -644,7 +644,11 @@
                   "type": "string"
                 }
               }
-            }
+            },
+            "required": [
+              "name",
+              "tools"
+            ]
           },
           "default": [
             {
@@ -717,7 +721,11 @@
               "env": {
                 "type": "object"
               }
-            }
+            },
+            "required": [
+              "name",
+              "command"
+            ]
           },
           "default": [
             {


### PR DESCRIPTION
Add properties to define the types of values of recipes and tools with JSON Schema.
See
- https://json-schema.org/understanding-json-schema/reference/object.html#properties
- https://json-schema.org/understanding-json-schema/reference/array.html#items

With this PR, users see a warning if the types of `recipes` and `tools` are invalid in `settings.json`.

Before:

![スクリーンショット 2020-05-09 22 23 28](https://user-images.githubusercontent.com/10665499/81474996-3aca7680-9244-11ea-931f-0a67b0259a7c.png)

After:

![スクリーンショット 2020-05-09 22 23 04](https://user-images.githubusercontent.com/10665499/81474998-3f8f2a80-9244-11ea-943b-ed0ca8bc2016.png)

![スクリーンショット 2020-05-09 22 23 17](https://user-images.githubusercontent.com/10665499/81475000-4322b180-9244-11ea-8041-00f7fd9e367d.png)
