### PR TITLE
Keep selected text in autocompletions/snippets

### DIFF
--- a/data/commands.json
+++ b/data/commands.json
@@ -5,6 +5,12 @@
     "detail": "Begin a new environment",
     "postAction": "editor.action.triggerSuggest"
   },
+  "beginend": {
+    "command": "beginend",
+    "snippet": "begin{$1}\n\t${0:${TM_SELECTED_TEXT}}\n\\end{$1}",
+    "detail": "Insert \\begin/\\end",
+    "postAction": "editor.action.triggerSuggest"
+  },
   "left(": {
     "command": "left(",
     "snippet": "left(${1}\\right)",

--- a/data/commands.json
+++ b/data/commands.json
@@ -9,6 +9,7 @@
     "command": "beginend",
     "snippet": "begin{$1}\n\t${0:${TM_SELECTED_TEXT}}\n\\end{$1}",
     "detail": "Insert \\begin/\\end",
+    "documentation": "Insert a `\\begin{} / \\end{}` pair and wrap the selected text if any. Autocompletion is automatically triggered to complete the environment name",
     "postAction": "editor.action.triggerSuggest"
   },
   "left(": {

--- a/snippets/latex.json
+++ b/snippets/latex.json
@@ -6,12 +6,12 @@
 	},
 	"subscript": {
 		"prefix": "__",
-		"body": "_{$1}",
+		"body": "_{${1:${TM_SELECTED_TEXT}}}",
 		"description": "subscript"
 	},
 	"superscript": {
 		"prefix": "**",
-		"body": "^{$1}",
+		"body": "^{${1:${TM_SELECTED_TEXT}}}",
 		"description": "superscript"
 	},
 	"etc": {
@@ -46,12 +46,12 @@
 	},
 	"hat": {
 		"prefix": "@^",
-		"body": "\\Hat{$1}$0",
+		"body": "\\Hat{${1:${TM_SELECTED_TEXT}}}$0",
 		"description": "hat"
 	},
 	"bar": {
 		"prefix": "@_",
-		"body": "\\bar{$1}$0",
+		"body": "\\bar{${1:${TM_SELECTED_TEXT}}}$0",
 		"description": "bar"
 	},
 	"circ": {
@@ -66,12 +66,12 @@
 	},
 	"dot": {
 		"prefix": "@;",
-		"body": "\\dot{$1}$0",
+		"body": "\\dot{${1:${TM_SELECTED_TEXT}}}$0",
 		"description": "dot"
 	},
 	"ddot": {
 		"prefix": "@:",
-		"body": "\\ddot{$1}$0",
+		"body": "\\ddot{${1:${TM_SELECTED_TEXT}}}$0",
 		"description": "ddot"
 	},
 
