### PR TITLE
Allow configurable viewer URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -1254,6 +1254,11 @@
           "default": "0",
           "markdownDescription": "Define the port to listen on for communicating with the internal viewer. The default value \"0\" means the port is chosen randomly by the application."
         },
+        "latex-workshop.viewer.pdf.internal.url": {
+          "type": "string",
+          "default": "http://localhost:%p",
+          "markdownDescription": "URL used for connecting to the internal viewer. \"%p\" is replaced by the listening port of the viewer."
+        },
         "latex-workshop.view.pdf.internal.synctex.keybinding": {
           "type": "string",
           "default": "ctrl-click",

--- a/src/components/server.ts
+++ b/src/components/server.ts
@@ -14,15 +14,18 @@ export class Server {
     private wsServer: ws.Server
     address?: string
     port?: number
+    url?: string
 
     constructor(extension: Extension) {
         this.extension = extension
         this.httpServer = http.createServer((request, response) => this.handler(request, response))
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         const viewerPort = configuration.get('viewer.pdf.internal.port') as number
+        const viewerURL = configuration.get('viewer.pdf.internal.url') as string
         this.httpServer.listen(viewerPort, '127.0.0.1', undefined, () => {
             const {address, port} = this.httpServer.address() as AddressInfo
             this.port = port
+            this.url = viewerURL.replace('%p', port.toString())
             if (address.includes(':')) {
                 // the colon is reserved in URL to separate IPv4 address from port number. IPv6 address needs to be enclosed in square brackets when used in URL
                 this.address = `[${address}]:${port}`

--- a/src/components/viewer.ts
+++ b/src/components/viewer.ts
@@ -167,7 +167,7 @@ export class Viewer {
             this.extension.logger.addLogMessage('Cannot establish server connection.')
             return
         }
-        const url = `http://localhost:${this.extension.server.port}/viewer.html?file=${encodePathWithPrefix(pdfFile)}`
+        const url = `${this.extension.server.url}/viewer.html?file=${encodePathWithPrefix(pdfFile)}`
         this.extension.logger.addLogMessage(`Serving PDF file at ${url}`)
         this.extension.logger.addLogMessage(`The encoded path is ${pdfFile}`)
         return url
@@ -267,10 +267,10 @@ export class Viewer {
      */
     getPDFViewerContent(pdfFile: string): string {
         // viewer/viewer.js automatically requests the file to server.ts, and server.ts decodes the encoded path of PDF file.
-        const url = `http://localhost:${this.extension.server.port}/viewer.html?incode=1&file=${encodePathWithPrefix(pdfFile)}`
+        const url = `${this.extension.server.url}/viewer.html?incode=1&file=${encodePathWithPrefix(pdfFile)}`
         const rebroadcast: boolean = this.getKeyboardEventConfig()
         return `
-            <!DOCTYPE html><html><head><meta http-equiv="Content-Security-Policy" content="default-src http://localhost:* http://127.0.0.1:*; script-src 'unsafe-inline'; style-src 'unsafe-inline';"></head>
+            <!DOCTYPE html><html><head><meta http-equiv="Content-Security-Policy" content="default-src ${this.extension.server.url} http://localhost:* http://127.0.0.1:*; script-src 'unsafe-inline'; style-src 'unsafe-inline';"></head>
             <body><iframe id="preview-panel" class="preview-panel" src="${url}" style="position:absolute; border: none; left: 0; top: 0; width: 100%; height: 100%;">
             </iframe>
             <script>
@@ -291,7 +291,7 @@ export class Viewer {
             // we have to dispatch keyboard events in the parent window.
             // See https://github.com/microsoft/vscode/issues/65452#issuecomment-586036474
             window.addEventListener('message', (e) => {
-                if (e.origin !== 'http://localhost:${this.extension.server.port}') {
+                if (e.origin !== '${this.extension.server.url}') {
                     return;
                 }
                 switch (e.data.type) {

--- a/viewer/latexworkshop.ts
+++ b/viewer/latexworkshop.ts
@@ -47,7 +47,7 @@ class LateXWorkshopPdfViewer implements ILatexWorkshopPdfViewer {
         this.pdfFilePath = pack.pdfFilePath
 
         this.viewerHistory = new ViewerHistory(this)
-        const server = `ws://${window.location.hostname}:${window.location.port}`
+        const server = `${window.location.protocol=='https:' ? 'wss:' : 'ws:'}//${window.location.hostname}:${window.location.port}`
         this.server = server
         this.socket = new WebSocket(server)
         this.synctex = new SyncTex(this)


### PR DESCRIPTION
this supports e.g. LaTeX-Workshop running in code-server

I know similar things were previously discussed - e.g. in #2326, #1265, #1271
I am not sure what the original PR in #1271 was as it seems to have been force-pushed to remove the configurable URL, but the approach here should have minimal security implications.

---

LaTeX-Workshop is already working reasonably well with code-server, with most of the features working out-of-box.
Only the integrated PDF viewer does not - for the simple reason that its iframe is loaded from `http://localhost:random_port`.

This pull request changes nothing in terms of security (e.g. embedded http server is _still_ only bound to 127.0.0.1). 
The only change is that the viewer can be loaded from a different **URL**. 
Then the [reverse proxy feature of code-server](https://github.com/cdr/code-server/blob/v3.6.1/doc/FAQ.md#sub-domains) can be leveraged for accessing the viewer.

## Example

`latex-workshop.viewer.pdf.internal.url` is set to `https://%p.codeserver.com`
and code-server started with `code-server --proxy-domain codeserver.com`

This request gets now sent to code-server, which proxies it to localhost:%p. All security implications of that are outsourced to code-server (and its proxy-domain feature) and/or the loadbalancer before.

Please let me know if you are willing to accept such a feature request. 