### PR TITLE
Invoke toLocaleLowerCase for the suffix of filenames. Close #2328.

### DIFF
--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -165,7 +165,7 @@ export class Manager {
     }
 
     private inferLanguageId(filename: string): string | undefined {
-        const ext = path.extname(filename)
+        const ext = path.extname(filename).toLocaleLowerCase()
         if (ext === '.tex') {
             return 'latex'
         } else if (this.jlweaveExt.includes(ext)) {


### PR DESCRIPTION
Close #2328.

1. Open `cap.TEX`
2.  VS Code detects the language of `cap.TEX` as `latex`.
3. Invoke the `build` command. Then, the build fails.
4. The cause is that `inferLanguageId` returns `undefined`.

https://github.com/James-Yu/LaTeX-Workshop/blob/672d7bc840af6a6827efa74138ee67b503f41ed8/src/components/manager.ts#L167-L178

We should invoke `toLocaleLowerCase` for the suffix of filenames.