### PR TITLE
Use vscode.env.asExternalUri for the internal PDF viewer

### DIFF
--- a/src/components/viewer.ts
+++ b/src/components/viewer.ts
@@ -231,8 +231,7 @@ export class Viewer {
         const htmlContent = await this.getPDFViewerContent(pdfFilePath)
         const panel = vscode.window.createWebviewPanel('latex-workshop-pdf', path.basename(pdfFilePath), viewColumn, {
             enableScripts: true,
-            retainContextWhenHidden: true,
-            portMapping : [{webviewPort: this.extension.server.port, extensionHostPort: this.extension.server.port}]
+            retainContextWhenHidden: true
         })
         panel.webview.html = htmlContent
         const pdfPanel = new PdfViewerPanel(pdfFilePath, panel)

--- a/src/components/viewer.ts
+++ b/src/components/viewer.ts
@@ -228,13 +228,13 @@ export class Viewer {
             this.extension.logger.addLogMessage('Server port is undefined')
             return
         }
-
+        const htmlContent = await this.getPDFViewerContent(pdfFilePath)
         const panel = vscode.window.createWebviewPanel('latex-workshop-pdf', path.basename(pdfFilePath), viewColumn, {
             enableScripts: true,
             retainContextWhenHidden: true,
             portMapping : [{webviewPort: this.extension.server.port, extensionHostPort: this.extension.server.port}]
         })
-        panel.webview.html = await this.getPDFViewerContent(pdfFilePath)
+        panel.webview.html = htmlContent
         const pdfPanel = new PdfViewerPanel(pdfFilePath, panel)
         this.pushPdfViewerPanel(pdfPanel)
         return pdfPanel


### PR DESCRIPTION
Use `vscode.env.asExternalUri` for the internal PDF viewer. Close #2206.

See https://github.com/microsoft/vscode/issues/102449#issuecomment-744405611

A drawback is that opening the internal PDF viewer becomes not smooth. The viewer appears in the current tab for a short period.


![Dec-15-2020 20-37-39](https://user-images.githubusercontent.com/10665499/102211052-5b635900-3f16-11eb-95c7-3d93244a8acc.gif)

The behavior itself is coded by @jlelong.

https://github.com/James-Yu/LaTeX-Workshop/blob/cb599c33dcf942999a360f8463bbb018fef772f5/src/utils/webview.ts#L21