### PR TITLE
Use WebView.asWebviewUri and WebView.cspSource. Close #2091.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -516,9 +516,9 @@
       "dev": true
     },
     "@types/vscode": {
-      "version": "1.34.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.34.0.tgz",
-      "integrity": "sha512-t81rGr6aFw8TMap7UJdikC5ilOtL0yNr/pkovyyTy31fZ4XJehrxLMRh8nJuoOF3+g4rG9ljmtQo7tm6wyoaYA==",
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.38.0.tgz",
+      "integrity": "sha512-aGo8LQ4J1YF0T9ORuCO+bhQ5sGR1MXa7VOyOdEP685se3wyQWYUExcdiDi6rvaK61KUwfzzA19JRLDrUbDl7BQ==",
       "dev": true
     },
     "@types/workerpool": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/James-Yu/LaTeX-Workshop.git"
   },
   "engines": {
-    "vscode": "^1.34.0"
+    "vscode": "^1.38.0"
   },
   "categories": [
     "Programming Languages",

--- a/package.json
+++ b/package.json
@@ -1807,7 +1807,7 @@
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.12.17",
     "@types/tmp": "^0.0.33",
-    "@types/vscode": "1.34.0",
+    "@types/vscode": "1.38.0",
     "@types/workerpool": "^5.0.1",
     "@types/ws": "^5.1.1",
     "@typescript-eslint/eslint-plugin": "^2.29.0",

--- a/resources/buildinfo/buildinfo.html
+++ b/resources/buildinfo/buildinfo.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <meta http-equiv="Content-Security-Policy" content="default-src vscode-resource:; style-src 'unsafe-inline';">
+        <meta http-equiv="Content-Security-Policy" content="default-src %VSCODE_CSP%; style-src 'unsafe-inline';">
         <style>
             #stepTimes div.column {
                 display: inline-block;
@@ -162,6 +162,6 @@
         </div>
         <div id="stepTimes"></div>
 
-        <script src="vscode-resource:./buildinfo.js"></script>
+        <script src="%VSCODE_RES%/buildinfo/buildinfo.js"></script>
     </body>
 </html>

--- a/resources/snippetpanel/snippetpanel.html
+++ b/resources/snippetpanel/snippetpanel.html
@@ -3,8 +3,8 @@
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <meta http-equiv="Content-Security-Policy" content="default-src vscode-resource:; script-src vscode-resource: 'unsafe-inline'; style-src vscode-resource: 'unsafe-inline';">
-        <link rel="stylesheet" href="vscode-resource:./snippetpanel.css">
+        <meta http-equiv="Content-Security-Policy" content="default-src %VSCODE_CSP%; script-src %VSCODE_CSP% 'unsafe-inline'; style-src %VSCODE_CSP% 'unsafe-inline';">
+        <link rel="stylesheet" href="%VSCODE_RES%/snippetpanel/snippetpanel.css">
     </head>
     <body>
         <h2><span class="latex">L<sup>A</sup>T<sub>E</sub>X</span> Snippet Panel</h2>
@@ -426,6 +426,6 @@
             </div>
         </div>
 
-        <script src="vscode-resource:./snippetpanel.js"></script>
+        <script src="%VSCODE_RES%/snippetpanel/snippetpanel.js"></script>
     </body>
 </html>

--- a/src/components/buildinfo.ts
+++ b/src/components/buildinfo.ts
@@ -3,6 +3,7 @@ import * as path from 'path'
 import { readFileSync } from 'fs'
 
 import { Extension } from '../main'
+import {replaceWebviewPlaceholders} from '../utils/webview'
 
 export class BuildInfo {
     extension: Extension
@@ -184,14 +185,7 @@ export class BuildInfo {
 
         const webviewSourcePath = path.join(this.extension.extensionRoot, 'resources', 'buildinfo', 'buildinfo.html')
         let webviewHtml = readFileSync(webviewSourcePath, { encoding: 'utf8' })
-        webviewHtml = webviewHtml.replace(
-            /vscode-resource:\.\//,
-            'vscode-resource:' +
-                vscode.Uri.file(path.join(this.extension.extensionRoot, 'resources', 'buildinfo')).with({
-                    scheme: 'vscode-resource'
-                }).path +
-                '/'
-        )
+        webviewHtml = replaceWebviewPlaceholders(webviewHtml, this.extension, this.panel.webview)
         this.panel.webview.html = webviewHtml
 
         if (this.currentBuild) {

--- a/src/components/snippetpanel.ts
+++ b/src/components/snippetpanel.ts
@@ -4,6 +4,7 @@ import { readFileSync } from 'fs'
 import * as fs from 'fs'
 
 import { Extension } from '../main'
+import {replaceWebviewPlaceholders} from '../utils/webview'
 
 type IMathSymbol = {
     name: string,
@@ -64,14 +65,7 @@ export class SnippetPanel {
 
         const webviewSourcePath = path.join(resourcesFolder, 'snippetpanel.html')
         let webviewHtml = readFileSync(webviewSourcePath, { encoding: 'utf8' })
-        webviewHtml = webviewHtml.replace(
-            /vscode-resource:\.\//g,
-            'vscode-resource:' +
-                vscode.Uri.file(resourcesFolder).with({
-                    scheme: 'vscode-resource'
-                }).path +
-                '/'
-        )
+        webviewHtml = replaceWebviewPlaceholders(webviewHtml, this.extension, this.panel.webview)
         this.panel.webview.html = webviewHtml
 
         this.initialisePanel()
@@ -81,14 +75,8 @@ export class SnippetPanel {
         fs.watchFile(webviewSourcePath, () => {
             {
                 if (this.panel) {
-                    this.panel.webview.html = readFileSync(webviewSourcePath, { encoding: 'utf8' }).replace(
-                        /vscode-resource:\.\//g,
-                        'vscode-resource:' +
-                            vscode.Uri.file(resourcesFolder).with({
-                                scheme: 'vscode-resource'
-                            }).path +
-                            '/'
-                    )
+                    const htmlStr = readFileSync(webviewSourcePath, { encoding: 'utf8' })
+                    this.panel.webview.html = replaceWebviewPlaceholders(htmlStr, this.extension, this.panel.webview)
                     this.initialisePanel()
                 }
             }

--- a/src/utils/webview.ts
+++ b/src/utils/webview.ts
@@ -1,0 +1,11 @@
+import * as vscode from 'vscode'
+import * as path from 'path'
+import {Extension} from '../main'
+
+export function replaceWebviewPlaceholders(content: string, extension: Extension, webview: vscode.Webview): string {
+    const resourcesFolder = path.join(extension.extensionRoot, 'resources')
+    const filePath = vscode.Uri.file(resourcesFolder)
+    const link = webview.asWebviewUri(filePath).toString()
+    return content.replace(/%VSCODE_RES%/g, link)
+                  .replace(/%VSCODE_CSP%/g, webview.cspSource)
+}


### PR DESCRIPTION
Use `WebView.asWebviewUri` and `WebView.cspSource`. Close #2091.

With this PR, we drop the support for the older versions of VS Code < v1.38. The methods, `WebView.asWebviewUri` and `WebView.cspSource`, are not available on the older versions.