### PR TITLE
Support real-time math preview panel.

### DIFF
--- a/package.json
+++ b/package.json
@@ -457,9 +457,24 @@
         "command": "latex-workshop.bibalignsort",
         "title": "Sort and align BibTeX file",
         "category": "LaTeX Workshop"
+      },
+      {
+        "command": "latex-workshop.openMathPreviewPanel",
+        "title": "Open Math Preview Panel",
+        "category": "LaTeX Workshop"
+      },
+      {
+        "command": "latex-workshop.closeMathPreviewPanel",
+        "title": "Close Math Preview Panel",
+        "category": "LaTeX Workshop"
       }
     ],
     "keybindings": [
+      {
+        "key": "ctrl+alt+m",
+        "mac": "cmd+alt+m",
+        "command": "latex-workshop.openMathPreviewPanel"
+      },
       {
         "key": "ctrl+l alt+b",
         "mac": "cmd+l alt+b",
@@ -1892,6 +1907,25 @@
           "type": "boolean",
           "default": false,
           "markdownDescription": "Sort content when calling VSCode format on a .bib file."
+        },
+        "latex-workshop.mathpreviewpanel.editorGroup": {
+          "type": "string",
+          "default": "below",
+          "enum": [
+            "current",
+            "left",
+            "right",
+            "above",
+            "below"
+          ],
+          "markdownDescription": "The editor group in which to open the math preview panel.",
+          "enumDescriptions": [
+            "Use the current editor group",
+            "Put the math preview panel in a new group on the left of the current one",
+            "Put the math preview panel in a new group on the right of the current one",
+            "Put the math preview panel in a new group above the current one",
+            "Put the math preview panel in a new group below the current one"
+          ]
         }
       }
     },

--- a/resources/mathpreviewpanel/mathpreview.js
+++ b/resources/mathpreviewpanel/mathpreview.js
@@ -1,28 +1,15 @@
 const vscode = acquireVsCodeApi();
 const img = document.getElementById('math');
-img.addEventListener('load', () => {
-  const mathBlock = document.getElementById('mathBlock');
-  mathBlock.style.height = window.innerHeight + 'px';
-  img.style.top = (window.innerHeight - img.height) / 2 + 'px';
-  if (img.width >= window.innerWidth) {
-    img.style.left = '0px';
-  } else {
-    const leftRatio = 0.5;
-    img.style.left = (window.innerWidth - img.width) * leftRatio + 'px';
-    window.addEventListener('resize', () => {
-      img.style.left = (window.innerWidth - img.width) * leftRatio + 'px';
-    })
-  }
-  img.style.visibility = 'visible';
-});
 window.addEventListener('message', event => {
-  const message = event.data; // The JSON data our extension sent
+  const message = event.data;
   switch (message.type) {
-    case "mathImage":
+    case "mathImage": {
       img.src = message.src;
       break;
-    default:
+    }
+    default: {
       break;
+    }
   }
 });
 vscode.postMessage({type: 'initialized'});

--- a/resources/mathpreviewpanel/mathpreview.js
+++ b/resources/mathpreviewpanel/mathpreview.js
@@ -1,0 +1,28 @@
+const vscode = acquireVsCodeApi();
+const img = document.getElementById('math');
+img.addEventListener('load', () => {
+  const mathBlock = document.getElementById('mathBlock');
+  mathBlock.style.height = window.innerHeight + 'px';
+  img.style.top = (window.innerHeight - img.height) / 2 + 'px';
+  if (img.width >= window.innerWidth) {
+    img.style.left = '0px';
+  } else {
+    const leftRatio = 0.5;
+    img.style.left = (window.innerWidth - img.width) * leftRatio + 'px';
+    window.addEventListener('resize', () => {
+      img.style.left = (window.innerWidth - img.width) * leftRatio + 'px';
+    })
+  }
+  img.style.visibility = 'visible';
+});
+window.addEventListener('message', event => {
+  const message = event.data; // The JSON data our extension sent
+  switch (message.type) {
+    case "mathImage":
+      img.src = message.src;
+      break;
+    default:
+      break;
+  }
+});
+vscode.postMessage({type: 'initialized'});

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -631,4 +631,13 @@ export class Commander {
         await vscode.window.activeTextEditor.document.save()
         setTimeout(() => this.extension.builder.disableBuildAfterSave = false, 1000)
     }
