### PR TITLE
Use the polyfilled version of pdfjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1936,7 +1936,7 @@
     "compile": "tsc -p tsconfig.json && tsc -p viewer/tsconfig.json",
     "lint": "eslint --cache --ext .ts,.js .",
     "lint:fix": "eslint --fix --cache --ext .ts,.js .",
-    "release": "npm run clean && npm run lint && npm run compile && vsce package",
+    "release": "cp -r node_modules/pdfjs-dist/es5/build/ node_modules/pdfjs-dist && npm run clean && npm run lint && npm run compile && vsce package",
     "test": "node ./out/test/runTest.js",
     "watch": "run-p watch-src watch-viewer",
     "watch-src": "tsc -watch -p tsconfig.json",


### PR DESCRIPTION
In `PDF.js v2.4.456`, the default `pdf.js` is changed to non-ployfilled version to cater with modern browsers. However, nodejs does not have several necessary polyfills implemented to support the pdf viewer used in the extension.

When using WSL/SSH remote, the extension essentially cannot work due to unknown causes which lead to the use of non-ployfilled version, even all references were pointing to `es5/build` instead of `build`. Therefore, this PR propose a somehow dirty but effective workaround by replacing the non-polyfilled pdf.js with the polyfilled one. I believe this won't cause any issues, and the performance impact shall be minuscule if not nothing.