### PR TITLE
CSP: Allow websocket connections from 'self'

### DIFF
--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -26,7 +26,7 @@ See https://github.com/adobe-type-tools/cmap-resources
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <meta name="google" content="notranslate">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-eval'; connect-src 'self' ws://localhost:* ws://127.0.0.1:*; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-eval'; connect-src 'self' ws:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:;">
     <title>PDF.js viewer</title>
 
     <!--


### PR DESCRIPTION
For reasons (TM), I would like to view the browser preview on another device than the one that VS Code is running on.
As far as I see, this is not supported per se (or am I overlooking something?) - anyway, I got the basics working using a reverse proxy on the VS Code machine.

However, when using Safari for the preview page on the other device, synctex is not working and the following error is produced:
```
Refused to connect to ws://foobar.local:8010/ because it does not appear in the connect-src directive of the Content Security Policy.
```

I was able to remove the error and get syntax working by removing the restriction that websocket connections are only allowed from `127.0.0.1` and `localhost`. 
Note that this **does not** allow websocket connections to arbitrary host, but only to the ones specified in `connect-src`, so in this case only to `self` 👍 