### PR TITLE
Introduce the interface class of completion providers 

### DIFF
--- a/src/providers/completer/citation.ts
+++ b/src/providers/completer/citation.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs'
 import {bibtexParser} from 'latex-utensils'
 
 import {Extension} from '../../main'
+import {IProvider} from './interface'
 
 export interface Suggestion extends vscode.CompletionItem {
     key: string,
@@ -11,12 +12,16 @@ export interface Suggestion extends vscode.CompletionItem {
     position: vscode.Position
 }
 
-export class Citation {
+export class Citation implements IProvider {
     extension: Extension
     private bibEntries: {[file: string]: Suggestion[]} = {}
 
     constructor(extension: Extension) {
         this.extension = extension
+    }
+
+    provideFrom(_type: string, _result: RegExpMatchArray, args: {document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken, context: vscode.CompletionContext}) {
+        return this.provide(args)
     }
 
     provide(args?: {document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken, context: vscode.CompletionContext}): vscode.CompletionItem[] {

--- a/src/providers/completer/command.ts
+++ b/src/providers/completer/command.ts
@@ -4,6 +4,7 @@ import {latexParser} from 'latex-utensils'
 
 import {Extension} from '../../main'
 import {Environment, EnvSnippetType} from './environment'
+import {IProvider} from './interface'
 
 interface CmdItemEntry {
     command: string, // frame
@@ -19,7 +20,7 @@ export interface Suggestion extends vscode.CompletionItem {
     package: string
 }
 
-export class Command {
+export class Command implements IProvider {
     extension: Extension
     private environment: Environment
 
@@ -61,6 +62,11 @@ export class Command {
         this.defaultCmds.filter(cmd => bracketCmds.includes(this.getCmdName(cmd))).forEach(cmd => {
             this.bracketCmds[cmd.label.slice(1)] = cmd
         })
+    }
+
+    provideFrom(_type: string, _result: RegExpMatchArray, args: {document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken, context: vscode.CompletionContext}) {
+        const payload = args.document.languageId
+        return this.provide(payload)
     }
 
     provide(languageId: string): vscode.CompletionItem[] {

--- a/src/providers/completer/documentclass.ts
+++ b/src/providers/completer/documentclass.ts
@@ -2,8 +2,9 @@ import * as vscode from 'vscode'
 import * as fs from 'fs-extra'
 
 import {Extension} from '../../main'
+import {IProvider} from './interface'
 
-export class DocumentClass {
+export class DocumentClass implements IProvider {
     extension: Extension
     suggestions: vscode.CompletionItem[] = []
 
@@ -19,6 +20,10 @@ export class DocumentClass {
             cl.documentation = new vscode.MarkdownString(`[${item.documentation}](${item.documentation})`)
             this.suggestions.push(cl)
         })
+    }
+
+    provideFrom() {
+        return this.provide()
     }
 
     provide(): vscode.CompletionItem[] {

--- a/src/providers/completer/environment.ts
+++ b/src/providers/completer/environment.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs-extra'
 import {latexParser} from 'latex-utensils'
 
 import {Extension} from '../../main'
+import {IProvider} from './interface'
 
 export interface EnvItemEntry {
     name: string, // Name of the environment, what comes inside \begin{...}
@@ -17,7 +18,7 @@ export interface Suggestion extends vscode.CompletionItem {
     package: string
 }
 
-export class Environment {
+export class Environment implements IProvider {
     extension: Extension
     private defaultEnvsAsName: Suggestion[] = []
     private defaultEnvsAsCommand: Suggestion[] = []
@@ -82,6 +83,10 @@ export class Environment {
         }
     }
 
+    provideFrom(_type: string, _result: RegExpMatchArray, args: {document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken, context: vscode.CompletionContext}) {
+        const payload = {document: args.document, position: args.position}
+        return this.provide(payload)
+    }
 
     provide(args: {document: vscode.TextDocument, position: vscode.Position}): vscode.CompletionItem[] {
         if (vscode.window.activeTextEditor === undefined) {

--- a/src/providers/completer/input.ts
+++ b/src/providers/completer/input.ts
@@ -6,10 +6,11 @@ import * as cp from 'child_process'
 import * as utils from '../../utils/utils'
 
 import {Extension} from '../../main'
+import {IProvider} from './interface'
 
 const ignoreFiles = ['**/.vscode', '**/.vscodeignore', '**/.gitignore']
 
-export class Input {
+export class Input implements IProvider {
     extension: Extension
     graphicsPath: string[] = []
 
@@ -56,6 +57,11 @@ export class Input {
 
     reset() {
         this.graphicsPath = []
+    }
+
+    provideFrom(type: string, result: RegExpMatchArray, args: {document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken, context: vscode.CompletionContext}) {
+        const payload = [type, args.document.fileName, result[1], ...result.slice(2).reverse()]
+        return this.provide(payload)
     }
 
     /**

--- a/src/providers/completer/interface.ts
+++ b/src/providers/completer/interface.ts
@@ -1,0 +1,9 @@
+import * as vscode from 'vscode'
+
+export interface IProvider {
+    provideFrom(
+        type: string,
+        result: RegExpMatchArray,
+        args: {document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken, context: vscode.CompletionContext}
+    ): vscode.CompletionItem[]
+}

--- a/src/providers/completer/package.ts
+++ b/src/providers/completer/package.ts
@@ -2,8 +2,9 @@ import * as vscode from 'vscode'
 import * as fs from 'fs-extra'
 
 import {Extension} from '../../main'
+import {IProvider} from './interface'
 
-export class Package {
+export class Package implements IProvider {
     extension: Extension
     suggestions: vscode.CompletionItem[] = []
 
@@ -19,6 +20,10 @@ export class Package {
             pack.documentation = new vscode.MarkdownString(`[${item.documentation}](${item.documentation})`)
             this.suggestions.push(pack)
         })
+    }
+
+    provideFrom() {
+        return this.provide()
     }
 
     provide(): vscode.CompletionItem[] {

--- a/src/providers/completer/reference.ts
+++ b/src/providers/completer/reference.ts
@@ -4,6 +4,7 @@ import * as path from 'path'
 import {latexParser} from 'latex-utensils'
 
 import {Extension} from '../../main'
+import {IProvider} from './interface'
 
 export interface Suggestion extends vscode.CompletionItem {
     file: string, // The file that defines the ref
@@ -11,7 +12,7 @@ export interface Suggestion extends vscode.CompletionItem {
     prevIndex?: {refNumber: string, pageNumber: string} // Stores the ref number
 }
 
-export class Reference {
+export class Reference implements IProvider {
     extension: Extension
     // Here we use an object instead of an array for de-duplication
     private suggestions: {[id: string]: Suggestion} = {}
@@ -19,6 +20,10 @@ export class Reference {
 
     constructor(extension: Extension) {
         this.extension = extension
+    }
+
+    provideFrom(_type: string, _result: RegExpMatchArray, args: {document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken, context: vscode.CompletionContext}) {
+        return this.provide(args)
     }
 
     provide(args: {document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken, context: vscode.CompletionContext}): vscode.CompletionItem[] {


### PR DESCRIPTION
Introduce the interface class of completion providers to make the code typed. With this PR, we can avoid using the following explicit `any` for the `payload` variable.

https://github.com/James-Yu/LaTeX-Workshop/blob/79c5e3e3eb5115e1e1d7170c9ea4502ad05e0ee8/src/providers/completion.ts#L130

https://github.com/James-Yu/LaTeX-Workshop/blob/79c5e3e3eb5115e1e1d7170c9ea4502ad05e0ee8/src/providers/completion.ts#L180-L189