### PR TITLE
Remove subfileincludegraphics in data/commands.json.

### DIFF
--- a/data/commands.json
+++ b/data/commands.json
@@ -766,11 +766,6 @@
     "snippet": "include{$1}",
     "postAction": "editor.action.triggerSuggest"
   },
-  "subfileincludegraphics": {
-    "command": "subfileincludegraphics",
-    "snippet": "subfile{$1}",
-    "postAction": "editor.action.triggerSuggest"
-  },
   "includegraphics": {
     "command": "includegraphics",
     "snippet": "includegraphics{$1}",


### PR DESCRIPTION
Remove `subfileincludegraphics` in data/commands.json.

The `subfile` command exists in `data/packages/subfiles_cmd.json`.