### PR TITLE
Tweak the latex-workshop.surround command

### DIFF
--- a/src/providers/completer/command.ts
+++ b/src/providers/completer/command.ts
@@ -168,7 +168,7 @@ export class Command implements IProvider {
             const command = (typeof item.insertText !== 'string') ? item.insertText.value : item.insertText
             if (command.match(/(.*)(\${\d.*?})/)) {
                 candidate.push({
-                    command: command.replace(/\n/g, '').replace(/\t/g, '').replace('\\\\', '\\').replace(':${TM_SELECTED_TEXT}', ''),
+                    command: command.replace('\\\\', '\\').replace(':${TM_SELECTED_TEXT}', ''),
                     label: item.label
                 })
             }

--- a/src/providers/completer/command.ts
+++ b/src/providers/completer/command.ts
@@ -157,7 +157,7 @@ export class Command implements IProvider {
             return
         }
         const editor = vscode.window.activeTextEditor
-        const candidate: string[] = []
+        const candidate: {command: string, label: string}[] = []
         this.provide(editor.document.languageId).forEach(item => {
             if (item.insertText === undefined) {
                 return
@@ -167,7 +167,10 @@ export class Command implements IProvider {
             }
             const command = (typeof item.insertText !== 'string') ? item.insertText.value : item.insertText
             if (command.match(/(.*)(\${\d.*?})/)) {
-                candidate.push(command.replace(/\n/g, '').replace(/\t/g, '').replace('\\\\', '\\').replace(':${TM_SELECTED_TEXT}', ''))
+                candidate.push({
+                    command: command.replace(/\n/g, '').replace(/\t/g, '').replace('\\\\', '\\').replace(':${TM_SELECTED_TEXT}', ''),
+                    label: item.label
+                })
             }
         })
         vscode.window.showQuickPick(candidate, {
@@ -179,12 +182,12 @@ export class Command implements IProvider {
                 return
             }
             editor.edit( editBuilder => {
-                let selectedCommand = selected
+                let selectedCommand = selected.command
                 let selectedContent = content
                 for (const selection of editor.selections) {
-                    if (!content) {
+                    if (!selectedContent) {
                         selectedContent = editor.document.getText(selection)
-                        selectedCommand = '\\' + selected
+                        selectedCommand = '\\' + selected.command
                     }
                     editBuilder.replace(new vscode.Range(selection.start, selection.end),
                         selectedCommand.replace(/(.*)(\${\d.*?})/, `$1${selectedContent}`) // Replace text

--- a/src/providers/completer/command.ts
+++ b/src/providers/completer/command.ts
@@ -157,7 +157,7 @@ export class Command implements IProvider {
             return
         }
         const editor = vscode.window.activeTextEditor
-        const candidate: {command: string, label: string}[] = []
+        const candidate: {command: string, detail: string, label: string}[] = []
         this.provide(editor.document.languageId).forEach(item => {
             if (item.insertText === undefined) {
                 return
@@ -167,16 +167,18 @@ export class Command implements IProvider {
             }
             const command = (typeof item.insertText !== 'string') ? item.insertText.value : item.insertText
             if (command.match(/(.*)(\${\d.*?})/)) {
+                const commandStr = command.replace('\\\\', '\\').replace(':${TM_SELECTED_TEXT}', '')
                 candidate.push({
-                    command: command.replace('\\\\', '\\').replace(':${TM_SELECTED_TEXT}', ''),
+                    command: commandStr,
+                    detail: '\\' + commandStr.replace(/[\n\t]/g, '').replace(/\$\{(\d+)\}/g, '$$$1'),
                     label: item.label
                 })
             }
         })
         vscode.window.showQuickPick(candidate, {
             placeHolder: 'Press ENTER to surround previous selection with selected command',
-            matchOnDetail: true,
-            matchOnDescription: true
+            matchOnDetail: false,
+            matchOnDescription: false
         }).then(selected => {
             if (selected === undefined) {
                 return


### PR DESCRIPTION
- Display labels in QuickPick instead of snippets.
- Stop removing `\n` and `\t` in the command.

![スクリーンショット 2020-11-29 19 57 45](https://user-images.githubusercontent.com/10665499/100539922-323b9b00-327d-11eb-8f66-cbb93453dedb.png)
