### PR TITLE
Enable math preview on suggest detail widgets for references

### DIFF
--- a/src/providers/completer/reference.ts
+++ b/src/providers/completer/reference.ts
@@ -8,9 +8,18 @@ import {IProvider} from './interface'
 import {TexMathEnv} from '../preview/mathpreview'
 
 export interface ReferenceEntry extends vscode.CompletionItem {
-    file: string, // The file that defines the ref
-    position: vscode.Position, // The position that defines the ref
-    prevIndex?: {refNumber: string, pageNumber: string} // Stores the ref number
+    /**
+     *  The file that defines the ref.
+     */
+    file: string,
+    /**
+     * The position that defines the ref.
+     */
+    position: vscode.Position,
+    /**
+     *  Stores the ref number.
+     */
+    prevIndex?: {refNumber: string, pageNumber: string}
 }
 
 export type ReferenceDocType = {

--- a/src/providers/completer/reference.ts
+++ b/src/providers/completer/reference.ts
@@ -6,7 +6,7 @@ import {latexParser} from 'latex-utensils'
 import {Extension} from '../../main'
 import {IProvider} from './interface'
 
-export interface Suggestion extends vscode.CompletionItem {
+export interface ReferenceEntry extends vscode.CompletionItem {
     file: string, // The file that defines the ref
     position: vscode.Position, // The position that defines the ref
     prevIndex?: {refNumber: string, pageNumber: string} // Stores the ref number
@@ -15,7 +15,7 @@ export interface Suggestion extends vscode.CompletionItem {
 export class Reference implements IProvider {
     private readonly extension: Extension
     // Here we use an object instead of an array for de-duplication
-    private readonly suggestions: {[id: string]: Suggestion} = {}
+    private readonly suggestions: {[id: string]: ReferenceEntry} = {}
     private prevIndexObj: { [k: string]: {refNumber: string, pageNumber: string} } = {}
 
     constructor(extension: Extension) {
@@ -61,7 +61,7 @@ export class Reference implements IProvider {
         }
     }
 
-    getRefDict(): {[key: string]: Suggestion} {
+    getRefDict(): {[key: string]: ReferenceEntry} {
         if (this.suggestions) {
             this.updateAll()
         }

--- a/src/providers/completer/reference.ts
+++ b/src/providers/completer/reference.ts
@@ -52,7 +52,7 @@ export class Reference implements IProvider {
         for (const key of keys) {
             const sug = this.suggestions[key]
             if (sug) {
-                const tex = this.extension.mathPreview.findHoverOnRef(args.document, args.position, sug, key)
+                const tex = this.extension.mathPreview.findHoverOnRef(sug, key)
                 if (tex) {
                     const data: ReferenceDocType = {tex, label: sug.label, prevIndex: sug.prevIndex}
                     sug.documentation = JSON.stringify(data)

--- a/src/providers/completer/reference.ts
+++ b/src/providers/completer/reference.ts
@@ -5,11 +5,18 @@ import {latexParser} from 'latex-utensils'
 
 import {Extension} from '../../main'
 import {IProvider} from './interface'
+import {TexMathEnv} from '../preview/mathpreview'
 
 export interface ReferenceEntry extends vscode.CompletionItem {
     file: string, // The file that defines the ref
     position: vscode.Position, // The position that defines the ref
     prevIndex?: {refNumber: string, pageNumber: string} // Stores the ref number
+}
+
+export type ReferenceDocType = {
+    tex: TexMathEnv,
+    label: ReferenceEntry['label'],
+    prevIndex: ReferenceEntry['prevIndex']
 }
 
 export class Reference implements IProvider {
@@ -38,7 +45,8 @@ export class Reference implements IProvider {
             if (sug) {
                 const tex = this.extension.mathPreview.findHoverOnRef(args.document, args.position, sug, key)
                 if (tex) {
-                    sug.documentation = JSON.stringify({tex, label: sug.label, prevIndex: sug.prevIndex})
+                    const data: ReferenceDocType = {tex, label: sug.label, prevIndex: sug.prevIndex}
+                    sug.documentation = JSON.stringify(data)
                 } else {
                     sug.documentation = JSON.stringify(sug.documentation)
                 }

--- a/src/providers/completer/reference.ts
+++ b/src/providers/completer/reference.ts
@@ -36,6 +36,12 @@ export class Reference implements IProvider {
         for (const key of keys) {
             const sug = this.suggestions[key]
             if (sug) {
+                const tex = this.extension.mathPreview.findHoverOnRef(args.document, args.position, sug, key)
+                if (tex) {
+                    sug.documentation = JSON.stringify({tex, label: sug.label, prevIndex: sug.prevIndex})
+                } else {
+                    sug.documentation = JSON.stringify(sug.documentation)
+                }
                 items.push(sug)
             } else {
                 items.push({label: key})

--- a/src/providers/completer/reference.ts
+++ b/src/providers/completer/reference.ts
@@ -3,9 +3,8 @@ import * as fs from 'fs'
 import * as path from 'path'
 import {latexParser} from 'latex-utensils'
 
-import {Extension} from '../../main'
-import {IProvider} from './interface'
-import {TexMathEnv} from '../preview/mathpreview'
+import type {Extension} from '../../main'
+import type {IProvider} from './interface'
 
 export interface ReferenceEntry extends vscode.CompletionItem {
     /**
@@ -23,7 +22,10 @@ export interface ReferenceEntry extends vscode.CompletionItem {
 }
 
 export type ReferenceDocType = {
-    tex: TexMathEnv,
+    documentation: ReferenceEntry['documentation'],
+    file: ReferenceEntry['file'],
+    position: {line: number, character: number},
+    key: string,
     label: ReferenceEntry['label'],
     prevIndex: ReferenceEntry['prevIndex']
 }
@@ -52,13 +54,18 @@ export class Reference implements IProvider {
         for (const key of keys) {
             const sug = this.suggestions[key]
             if (sug) {
-                const tex = this.extension.mathPreview.findHoverOnRef(sug, key)
-                if (tex) {
-                    const data: ReferenceDocType = {tex, label: sug.label, prevIndex: sug.prevIndex}
-                    sug.documentation = JSON.stringify(data)
-                } else {
-                    sug.documentation = JSON.stringify(sug.documentation)
+                const data: ReferenceDocType = {
+                    documentation: sug.documentation,
+                    file: sug.file,
+                    position: {
+                        line: sug.position.line,
+                        character: sug.position.character
+                    },
+                    key,
+                    label: sug.label,
+                    prevIndex: sug.prevIndex
                 }
+                sug.documentation = JSON.stringify(data)
                 items.push(sug)
             } else {
                 items.push({label: key})

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -106,6 +106,7 @@ export class Completer implements vscode.CompletionItemProvider {
     }
 
     async resolveCompletionItem(item: vscode.CompletionItem, token: vscode.CancellationToken): Promise<vscode.CompletionItem> {
+        const configuration = vscode.workspace.getConfiguration('latex-workshop')
         if (item.kind === vscode.CompletionItemKind.Reference) {
             if (typeof item.documentation !== 'string') {
                 return item
@@ -114,6 +115,10 @@ export class Completer implements vscode.CompletionItemProvider {
             const sug = {
                 file: data.file,
                 position: new vscode.Position(data.position.line, data.position.character)
+            }
+            if (!configuration.get('hover.ref.enabled')) {
+                item.documentation = data.documentation
+                return item
             }
             const tex = this.extension.mathPreview.findHoverOnRef(sug, data.key)
             if (tex) {
@@ -125,7 +130,7 @@ export class Completer implements vscode.CompletionItemProvider {
                 return item
             }
         } else if (item.kind === vscode.CompletionItemKind.File) {
-            const preview = vscode.workspace.getConfiguration('latex-workshop').get('intellisense.includegraphics.preview.enabled') as boolean
+            const preview = configuration.get('intellisense.includegraphics.preview.enabled') as boolean
             if (!preview) {
                 return item
             }

--- a/src/providers/preview/mathpreview.ts
+++ b/src/providers/preview/mathpreview.ts
@@ -131,11 +131,11 @@ export class MathPreview {
     }
 
     findHoverOnRef(
-        document: vscode.TextDocument | TextDocumentLike,
-        position: vscode.Position,
         refData: Pick<ReferenceEntry, 'file' | 'position'>,
         token: string
     ) {
+        const document = TextDocumentLike.load(refData.file)
+        const position = refData.position
         return this.texMathEnvFinder.findHoverOnRef(document, position, refData, token)
     }
 

--- a/src/providers/preview/mathpreview.ts
+++ b/src/providers/preview/mathpreview.ts
@@ -76,7 +76,7 @@ export class MathPreview {
         const mdLink = new vscode.MarkdownString(`[View on pdf](${link})`)
         mdLink.isTrusted = true
         if (configuration.get('hover.ref.enabled') as boolean) {
-            const tex = this.texMathEnvFinder.findHoverOnRef(document, position, token, refData)
+            const tex = this.texMathEnvFinder.findHoverOnRef(document, position, refData, token)
             if (tex) {
                 const newCommands = await this.findProjectNewCommand(ctoken)
                 return this.hoverPreviewOnRefProvider.provideHoverPreviewOnRef(tex, newCommands, refData, this.color)
@@ -91,7 +91,7 @@ export class MathPreview {
         return new vscode.Hover([md, mdLink], refRange)
     }
 
-    private refNumberMessage(refData: ReferenceEntry): string | undefined {
+    private refNumberMessage(refData: Pick<ReferenceEntry, 'prevIndex'>): string | undefined {
         if (refData.prevIndex) {
             const refNum = refData.prevIndex.refNumber
             const refMessage = `numbered ${refNum} at last compilation`
@@ -130,8 +130,13 @@ export class MathPreview {
         return this.texMathEnvFinder.findHoverOnTex(document, position)
     }
 
-    findHoverOnRef( document: vscode.TextDocument | TextDocumentLike, position: vscode.Position, refData: ReferenceEntry, token: string) {
-        return this.texMathEnvFinder.findHoverOnRef(document, position, token, refData)
+    findHoverOnRef(
+        document: vscode.TextDocument | TextDocumentLike,
+        position: vscode.Position,
+        refData: Pick<ReferenceEntry, 'file' | 'position'>,
+        token: string
+    ) {
+        return this.texMathEnvFinder.findHoverOnRef(document, position, refData, token)
     }
 
     async renderSvgOnRef(tex: TexMathEnv, refData: Pick<ReferenceEntry, 'label' | 'prevIndex'>, ctoken: vscode.CancellationToken) {

--- a/src/providers/preview/mathpreview.ts
+++ b/src/providers/preview/mathpreview.ts
@@ -134,7 +134,8 @@ export class MathPreview {
         return this.texMathEnvFinder.findHoverOnRef(document, position, token, refData)
     }
 
-    renderSvgOnRef(tex: TexMathEnv, newCommand: string, refData: Pick<ReferenceEntry, 'label' | 'prevIndex'>) {
+    async renderSvgOnRef(tex: TexMathEnv, refData: Pick<ReferenceEntry, 'label' | 'prevIndex'>, ctoken: vscode.CancellationToken) {
+        const newCommand = await this.findProjectNewCommand(ctoken)
         return this.hoverPreviewOnRefProvider.renderSvgOnRef(tex, newCommand, refData, this.color)
     }
 

--- a/src/providers/preview/mathpreview.ts
+++ b/src/providers/preview/mathpreview.ts
@@ -3,7 +3,7 @@ import * as vscode from 'vscode'
 import {MathJaxPool, TypesetArg} from './mathjaxpool'
 import * as utils from '../../utils/utils'
 import {Extension} from '../../main'
-import {Suggestion as ReferenceEntry} from '../completer/reference'
+import {ReferenceEntry} from '../completer/reference'
 import {getCurrentThemeLightness} from '../../utils/theme'
 
 import {CursorRenderer} from './mathpreviewlib/cursorrenderer'

--- a/src/providers/preview/mathpreview.ts
+++ b/src/providers/preview/mathpreview.ts
@@ -130,6 +130,14 @@ export class MathPreview {
         return this.texMathEnvFinder.findHoverOnTex(document, position)
     }
 
+    findHoverOnRef( document: vscode.TextDocument | TextDocumentLike, position: vscode.Position, refData: ReferenceEntry, token: string) {
+        return this.texMathEnvFinder.findHoverOnRef(document, position, token, refData)
+    }
+
+    renderSvgOnRef(tex: TexMathEnv, newCommand: string, refData: Pick<ReferenceEntry, 'label' | 'prevIndex'>) {
+        return this.hoverPreviewOnRefProvider.renderSvgOnRef(tex, newCommand, refData, this.color)
+    }
+
     findMathEnvIncludingPosition(document: vscode.TextDocument, position: vscode.Position): TexMathEnv | undefined {
         return this.texMathEnvFinder.findMathEnvIncludingPosition(document, position)
     }

--- a/src/providers/preview/mathpreview.ts
+++ b/src/providers/preview/mathpreview.ts
@@ -2,8 +2,8 @@ import * as vscode from 'vscode'
 
 import {MathJaxPool, TypesetArg} from './mathjaxpool'
 import * as utils from '../../utils/utils'
-import {Extension} from '../../main'
-import {ReferenceEntry} from '../completer/reference'
+import type {Extension} from '../../main'
+import type {ReferenceEntry} from '../completer/reference'
 import {getCurrentThemeLightness} from '../../utils/theme'
 
 import {CursorRenderer} from './mathpreviewlib/cursorrenderer'
@@ -13,7 +13,7 @@ import {TexMathEnv, TeXMathEnvFinder} from './mathpreviewlib/texmathenvfinder'
 import {HoverPreviewOnRefProvider} from './mathpreviewlib/hoverpreviewonref'
 import {MathPreviewUtils} from './mathpreviewlib/mathpreviewutils'
 
-export {TexMathEnv} from './mathpreviewlib/texmathenvfinder'
+export type {TexMathEnv} from './mathpreviewlib/texmathenvfinder'
 
 
 export class MathPreview {

--- a/src/providers/preview/mathpreviewlib/hoverpreviewonref.ts
+++ b/src/providers/preview/mathpreviewlib/hoverpreviewonref.ts
@@ -19,6 +19,15 @@ export class HoverPreviewOnRefProvider {
     }
 
     async provideHoverPreviewOnRef(tex: TexMathEnv, newCommand: string, refData: ReferenceEntry, color: string): Promise<vscode.Hover> {
+        const md = await this.renderSvgOnRef(tex, newCommand, refData, color)
+        const line = refData.position.line
+        const link = vscode.Uri.parse('command:latex-workshop.synctexto').with({ query: JSON.stringify([line, refData.file]) })
+        const mdLink = new vscode.MarkdownString(`[View on pdf](${link})`)
+        mdLink.isTrusted = true
+        return new vscode.Hover( [this.mputils.addDummyCodeBlock(`![equation](${md})`), mdLink], tex.range )
+    }
+
+    async renderSvgOnRef(tex: TexMathEnv, newCommand: string, refData: Pick<ReferenceEntry, 'label' | 'prevIndex'>, color: string) {
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         const scale = configuration.get('hover.preview.scale') as number
 
@@ -42,12 +51,8 @@ export class HoverPreviewOnRefProvider {
         const typesetOpts = { scale, color }
         try {
             const xml = await this.mj.typeset(typesetArg, typesetOpts)
-            const md = utils.svgToDataUrl(xml)
-            const line = refData.position.line
-            const link = vscode.Uri.parse('command:latex-workshop.synctexto').with({ query: JSON.stringify([line, refData.file]) })
-            const mdLink = new vscode.MarkdownString(`[View on pdf](${link})`)
-            mdLink.isTrusted = true
-            return new vscode.Hover( [this.mputils.addDummyCodeBlock(`![equation](${md})`), mdLink], tex.range )
+            const svg = utils.svgToDataUrl(xml)
+            return svg
         } catch(e) {
             this.extension.logger.logOnRejected(e)
             this.extension.logger.addLogMessage(`Error when MathJax is rendering ${typesetArg.math}`)

--- a/src/providers/preview/mathpreviewlib/hoverpreviewonref.ts
+++ b/src/providers/preview/mathpreviewlib/hoverpreviewonref.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode'
 import * as utils from '../../../utils/utils'
 import {MathJaxPool, TypesetArg} from '../mathjaxpool'
-import type {Suggestion as ReferenceEntry} from '../../completer/reference'
+import type {ReferenceEntry} from '../../completer/reference'
 import type {Extension} from '../../../main'
 import type {TexMathEnv} from './texmathenvfinder'
 import type {MathPreviewUtils} from './mathpreviewutils'

--- a/src/providers/preview/mathpreviewlib/texmathenvfinder.ts
+++ b/src/providers/preview/mathpreviewlib/texmathenvfinder.ts
@@ -43,7 +43,7 @@ export class TeXMathEnvFinder {
                 const t = this.findHoverOnTex(docOfRef, beginPos)
                 if (t) {
                     const beginEndRange = t.range
-                    const refRange = document.getWordRangeAtPosition(position, /\S+\{.*?\}/)
+                    const refRange = document.getWordRangeAtPosition(position, /\S+?\{.*?\}/)
                     if (refRange && beginEndRange.contains(labelPos)) {
                         t.range = refRange
                         return t

--- a/src/providers/preview/mathpreviewlib/texmathenvfinder.ts
+++ b/src/providers/preview/mathpreviewlib/texmathenvfinder.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode'
 
 import * as utils from '../../../utils/utils'
 import {TextDocumentLike} from './textdocumentlike'
-import type {Suggestion as ReferenceEntry} from '../../completer/reference'
+import type {ReferenceEntry} from '../../completer/reference'
 
 export type TexMathEnv = { texString: string, range: vscode.Range, envname: string }
 

--- a/src/providers/preview/mathpreviewlib/texmathenvfinder.ts
+++ b/src/providers/preview/mathpreviewlib/texmathenvfinder.ts
@@ -43,7 +43,7 @@ export class TeXMathEnvFinder {
                 const t = this.findHoverOnTex(docOfRef, beginPos)
                 if (t) {
                     const beginEndRange = t.range
-                    const refRange = document.getWordRangeAtPosition(position, /\{.*?\}/)
+                    const refRange = document.getWordRangeAtPosition(position, /\S+\{.*?\}/)
                     if (refRange && beginEndRange.contains(labelPos)) {
                         t.range = refRange
                         return t

--- a/src/providers/preview/mathpreviewlib/texmathenvfinder.ts
+++ b/src/providers/preview/mathpreviewlib/texmathenvfinder.ts
@@ -24,7 +24,12 @@ export class TeXMathEnvFinder {
         return this.findHoverOnInline(document, position)
     }
 
-    findHoverOnRef(document: vscode.TextDocument | TextDocumentLike, position: vscode.Position, token: string, refData: ReferenceEntry): TexMathEnv | undefined {
+    findHoverOnRef(
+        document: vscode.TextDocument | TextDocumentLike,
+        position: vscode.Position,
+        refData: Pick<ReferenceEntry, 'file' | 'position'>,
+        token: string,
+    ): TexMathEnv | undefined {
         const limit = vscode.workspace.getConfiguration('latex-workshop').get('hover.preview.maxLines') as number
         const docOfRef = TextDocumentLike.load(refData.file)
         const envBeginPatMathMode = /\\begin\{(align|align\*|alignat|alignat\*|eqnarray|eqnarray\*|equation|equation\*|gather|gather\*)\}/

--- a/src/providers/preview/mathpreviewlib/texmathenvfinder.ts
+++ b/src/providers/preview/mathpreviewlib/texmathenvfinder.ts
@@ -24,7 +24,7 @@ export class TeXMathEnvFinder {
         return this.findHoverOnInline(document, position)
     }
 
-    findHoverOnRef(document: vscode.TextDocument, position: vscode.Position, token: string, refData: ReferenceEntry): TexMathEnv | undefined {
+    findHoverOnRef(document: vscode.TextDocument | TextDocumentLike, position: vscode.Position, token: string, refData: ReferenceEntry): TexMathEnv | undefined {
         const limit = vscode.workspace.getConfiguration('latex-workshop').get('hover.preview.maxLines') as number
         const docOfRef = TextDocumentLike.load(refData.file)
         const envBeginPatMathMode = /\\begin\{(align|align\*|alignat|alignat\*|eqnarray|eqnarray\*|equation|equation\*|gather|gather\*)\}/


### PR DESCRIPTION
Enable math preview on suggest detail widgets for references.

Notice that the detail widgets are now resizable:
- https://code.visualstudio.com/updates/v1_51#_resizable-suggestions

![スクリーンショット 2020-11-21 9 44 49](https://user-images.githubusercontent.com/10665499/99862808-817b2f00-2bde-11eb-92db-e0785a26f5fe.png)

We are abusing the `documentation` property to store JSON.
https://github.com/James-Yu/LaTeX-Workshop/blob/aa868b995791a47b5654f42520ddf353d7951ee7/src/providers/completer/reference.ts#L68

We would fix it if possible after merged, which requires modifying the return type of methods of `Completer`.