### PR TITLE
Tweak the transition of the toolbar of the PDF viewer.

### DIFF
--- a/viewer/latexworkshop.css
+++ b/viewer/latexworkshop.css
@@ -67,11 +67,12 @@ html #outerContainer.sidebarOpen > #sidebarContainer {
 .toolbar {
     position: absolute;
     top: 0;
-    transition: all 0.4s;
+    transition: all 0.2s cubic-bezier(.23,.96,.57,.99);
 }
 
 .toolbar.hide {
     top: -32px;
+    transition-duration: 0.4s;
 }
 
 .toolbar.hide:hover {


### PR DESCRIPTION
Tweak the transition of the toolbar of the PDF viewer.

Before:

![Sep-19-2020 15-31-23](https://user-images.githubusercontent.com/10665499/93660764-341efc00-fa8d-11ea-842f-b998f4581b55.gif)


After:

![Sep-19-2020 15-30-15](https://user-images.githubusercontent.com/10665499/93660759-1356a680-fa8d-11ea-93c4-6da795b396c7.gif)

ref https://cubic-bezier.com/#.23,.96,.57,.99