@@ -97,7 +97,7 @@
 	},
 	"sqrt": {
 		"prefix": "@2",
-		"body": "\\sqrt{$1}$0",
+		"body": "\\sqrt{${1:${TM_SELECTED_TEXT}}}$0",
 		"description": "sqrt command"
 	},
 	"int": {
@@ -502,17 +502,17 @@
 	},
 	"(": {
 		"prefix": "@(",
-		"body": "\\left( $1 \\right)",
+		"body": "\\left( ${1:${TM_SELECTED_TEXT}} \\right)",
 		"description": "left( ... right)"
 	},
 	"{": {
 		"prefix": "@{",
-		"body": "\\left\\{ $1 \\right\\\\}",
+		"body": "\\left\\{ ${1:${TM_SELECTED_TEXT}} \\right\\\\}",
 		"description": "left{ ... right}"
 	},
 	"[": {
 		"prefix": "@[",
-		"body": "\\left[ $1 \\right]",
+		"body": "\\left[ ${1:${TM_SELECTED_TEXT}} \\right]",
 		"description": "left[ ... right]"
 	},
 	"wrapEnv": {
@@ -521,38 +521,38 @@
 	},
 	"part": {
 		"prefix": "SPA",
-		"body": "\\part{$1}",
+		"body": "\\part{${1:${TM_SELECTED_TEXT}}}",
 		"description": "part"
 		},
 	"chapter": {
 		"prefix": "SCH",
-		"body": "\\chapter{$1}",
+		"body": "\\chapter{${1:${TM_SELECTED_TEXT}}}",
 		"description": "chapter"
 	},
 	"section": {
 		"prefix": "SSE",
-		"body": "\\section{$1}",
+		"body": "\\section{${1:${TM_SELECTED_TEXT}}}",
 		"description": "section"
 
 	},
 	"subsection": {
 		"prefix": "SSS",
-		"body": "\\subsection{$1}",
+		"body": "\\subsection{${1:${TM_SELECTED_TEXT}}}",
 		"description": "subsection"
 	},
 	"subsubsection": {
 		"prefix": "SS2",
-		"body": "\\subsubsection{$1}",
+		"body": "\\subsubsection{${1:${TM_SELECTED_TEXT}}}",
 		"description": "subsubsection"
 	},
 	"paragraph": {
 		"prefix": "SPG",
-		"body": "\\paragraph{$1}",
+		"body": "\\paragraph{${1:${TM_SELECTED_TEXT}}}",
 		"description": "paragraph"
 	},
 	"subparagraph": {
 		"prefix": "SSP",
-		"body": "\\subparagraph{$1}",
+		"body": "\\subparagraph{${1:${TM_SELECTED_TEXT}}}",
 		"description": "subparagraph"
 	}
 }

