### PR TITLE
Add auto-close of inline math

### DIFF
--- a/snippets/latex.json
+++ b/snippets/latex.json
@@ -494,6 +494,11 @@
 		"body": "\n\\begin{$1}\n\t${TM_SELECTED_TEXT}\n\\end{$1}",
 		"description": "Wrap selection into an environment"
 	},
+	"environment": {
+		"prefix": "begin",
+		"body": "\\begin{$1}\n\t$0\n\\end{$1}",
+		"description": "Create a new environment"
+	},
 	"part": {
 		"prefix": "SPA",
 		"body": "\\part{$1}",

--- a/syntax/syntax.json
+++ b/syntax/syntax.json
@@ -14,7 +14,6 @@
 	"autoClosingPairs": [
 		["{", "}"],
 		["[", "]"],
-		["(", ")"],
 		["`", "'"]
 	],
 	"surroundingPairs": [


### PR DESCRIPTION
Add auto-closing of inline math: typing `\(` expands automatically the inline math snippet and yields `\( | \)` (`|` represents the cursor). Pressing tab again jumps after the closing bracket.

Moreover, I've added a new `begin` snippet which creates a new `\begin{...} ... \end{...}` pair. It's similar to the existing snippet that triggers on `\begin` just that you don't have to type the beginning slash.