+
+    openMathPreviewPanel() {
+        this.extension.mathPreviewPanel.open()
+    }
+
+    closeMathPreviewPanel() {
+        this.extension.mathPreviewPanel.close()
+    }
+
 }

--- a/src/components/mathpreviewpanel.ts
+++ b/src/components/mathpreviewpanel.ts
@@ -118,7 +118,6 @@ export class MathPreviewPanel {
                 #math {
                     padding-top: 35px;
                     padding-left: 50px;
-                    visibility: hidden;
                 }
             </style>
             <script src='${jsPathSrc}' defer></script>

--- a/src/components/mathpreviewpanel.ts
+++ b/src/components/mathpreviewpanel.ts
@@ -1,0 +1,155 @@
+import * as vscode from 'vscode'
+import * as path from 'path'
+import {MathPreview, TexMathEnv} from '../providers/preview/mathpreview'
+import {openWebviewPanel} from '../utils/webview'
+import type {Extension} from '../main'
+
+
+export class MathPreviewPanelSerializer implements vscode.WebviewPanelSerializer {
+    private readonly extension: Extension
+
+    constructor(extension: Extension) {
+        this.extension = extension
+    }
+
+    deserializeWebviewPanel(panel: vscode.WebviewPanel) {
+        this.extension.mathPreviewPanel.initializePanel(panel)
+        panel.webview.html = this.extension.mathPreviewPanel.getHtml(panel.webview)
+        return Promise.resolve()
+    }
+
+}
+
+export class MathPreviewPanel {
+    extension: Extension
+    mathPreview: MathPreview
+    panel?: vscode.WebviewPanel
+    prevDocumentUri?: string
+    prevCursorPosition?: vscode.Position
+    prevNewCommands?: string
+    mathPreviewPanelSerializer: MathPreviewPanelSerializer
+
+    constructor(extension: Extension) {
+        this.extension = extension
+        this.mathPreview = extension.mathPreview
+        this.mathPreviewPanelSerializer = new MathPreviewPanelSerializer(extension)
+    }
+
+    async open() {
+        if (this.panel) {
+            if (!this.panel.visible) {
+                this.panel.reveal(undefined, true)
+            }
+            return
+        }
+        const panel = vscode.window.createWebviewPanel(
+            'latex-workshop-mathpreview',
+            'Math Preview',
+            { viewColumn: vscode.ViewColumn.Active, preserveFocus: true },
+            { enableScripts: true, retainContextWhenHidden: true }
+        )
+        this.initializePanel(panel)
+        panel.webview.html = this.getHtml(panel.webview)
+        const configuration = vscode.workspace.getConfiguration('latex-workshop')
+        const editorGroup = configuration.get('mathpreviewpanel.editorGroup') as string
+        await openWebviewPanel(panel, editorGroup)
+        this.extension.mathPreview.getColor()
+        setTimeout(() => this.update(), 700)
+    }
+
+    initializePanel(panel: vscode.WebviewPanel) {
+        this.panel = panel
+        panel.onDidDispose(() => {
+            this.clearCache()
+            this.panel = undefined
+        })
+        panel.webview.onDidReceiveMessage(() => this.update())
+    }
+
+    close() {
+        this.panel?.dispose()
+        this.panel = undefined
+        this.clearCache()
+    }
+
+    clearCache() {
+        this.prevDocumentUri = undefined
+        this.prevCursorPosition = undefined
+        this.prevNewCommands = undefined
+    }
+
+    getHtml(webview: vscode.Webview) {
+        const jsPath = vscode.Uri.file(path.join(this.extension.extensionRoot, './resources/mathpreviewpanel/mathpreview.js'))
+        const jsPathSrc = webview.asWebviewUri(jsPath)
+        return `<!DOCTYPE html>
+        <html lang="en">
+        <head>
+            <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src ${webview.cspSource}; img-src data:; style-src 'unsafe-inline';">
+            <meta charset="UTF-8">
+            <style>
+                body {
+                    padding: 0;
+                    margin: 0;
+                }
+                #math {
+                    padding-top: 35px;
+                    padding-left: 50px;
+                    visibility: hidden;
+                }
+            </style>
+            <script src='${jsPathSrc}' defer></script>
+        </head>
+        <body>
+            <div id="mathBlock"><img src="" id="math" /></div>
+        </body>
+        </html>`
+    }
+
+    async update() {
+        if (!this.panel || !this.panel.visible) {
+            return
+        }
+        const editor = vscode.window.activeTextEditor
+        const document = editor?.document
+        if (!editor || document?.languageId !== 'latex') {
+            this.clearCache()
+            return
+        }
+        const documentUri = document.uri.toString()
+        const position = editor.selection.active
+        const texMath = this.getTexMath(document, position)
+        if (!texMath) {
+            this.clearCache()
+            return
+        }
+        let cachedCommands: string | undefined
+        if ( position.line === this.prevCursorPosition?.line && documentUri === this.prevDocumentUri ) {
+            cachedCommands = this.prevNewCommands
+        }
+        const {svgDataUrl, newCommands} = await this.mathPreview.generateSVG(document, texMath, cachedCommands)
+        this.prevDocumentUri = documentUri
+        this.prevNewCommands = newCommands
+        this.prevCursorPosition = position
+        return this.panel.webview.postMessage({type: 'mathImage', src: svgDataUrl })
+    }
+
+    getTexMath(document: vscode.TextDocument, position: vscode.Position) {
+        const texMath = this.mathPreview.findMathEnvIncludingPosition(document, position)
+        if (texMath) {
+            // this.renderCursor(document, texMath)
+            if (texMath.envname !== '$') {
+                return texMath
+            }
+            if (texMath.range.start.character !== position.character && texMath.range.end.character !== position.character) {
+                return texMath
+            }
+        }
+        return
+    }
+
+    renderCursor(document: vscode.TextDocument, tex: TexMathEnv) {
+        const s = this.mathPreview.renderCursor(document, tex.range)
+        tex.texString = s
+    }
+
+}

