### PR TITLE
Fix \textins command completion

### DIFF
--- a/data/packages/csquotes_cmd.json
+++ b/data/packages/csquotes_cmd.json
@@ -234,10 +234,15 @@
     "package": "csquotes",
     "snippet": "textelp*{${1:text}}"
   },
-  "textins{}\\textins*{}": {
-    "command": "textins{text} \\textins*{text}",
+  "textins{}": {
+    "command": "textins{text}",
     "package": "csquotes",
-    "snippet": "textins{${1:text}} \\textins*{${2:text}}"
+    "snippet": "textins{${1:text}}"
+  },
+  "textins*{}": {
+    "command": "textins*{text}",
+    "package": "csquotes",
+    "snippet": "textins*{${1:text}}"
   },
   "DeclareQuoteStyle[]{}[][]{}[]{}[]{}[]{}": {
     "command": "DeclareQuoteStyle[variant]{style}[outer init][inner init]{opening outer mark}[middle outer mark]{closing outer mark}[kern]{opening inner mark}[middle inner mark]{closing inner mark}",


### PR DESCRIPTION
There existed a small error in the cwl leading to a wrongly generated completion for the `\textins` command. Since this is now fixed in the upstream repo I think it should also be fixed here.