### PR TITLE
Improve scope names

### DIFF
--- a/syntax/LaTeX.tmLanguage.json
+++ b/syntax/LaTeX.tmLanguage.json
@@ -1524,13 +1524,14 @@
               "name": "punctuation.definition.optional.arguments.begin.latex"
             },
             "2": {
-              "name": "variable.parameter.latex"
+              "name": "variable.parameter.function.latex"
             },
             "3": {
               "name": "punctuation.definition.optional.arguments.end.latex"
             }
           },
-          "match": "(\\[)([^\\[]*?)(\\])"
+          "match": "(\\[)([^\\[]*?)(\\])",
+          "name": "meta.parameter.optional.latex"
         }
       ]
     },

--- a/syntax/LaTeX.tmLanguage.json
+++ b/syntax/LaTeX.tmLanguage.json
@@ -553,11 +553,11 @@
           "begin": "%",
           "beginCaptures": {
             "0": {
-              "name": "punctuation.definition.comment.tex"
+              "name": "punctuation.definition.comment.latex"
             }
           },
           "end": "$\\n?",
-          "name": "comment.line.percentage.tex"
+          "name": "comment.line.percentage.latex"
         },
         {
           "include": "source.gnuplot"
@@ -646,11 +646,11 @@
         {
           "captures": {
             "1": {
-              "name": "punctuation.definition.function.tex"
+              "name": "punctuation.definition.function.latex"
             }
           },
           "match": "(\\\\)[A-Za-z]+",
-          "name": "support.function.general.tex"
+          "name": "support.function.general.latex"
         }
       ]
     },
@@ -673,7 +673,7 @@
           "name": "punctuation.definition.arguments.end.latex"
         }
       },
-      "contentName": "punctuation.definition.comment.tex",
+      "contentName": "punctuation.definition.comment.latex",
       "end": "((\\\\)end)(\\{)(\\4)(\\})",
       "name": "meta.function.verbatim.latex"
     },
@@ -961,7 +961,7 @@
           "name": "punctuation.definition.begin.latex"
         },
         "4": {
-          "name": "support.function.general.tex"
+          "name": "support.function.general.latex"
         },
         "5": {
           "name": "punctuation.definition.function.latex"
@@ -1416,7 +1416,7 @@
     },
     {
       "match": "\\\\(?:newline|pagebreak|clearpage|linebreak|pause)(?:\\b)",
-      "name": "keyword.control.layout.tex"
+      "name": "keyword.control.layout.latex"
     },
     {
       "begin": "\\\\\\(",
@@ -1458,7 +1458,7 @@
       "patterns": [
         {
           "match": "\\\\\\$",
-          "name": "constant.character.escape.tex"
+          "name": "constant.character.escape.latex"
         },
         {
           "include": "text.tex#math"

--- a/syntax/LaTeX.tmLanguage.json
+++ b/syntax/LaTeX.tmLanguage.json
@@ -58,7 +58,6 @@
           "name": "punctuation.definition.arguments.begin.latex"
         }
       },
-      "contentName": "support.class.latex",
       "end": "\\}",
       "endCaptures": {
         "0": {

--- a/syntax/LaTeX.tmLanguage.json
+++ b/syntax/LaTeX.tmLanguage.json
@@ -760,7 +760,7 @@
           "name": "punctuation.definition.arguments.end.latex"
         }
       },
-      "contentName": "support.class.math.block.environment.latex",
+      "contentName": "meta.math.block.latex support.class.math.block.environment.latex",
       "end": "(?:\\s*)((\\\\)end)(\\{)(\\4)(\\})(?:\\s*\\n)?",
       "name": "meta.function.environment.math.latex",
       "patterns": [
@@ -1431,7 +1431,7 @@
           "name": "punctuation.definition.string.end.latex"
         }
       },
-      "name": "support.class.math.latex",
+      "name": "meta.math.block.latex support.class.math.block.environment.latex",
       "patterns": [
         {
           "include": "text.tex#math"
@@ -1454,7 +1454,7 @@
           "name": "punctuation.definition.string.end.latex"
         }
       },
-      "name": "support.class.math.latex",
+      "name": "meta.math.block.latex support.class.math.block.environment.latex",
       "patterns": [
         {
           "match": "\\\\\\$",
@@ -1481,7 +1481,7 @@
           "name": "punctuation.definition.string.end.latex"
         }
       },
-      "name": "support.class.math.latex",
+      "name": "meta.math.block.latex support.class.math.block.environment.latex",
       "patterns": [
         {
           "include": "text.tex#math"

--- a/syntax/TeX.tmLanguage.json
+++ b/syntax/TeX.tmLanguage.json
@@ -93,7 +93,7 @@
           "name": "punctuation.definition.string.end.tex"
         }
       },
-      "name": "support.class.math.block.tex",
+      "name": "meta.math.block.tex support.class.math.block.tex",
       "patterns": [
         {
           "match": "\\\\\\$",

--- a/syntax/TeX.tmLanguage.json
+++ b/syntax/TeX.tmLanguage.json
@@ -117,7 +117,7 @@
           "name": "punctuation.definition.function.tex"
         }
       },
-      "match": "(\\\\)[A-Za-z@]+",
+      "match": "(\\\\)[A-Za-z@,;]+",
       "name": "support.function.general.tex"
     },
     {

--- a/syntax/TeX.tmLanguage.json
+++ b/syntax/TeX.tmLanguage.json
@@ -236,6 +236,10 @@
         {
           "match": "«press a-z and space for greek letter»[a-zA-Z]*",
           "name": "meta.placeholder.greek.math.tex"
+        },
+        {
+          "match": "[\\+\\*/_\\^-]",
+          "name": "punctuation.math.operator.latex"
         }
       ]
     },


### PR DESCRIPTION
**Warning: This is PR must not be merged.** It is basically intended for discussing scope names. 

This PR is related to #2126. 

The commit messages should be sufficiently self explanatory to make clear what the changes are.

The most noticeable change is that math text is no special highlighting anymore. This is induced by the use of `meta.math` instead of `support.class.math`.

Before: 
![Capture d’écran 2020-07-02 à 15 18 16](https://user-images.githubusercontent.com/2910140/86363559-51ef7880-bc77-11ea-8d11-75699619db37.png)

After: 
![Capture d’écran 2020-07-02 à 15 18 02](https://user-images.githubusercontent.com/2910140/86363574-561b9600-bc77-11ea-9ada-2d0e2746d1c0.png)

