### PR TITLE
Enable @typescript-eslint/prefer-readonly

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -53,6 +53,7 @@
         "@typescript-eslint/no-inferrable-types": "off",
         "@typescript-eslint/no-empty-function": "off",
         "@typescript-eslint/no-misused-promises": [ "error", { "checksVoidReturn": false } ],
+        "@typescript-eslint/prefer-readonly": "error",
         "curly": "error",
         "eol-last": "error",
         "no-caller": "error",

--- a/src/components/server.ts
+++ b/src/components/server.ts
@@ -10,8 +10,8 @@ import {decodePathWithPrefix, pdfFilePrefix} from '../utils/utils'
 
 export class Server {
     private readonly extension: Extension
-    private httpServer: http.Server
-    private wsServer: ws.Server
+    private readonly httpServer: http.Server
+    private readonly wsServer: ws.Server
     address?: string
     port?: number
 

--- a/src/components/snippetpanel.ts
+++ b/src/components/snippetpanel.ts
@@ -73,7 +73,7 @@ export class SnippetPanel {
 
     }
 
-    private mathSymbols: IMathSymbol[] = []
+    private readonly mathSymbols: IMathSymbol[] = []
 
     private loadSnippets() {
         const snipetsFile = path.join(this.extension.extensionRoot, 'resources', 'snippetpanel', 'snippetpanel.json')

--- a/src/providers/bibtexformatter.ts
+++ b/src/providers/bibtexformatter.ts
@@ -157,7 +157,7 @@ export class BibtexFormatter {
 }
 
 export class BibtexFormatterProvider implements vscode.DocumentFormattingEditProvider, vscode.DocumentRangeFormattingEditProvider {
-    private formatter: BibtexFormatter
+    private readonly formatter: BibtexFormatter
     extension: Extension
 
     constructor(extension: Extension) {

--- a/src/providers/completer/command.ts
+++ b/src/providers/completer/command.ts
@@ -29,8 +29,8 @@ export class Command implements IProvider {
     private readonly commandFinder: CommandFinder
     private readonly surroundCommand: SurroundCommand
 
-    private defaultCmds: Suggestion[] = []
-    private defaultSymbols: Suggestion[] = []
+    private readonly defaultCmds: Suggestion[] = []
+    private readonly defaultSymbols: Suggestion[] = []
     private packageCmds: {[pkg: string]: Suggestion[]} = {}
 
     constructor(extension: Extension, environment: Environment) {

--- a/src/providers/completer/environment.ts
+++ b/src/providers/completer/environment.ts
@@ -23,9 +23,9 @@ export class Environment implements IProvider {
     private defaultEnvsAsName: Suggestion[] = []
     private defaultEnvsAsCommand: Suggestion[] = []
     private defaultEnvsForBegin: Suggestion[] = []
-    private packageEnvsAsName: {[pkg: string]: Suggestion[]} = {}
+    private readonly packageEnvsAsName: {[pkg: string]: Suggestion[]} = {}
     private packageEnvsAsCommand: {[pkg: string]: Suggestion[]} = {}
-    private packageEnvsForBegin: {[pkg: string]: Suggestion[]} = {}
+    private readonly packageEnvsForBegin: {[pkg: string]: Suggestion[]} = {}
 
     constructor(extension: Extension) {
         this.extension = extension

--- a/src/providers/latexformatter.ts
+++ b/src/providers/latexformatter.ts
@@ -203,7 +203,7 @@ export class LaTexFormatter {
 }
 
 export class LatexFormatterProvider implements vscode.DocumentFormattingEditProvider, vscode.DocumentRangeFormattingEditProvider {
-    private formatter: LaTexFormatter
+    private readonly formatter: LaTexFormatter
 
     constructor(extension: Extension) {
         this.formatter = new LaTexFormatter(extension)

--- a/src/providers/preview/mathpreviewlib/textdocumentlike.ts
+++ b/src/providers/preview/mathpreviewlib/textdocumentlike.ts
@@ -6,7 +6,7 @@ export class TextDocumentLike {
     private readonly _lines: string[]
     readonly lineCount: number
     readonly eol: vscode.EndOfLine
-    private _eol: string
+    private readonly _eol: string
 
     static load(filePath: string): TextDocumentLike | vscode.TextDocument {
         const uri = vscode.Uri.file(filePath)

--- a/src/providers/structure.ts
+++ b/src/providers/structure.ts
@@ -12,15 +12,15 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
     readonly onDidChangeTreeData: vscode.Event<Section | undefined>
     private readonly hierarchy: string[]
     private readonly sectionDepths: { [key: string]: number } = {}
-    private showLabels: boolean
-    private showFloats: boolean
-    private showNumbers: boolean
+    private readonly showLabels: boolean
+    private readonly showFloats: boolean
+    private readonly showNumbers: boolean
     public root: string = ''
 
     // our data source is a set multi-rooted set of trees
     public ds: Section[] = []
 
-    constructor(private extension: Extension) {
+    constructor(private readonly extension: Extension) {
         this.onDidChangeTreeData = this._onDidChangeTreeData.event
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         this.hierarchy = configuration.get('view.outline.sections') as string[]
@@ -353,12 +353,12 @@ export class Section extends vscode.TreeItem {
 }
 
 export class StructureTreeView {
-    private _viewer: vscode.TreeView<Section | undefined>
-    private _treeDataProvider: SectionNodeProvider
+    private readonly _viewer: vscode.TreeView<Section | undefined>
+    private readonly _treeDataProvider: SectionNodeProvider
     private _followCursor: boolean = true
 
 
-    constructor(private extension: Extension) {
+    constructor(private readonly extension: Extension) {
         this._treeDataProvider = this.extension.structureProvider
         this._viewer = vscode.window.createTreeView('latex-structure', { treeDataProvider: this._treeDataProvider })
         vscode.commands.registerCommand('latex-structure.toggle-follow-cursor', () => {


### PR DESCRIPTION
- Enable [`@typescript-eslint/prefer-readonly`](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/prefer-readonly.md).
- Add `readonly` if possible.