### PR TITLE
Define .bcf and .run.xml as auxiliary extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1025,7 +1025,9 @@
             "*.snm",
             "*.synctex(busy)",
             "*.synctex.gz(busy)",
-            "*.nav"
+            "*.nav",
+            "*.bcf",
+            "*.run.xml"
           ],
           "markdownDescription": "Files to clean.\nThis property must be an array of strings. File globs such as *.removeme, something?.aux can be used."
         },


### PR DESCRIPTION
I would define them locally under user settings, but apparently there's no way to append to the default list: https://stackoverflow.com/q/57796423

The file extensions are related to biblatex/biber.