### PR TITLE
Rename to latex-workshop.hover.preview.maxLines

### DIFF
--- a/package.json
+++ b/package.json
@@ -1724,7 +1724,7 @@
           "default": true,
           "markdownDescription": "Enable Hover Preview."
         },
-        "latex-workshop.hover.math.preview.maxLines": {
+        "latex-workshop.hover.preview.maxLines": {
           "type": "number",
           "default": 20,
           "markdownDescription": "Maximum number of lines between the beginning of the math environment and the cursor position to allow preview."

--- a/src/providers/preview/mathpreviewlib/texmathenvfinder.ts
+++ b/src/providers/preview/mathpreviewlib/texmathenvfinder.ts
@@ -25,7 +25,7 @@ export class TeXMathEnvFinder {
     }
 
     findHoverOnRef(document: vscode.TextDocument, position: vscode.Position, token: string, refData: ReferenceEntry): TexMathEnv | undefined {
-        const limit = vscode.workspace.getConfiguration('latex-workshop').get('hover.math.preview.maxLines') as number
+        const limit = vscode.workspace.getConfiguration('latex-workshop').get('hover.preview.maxLines') as number
         const docOfRef = TextDocumentLike.load(refData.file)
         const envBeginPatMathMode = /\\begin\{(align|align\*|alignat|alignat\*|eqnarray|eqnarray\*|equation|equation\*|gather|gather\*)\}/
         const l = docOfRef.lineAt(refData.position.line).text
@@ -50,7 +50,7 @@ export class TeXMathEnvFinder {
     }
 
     findMathEnvIncludingPosition(document: vscode.TextDocument, position: vscode.Position): TexMathEnv | undefined {
-        const limit = vscode.workspace.getConfiguration('latex-workshop').get('hover.math.preview.maxLines') as number
+        const limit = vscode.workspace.getConfiguration('latex-workshop').get('hover.preview.maxLines') as number
         const envNamePatMathMode = /(align|align\*|alignat|alignat\*|eqnarray|eqnarray\*|equation|equation\*|gather|gather\*)/
         const envBeginPatMathMode = /\\\[|\\\(|\\begin\{(align|align\*|alignat|alignat\*|eqnarray|eqnarray\*|equation|equation\*|gather|gather\*)\}/
         let texMath = this.findHoverOnTex(document, position)


### PR DESCRIPTION
Rename to `latex-workshop.hover.preview.maxLines`, to make config names consistent.