### PR TITLE
Activate onEnterKey even when suggestion is visible

### DIFF
--- a/package.json
+++ b/package.json
@@ -622,17 +622,17 @@
       {
         "command": "latex-workshop.onEnterKey",
         "key": "enter",
-        "when": "editorTextFocus && !editorReadonly && editorLangId == 'latex' && !suggestWidgetVisible &&  vim.active && vim.mode == 'Insert'"
+        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /latex|rsweave/ && vim.active && vim.mode == 'Insert'"
       },
       {
         "command": "latex-workshop.onEnterKey",
         "key": "enter",
-        "when": "editorTextFocus && !editorReadonly && editorLangId == 'latex' && !suggestWidgetVisible &&  !vim.active"
+        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /latex|rsweave/ && !vim.active"
       },
       {
         "command": "latex-workshop.onAltEnterKey",
         "key": "alt+enter",
-        "when": "editorTextFocus && !editorReadonly && editorLangId == 'latex' && !suggestWidgetVisible"
+        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /latex|rsweave/"
       }
     ],
     "configurationDefaults": {


### PR DESCRIPTION
Hitting `enter` inside an itemize like environment while the intellisense popup is visible does not call `latex-workshop.onEnterKey` and hence `\item` is not inserted on the newline. This PR fixes it.
