### PR TITLE
Test if dir exists before calling ensureDir

### DIFF
--- a/src/components/builder.ts
+++ b/src/components/builder.ts
@@ -232,7 +232,12 @@ export class Builder {
             }
             this.extension.manager.getIncludedTeX(rootFile).forEach(file => {
                 const relativePath = path.dirname(file.replace(rootDir, '.'))
-                fs.ensureDirSync(path.resolve(outDir, relativePath))
+                const fullOutDir = path.resolve(outDir, relativePath)
+                // To avoid issues when fullOutDir is the root dir
+                // Using fs.mkdir() on the root directory even with recursion will result in an error
+                if (! (fs.pathExistsSync(fullOutDir) && fs.statSync(fullOutDir).isDirectory())) {
+                    fs.ensureDirSync(fullOutDir)
+                }
             })
             this.buildInitiator(rootFile, languageId, recipeName, releaseBuildMutex)
         } catch (e) {


### PR DESCRIPTION
From node.js documentation

On Windows, using fs.mkdir() on the root directory even with recursion will result in an error:

```js
fs.mkdir('/', { recursive: true }, (err) => {
 // => [Error: EPERM: operation not permitted, mkdir 'C:\']
})
```
It needs to be tested on Windows before merging.
Close #2362. 