### PR TITLE
Improve support for LaTeX fenced code block in Markdown

### DIFF
--- a/syntax/latexblock.json
+++ b/syntax/latexblock.json
@@ -9,7 +9,7 @@
 	],
 	"repository": {
 		"fenced_code_block_latex": {
-			"begin": "(^|\\G)(\\s*)(`{3,}|~{3,})\\s*(latex)\\s*(?:\\{[^\\{\\}]*\\})?\\s*$",
+			"begin": "(^|\\G)(\\s*)(`{3,}|~{3,})\\s*(?i:(latex)((\\s+|:|\\{)[^`~]*)?$)",
 			"name": "markup.fenced_code.block.markdown",
 			"end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
 			"beginCaptures": {
@@ -17,7 +17,10 @@
 						"name": "punctuation.definition.markdown"
 				},
 				"4": {
-						"name": "fenced_code.block.language"
+					"name": "fenced_code.block.language.markdown"
+				},
+				"5": {
+					"name": "fenced_code.block.language.attributes.markdown"
 				}
 			},
 			"endCaptures": {


### PR DESCRIPTION
## Summary

There are various extensions to fenced code blocks in Markdown. This PR adds support for more kinds of them according to VS Code's implementation.

## References

* <https://github.com/microsoft/vscode/blob/1cd126f9afe24923441aeeba46a5650c9de34dd2/extensions/markdown-basics/syntaxes/markdown.tmLanguage.json#L197-L229>
* <https://github.com/mjbvz/vscode-fenced-code-block-grammar-injection-example/blob/e333677e840fd28f382935650553736aaebc2207/syntaxes/codeblock.json>
* <https://macromates.com/manual/en/language_grammars#naming_conventions>