### PR TITLE
Honor region markers for folding

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -32,7 +32,7 @@ import {ProjectSymbolProvider} from './providers/projectsymbol'
 import {SectionNodeProvider, StructureTreeView} from './providers/structure'
 import {DefinitionProvider} from './providers/definition'
 import {LatexFormatterProvider} from './providers/latexformatter'
-import {FoldingProvider} from './providers/folding'
+import {FoldingProvider, WeaveFoldingProvider} from './providers/folding'
 import { SnippetPanel } from './components/snippetpanel'
 import { BibtexFormatter, BibtexFormatterProvider } from './providers/bibtexformatter'
 import {SnippetViewProvider} from './providers/snippetview'
@@ -226,6 +226,7 @@ export function activate(context: vscode.ExtensionContext) {
     }))
 
     const latexSelector = selectDocumentsWithId(['latex', 'latex-expl3', 'jlweave', 'rsweave'])
+    const weaveSelector = selectDocumentsWithId(['jlweave', 'rsweave'])
     const latexDoctexSelector = selectDocumentsWithId(['latex', 'latex-expl3', 'jlweave', 'rsweave', 'doctex'])
     const latexFormatter = new LatexFormatterProvider(extension)
     const bibtexFormatter = new BibtexFormatterProvider(extension)
@@ -254,6 +255,7 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(vscode.languages.registerCompletionItemProvider({ scheme: 'file', language: 'bibtex'}, new BibtexCompleter(extension), '@'))
     context.subscriptions.push(vscode.languages.registerCodeActionsProvider(latexSelector, extension.codeActions))
     context.subscriptions.push(vscode.languages.registerFoldingRangeProvider(latexSelector, new FoldingProvider(extension)))
+    context.subscriptions.push(vscode.languages.registerFoldingRangeProvider(weaveSelector, new WeaveFoldingProvider(extension)))
 
     context.subscriptions.push(vscode.window.registerWebviewViewProvider('latex-snippet-view', new SnippetViewProvider(extension), {webviewOptions: {retainContextWhenHidden: true}}))
 

--- a/src/providers/folding.ts
+++ b/src/providers/folding.ts
@@ -82,10 +82,14 @@ export class FoldingProvider implements vscode.FoldingRangeProvider {
         const ranges: vscode.FoldingRange[] = []
         const opStack: { keyword: string, index: number }[] = []
         const text: string = document.getText()
-        const envRegex = /(?:\\(begin){(.*?)})|(?:\\(begingroup)(?=$|%|\s|\\))|(?:\\(end){(.*?)})|(?:\\(endgroup)(?=$|%|\s|\\))|(?:%\s*#?([rR]egion))|(?:%\s*#?([eE]ndregion))/g //to match one 'begin' OR 'end'
+        const envRegex = /\\(begin){(.*?)}|\\(begingroup)[%\s\\]|\\(end){(.*?)}|\\(endgroup)[%\s\\]|^%\s*#?([rR]egion)|^%\s*#?([eE]ndregion)/gm //to match one 'begin' OR 'end'
 
-        let match = envRegex.exec(text) // init regex search
-        while (match) {
+        while (true) {
+            const match = envRegex.exec(text)
+            if (match === null) {
+                //TODO: if opStack still not empty
+                return ranges
+            }
             //for 'begin': match[1] contains 'begin', match[2] contains keyword
             //for 'end':   match[4] contains 'end',   match[5] contains keyword
             //for 'begingroup': match[3] contains 'begingroup', keyword is 'group'
@@ -118,11 +122,7 @@ export class FoldingProvider implements vscode.FoldingRangeProvider {
             } else {
                 opStack.push(item)
             }
-
-            match = envRegex.exec(text) //iterate regex search
         }
-        //TODO: if opStack still not empty
-        return ranges
     }
 }
 

--- a/syntax/syntax-expl3.json
+++ b/syntax/syntax-expl3.json
@@ -52,12 +52,6 @@
 		"increaseIndentPattern": "\\\\begin{(?!document)([^}]*)}(?!.*\\\\end{\\1})",
 		"decreaseIndentPattern": "^\\s*\\\\end{(?!document)"
 	},
-	"folding": {
-		"markers": {
-			"start": "^\\s*%\\s*#?region\\b.*",
-			"end": "^\\s*%\\s*#?endregion\\b.*"
-		}
-	},
 	"autoCloseBefore": ";:.,=}])>\\` \n\t$",
 	"wordPattern": "(__)|(\\*\\*)|(@.)|(\\.\\.\\.)|([^\\s`'\"~!?|$#@%^&*\\-=+;,.<>(){}[\\]\\\\\\/]{2,})"
 }

--- a/syntax/syntax-weave.json
+++ b/syntax/syntax-weave.json
@@ -56,12 +56,6 @@
 		"increaseIndentPattern": "\\\\begin{(?!document)([^}]*)}(?!.*\\\\end{\\1})",
 		"decreaseIndentPattern": "^\\s*\\\\end{(?!document)"
 	},
-	"folding": {
-		"markers": {
-			"start": "^((\\s*?)<<.*?>>=(?:\\s*))$",
-			"end": "^(\\2@(?:\\s*))$"
-		}
-	},
 	"autoCloseBefore": ";:.,=}])>\\` \n\t$",
 	"wordPattern": "(__)|(\\*\\*)|(@.)|(\\.\\.\\.)|([^\\s`'\"~_!?|$#@%^&*\\-=+;:,.<>(){}[\\]\\\\\\/]{2,})"
 

--- a/syntax/syntax.json
+++ b/syntax/syntax.json
@@ -52,12 +52,6 @@
 		"increaseIndentPattern": "\\\\begin{(?!document)([^}]*)}(?!.*\\\\end{\\1})",
 		"decreaseIndentPattern": "^\\s*\\\\end{(?!document)"
 	},
-	"folding": {
-		"markers": {
-			"start": "^\\s*%\\s*#?region\\b.*",
-			"end": "^\\s*%\\s*#?endregion\\b.*"
-		}
-	},
 	"autoCloseBefore": ";:.,=}])>\\` \n\t$",
 	"wordPattern": "(__)|(\\*\\*)|(@.)|(\\.\\.\\.)|([^\\s`'\"~_!?|$#@%^&*\\-=+;:,.<>(){}[\\]\\\\\\/]{2,})"
 }


### PR DESCRIPTION
Close #2407. Related to #2406.

The region markers mechanism is implemented in the FoldingRangeProvider

We should also integrate the following region markers for `sweave` files

```
"start": "^((\\s*?)<<.*?>>=(?:\\s*))$",
"end": "^(\\2@(?:\\s*))$"
```

Edit: done in b110afd.
