### PR TITLE
Improve the invert mode of the PDF viewer with additional filters.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1203,6 +1203,26 @@
           "default": 0,
           "markdownDescription": "Define the CSS invert filter level of the PDF viewer.\nThis config can invert the color of PDF. Possible values are from 0 to 1."
         },
+        "latex-workshop.view.pdf.invertMode.brightness": {
+          "type": "number",
+          "default": 1,
+          "markdownDescription": "Define the CSS brightness filter level of the PDF viewer when the invert mode is enabled. Possible values are from 0 to 2."
+        },
+        "latex-workshop.view.pdf.invertMode.grayscale": {
+          "type": "number",
+          "default": 0.6,
+          "markdownDescription": "Define the CSS grayscale filter level of the PDF viewer when the invert mode is enabled. Possible values are from 0 to 1."
+        },
+        "latex-workshop.view.pdf.invertMode.hueRotate": {
+          "type": "number",
+          "default": 180,
+          "markdownDescription": "Define the CSS hue-rotate filter angle of the PDF viewer when the invert mode is enabled. Possible values are from 0 to 360."
+        },
+        "latex-workshop.view.pdf.invertMode.sepia": {
+          "type": "number",
+          "default": 0,
+          "markdownDescription": "Define the CSS sepia filter level of the PDF viewer when the invert mode is enabled. Possible values are from 0 to 1."
+        },
         "latex-workshop.view.pdf.backgroundColor": {
           "type": "string",
           "default": "#ffffff",

--- a/src/components/viewer.ts
+++ b/src/components/viewer.ts
@@ -378,7 +378,13 @@ export class Viewer {
                         scrollMode: configuration.get('view.pdf.scrollMode') as number,
                         spreadMode: configuration.get('view.pdf.spreadMode') as number,
                         hand: configuration.get('view.pdf.hand') as boolean,
-                        invert: configuration.get('view.pdf.invert') as number,
+                        invertMode: {
+                            brightness: configuration.get('view.pdf.invertMode.brightness') as number,
+                            grayscale: configuration.get('view.pdf.invertMode.grayscale') as number,
+                            hueRotate: configuration.get('view.pdf.invertMode.hueRotate') as number,
+                            invert: configuration.get('view.pdf.invert') as number,
+                            sepia: configuration.get('view.pdf.invertMode.sepia') as number,
+                        },
                         bgColor: configuration.get('view.pdf.backgroundColor') as string,
                         keybindings: {
                             synctex: configuration.get('view.pdf.internal.synctex.keybinding') as 'ctrl-click' | 'double-click'

--- a/viewer/components/protocol.ts
+++ b/viewer/components/protocol.ts
@@ -9,7 +9,13 @@ export type ServerResponse = {
     scrollMode: number,
     spreadMode: number,
     hand: boolean,
-    invert: number,
+    invertMode: {
+        brightness: number,
+        grayscale: number,
+        hueRotate: number,
+        invert: number,
+        sepia: number
+    },
     bgColor: string,
     keybindings: {
         synctex: 'ctrl-click' | 'double-click'

--- a/viewer/latexworkshop.ts
+++ b/viewer/latexworkshop.ts
@@ -230,8 +230,10 @@ class LateXWorkshopPdfViewer implements ILatexWorkshopPdfViewer {
                     if (!this.isRestoredWithSerializer) {
                         this.restorePdfViewerState(data)
                     }
-                    if (data.invert > 0) {
-                        (document.querySelector('html') as HTMLHtmlElement).style.filter = `invert(${data.invert * 100}%)`;
+                    if (data.invertMode.invert > 0) {
+                        const { brightness, grayscale, hueRotate, invert, sepia } = data.invertMode
+                        const filter = `invert(${invert * 100}%) hue-rotate(${hueRotate}deg) grayscale(${grayscale}) sepia(${sepia}) brightness(${brightness})`;
+                        (document.querySelector('html') as HTMLHtmlElement).style.filter = filter;
                         (document.querySelector('html') as HTMLHtmlElement).style.background = 'white'
                     }
                     (document.querySelector('#viewerContainer') as HTMLElement).style.background = data.bgColor


### PR DESCRIPTION
Improve the invert mode of the PDF viewer with additional filters, `hue-rotate` and `grayscale`. See [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/filter-function) for details.

Before:

![スクリーンショット 2020-06-13 17 56 50](https://user-images.githubusercontent.com/10665499/84564795-828e7180-ad9f-11ea-8a77-8ff267500aab.png)

After:

![スクリーンショット 2020-06-13 17 57 12](https://user-images.githubusercontent.com/10665499/84564802-88845280-ad9f-11ea-8b54-8519c46ef796.png)

We can see that lots of non-gray colors on characters have disappeared.