### PR TITLE
Use kpsewhich to resolve bibliography files

### DIFF
--- a/package.json
+++ b/package.json
@@ -918,13 +918,18 @@
           "default": [],
           "markdownDescription": "List of directories where to look for extra input `.tex` files. \nAbsolute paths are required. You may also need to set the environment variable `TEXINPUTS` properly for the LaTeX compiler to find the `.tex` files, see the `env` parameter of [recipes](https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#latex-recipes)."
         },
+        "latex-workshop.kpsewhich.path": {
+          "type": "string",
+          "default": "kpsewhich",
+          "markdownDescription": "Define the location of the kpsewhich executable file."
+        },
         "latex-workshop.latex.bibDirs": {
           "type": "array",
           "items": {
             "type": "string"
           },
           "default": [],
-          "markdownDescription": "List of directories where to look for `.bib` files.\nAbsolute paths are required. This setting is only used by the intellisense feature, you may also need to set the environment variable `BIBINPUTS` properly for the LaTeX compiler to find the `.bib` files."
+          "markdownDescription": "List of directories where to look for `.bib` files on top of the directories returned by `kpsewhich -show-path=bib`.\nAbsolute paths are required. This setting is only used by the intellisense feature, you may also need to set the environment variable `BIBINPUTS` properly for the LaTeX compiler to find the `.bib` files."
         },
         "latex-workshop.latex.search.rootFiles.include": {
           "type": "array",

--- a/package.json
+++ b/package.json
@@ -923,6 +923,11 @@
           "default": "kpsewhich",
           "markdownDescription": "Define the location of the kpsewhich executable file."
         },
+        "latex-workshop.kpsewhich.enabled": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Use kpsewhich as defined by `latex-workshop.kpsewhich.path` to resolve bibliography files in addition to looking into the directories listed in `latex-workshop.latex.bibDirs`."
+        },
         "latex-workshop.latex.bibDirs": {
           "type": "array",
           "items": {

--- a/package.json
+++ b/package.json
@@ -934,7 +934,7 @@
             "type": "string"
           },
           "default": [],
-          "markdownDescription": "List of directories where to look for `.bib` files on top of the directories returned by `kpsewhich -show-path=bib`.\nAbsolute paths are required. This setting is only used by the intellisense feature, you may also need to set the environment variable `BIBINPUTS` properly for the LaTeX compiler to find the `.bib` files."
+          "markdownDescription": "List of directories where to look for `.bib` files.\nAbsolute paths are required. This setting is only used by the intellisense feature, you may also need to set the environment variable `BIBINPUTS` properly for the LaTeX compiler to find the `.bib` files."
         },
         "latex-workshop.latex.search.rootFiles.include": {
           "type": "array",

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode'
 import * as os from 'os'
 import * as path from 'path'
 import * as fs from 'fs-extra'
+import * as cs from 'cross-spawn'
 import * as chokidar from 'chokidar'
 import * as micromatch from 'micromatch'
 import {latexParser} from 'latex-utensils'
@@ -865,13 +866,33 @@ export class Manager {
         }
     }
 
+    private kpsewhichBibPath(bib: string): string | undefined {
+        const kpsewhich = vscode.workspace.getConfiguration('latex-workshop').get('kpsewhich.path') as string
+        try {
+            const kpsewhichReturn = cs.sync(kpsewhich, ['-format=.bib', bib])
+            if (kpsewhichReturn.status === 0) {
+                const bibPath = kpsewhichReturn.stdout.toString().replace(/\r?\n/, '')
+                if (bibPath === '') {
+                    return undefined
+                } else {
+                    this.extension.logger.addLogMessage(`Found .bib file using kpsewhich: ${bibPath}`)
+                    return bibPath
+                }
+            }
+        } catch(e) {
+            this.extension.logger.addLogMessage(`Cannot run kpsewhich to resolve .bib file: ${bib}`)
+        }
+        return undefined
+    }
+
     private resolveBibPath(bib: string, rootDir: string) {
         const bibDirs = vscode.workspace.getConfiguration('latex-workshop').get('latex.bibDirs') as string[]
         const bibPath = utils.resolveFile([rootDir, ...bibDirs], bib, '.bib')
 
         if (!bibPath) {
             this.extension.logger.addLogMessage(`Cannot find .bib file: ${bib}`)
-            return undefined
+            this.extension.logger.addLogMessage('Trying to use kpsewhich')
+            return this.kpsewhichBibPath(bib)
         }
         this.extension.logger.addLogMessage(`Found .bib file: ${bibPath}`)
         return bibPath

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -887,12 +887,17 @@ export class Manager {
     }
 
     private resolveBibPath(bib: string, rootDir: string) {
-        const bibDirs = vscode.workspace.getConfiguration('latex-workshop').get('latex.bibDirs') as string[]
+        const configuration = vscode.workspace.getConfiguration('latex-workshop')
+        const bibDirs = configuration.get('latex.bibDirs') as string[]
         const bibPath = utils.resolveFile([rootDir, ...bibDirs], bib, '.bib')
 
         if (!bibPath) {
             this.extension.logger.addLogMessage(`Cannot find .bib file: ${bib}`)
-            return this.kpsewhichBibPath(bib)
+            if (configuration.get('kpsewhich.enabled')) {
+                return this.kpsewhichBibPath(bib)
+            } else {
+                return undefined
+            }
         }
         this.extension.logger.addLogMessage(`Found .bib file: ${bibPath}`)
         return bibPath

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -868,6 +868,7 @@ export class Manager {
 
     private kpsewhichBibPath(bib: string): string | undefined {
         const kpsewhich = vscode.workspace.getConfiguration('latex-workshop').get('kpsewhich.path') as string
+        this.extension.logger.addLogMessage(`Calling ${kpsewhich} to resolve file: ${bib}`)
         try {
             const kpsewhichReturn = cs.sync(kpsewhich, ['-format=.bib', bib])
             if (kpsewhichReturn.status === 0) {
@@ -891,7 +892,6 @@ export class Manager {
 
         if (!bibPath) {
             this.extension.logger.addLogMessage(`Cannot find .bib file: ${bib}`)
-            this.extension.logger.addLogMessage('Trying to use kpsewhich')
             return this.kpsewhichBibPath(bib)
         }
         this.extension.logger.addLogMessage(`Found .bib file: ${bibPath}`)


### PR DESCRIPTION
When a `.bib` cannot be found in the root directory or using `bibDirs`, we use `kpsewhich -format=.bib bib_file_name`.

Fix #2163. 