### PR TITLE
Stop overriding the cpp grammar

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,6 +152,9 @@
           ".Snw"
         ],
         "configuration": "./syntax/syntax-weave.json"
+      },
+      {
+        "id": "cpp_embedded_latex"
       }
     ],
     "grammars": [
@@ -171,7 +174,7 @@
         "path": "./syntax/LaTeX.tmLanguage.json",
         "embeddedLanguages": {
           "source.asymptote": "asymptote",
-          "source.cpp": "cpp",
+          "source.cpp": "cpp_embedded_latex",
           "source.css": "css",
           "source.dot": "dot",
           "source.gnuplot": "gnuplot",
@@ -214,7 +217,7 @@
         }
       },
       {
-        "language": "cpp",
+        "language": "cpp_embedded_latex",
         "scopeName": "source.cpp.embedded.latex",
         "path": "./syntax/cpp-grammar-bailout.tmLanguage.json",
         "embeddedLanguages": {


### PR DESCRIPTION
We should stop overriding the `cpp` grammar. We can avoid overriding by defining a new language id. Related to #2395.