### PR TITLE
Add a command to select the full content of the current environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -267,6 +267,11 @@
         "category": "LaTeX Workshop"
       },
       {
+        "command": "latex-workshop.select-env",
+        "title": "Select the current environment content",
+        "category": "LaTeX Workshop"
+      },
+      {
         "command": "latex-workshop.multicursor-envname",
         "title": "Add a multicursor to the current environment name",
         "category": "LaTeX Workshop"

--- a/package.json
+++ b/package.json
@@ -267,7 +267,7 @@
         "category": "LaTeX Workshop"
       },
       {
-        "command": "latex-workshop.select-env",
+        "command": "latex-workshop.select-envcontent",
         "title": "Select the current environment content",
         "category": "LaTeX Workshop"
       },

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -351,7 +351,7 @@ export class Commander {
         if (!vscode.window.activeTextEditor || !this.extension.manager.hasTexId(vscode.window.activeTextEditor.document.languageId)) {
             return
         }
-        this.extension.envPair.envAction('selection')
+        this.extension.envPair.envNameAction('selection')
     }
 
     multiCursorEnvName() {
@@ -359,7 +359,7 @@ export class Commander {
         if (!vscode.window.activeTextEditor || !this.extension.manager.hasTexId(vscode.window.activeTextEditor.document.languageId)) {
             return
         }
-        this.extension.envPair.envAction('cursor')
+        this.extension.envPair.envNameAction('cursor')
     }
 
     toggleEquationEnv() {
@@ -367,7 +367,7 @@ export class Commander {
         if (!vscode.window.activeTextEditor || !this.extension.manager.hasTexId(vscode.window.activeTextEditor.document.languageId)) {
             return
         }
-        this.extension.envPair.envAction('equationToggle')
+        this.extension.envPair.envNameAction('equationToggle')
     }
 
     closeEnv() {

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -346,7 +346,7 @@ export class Commander {
         this.extension.envPair.gotoPair()
     }
 
-    selectEnv() {
+    selectEnvContent() {
         this.extension.logger.addLogMessage('SelectEnv command invoked.')
         if (!vscode.window.activeTextEditor || !this.extension.manager.hasTexId(vscode.window.activeTextEditor.document.languageId)) {
             return

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -346,6 +346,14 @@ export class Commander {
         this.extension.envPair.gotoPair()
     }
 
+    selectEnv() {
+        this.extension.logger.addLogMessage('SelectEnv command invoked.')
+        if (!vscode.window.activeTextEditor || !this.extension.manager.hasTexId(vscode.window.activeTextEditor.document.languageId)) {
+            return
+        }
+        this.extension.envPair.selectEnv()
+    }
+
     selectEnvName() {
         this.extension.logger.addLogMessage('SelectEnvName command invoked.')
         if (!vscode.window.activeTextEditor || !this.extension.manager.hasTexId(vscode.window.activeTextEditor.document.languageId)) {

--- a/src/components/commander.ts
+++ b/src/components/commander.ts
@@ -43,6 +43,7 @@ export class LaTeXCommander implements vscode.TreeDataProvider<LaTeXCommand> {
         this.commands.push(navCommand)
         navCommand.children.push(new LaTeXCommand('SyncTeX from cursor', vscode.TreeItemCollapsibleState.None, {command: 'latex-workshop.synctex', title: ''}))
         navCommand.children.push(new LaTeXCommand('Navigate to matching begin/end', vscode.TreeItemCollapsibleState.None, {command: 'latex-workshop.navigate-envpair', title: ''}))
+        navCommand.children.push(new LaTeXCommand('Select current environment content', vscode.TreeItemCollapsibleState.None, {command: 'latex-workshop.select-env', title: ''}))
         navCommand.children.push(new LaTeXCommand('Select current environment name', vscode.TreeItemCollapsibleState.None, {command: 'latex-workshop.select-envname', title: ''}))
         navCommand.children.push(new LaTeXCommand('Close current environment', vscode.TreeItemCollapsibleState.None, {command: 'latex-workshop.close-env', title: ''}))
         navCommand.children.push(new LaTeXCommand('Surround with begin{}...\\end{}', vscode.TreeItemCollapsibleState.None, {command: 'latex-workshop.wrap-env', title: ''}))

--- a/src/components/commander.ts
+++ b/src/components/commander.ts
@@ -43,7 +43,7 @@ export class LaTeXCommander implements vscode.TreeDataProvider<LaTeXCommand> {
         this.commands.push(navCommand)
         navCommand.children.push(new LaTeXCommand('SyncTeX from cursor', vscode.TreeItemCollapsibleState.None, {command: 'latex-workshop.synctex', title: ''}))
         navCommand.children.push(new LaTeXCommand('Navigate to matching begin/end', vscode.TreeItemCollapsibleState.None, {command: 'latex-workshop.navigate-envpair', title: ''}))
-        navCommand.children.push(new LaTeXCommand('Select current environment content', vscode.TreeItemCollapsibleState.None, {command: 'latex-workshop.select-env', title: ''}))
+        navCommand.children.push(new LaTeXCommand('Select current environment content', vscode.TreeItemCollapsibleState.None, {command: 'latex-workshop.select-envcontent', title: ''}))
         navCommand.children.push(new LaTeXCommand('Select current environment name', vscode.TreeItemCollapsibleState.None, {command: 'latex-workshop.select-envname', title: ''}))
         navCommand.children.push(new LaTeXCommand('Close current environment', vscode.TreeItemCollapsibleState.None, {command: 'latex-workshop.close-env', title: ''}))
         navCommand.children.push(new LaTeXCommand('Surround with begin{}...\\end{}', vscode.TreeItemCollapsibleState.None, {command: 'latex-workshop.wrap-env', title: ''}))

--- a/src/components/envpair.ts
+++ b/src/components/envpair.ts
@@ -170,7 +170,7 @@ export class EnvPair {
      *      - 'cursor': a multicursor is added at the beginning of the environment name is selected both in the begin and end part
      *      - 'equationToggle': toggles between `\[...\]` and `\begin{}...\end{}`
      */
-    envAction(action: 'selection'|'cursor'|'equationToggle') {
+    envNameAction(action: 'selection'|'cursor'|'equationToggle') {
         const editor = vscode.window.activeTextEditor
         if (!editor || editor.document.languageId !== 'latex') {
             return

--- a/src/main.ts
+++ b/src/main.ts
@@ -83,7 +83,7 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('latex-workshop.code-action', (d, r, c, m) => extension.codeActions.runCodeAction(d, r, c, m))
     vscode.commands.registerCommand('latex-workshop.goto-section', (filePath, lineNumber) => extension.commander.gotoSection(filePath, lineNumber))
     vscode.commands.registerCommand('latex-workshop.navigate-envpair', () => extension.commander.navigateToEnvPair())
-    vscode.commands.registerCommand('latex-workshop.select-env', () => extension.commander.selectEnv())
+    vscode.commands.registerCommand('latex-workshop.select-envcontent', () => extension.commander.selectEnvContent())
     vscode.commands.registerCommand('latex-workshop.select-envname', () => extension.commander.selectEnvName())
     vscode.commands.registerCommand('latex-workshop.multicursor-envname', () => extension.commander.multiCursorEnvName())
     vscode.commands.registerCommand('latex-workshop.toggle-equation-envname', () => extension.commander.toggleEquationEnv())

--- a/src/main.ts
+++ b/src/main.ts
@@ -83,6 +83,7 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('latex-workshop.code-action', (d, r, c, m) => extension.codeActions.runCodeAction(d, r, c, m))
     vscode.commands.registerCommand('latex-workshop.goto-section', (filePath, lineNumber) => extension.commander.gotoSection(filePath, lineNumber))
     vscode.commands.registerCommand('latex-workshop.navigate-envpair', () => extension.commander.navigateToEnvPair())
+    vscode.commands.registerCommand('latex-workshop.select-env', () => extension.commander.selectEnv())
     vscode.commands.registerCommand('latex-workshop.select-envname', () => extension.commander.selectEnvName())
     vscode.commands.registerCommand('latex-workshop.multicursor-envname', () => extension.commander.multiCursorEnvName())
     vscode.commands.registerCommand('latex-workshop.toggle-equation-envname', () => extension.commander.toggleEquationEnv())


### PR DESCRIPTION
Calling the new command `latex-workshop.select-envcontent` selects both the content of the environment and the begin/end statements. The pairs`\[...\]`  and `\(...\)` are considered as environments. Repeated calls select the outer environments.

See https://github.com/James-Yu/LaTeX-Workshop/wiki/Environments#navigating-and-selecting

Related to #1901
