### PR TITLE
Enable `latex-workshop.surround` on the Command Palette.

### DIFF
--- a/package.json
+++ b/package.json
@@ -282,6 +282,11 @@
         "category": "LaTeX Workshop"
       },
       {
+        "command": "latex-workshop.surround",
+        "title": "Surround selection with LaTeX command",
+        "category": "LaTeX Workshop"
+      },
+      {
         "command": "latex-workshop.close-env",
         "title": "Close current environment",
         "category": "LaTeX Workshop"


### PR DESCRIPTION
Enable `latex-workshop.surround` on the Command Palette, which makes us free from remembering the shortcut.