### PR TITLE
Filename completion with already typed path

### DIFF
--- a/src/providers/completer/input.ts
+++ b/src/providers/completer/input.ts
@@ -137,7 +137,11 @@ export class Input implements IProvider {
         const suggestions: vscode.CompletionItem[] = []
         baseDir.forEach(dir => {
             if (typedFolder !== '') {
-                dir = path.resolve(dir, typedFolder)
+                let currentFolder = typedFolder
+                if (! typedFolder.endsWith('/')) {
+                    currentFolder = path.dirname(typedFolder)
+                }
+                dir = path.resolve(dir, currentFolder)
             }
             try {
                 let files = fs.readdirSync(dir)

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -81,7 +81,7 @@ export class Completer implements vscode.CompletionItemProvider {
             }
 
             const line = document.lineAt(position.line).text.substr(0, position.character)
-            for (const type of ['command', 'environment', 'citation', 'reference', 'package', 'documentclass', 'input', 'includeonly', 'subimport', 'import']) {
+            for (const type of ['citation', 'reference', 'environment', 'package', 'documentclass', 'input', 'subimport', 'import', 'includeonly', 'command']) {
                 const suggestions = this.completion(type, line, {document, position, token, context})
                 if (suggestions.length > 0) {
                     if (type === 'citation') {


### PR DESCRIPTION
Enable filename completion when a part of the path has already been typed.
Close #2132