### PR TITLE
Highlight optidef envs as math envs

### DIFF
--- a/syntax/LaTeX.tmLanguage.json
+++ b/syntax/LaTeX.tmLanguage.json
@@ -741,7 +741,7 @@
       "name": "meta.function.end-document.latex"
     },
     {
-      "begin": "(?:\\s*)((\\\\)begin)(\\{)((?:align|equation|(?:IEEE)?eqnarray|multline|aligned|alignat|split|gather|gathered|cases|displaymath|[a-zA-Z]*matrix)(?:\\*)?)(\\})(\\s*\\n)?",
+      "begin": "(?:\\s*)((\\\\)begin)(\\{)((?:align|equation|(?:IEEE)?eqnarray|multline|aligned|alignat|split|gather|gathered|cases|displaymath|[a-zA-Z]*matrix|(?:(?:arg)?(?:mini|maxi)))(?:\\*|!)?)(\\})(\\s*\\n)?",
       "captures": {
         "1": {
           "name": "support.function.be.latex"


### PR DESCRIPTION
Close #2347.

Yet, I am not so convinced using math mode is relevant. Consider

```latex
\begin{mini}  % formulate minimization problem
  {w}{f(w_a^2)+ R(w+6x) + \sum_{i=1}^4 y_i^2}
  {\label{eq:Example1}}{}
  \addConstraint{g(w)}{=0}
  \addConstraint{n(w)}{= 6}
  \addConstraint{L(w)+r(x)}{=Kw+p}
  \addConstraint{h(x)}{=0.}
\end{mini}
```

Before this PR

<img width="371" alt="Capture d’écran 2020-10-28 à 21 18 33" src="https://user-images.githubusercontent.com/2910140/97492080-5a289d80-1963-11eb-9e63-805e7adf22bd.png">

with this PR

<img width="371" alt="Capture d’écran 2020-10-28 à 21 18 05" src="https://user-images.githubusercontent.com/2910140/97492060-5268f900-1963-11eb-8f37-8057cd38548e.png">

@martincornejo, @tamuratak Your opinion?
