### PR TITLE
Refactor and add above/below to view.pdf.tab.editorGroup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1166,13 +1166,17 @@
           "enum": [
             "current",
             "left",
-            "right"
+            "right",
+            "above",
+            "below"
           ],
           "markdownDescription": "The editor group in which to open the tab viewer.",
           "enumDescriptions": [
             "Use the current editor group",
             "Put the viewer tab in a new group on the left of the current one",
-            "Put the viewer tab in a new group on the right of the current one"
+            "Put the viewer tab in a new group on the right of the current one",
+            "Put the viewer tab in a new group above the current one",
+            "Put the viewer tab in a new group below the current one"
           ]
         },
         "latex-workshop.view.pdf.ref.viewer": {

--- a/src/components/viewer.ts
+++ b/src/components/viewer.ts
@@ -203,7 +203,7 @@ export class Viewer {
      * @param respectOutDir
      * @param tabEditorGroup
      */
-    openTab(sourceFile: string, respectOutDir: boolean = true, tabEditorGroup: string) {
+    async openTab(sourceFile: string, respectOutDir: boolean = true, tabEditorGroup: string) {
         const url = this.checkViewer(sourceFile, respectOutDir)
         if (!url) {
             return
@@ -217,25 +217,32 @@ export class Viewer {
         if (editor) {
             // We need to turn the viewer into the active editor to move it to an other editor group
             panel.webviewPanel.reveal(undefined, false)
+            let focusAction: string | undefined
             switch (tabEditorGroup) {
                 case 'left':
-                    vscode.commands.executeCommand('workbench.action.moveEditorToLeftGroup')
+                    await vscode.commands.executeCommand('workbench.action.moveEditorToLeftGroup')
+                    focusAction = 'workbench.action.focusRightGroup'
                     break
                 case 'right':
-                    vscode.commands.executeCommand('workbench.action.moveEditorToRightGroup')
+                    await vscode.commands.executeCommand('workbench.action.moveEditorToRightGroup')
+                    focusAction = 'workbench.action.focusLeftGroup'
                     break
                 case 'above':
-                    vscode.commands.executeCommand('workbench.action.moveEditorToAboveGroup')
+                    await vscode.commands.executeCommand('workbench.action.moveEditorToAboveGroup')
+                    focusAction = 'workbench.action.focusBelowGroup'
                     break
                 case 'below':
-                    vscode.commands.executeCommand('workbench.action.moveEditorToBelowGroup')
+                    await vscode.commands.executeCommand('workbench.action.moveEditorToBelowGroup')
+                    focusAction = 'workbench.action.focusAboveGroup'
                     break
                 default:
                     break
             }
             // Then, we set the focus back to the .tex file
             setTimeout(async () => {
-                await vscode.window.showTextDocument(editor.document, undefined, false)
+                if (focusAction ) {
+                    await vscode.commands.executeCommand(focusAction)
+                }
             }, 500)
         }
         this.extension.logger.addLogMessage(`Open PDF tab for ${pdfFile}`)

--- a/src/components/viewer.ts
+++ b/src/components/viewer.ts
@@ -215,7 +215,7 @@ export class Viewer {
             return
         }
         if (editor) {
-            // We need to make the viewer the active editor to move it to an other editor group
+            // We need to turn the viewer into the active editor to move it to an other editor group
             panel.webviewPanel.reveal(undefined, false)
             switch (tabEditorGroup) {
                 case 'left':

--- a/src/components/viewer.ts
+++ b/src/components/viewer.ts
@@ -244,6 +244,7 @@ export class Viewer {
                 if (focusAction ) {
                     await vscode.commands.executeCommand(focusAction)
                 }
+                await vscode.window.showTextDocument(editor.document, vscode.ViewColumn.Active)
             }, 500)
         }
         this.extension.logger.addLogMessage(`Open PDF tab for ${pdfFile}`)


### PR DESCRIPTION
This PR adds two new positions for the viewer tab: `above` and `below`.

This PR changes how to handle the viewer placement. So far, a new editor group was created to hold the viewer and then we tried to fiddle with the group placement. Now, we create the viewer in the same group as the `.tex` file and we rely on vscode internal functions to move the viewer. This leads to a far more robust placement when several there are editor groups.

Close #2200