### PR TITLE
Fix XML & HTML scopes

### DIFF
--- a/package.json
+++ b/package.json
@@ -183,7 +183,7 @@
           "source.ruby": "ruby",
           "source.scala": "scala",
           "source.ts": "typescript",
-          "text.xtml": "xtml",
+          "text.xml": "xml",
           "source.yaml": "yaml"
         }
       },

--- a/syntax/LaTeX.tmLanguage.json
+++ b/syntax/LaTeX.tmLanguage.json
@@ -305,10 +305,10 @@
               ]
             }
           },
-          "contentName": "yaml.xml",
+          "contentName": "source.xml",
           "patterns": [
             {
-              "include": "yaml.xml"
+              "include": "source.xml"
             }
           ],
           "end": "(\\\\end\\{minted\\})"

--- a/syntax/LaTeX.tmLanguage.json
+++ b/syntax/LaTeX.tmLanguage.json
@@ -305,10 +305,10 @@
               ]
             }
           },
-          "contentName": "source.xml",
+          "contentName": "text.xml",
           "patterns": [
             {
-              "include": "source.xml"
+              "include": "text.xml"
             }
           ],
           "end": "(\\\\end\\{minted\\})"

--- a/syntax/LaTeX.tmLanguage.json
+++ b/syntax/LaTeX.tmLanguage.json
@@ -175,7 +175,7 @@
           "contentName": "text.html",
           "patterns": [
             {
-              "include": "text.html"
+              "include": "text.html.basic"
             }
           ],
           "end": "(\\\\end\\{minted\\})"


### PR DESCRIPTION
`LaTeX.tmLanguage.json` is referring to incorrect scope for XML. Correct XML scope is `"source.xml"`.

Also, `package.json` lists `"source.xtml": "xtml"` but there's no reference for `xtml` inside `LaTeX.tmLanguage.json`. Embedded language should be `"source.xml": "xml"`