### PR TITLE
Add invert PDF in dark mode only.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1280,7 +1280,7 @@
             "compat",
             "never"
           ],
-          "default": "never",
+          "default": "compat",
           "markdownDescription": "Enable the CSS invert filter.",
           "enumDescriptions": [
             "Enable the invert filter when using a dark theme.",

--- a/package.json
+++ b/package.json
@@ -1223,6 +1223,11 @@
           "default": 0,
           "markdownDescription": "Define the CSS sepia filter level of the PDF viewer when the invert mode is enabled. Possible values are from 0 to 1."
         },
+        "latex-workshop.view.pdf.invertMode.darkModeOnly": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Apply CSS invert filter for the PDF viewer in dark mode only.\nDefaults to `false`, which applies invert filter, if it is enabled, in both dark and light mode."
+        },
         "latex-workshop.view.pdf.backgroundColor": {
           "type": "string",
           "default": "#ffffff",

--- a/package.json
+++ b/package.json
@@ -1272,7 +1272,24 @@
           "default": false,
           "markdownDescription": "Define if the hand tool is enabled by default in the PDF viewer."
         },
-        "latex-workshop.view.pdf.invert": {
+        "latex-workshop.view.pdf.invertMode.enabled": {
+          "type": "string",
+          "enum": [
+            "auto",
+            "always",
+            "compat",
+            "never"
+          ],
+          "default": "never",
+          "markdownDescription": "Enable the CSS invert filter.",
+          "enumDescriptions": [
+            "Enable the invert filter when using a dark theme.",
+            "Always enable invert filter.",
+            "Enable the invert filter only if `invert > 0`.",
+            "Disable the invert filter"
+          ]
+        },
+        "latex-workshop.view.pdf.invertMode.invert": {
           "type": "number",
           "default": 0,
           "markdownDescription": "Define the CSS invert filter level of the PDF viewer.\nThis config can invert the color of PDF. Possible values are from 0 to 1."
@@ -1296,11 +1313,6 @@
           "type": "number",
           "default": 0,
           "markdownDescription": "Define the CSS sepia filter level of the PDF viewer when the invert mode is enabled. Possible values are from 0 to 1."
-        },
-        "latex-workshop.view.pdf.invertMode.darkModeOnly": {
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "Apply CSS invert filter for the PDF viewer in dark mode only.\nDefaults to `false`, which applies invert filter, if it is enabled, in both dark and light mode."
         },
         "latex-workshop.view.pdf.backgroundColor": {
           "type": "string",

--- a/src/components/viewer.ts
+++ b/src/components/viewer.ts
@@ -408,8 +408,10 @@ export class Viewer {
                         continue
                     }
                     const configuration = vscode.workspace.getConfiguration('latex-workshop')
-                    const darkModeOnly = configuration.get('view.pdf.invertMode.darkModeOnly') as boolean
-                    const invert = (!darkModeOnly || (darkModeOnly && (getCurrentThemeLightness() == 'dark'))) ? configuration.get('view.pdf.invert') as number : 0
+                    const invertType = configuration.get('view.pdf.invertMode.enabled') as string
+                    const invertEnabled = (invertType == "auto" && (getCurrentThemeLightness() == 'dark')) ||
+                        invertType == "always" ||
+                        (invertType == "compat" && ((configuration.get('view.pdf.invert') as number) > 0))
                     client.send({
                         type: 'params',
                         scale: configuration.get('view.pdf.zoom') as string,
@@ -418,10 +420,11 @@ export class Viewer {
                         spreadMode: configuration.get('view.pdf.spreadMode') as number,
                         hand: configuration.get('view.pdf.hand') as boolean,
                         invertMode: {
+                            enabled: invertEnabled,
                             brightness: configuration.get('view.pdf.invertMode.brightness') as number,
                             grayscale: configuration.get('view.pdf.invertMode.grayscale') as number,
                             hueRotate: configuration.get('view.pdf.invertMode.hueRotate') as number,
-                            invert: invert,
+                            invert: configuration.get('view.pdf.invert') as number,
                             sepia: configuration.get('view.pdf.invertMode.sepia') as number,
                         },
                         bgColor: configuration.get('view.pdf.backgroundColor') as string,

--- a/src/components/viewer.ts
+++ b/src/components/viewer.ts
@@ -11,6 +11,7 @@ import {SyncTeXRecordForward} from './locator'
 import {encodePathWithPrefix} from '../utils/utils'
 
 import {ClientRequest, ServerResponse, PanelRequest, PdfViewerState} from '../../viewer/components/protocol'
+import {getCurrentThemeLightness} from '../utils/theme'
 
 class Client {
     readonly viewer: 'browser' | 'tab'
@@ -371,6 +372,7 @@ export class Viewer {
                         continue
                     }
                     const configuration = vscode.workspace.getConfiguration('latex-workshop')
+                    const invert = ((configuration.get('view.pdf.invertMode.darkModeOnly') && getCurrentThemeLightness() == 'dark') || !configuration.get('view.pdf.invertMode.darkModeOnly')) ? configuration.get('view.pdf.invert') as number : 0
                     client.send({
                         type: 'params',
                         scale: configuration.get('view.pdf.zoom') as string,
@@ -382,9 +384,8 @@ export class Viewer {
                             brightness: configuration.get('view.pdf.invertMode.brightness') as number,
                             grayscale: configuration.get('view.pdf.invertMode.grayscale') as number,
                             hueRotate: configuration.get('view.pdf.invertMode.hueRotate') as number,
-                            invert: configuration.get('view.pdf.invert') as number,
+                            invert: invert,
                             sepia: configuration.get('view.pdf.invertMode.sepia') as number,
-                            darkModeOnly: configuration.get('view.pdf.invertMode.darkModeOnly') as boolean,
                         },
                         bgColor: configuration.get('view.pdf.backgroundColor') as string,
                         keybindings: {

--- a/src/components/viewer.ts
+++ b/src/components/viewer.ts
@@ -372,7 +372,8 @@ export class Viewer {
                         continue
                     }
                     const configuration = vscode.workspace.getConfiguration('latex-workshop')
-                    const invert = ((configuration.get('view.pdf.invertMode.darkModeOnly') && getCurrentThemeLightness() == 'dark') || !configuration.get('view.pdf.invertMode.darkModeOnly')) ? configuration.get('view.pdf.invert') as number : 0
+                    const darkModeOnly = configuration.get('view.pdf.invertMode.darkModeOnly') as boolean
+                    const invert = (!darkModeOnly || (darkModeOnly && (getCurrentThemeLightness() == 'dark'))) ? configuration.get('view.pdf.invert') as number : 0
                     client.send({
                         type: 'params',
                         scale: configuration.get('view.pdf.zoom') as string,

--- a/src/components/viewer.ts
+++ b/src/components/viewer.ts
@@ -384,6 +384,7 @@ export class Viewer {
                             hueRotate: configuration.get('view.pdf.invertMode.hueRotate') as number,
                             invert: configuration.get('view.pdf.invert') as number,
                             sepia: configuration.get('view.pdf.invertMode.sepia') as number,
+                            darkModeOnly: configuration.get('view.pdf.invertMode.darkModeOnly') as boolean,
                         },
                         bgColor: configuration.get('view.pdf.backgroundColor') as string,
                         keybindings: {

--- a/src/components/viewer.ts
+++ b/src/components/viewer.ts
@@ -409,9 +409,9 @@ export class Viewer {
                     }
                     const configuration = vscode.workspace.getConfiguration('latex-workshop')
                     const invertType = configuration.get('view.pdf.invertMode.enabled') as string
-                    const invertEnabled = (invertType == "auto" && (getCurrentThemeLightness() == 'dark')) ||
-                        invertType == "always" ||
-                        (invertType == "compat" && ((configuration.get('view.pdf.invert') as number) > 0))
+                    const invertEnabled = (invertType === 'auto' && (getCurrentThemeLightness() === 'dark')) ||
+                        invertType === 'always' ||
+                        (invertType === 'compat' && ((configuration.get('view.pdf.invert') as number) > 0))
                     client.send({
                         type: 'params',
                         scale: configuration.get('view.pdf.zoom') as string,

--- a/viewer/components/protocol.ts
+++ b/viewer/components/protocol.ts
@@ -14,7 +14,8 @@ export type ServerResponse = {
         grayscale: number,
         hueRotate: number,
         invert: number,
-        sepia: number
+        sepia: number,
+        darkModeOnly: boolean
     },
     bgColor: string,
     keybindings: {

--- a/viewer/components/protocol.ts
+++ b/viewer/components/protocol.ts
@@ -14,8 +14,7 @@ export type ServerResponse = {
         grayscale: number,
         hueRotate: number,
         invert: number,
-        sepia: number,
-        darkModeOnly: boolean
+        sepia: number
     },
     bgColor: string,
     keybindings: {

--- a/viewer/components/protocol.ts
+++ b/viewer/components/protocol.ts
@@ -8,6 +8,7 @@ export type ServerResponse = {
     spreadMode: number,
     hand: boolean,
     invertMode: {
+        enabled: boolean,
         brightness: number,
         grayscale: number,
         hueRotate: number,

--- a/viewer/latexworkshop.ts
+++ b/viewer/latexworkshop.ts
@@ -4,6 +4,7 @@ import {PageTrimmer} from './components/pagetrimmer.js'
 import {ClientRequest, ServerResponse, PanelManagerResponse, PanelRequest, PdfViewerState} from './components/protocol.js'
 import * as utils from './components/utils.js'
 import {ViewerHistory} from './components/viewerhistory.js'
+import {getCurrentThemeLightness} from '../src/utils/theme'
 
 declare const PDFViewerApplication: IPDFViewerApplication
 declare const PDFViewerApplicationOptions: IPDFViewerApplicationOptions
@@ -230,7 +231,7 @@ class LateXWorkshopPdfViewer implements ILatexWorkshopPdfViewer {
                     if (!this.isRestoredWithSerializer) {
                         this.restorePdfViewerState(data)
                     }
-                    if (((data.invertMode.darkModeOnly && window.matchMedia(`(prefers-color-scheme: dark)`).matches) || !data.invertMode.darkModeOnly) && (data.invertMode.invert > 0)) {
+                    if (((data.invertMode.darkModeOnly && getCurrentThemeLightness() == 'dark') || !data.invertMode.darkModeOnly) && (data.invertMode.invert > 0)) {
                         const { brightness, grayscale, hueRotate, invert, sepia } = data.invertMode
                         const filter = `invert(${invert * 100}%) hue-rotate(${hueRotate}deg) grayscale(${grayscale}) sepia(${sepia}) brightness(${brightness})`;
                         (document.querySelector('html') as HTMLHtmlElement).style.filter = filter;

--- a/viewer/latexworkshop.ts
+++ b/viewer/latexworkshop.ts
@@ -4,7 +4,6 @@ import {PageTrimmer} from './components/pagetrimmer.js'
 import {ClientRequest, ServerResponse, PanelManagerResponse, PanelRequest, PdfViewerState} from './components/protocol.js'
 import * as utils from './components/utils.js'
 import {ViewerHistory} from './components/viewerhistory.js'
-import {getCurrentThemeLightness} from '../src/utils/theme'
 
 declare const PDFViewerApplication: IPDFViewerApplication
 declare const PDFViewerApplicationOptions: IPDFViewerApplicationOptions
@@ -231,7 +230,7 @@ class LateXWorkshopPdfViewer implements ILatexWorkshopPdfViewer {
                     if (!this.isRestoredWithSerializer) {
                         this.restorePdfViewerState(data)
                     }
-                    if (((data.invertMode.darkModeOnly && getCurrentThemeLightness() == 'dark') || !data.invertMode.darkModeOnly) && (data.invertMode.invert > 0)) {
+                    if (data.invertMode.invert > 0) {
                         const { brightness, grayscale, hueRotate, invert, sepia } = data.invertMode
                         const filter = `invert(${invert * 100}%) hue-rotate(${hueRotate}deg) grayscale(${grayscale}) sepia(${sepia}) brightness(${brightness})`;
                         (document.querySelector('html') as HTMLHtmlElement).style.filter = filter;

--- a/viewer/latexworkshop.ts
+++ b/viewer/latexworkshop.ts
@@ -230,7 +230,7 @@ class LateXWorkshopPdfViewer implements ILatexWorkshopPdfViewer {
                     if (!this.isRestoredWithSerializer) {
                         this.restorePdfViewerState(data)
                     }
-                    if (data.invertMode.invert > 0) {
+                    if (((data.invertMode.darkModeOnly && window.matchMedia(`(prefers-color-scheme: dark)`).matches) || !data.invertMode.darkModeOnly) && (data.invertMode.invert > 0)) {
                         const { brightness, grayscale, hueRotate, invert, sepia } = data.invertMode
                         const filter = `invert(${invert * 100}%) hue-rotate(${hueRotate}deg) grayscale(${grayscale}) sepia(${sepia}) brightness(${brightness})`;
                         (document.querySelector('html') as HTMLHtmlElement).style.filter = filter;

--- a/viewer/latexworkshop.ts
+++ b/viewer/latexworkshop.ts
@@ -230,7 +230,7 @@ class LateXWorkshopPdfViewer implements ILatexWorkshopPdfViewer {
                     if (!this.isRestoredWithSerializer) {
                         this.restorePdfViewerState(data)
                     }
-                    if (data.invertMode.invert > 0) {
+                    if (data.invertMode.enabled) {
                         const { brightness, grayscale, hueRotate, invert, sepia } = data.invertMode
                         const filter = `invert(${invert * 100}%) hue-rotate(${hueRotate}deg) grayscale(${grayscale}) sepia(${sepia}) brightness(${brightness})`;
                         (document.querySelector('html') as HTMLHtmlElement).style.filter = filter;


### PR DESCRIPTION
This creates an option which applies "invert PDF" when the operating system's dark mode setting is enabled. 

This is detected via `window.matchMedia(`(prefers-color-scheme: dark)`).matches`, which is the same mechanism VS Code internally uses for the `window.autoDetectColorScheme` option which auto-switches between light and dark themes.