--- a/snippets/latex.json
+++ b/snippets/latex.json
@@ -127,82 +127,82 @@
 	},
 	"equation": {
 		"prefix": "BEQ",
-		"body": "\\begin{equation}\n\t$0\n\\end{equation}",
+		"body": "\\begin{equation}\n\t${0:${TM_SELECTED_TEXT}}\n\\end{equation}",
 		"description": "equation environment"
 	},
 	"equation*": {
 		"prefix": "BSEQ",
-		"body": "\\begin{equation*}\n\t$0\n\\end{equation*}",
+		"body": "\\begin{equation*}\n\t${0:${TM_SELECTED_TEXT}}\n\\end{equation*}",
 		"description": "equation* environment"
 	},
 	"align": {
 		"prefix": "BAL",
-		"body": "\\begin{align}\n\t$0\n\\end{align}",
+		"body": "\\begin{align}\n\t${0:${TM_SELECTED_TEXT}}\n\\end{align}",
 		"description": "align environment"
 	},
 	"align*": {
 		"prefix": "BSAL",
-		"body": "\\begin{align*}\n\t$0\n\\end{align*}",
+		"body": "\\begin{align*}\n\t${0:${TM_SELECTED_TEXT}}\n\\end{align*}",
 		"description": "align* environment"
 	},
 	"gather": {
 		"prefix": "BGA",
-		"body": "\\begin{gather}\n\t$0\n\\end{gather}",
+		"body": "\\begin{gather}\n\t${0:${TM_SELECTED_TEXT}}\n\\end{gather}",
 		"description": "gather environment"
 	},
 	"gather*": {
 		"prefix": "BSGA",
-		"body": "\\begin{gather*}\n\t$0\n\\end{gather*}",
+		"body": "\\begin{gather*}\n\t${0:${TM_SELECTED_TEXT}}\n\\end{gather*}",
 		"description": "gather* environment"
 	},
 	"multline": {
 		"prefix": "BMU",
-		"body": "\\begin{multline}\n\t$0\n\\end{multline}",
+		"body": "\\begin{multline}\n\t${0:${TM_SELECTED_TEXT}}\n\\end{multline}",
 		"description": "multline environment"
 	},
 	"multline*": {
 		"prefix": "BSMU",
-		"body": "\\begin{multline*}\n\t$0\n\\end{multline*}",
+		"body": "\\begin{multline*}\n\t${0:${TM_SELECTED_TEXT}}\n\\end{multline*}",
 		"description": "multline* environment"
-	},	
+	},
 	"itemize": {
 		"prefix": "BIT",
-		"body": "\\begin{itemize}\n\t\\item $0\n\\end{itemize}",
+		"body": "\\begin{itemize}\n\t\\item ${0:${TM_SELECTED_TEXT}}\n\\end{itemize}",
 		"description": "itemize environment"
 	},
 	"enumerate": {
 		"prefix": "BEN",
-		"body": "\\begin{enumerate}\n\t\\item $0\n\\end{enumerate}",
+		"body": "\\begin{enumerate}\n\t\\item ${0:${TM_SELECTED_TEXT}}\n\\end{enumerate}",
 		"description": "enumerate environment"
 	},
 	"split": {
 		"prefix": "BSPL",
-		"body": "\\begin{split}\n\t$0\n\\end{split}",
+		"body": "\\begin{split}\n\t${0:${TM_SELECTED_TEXT}}\n\\end{split}",
 		"description": "split environment"
 	},
 	"cases": {
 		"prefix": "BCAS",
-		"body": "\\begin{cases}\n\t$0\n\\end{cases}",
+		"body": "\\begin{cases}\n\t${0:${TM_SELECTED_TEXT}}\n\\end{cases}",
 		"description": "cases environment"
 	},
 	"frame": {
 		"prefix": "BFR",
-		"body": "\\begin{frame}\n\t\\frametitle{${1:<title>}}\n\n\t$0\n\n\\end{frame}",
+		"body": "\\begin{frame}\n\t\\frametitle{${1:<title>}}\n\n\t${0:${TM_SELECTED_TEXT}}\n\n\\end{frame}",
 		"description": "frame"
 	},
 	"figure": {
 		"prefix": "BFI",
-		"body": "\\begin{figure}[${1:htbp}]\n\t\\centering\n\t$0\n\t\\caption{${2:<caption>}}\n\t\\label{${3:<label>}}\n\\end{figure}",
+		"body": "\\begin{figure}[${1:htbp}]\n\t\\centering\n\t${0:${TM_SELECTED_TEXT}}\n\t\\caption{${2:<caption>}}\n\t\\label{${3:<label>}}\n\\end{figure}",
 		"description": "figure"
 	},
 	"table": {
 		"prefix": "BTA",
-		"body": "\\begin{table}[${1:htbp}]\n\t\\centering\\begin{tabular}{${4:<columns>}}\n\t\t$0\n\t\\end{tabular}\n\t\\caption{${2:<caption>}}\n\t\\label{${3:<label>}}\n\\end{table}",
+		"body": "\\begin{table}[${1:htbp}]\n\t\\centering\\begin{tabular}{${4:<columns>}}\n\t\t${0:${TM_SELECTED_TEXT}}\n\t\\end{tabular}\n\t\\caption{${2:<caption>}}\n\t\\label{${3:<label>}}\n\\end{table}",
 		"description": "table"
 	},
 	"tikzpicture": {
 		"prefix": "BTP",
-		"body": "\\begin{tikzpicture}\n\t$0\n\\end{tikzpicture}",
+		"body": "\\begin{tikzpicture}\n\t${0:${TM_SELECTED_TEXT}}\n\\end{tikzpicture}",
 		"description": "tikzpicture"
 	},
 	"set font size": {
@@ -516,7 +516,7 @@
 		"description": "left[ ... right]"
 	},
 	"wrapEnv": {
-		"body": "\n\\begin{$1}\n\t${TM_SELECTED_TEXT}\n\\end{$1}",
+		"body": "\n\\begin{$1}\n\t${0:${TM_SELECTED_TEXT}}\n\\end{$1}",
 		"description": "Wrap selection into an environment"
 	},
 	"part": {

--- a/src/providers/completer/command.ts
+++ b/src/providers/completer/command.ts
@@ -536,7 +536,7 @@ export class Command implements IProvider {
 
         if (item.snippet) {
             if (useTabStops) {
-                item.snippet = item.snippet.replace(/\$\{(\d+):[^}]*\}/g, '$${$1}')
+                item.snippet = item.snippet.replace(/\$\{(\d+):[^$}]*\}/g, '$${$1}')
             }
             suggestion.insertText = new vscode.SnippetString(item.snippet)
         } else {

--- a/src/providers/completer/command.ts
+++ b/src/providers/completer/command.ts
@@ -538,6 +538,10 @@ export class Command implements IProvider {
             if (useTabStops) {
                 item.snippet = item.snippet.replace(/\$\{(\d+):[^$}]*\}/g, '$${$1}')
             }
+            // Wrap the selected text when there is a single placeholder
+            if (! (item.snippet.match(/\$\{?2/) || (item.snippet.match(/\$\{?0/) && item.snippet.match(/\$\{?1/)))) {
+                item.snippet = item.snippet.replace(/\$1|\$\{1\}/, '$${1:$${TM_SELECTED_TEXT}}').replace(/\$\{1:([^$}]+)\}/, '$${1:$${TM_SELECTED_TEXT:$1}}')
+            }
             suggestion.insertText = new vscode.SnippetString(item.snippet)
         } else {
             suggestion.insertText = item.command

--- a/src/providers/completer/command.ts
+++ b/src/providers/completer/command.ts
@@ -172,7 +172,7 @@ export class Command implements IProvider {
             }
             const command = (typeof item.insertText !== 'string') ? item.insertText.value : item.insertText
             if (command.match(/(.*)(\${\d.*?})/)) {
-                candidate.push(command.replace(/\n/g, '').replace(/\t/g, '').replace('\\\\', '\\'))
+                candidate.push(command.replace(/\n/g, '').replace(/\t/g, '').replace('\\\\', '\\').replace(':${TM_SELECTED_TEXT}', ''))
             }
         })
         vscode.window.showQuickPick(candidate, {

--- a/src/providers/completer/environment.ts
+++ b/src/providers/completer/environment.ts
@@ -35,15 +35,6 @@ export class Environment implements IProvider {
         this.defaultEnvsAsCommand = []
         this.defaultEnvsForBegin = []
         this.defaultEnvsAsName = []
-        const endCompletion: Suggestion = {
-            label: 'Complete with \\end',
-            sortText: ' ',
-            insertText: new vscode.SnippetString('$1}\n\t$0\n\\end{$1}'),
-            command: { title: 'Post-Action', command: 'editor.action.triggerSuggest' },
-            kind: vscode.CompletionItemKind.Module,
-            package: ''
-        }
-        this.defaultEnvsForBegin.push(endCompletion)
         Object.keys(envs).forEach(key => {
            this.defaultEnvsAsCommand.push(this.entryEnvToCompletion(key, envs[key], EnvSnippetType.AsCommand))
            this.defaultEnvsForBegin.push(this.entryEnvToCompletion(key, envs[key], EnvSnippetType.ForBegin))

--- a/src/providers/completer/environment.ts
+++ b/src/providers/completer/environment.ts
@@ -329,9 +329,10 @@ export class Environment implements IProvider {
                 }
             }
             if (snippet.match(/\$\{?0\}?/)) {
+                snippet = snippet.replace(/\$\{?0\}?/, '$${0:$${TM_SELECTED_TEXT}}')
                 snippet += '\n'
             } else {
-                snippet += '\n\t$0\n'
+                snippet += '\n\t${0:${TM_SELECTED_TEXT}}\n'
             }
             if (item.detail) {
                 suggestion.label = item.detail


### PR DESCRIPTION
Close #2386

- [x] **environments** This works when inserting environments with `\envname` or the [`B` snippets](https://github.com/James-Yu/LaTeX-Workshop/wiki/Snippets#Environments) and when using the `\begin/\end` snippet. 
  https://github.com/James-Yu/LaTeX-Workshop/blob/7eb309ec1ae6521f1f8887bccae3f1f02c557cc5/data%2Fcommands.json#L8-L13

  Note that the autocompletion on `\begin{`, which inserts `envname` and `\end{envname}` does not keep the selected text because the environment is actually inserted by a second call to autocompletion. See https://github.com/James-Yu/LaTeX-Workshop/blob/7eb309ec1ae6521f1f8887bccae3f1f02c557cc5/data%2Fcommands.json#L2-L7

- [x] **commands**

With this PR, the `wrap-env` function becomes useless, we should mark it as deprecated.