### PR TITLE
Add toggle math preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -467,13 +467,18 @@
         "command": "latex-workshop.closeMathPreviewPanel",
         "title": "Close Math Preview Panel",
         "category": "LaTeX Workshop"
+      },
+      {
+        "command": "latex-workshop.toggleMathPreviewPanel",
+        "title": "Toggle Math Preview Panel",
+        "category": "LaTeX Workshop"
       }
     ],
     "keybindings": [
       {
         "key": "ctrl+alt+m",
         "mac": "cmd+alt+m",
-        "command": "latex-workshop.openMathPreviewPanel"
+        "command": "latex-workshop.toggleMathPreviewPanel"
       },
       {
         "key": "ctrl+l alt+b",

--- a/package.json
+++ b/package.json
@@ -476,9 +476,10 @@
     ],
     "keybindings": [
       {
-        "key": "ctrl+alt+m",
-        "mac": "cmd+alt+m",
-        "command": "latex-workshop.toggleMathPreviewPanel"
+        "key": "ctrl+l alt+m",
+        "mac": "cmd+l alt+m",
+        "command": "latex-workshop.toggleMathPreviewPanel",
+        "when": "editorLangId =~ /latex|rsweave|jlweave/ && config.latex-workshop.bind.altKeymap.enabled"
       },
       {
         "key": "ctrl+l alt+b",
@@ -509,6 +510,12 @@
         "mac": "cmd+l alt+x",
         "command": "workbench.view.extension.latex",
         "when": "config.latex-workshop.bind.altKeymap.enabled"
+      },
+      {
+        "key": "ctrl+alt+m",
+        "mac": "cmd+alt+m",
+        "command": "latex-workshop.toggleMathPreviewPanel",
+        "when": "editorLangId =~ /latex|rsweave|jlweave/ && !config.latex-workshop.bind.altKeymap.enabled"
       },
       {
         "key": "ctrl+alt+b",

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -640,4 +640,8 @@ export class Commander {
         this.extension.mathPreviewPanel.close()
     }
 
+    toggleMathPreviewPanel() {
+        this.extension.mathPreviewPanel.toggle()
+    }
+
 }

--- a/src/components/mathpreviewpanel.ts
+++ b/src/components/mathpreviewpanel.ts
@@ -101,6 +101,14 @@ export class MathPreviewPanel {
         this.extension.logger.addLogMessage('Math preview panel: closed')
     }
 
+    toggle() {
+        if (this.panel) {
+            this.close()
+        } else {
+            this.open()
+        }
+    }
+
     private clearCache() {
         this.prevEditTime = 0
         this.prevDocumentUri = undefined

--- a/src/main.ts
+++ b/src/main.ts
@@ -137,6 +137,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     vscode.commands.registerCommand('latex-workshop.openMathPreviewPanel', () => extension.commander.openMathPreviewPanel())
     vscode.commands.registerCommand('latex-workshop.closeMathPreviewPanel', () => extension.commander.closeMathPreviewPanel())
+    vscode.commands.registerCommand('latex-workshop.toggleMathPreviewPanel', () => extension.commander.toggleMathPreviewPanel())
 
     context.subscriptions.push(vscode.workspace.onDidSaveTextDocument( (e: vscode.TextDocument) => {
         if (extension.manager.hasTexId(e.languageId)) {


### PR DESCRIPTION
Fix #2379.
I would even be tempted to remove close and open math preview panel commands as they become useless once we have a toggle action.