### PR TITLE
Stop using unnecessary promises.

### DIFF
--- a/src/components/commander.ts
+++ b/src/components/commander.ts
@@ -76,12 +76,12 @@ export class LaTeXCommander implements vscode.TreeDataProvider<LaTeXCommand> {
         return treeItem
     }
 
-    getChildren(element?: LaTeXCommand): Thenable<LaTeXCommand[]> {
+    getChildren(element?: LaTeXCommand): LaTeXCommand[] {
         if (!element) {
-            return Promise.resolve(this.commands)
+            return this.commands
         }
 
-        return Promise.resolve(element.children)
+        return element.children
     }
 }
 

--- a/src/providers/bibtexcompletion.ts
+++ b/src/providers/bibtexcompletion.ts
@@ -101,21 +101,18 @@ export class BibtexCompleter implements vscode.CompletionItemProvider {
         return suggestions
     }
 
-    provideCompletionItems(document: vscode.TextDocument, position: vscode.Position, _token: vscode.CancellationToken, _context: vscode.CompletionContext): Promise<vscode.CompletionItem[]> {
-        return new Promise((resolve, _reject) => {
-            const currentLine = document.lineAt(position.line).text
-            const prevLine = document.lineAt(position.line - 1).text
-            if (currentLine.match(/@[a-zA-Z]*$/)) {
-                // Complete an entry name
-                resolve(this.entryItems)
-                return
-            } else if (currentLine.match(/^\s*[a-zA-Z]*/) && prevLine.match(/(?:@[a-zA-Z]{)|(?:["}0-9],\s*$)/)) {
-                // Add optional fields
-                const optFields = this.provideOptFields(document, position)
-                resolve(optFields)
-            }
-            resolve()
-        })
+    provideCompletionItems(document: vscode.TextDocument, position: vscode.Position): vscode.CompletionItem[] | undefined {
+        const currentLine = document.lineAt(position.line).text
+        const prevLine = document.lineAt(position.line - 1).text
+        if (currentLine.match(/@[a-zA-Z]*$/)) {
+            // Complete an entry name
+            return this.entryItems
+        } else if (currentLine.match(/^\s*[a-zA-Z]*/) && prevLine.match(/(?:@[a-zA-Z]{)|(?:["}0-9],\s*$)/)) {
+            // Add optional fields
+            const optFields = this.provideOptFields(document, position)
+            return optFields
+        }
+        return
     }
 
     private provideOptFields(document: vscode.TextDocument, position: vscode.Position): vscode.CompletionItem[] {

--- a/src/providers/docsymbol.ts
+++ b/src/providers/docsymbol.ts
@@ -16,10 +16,8 @@ export class DocSymbolProvider implements vscode.DocumentSymbolProvider {
         })
     }
 
-    public provideDocumentSymbols(document: vscode.TextDocument): Promise<vscode.DocumentSymbol[]> {
-        return new Promise((resolve, _reject) => {
-            resolve(this.sectionToSymbols(this.extension.structureProvider.buildModel(document.fileName, undefined, undefined, undefined, undefined, false)))
-        })
+    provideDocumentSymbols(document: vscode.TextDocument): vscode.DocumentSymbol[] {
+        return this.sectionToSymbols(this.extension.structureProvider.buildModel(document.fileName, undefined, undefined, undefined, undefined, false))
     }
 
     private sectionToSymbols(sections: Section[]): vscode.DocumentSymbol[] {

--- a/src/providers/projectsymbol.ts
+++ b/src/providers/projectsymbol.ts
@@ -10,17 +10,13 @@ export class ProjectSymbolProvider implements vscode.WorkspaceSymbolProvider {
         this.extension = extension
     }
 
-    public provideWorkspaceSymbols(_query: string, _token: vscode.CancellationToken):
-        Thenable<vscode.SymbolInformation[]> {
-        return new Promise((resolve, _reject) => {
-            const symbols: vscode.SymbolInformation[] = []
-            if (this.extension.manager.rootFile === undefined) {
-                resolve(symbols)
-                return
-            }
-            this.sectionToSymbols(symbols, this.extension.structureProvider.buildModel(this.extension.manager.rootFile))
-            resolve(symbols)
-        })
+    provideWorkspaceSymbols(): vscode.SymbolInformation[] {
+        const symbols: vscode.SymbolInformation[] = []
+        if (this.extension.manager.rootFile === undefined) {
+            return symbols
+        }
+        this.sectionToSymbols(symbols, this.extension.structureProvider.buildModel(this.extension.manager.rootFile))
+        return symbols
     }
 
     private sectionToSymbols(symbols: vscode.SymbolInformation[], sections: Section[], containerName: string = 'Document') {

--- a/src/providers/structure.ts
+++ b/src/providers/structure.ts
@@ -277,24 +277,24 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
         return treeItem
     }
 
-    getChildren(element?: Section): Thenable<Section[]> {
+    getChildren(element?: Section): Section[] {
         if (this.extension.manager.rootFile === undefined) {
-            return Promise.resolve([])
+            return []
         }
         // if the root doesn't exist, we need
         // to explicitly build the model from disk
         if (!element) {
-            return Promise.resolve(this.refresh())
+            return this.refresh()
         }
 
-        return Promise.resolve(element.children)
+        return element.children
     }
 
-    getParent(element?: Section): Thenable<Section | undefined> {
+    getParent(element?: Section): Section | undefined {
         if (this.extension.manager.rootFile === undefined || !element) {
-            return Promise.resolve(undefined)
+            return undefined
         }
-        return Promise.resolve(element.parent)
+        return element.parent
     }
 
     getCaptionOrTitle(lines: string[], env: {name: string, start: number, end: number}) {


### PR DESCRIPTION
Stop using unnecessary promises. We should avoid using it if possible.

Since TypeScript 4.1, the type of `resolve` gets stricter. See https://github.com/microsoft/TypeScript/pull/40466.