--- a/src/components/mathpreviewpanel.ts
+++ b/src/components/mathpreviewpanel.ts
@@ -51,6 +51,7 @@ export class MathPreviewPanel {
             }
             return
         }
+        this.mathPreview.getColor()
         const panel = vscode.window.createWebviewPanel(
             'latex-workshop-mathpreview',
             'Math Preview',
@@ -62,8 +63,6 @@ export class MathPreviewPanel {
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         const editorGroup = configuration.get('mathpreviewpanel.editorGroup') as string
         await openWebviewPanel(panel, editorGroup)
-        this.mathPreview.getColor()
-        setTimeout(() => this.update(), 700)
     }
 
     initializePanel(panel: vscode.WebviewPanel) {

--- a/src/components/mathpreviewpanel.ts
+++ b/src/components/mathpreviewpanel.ts
@@ -70,9 +70,6 @@ export class MathPreviewPanel {
     initializePanel(panel: vscode.WebviewPanel) {
         const disposable = vscode.Disposable.from(
             vscode.workspace.onDidChangeTextDocument( (event) => {
-                if (!this.extension.manager.hasTexId(event.document.languageId)) {
-                    return
-                }
                 this.extension.mathPreviewPanel.update({type: 'edit', event})
             }),
             vscode.window.onDidChangeTextEditorSelection( (event) => {
@@ -155,6 +152,9 @@ export class MathPreviewPanel {
             return
         }
         const documentUri = document.uri.toString()
+        if (ev?.type === 'edit' && documentUri !== ev.event.document.uri.toString()) {
+            return
+        }
         const position = editor.selection.active
         const texMath = this.getTexMath(document, position)
         if (!texMath) {

--- a/src/components/mathpreviewpanel.ts
+++ b/src/components/mathpreviewpanel.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode'
 import * as path from 'path'
-import {MathPreview, TexMathEnv} from '../providers/preview/mathpreview'
+import type {MathPreview, TexMathEnv} from '../providers/preview/mathpreview'
 import {openWebviewPanel} from '../utils/webview'
 import type {Extension} from '../main'
 

--- a/src/components/mathpreviewpanel.ts
+++ b/src/components/mathpreviewpanel.ts
@@ -165,11 +165,14 @@ export class MathPreviewPanel {
         if ( position.line === this.prevCursorPosition?.line && documentUri === this.prevDocumentUri ) {
             cachedCommands = this.prevNewCommands
         }
-        const {svgDataUrl, newCommands} = await this.mathPreview.generateSVG(document, texMath, cachedCommands)
+        const result = await this.mathPreview.generateSVG(document, texMath, cachedCommands).catch(() => undefined)
+        if (!result) {
+            return
+        }
         this.prevDocumentUri = documentUri
-        this.prevNewCommands = newCommands
+        this.prevNewCommands = result.newCommands
         this.prevCursorPosition = position
-        return this.panel.webview.postMessage({type: 'mathImage', src: svgDataUrl })
+        return this.panel.webview.postMessage({type: 'mathImage', src: result.svgDataUrl })
     }
 
     private getTexMath(document: vscode.TextDocument, position: vscode.Position) {

--- a/src/components/mathpreviewpanel.ts
+++ b/src/components/mathpreviewpanel.ts
@@ -21,13 +21,13 @@ export class MathPreviewPanelSerializer implements vscode.WebviewPanelSerializer
 }
 
 export class MathPreviewPanel {
-    extension: Extension
-    mathPreview: MathPreview
-    panel?: vscode.WebviewPanel
-    prevDocumentUri?: string
-    prevCursorPosition?: vscode.Position
-    prevNewCommands?: string
-    mathPreviewPanelSerializer: MathPreviewPanelSerializer
+    private readonly extension: Extension
+    private readonly mathPreview: MathPreview
+    private panel?: vscode.WebviewPanel
+    private prevDocumentUri?: string
+    private prevCursorPosition?: vscode.Position
+    private prevNewCommands?: string
+    readonly mathPreviewPanelSerializer: MathPreviewPanelSerializer
 
     constructor(extension: Extension) {
         this.extension = extension
@@ -53,7 +53,7 @@ export class MathPreviewPanel {
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         const editorGroup = configuration.get('mathpreviewpanel.editorGroup') as string
         await openWebviewPanel(panel, editorGroup)
-        this.extension.mathPreview.getColor()
+        this.mathPreview.getColor()
         setTimeout(() => this.update(), 700)
     }
 
@@ -72,7 +72,7 @@ export class MathPreviewPanel {
         this.clearCache()
     }
 
-    clearCache() {
+    private clearCache() {
         this.prevDocumentUri = undefined
         this.prevCursorPosition = undefined
         this.prevNewCommands = undefined
@@ -133,7 +133,7 @@ export class MathPreviewPanel {
         return this.panel.webview.postMessage({type: 'mathImage', src: svgDataUrl })
     }
 
-    getTexMath(document: vscode.TextDocument, position: vscode.Position) {
+    private getTexMath(document: vscode.TextDocument, position: vscode.Position) {
         const texMath = this.mathPreview.findMathEnvIncludingPosition(document, position)
         if (texMath) {
             // this.renderCursor(document, texMath)

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,6 +26,7 @@ import {CodeActions} from './providers/codeactions'
 import {HoverProvider} from './providers/hover'
 import {GraphicsPreview} from './providers/preview/graphicspreview'
 import {MathPreview} from './providers/preview/mathpreview'
+import {MathPreviewPanel} from './components/mathpreviewpanel'
 import {DocSymbolProvider} from './providers/docsymbol'
 import {ProjectSymbolProvider} from './providers/projectsymbol'
 import {SectionNodeProvider, StructureTreeView} from './providers/structure'
@@ -133,6 +134,9 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('latex-workshop.bibalign', () => extension.bibtexFormatter.bibtexFormat(false, true))
     vscode.commands.registerCommand('latex-workshop.bibalignsort', () => extension.bibtexFormatter.bibtexFormat(true, true))
 
+    vscode.commands.registerCommand('latex-workshop.openMathPreviewPanel', () => extension.commander.openMathPreviewPanel())
+    vscode.commands.registerCommand('latex-workshop.closeMathPreviewPanel', () => extension.commander.closeMathPreviewPanel())
+
     context.subscriptions.push(vscode.workspace.onDidSaveTextDocument( (e: vscode.TextDocument) => {
         if (extension.manager.hasTexId(e.languageId)) {
             extension.linter.lintRootFileIfEnabled()
@@ -192,6 +196,13 @@ export function activate(context: vscode.ExtensionContext) {
         }
     }))
 
+    context.subscriptions.push(vscode.workspace.onDidChangeTextDocument( () => {
+        extension.mathPreviewPanel.update()
+    }))
+    context.subscriptions.push(vscode.window.onDidChangeTextEditorSelection( () => {
+        extension.mathPreviewPanel.update()
+    }))
+
     let isLaTeXActive = false
     context.subscriptions.push(vscode.window.onDidChangeActiveTextEditor((e: vscode.TextEditor | undefined) => {
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
@@ -237,6 +248,7 @@ export function activate(context: vscode.ExtensionContext) {
     }))
 
     context.subscriptions.push(vscode.window.registerWebviewPanelSerializer('latex-workshop-pdf', extension.viewer.pdfViewerPanelSerializer))
+    context.subscriptions.push(vscode.window.registerWebviewPanelSerializer('latex-workshop-mathpreview', extension.mathPreviewPanel.mathPreviewPanelSerializer))
 
     context.subscriptions.push(vscode.languages.registerHoverProvider(latexSelector, new HoverProvider(extension)))
     context.subscriptions.push(vscode.languages.registerDefinitionProvider(latexSelector, new DefinitionProvider(extension)))
@@ -335,6 +347,7 @@ export class Extension {
     readonly graphicsPreview: GraphicsPreview
     readonly mathPreview: MathPreview
     readonly bibtexFormatter: BibtexFormatter
+    readonly mathPreviewPanel: MathPreviewPanel
 
     constructor() {
         this.extensionRoot = path.resolve(`${__dirname}/../../`)
@@ -365,6 +378,7 @@ export class Extension {
         this.graphicsPreview = new GraphicsPreview(this)
         this.mathPreview = new MathPreview(this)
         this.bibtexFormatter = new BibtexFormatter(this)
+        this.mathPreviewPanel = new MathPreviewPanel(this)
         this.logger.addLogMessage('LaTeX Workshop initialized.')
     }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -196,13 +196,6 @@ export function activate(context: vscode.ExtensionContext) {
         }
     }))
 
-    context.subscriptions.push(vscode.workspace.onDidChangeTextDocument( () => {
-        extension.mathPreviewPanel.update()
-    }))
-    context.subscriptions.push(vscode.window.onDidChangeTextEditorSelection( () => {
-        extension.mathPreviewPanel.update()
-    }))
-
     let isLaTeXActive = false
     context.subscriptions.push(vscode.window.onDidChangeActiveTextEditor((e: vscode.TextEditor | undefined) => {
         const configuration = vscode.workspace.getConfiguration('latex-workshop')

--- a/src/utils/webview.ts
+++ b/src/utils/webview.ts
@@ -2,10 +2,53 @@ import * as vscode from 'vscode'
 import * as path from 'path'
 import {Extension} from '../main'
 
+
 export function replaceWebviewPlaceholders(content: string, extension: Extension, webview: vscode.Webview): string {
     const resourcesFolder = path.join(extension.extensionRoot, 'resources')
     const filePath = vscode.Uri.file(resourcesFolder)
     const link = webview.asWebviewUri(filePath).toString()
     return content.replace(/%VSCODE_RES%/g, link)
                   .replace(/%VSCODE_CSP%/g, webview.cspSource)
+}
+
+export async function openWebviewPanel(panel: vscode.WebviewPanel, tabEditorGroup: string) {
+    const editor = vscode.window.activeTextEditor
+    if (!editor) {
+        return
+    }
+    // We need to turn the viewer into the active editor to move it to an other editor group
+    panel.reveal(undefined, false)
+    let focusAction: string | undefined
+    switch (tabEditorGroup) {
+        case 'left': {
+            await vscode.commands.executeCommand('workbench.action.moveEditorToLeftGroup')
+            focusAction = 'workbench.action.focusRightGroup'
+            break
+        }
+        case 'right': {
+            await vscode.commands.executeCommand('workbench.action.moveEditorToRightGroup')
+            focusAction = 'workbench.action.focusLeftGroup'
+            break
+        }
+        case 'above': {
+            await vscode.commands.executeCommand('workbench.action.moveEditorToAboveGroup')
+            focusAction = 'workbench.action.focusBelowGroup'
+            break
+        }
+        case 'below': {
+            await vscode.commands.executeCommand('workbench.action.moveEditorToBelowGroup')
+            focusAction = 'workbench.action.focusAboveGroup'
+            break
+        }
+        default: {
+            break
+        }
+    }
+    // Then, we set the focus back to the .tex file
+    setTimeout(async () => {
+        if (focusAction ) {
+            await vscode.commands.executeCommand(focusAction)
+        }
+        await vscode.window.showTextDocument(editor.document, vscode.ViewColumn.Active)
+    }, 500)
 }


### PR DESCRIPTION
Support real-time math preview panel. Close #1427.

It does not seem that [`WebviewEditorInset`](https://github.com/microsoft/vscode/issues/85682) will ship with the stable version of VS Code in a near future. So, let's use `WebviewPanel` instead.

![スクリーンショット 2020-09-20 19 25 03](https://user-images.githubusercontent.com/10665499/93709173-13cb6c00-fb77-11ea-9dc4-5ce5bfbd4fc6.png)
