### PR TITLE
Add command to toggle autobuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -329,6 +329,11 @@
         "category": "LaTeX Workshop"
       },
       {
+        "command": "latex-workshop.toggleAutoBuild",
+        "title": "Toggle autobuild configuration",
+        "category": "LaTeX Workshop"
+      },
+      {
         "command": "latex-workshop.synctex",
         "title": "SyncTeX from cursor",
         "category": "LaTeX Workshop"

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -206,6 +206,11 @@ export class Commander {
         this.extension.builder.kill()
     }
 
+    toggleAutoBuild() {
+        const enabled = this.extension.manager.toggleAutoBuild()
+        vscode.window.showInformationMessage(`LaTeX Workshop AutoBuild is ${enabled ? 'enabled' : 'disabled'}.`)
+    }
+
     pdf(uri: vscode.Uri | undefined) {
         this.extension.logger.addLogMessage('PDF command invoked.')
         if (uri === undefined || !uri.fsPath.endsWith('.pdf')) {

--- a/src/components/commander.ts
+++ b/src/components/commander.ts
@@ -21,6 +21,7 @@ export class LaTeXCommander implements vscode.TreeDataProvider<LaTeXCommand> {
         const recipes = configuration.get('latex.recipes') as {name: string}[]
         buildCommand.children.push(new LaTeXCommand('Clean up auxiliary files', None, {command: 'latex-workshop.clean', title: ''}, 'clear-all'))
         buildCommand.children.push(new LaTeXCommand('Terminate current compilation', None, {command: 'latex-workshop.kill', title: ''}, 'debug-stop'))
+        buildCommand.children.push(new LaTeXCommand('Toggle autobuild', None, {command: 'latex-workshop.toggleAutoBuild', title: ''}, 'clock'))
         if (recipes) {
             recipes.forEach(recipe => {
                 buildCommand.children.push(new LaTeXCommand(`Recipe: ${recipe.name}`, None, {command: 'latex-workshop.recipes', title: '', arguments: [recipe.name]}, 'debug-start'))

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -52,6 +52,11 @@ interface Content {
     }
 }
 
+const enum BuildEvents {
+    never = 'never',
+    onFileChange = 'onFileChange'
+}
+
 export class Manager {
     /**
      * The content cache for each LaTeX file.
@@ -870,7 +875,7 @@ export class Manager {
 
     private buildOnFileChanged(file: string, bibChanged: boolean = false) {
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
-        if (configuration.get('latex.autoBuild.run') as string !== 'onFileChange') {
+        if (configuration.get('latex.autoBuild.run') as BuildEvents !== BuildEvents.onFileChange) {
             return
         }
         if (this.disableAutoBuild) {

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -70,6 +70,7 @@ export class Manager {
     private jlweaveExt: string[] = ['.jnw', '.jtexw']
     private weaveExt: string[] = []
     private pdfWatcherOptions: chokidar.WatchOptions
+    private disableAutoBuild: boolean = false
 
     constructor(extension: Extension) {
         this.extension = extension
@@ -861,9 +862,18 @@ export class Manager {
         }
     }
 
+    // This function toggles the autobuild state and returns whether autobuild is enabled.
+    toggleAutoBuild() {
+        this.disableAutoBuild = !this.disableAutoBuild
+        return !this.disableAutoBuild
+    }
+
     private buildOnFileChanged(file: string, bibChanged: boolean = false) {
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         if (configuration.get('latex.autoBuild.run') as string !== 'onFileChange') {
+            return
+        }
+        if (this.disableAutoBuild) {
             return
         }
         if (this.extension.builder.disableBuildAfterSave) {

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -75,7 +75,6 @@ export class Manager {
     private jlweaveExt: string[] = ['.jnw', '.jtexw']
     private weaveExt: string[] = []
     private pdfWatcherOptions: chokidar.WatchOptions
-    private disableAutoBuild: boolean = false
 
     constructor(extension: Extension) {
         this.extension = extension
@@ -869,16 +868,20 @@ export class Manager {
 
     // This function toggles the autobuild state and returns whether autobuild is enabled.
     toggleAutoBuild() {
-        this.disableAutoBuild = !this.disableAutoBuild
-        return !this.disableAutoBuild
+        const configuration = vscode.workspace.getConfiguration('latex-workshop')
+        const oldState = configuration.get('latex.autoBuild.run') as BuildEvents
+        if (oldState === BuildEvents.onFileChange) {
+            configuration.update('latex.autoBuild.run', BuildEvents.never)
+            return false
+        } else {
+            configuration.update('latex.autoBuild.run', BuildEvents.onFileChange)
+            return true
+        }
     }
 
     private buildOnFileChanged(file: string, bibChanged: boolean = false) {
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         if (configuration.get('latex.autoBuild.run') as BuildEvents !== BuildEvents.onFileChange) {
-            return
-        }
-        if (this.disableAutoBuild) {
             return
         }
         if (this.extension.builder.disableBuildAfterSave) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -70,6 +70,7 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('latex-workshop.refresh-viewer', () => extension.commander.refresh())
     vscode.commands.registerCommand('latex-workshop.tab', () => extension.commander.view('tab'))
     vscode.commands.registerCommand('latex-workshop.kill', () => extension.commander.kill())
+    vscode.commands.registerCommand('latex-workshop.toggleAutoBuild', () => extension.commander.toggleAutoBuild())
     vscode.commands.registerCommand('latex-workshop.synctex', () => extension.commander.synctex())
     vscode.commands.registerCommand('latex-workshop.texdoc', (pkg) => extension.commander.texdoc(pkg))
     vscode.commands.registerCommand('latex-workshop.texdocUsepackages', () => extension.commander.texdocUsepackages())


### PR DESCRIPTION
Hi everyone,

This PR adds a new command `latex-workshop.toggleAutoBuild` which can temporarily disable (and re-enable) the auto build functionality.

The feature can be useful when someone has a bunch of modifications to apply in a large LaTeX project. He/she may need to temporarily disable the auto build feature until he/she has finished all the modifications.

Hope this helps. :)
