### PR TITLE
Fix the bibtex entry "masterthesis"

### DIFF
--- a/data/bibtex-entries.json
+++ b/data/bibtex-entries.json
@@ -52,7 +52,7 @@
         "title",
         "author"
     ],
-    "masterthesis": [
+    "mastersthesis": [
         "author",
         "title",
         "school",

--- a/data/bibtex-optional-entries.json
+++ b/data/bibtex-optional-entries.json
@@ -276,7 +276,7 @@
     "version",
     "year"
   ],
-  "masterthesis": [
+  "mastersthesis": [
     "address",
     "month",
     "note",


### PR DESCRIPTION
According to http://mirrors.ctan.org/biblio/bibtex/base/btxdoc.pdf and http://mirrors.ctan.org/macros/latex/contrib/biblatex/doc/biblatex.pdf the correct spelling is mastersthesis with an s. Failing to include the s will generate a broken record that falls back to the default and omits entries (e.g. school).