### PR TITLE
Make trigger characters for intellisense of LaTeX documents configurable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1548,6 +1548,14 @@
           "default": 5,
           "markdownDescription": "Defines the maximum bibtex file size for the extension to parse in MB."
         },
+        "latex-workshop.intellisense.triggers.latex":{
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "markdownDescription": "Additional trigger characters for intellisense of LaTeX documents. You must reload VSCode to take into account a change in this configuration."
+        },
         "latex-workshop.intellisense.file.exclude": {
           "type": "array",
           "items": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -247,9 +247,16 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(vscode.languages.registerDefinitionProvider(latexSelector, new DefinitionProvider(extension)))
     context.subscriptions.push(vscode.languages.registerDocumentSymbolProvider(latexSelector, new DocSymbolProvider(extension)))
     context.subscriptions.push(vscode.languages.registerWorkspaceSymbolProvider(new ProjectSymbolProvider(extension)))
+
+    const configuration = vscode.workspace.getConfiguration('latex-workshop')
+    const userTriggersLatex = configuration.get('intellisense.triggers.latex') as string[]
+    const latexTriggers = ['\\', '{', ',', '(', '['].concat(userTriggersLatex)
+    extension.logger.addLogMessage(`Trigger characters for intellisense of LaTeX documents: ${JSON.stringify(latexTriggers)}`)
+
     context.subscriptions.push(vscode.languages.registerCompletionItemProvider({ scheme: 'file', language: 'tex'}, extension.completer, '\\', '{'))
-    context.subscriptions.push(vscode.languages.registerCompletionItemProvider(latexDoctexSelector, extension.completer, '\\', '{', ',', '(', '['))
+    context.subscriptions.push(vscode.languages.registerCompletionItemProvider(latexDoctexSelector, extension.completer, ...latexTriggers))
     context.subscriptions.push(vscode.languages.registerCompletionItemProvider({ scheme: 'file', language: 'bibtex'}, new BibtexCompleter(extension), '@'))
+
     context.subscriptions.push(vscode.languages.registerCodeActionsProvider(latexSelector, extension.codeActions))
     context.subscriptions.push(vscode.languages.registerFoldingRangeProvider(latexSelector, new FoldingProvider(extension)))
     context.subscriptions.push(vscode.languages.registerFoldingRangeProvider(weaveSelector, new WeaveFoldingProvider(extension)))


### PR DESCRIPTION
Make trigger characters for intellisense of LaTeX documents configurable. 

With this PR, users can trigger their defined snippets with their prefix, e.g.`@`, `#`, and other characters when `editor.suggest.showSnippets` enabled.
 
