### PR TITLE
Split log parser

### DIFF
--- a/src/commander.ts
+++ b/src/commander.ts
@@ -596,7 +596,7 @@ export class Commander {
         if (vscode.window.activeTextEditor === undefined) {
             return
         }
-        this.extension.logParser.parse(vscode.window.activeTextEditor.document.getText())
+        this.extension.latexLogParser.parse(vscode.window.activeTextEditor.document.getText())
     }
 
     async devParseTeX() {

--- a/src/components/builder.ts
+++ b/src/components/builder.ts
@@ -136,7 +136,7 @@ export class Builder {
         })
 
         this.currentProcess.on('exit', (exitCode, signal) => {
-            this.extension.logParser.parse(stdout)
+            this.extension.latexLogParser.parse(stdout)
             if (exitCode !== 0) {
                 this.extension.logger.addLogMessage(`Build returns with error: ${exitCode}/${signal}. PID: ${pid}.`)
                 this.extension.logger.displayStatus('x', 'errorForeground', 'Build terminated with error', 'warning')
@@ -328,7 +328,7 @@ export class Builder {
         })
 
         this.currentProcess.on('exit', (exitCode, signal) => {
-            this.extension.logParser.parse(stdout, rootFile)
+            this.extension.latexLogParser.parse(stdout, rootFile)
             if (exitCode !== 0) {
                 this.extension.logger.addLogMessage(`Recipe returns with error: ${exitCode}/${signal}. PID: ${pid}. message: ${stderr}.`)
                 this.extension.logger.addLogMessage(`The environment variable $PATH: ${envVars['PATH']}`)
@@ -391,7 +391,7 @@ export class Builder {
         this.extension.buildInfo.buildEnded()
         this.extension.logger.addLogMessage(`Successfully built ${rootFile}.`)
         this.extension.logger.displayStatus('check', 'statusBar.foreground', 'Recipe succeeded.')
-        if (this.extension.logParser.isLaTeXmkSkipped) {
+        if (this.extension.latexLogParser.isLaTeXmkSkipped) {
             return
         }
         this.extension.viewer.refreshExistingViewer(rootFile)

--- a/src/components/linter.ts
+++ b/src/components/linter.ts
@@ -97,7 +97,7 @@ export class Linter {
         }
         // provide the original path to the active file as the second argument, so
         // we report this second path in the diagnostics instead of the temporary one.
-        this.extension.logParser.parseLinter(stdout, filePath)
+        this.extension.linterLogParser.parse(stdout, filePath)
     }
 
     async lintRootFile() {
@@ -129,7 +129,7 @@ export class Linter {
                 return
             }
         }
-        this.extension.logParser.parseLinter(stdout)
+        this.extension.linterLogParser.parse(stdout)
     }
 
     processWrapper(linterId: string, command: string, args: string[], options: SpawnOptionsWithoutStdio, stdin?: string): Promise<string> {

--- a/src/components/parser/latexlog.ts
+++ b/src/components/parser/latexlog.ts
@@ -34,16 +34,6 @@ const DIAGNOSTIC_SEVERITY: { [key: string]: vscode.DiagnosticSeverity } = {
     'error': vscode.DiagnosticSeverity.Error,
 }
 
-interface LinterLogEntry {
-    file: string,
-    line: number,
-    position: number,
-    length: number,
-    type: string,
-    code: number,
-    text: string
-}
-
 interface LogEntry { type: string, file: string, text: string, line: number }
 
 class ParserState {
@@ -61,13 +51,12 @@ class ParserState {
     }
 }
 
-export class Parser {
+export class LatexLogParser {
     private readonly extension: Extension
     isLaTeXmkSkipped: boolean = false
     private buildLog: LogEntry[] = []
     buildLogRaw: string = ''
     private readonly compilerDiagnostics = vscode.languages.createDiagnosticCollection('LaTeX')
-    private readonly linterDiagnostics = vscode.languages.createDiagnosticCollection('ChkTeX')
 
     constructor(extension: Extension) {
         this.extension = extension
@@ -316,38 +305,6 @@ export class Parser {
         return nested
     }
 
-    parseLinter(log: string, singleFileOriginalPath?: string) {
-        const re = /^(.*?):(\d+):(\d+):(\d+):(.*?):(\d+):(.*?)$/gm
-        const linterLog: LinterLogEntry[] = []
-        let match = re.exec(log)
-        while (match) {
-            // This log may be for a single file in memory, in which case we override the
-            // path with what is provided
-            const filePath = singleFileOriginalPath ? singleFileOriginalPath : match[1]
-            linterLog.push({
-                file: (!path.isAbsolute(filePath) && this.extension.manager.rootDir !== undefined) ?
-                    path.resolve(this.extension.manager.rootDir, filePath) : filePath,
-                line: parseInt(match[2]),
-                position: parseInt(match[3]),
-                length: parseInt(match[4]),
-                type: match[5].toLowerCase(),
-                code: parseInt(match[6]),
-                text: `${match[6]}: ${match[7]}`
-            })
-            match = re.exec(log)
-        }
-        this.extension.logger.addLogMessage(`Linter log parsed with ${linterLog.length} messages.`)
-        if (singleFileOriginalPath === undefined) {
-            // A full lint of the project has taken place - clear all previous results.
-            this.linterDiagnostics.clear()
-        } else if (linterLog.length === 0) {
-            // We are linting a single file and the new log is empty for it -
-            // clean existing records.
-            this.linterDiagnostics.set(vscode.Uri.file(singleFileOriginalPath), [])
-        }
-        this.showLinterDiagnostics(linterLog)
-    }
-
     private showCompilerDiagnostics() {
         this.compilerDiagnostics.clear()
         const diagsCollection: { [key: string]: vscode.Diagnostic[] } = {}
@@ -372,37 +329,6 @@ export class Parser {
                 }
             }
             this.compilerDiagnostics.set(vscode.Uri.file(file1), diagsCollection[file])
-        }
-    }
-
-    private showLinterDiagnostics(linterLog: LinterLogEntry[]) {
-        const diagsCollection: { [key: string]: vscode.Diagnostic[] } = {}
-        for (const item of linterLog) {
-            const range = new vscode.Range(new vscode.Position(item.line - 1, item.position - 1),
-                new vscode.Position(item.line - 1, item.position - 1 + item.length))
-            const diag = new vscode.Diagnostic(range, item.text, DIAGNOSTIC_SEVERITY[item.type])
-            diag.code = item.code
-            diag.source = 'ChkTeX'
-            if (diagsCollection[item.file] === undefined) {
-                diagsCollection[item.file] = []
-            }
-            diagsCollection[item.file].push(diag)
-        }
-        const configuration = vscode.workspace.getConfiguration('latex-workshop')
-        const convEnc = configuration.get('message.convertFilenameEncoding') as boolean
-        for (const file in diagsCollection) {
-            let file1 = file
-            if (['.tex', '.bbx', '.cbx', '.dtx'].includes(path.extname(file))) {
-                // Only report ChkTeX errors on TeX files. This is done to avoid
-                // reporting errors in .sty files, which are irrelevant for most users.
-                if (!fs.existsSync(file1) && convEnc) {
-                    const f = convertFilenameEncoding(file1)
-                    if (f !== undefined) {
-                        file1 = f
-                    }
-                }
-                this.linterDiagnostics.set(vscode.Uri.file(file1), diagsCollection[file])
-            }
         }
     }
 }

--- a/src/components/parser/linterlog.ts
+++ b/src/components/parser/linterlog.ts
@@ -1,0 +1,94 @@
+import * as vscode from 'vscode'
+import * as path from 'path'
+import * as fs from 'fs'
+
+import type { Extension } from '../../main'
+import { convertFilenameEncoding } from '../../utils/utils'
+
+interface LinterLogEntry {
+    file: string,
+    line: number,
+    position: number,
+    length: number,
+    type: string,
+    code: number,
+    text: string
+}
+
+const DIAGNOSTIC_SEVERITY: { [key: string]: vscode.DiagnosticSeverity } = {
+    'typesetting': vscode.DiagnosticSeverity.Information,
+    'warning': vscode.DiagnosticSeverity.Warning,
+    'error': vscode.DiagnosticSeverity.Error,
+}
+
+export class LinterLogParser {
+    private readonly extension: Extension
+    private readonly linterDiagnostics = vscode.languages.createDiagnosticCollection('ChkTeX')
+
+    constructor(extension: Extension) {
+        this.extension = extension
+    }
+
+    parse(log: string, singleFileOriginalPath?: string) {
+        const re = /^(.*?):(\d+):(\d+):(\d+):(.*?):(\d+):(.*?)$/gm
+        const linterLog: LinterLogEntry[] = []
+        let match = re.exec(log)
+        while (match) {
+            // This log may be for a single file in memory, in which case we override the
+            // path with what is provided
+            const filePath = singleFileOriginalPath ? singleFileOriginalPath : match[1]
+            linterLog.push({
+                file: (!path.isAbsolute(filePath) && this.extension.manager.rootDir !== undefined) ?
+                    path.resolve(this.extension.manager.rootDir, filePath) : filePath,
+                line: parseInt(match[2]),
+                position: parseInt(match[3]),
+                length: parseInt(match[4]),
+                type: match[5].toLowerCase(),
+                code: parseInt(match[6]),
+                text: `${match[6]}: ${match[7]}`
+            })
+            match = re.exec(log)
+        }
+        this.extension.logger.addLogMessage(`Linter log parsed with ${linterLog.length} messages.`)
+        if (singleFileOriginalPath === undefined) {
+            // A full lint of the project has taken place - clear all previous results.
+            this.linterDiagnostics.clear()
+        } else if (linterLog.length === 0) {
+            // We are linting a single file and the new log is empty for it -
+            // clean existing records.
+            this.linterDiagnostics.set(vscode.Uri.file(singleFileOriginalPath), [])
+        }
+        this.showLinterDiagnostics(linterLog)
+    }
+
+    private showLinterDiagnostics(linterLog: LinterLogEntry[]) {
+        const diagsCollection: { [key: string]: vscode.Diagnostic[] } = {}
+        for (const item of linterLog) {
+            const range = new vscode.Range(new vscode.Position(item.line - 1, item.position - 1),
+                new vscode.Position(item.line - 1, item.position - 1 + item.length))
+            const diag = new vscode.Diagnostic(range, item.text, DIAGNOSTIC_SEVERITY[item.type])
+            diag.code = item.code
+            diag.source = 'ChkTeX'
+            if (diagsCollection[item.file] === undefined) {
+                diagsCollection[item.file] = []
+            }
+            diagsCollection[item.file].push(diag)
+        }
+        const configuration = vscode.workspace.getConfiguration('latex-workshop')
+        const convEnc = configuration.get('message.convertFilenameEncoding') as boolean
+        for (const file in diagsCollection) {
+            let file1 = file
+            if (['.tex', '.bbx', '.cbx', '.dtx'].includes(path.extname(file))) {
+                // Only report ChkTeX errors on TeX files. This is done to avoid
+                // reporting errors in .sty files, which are irrelevant for most users.
+                if (!fs.existsSync(file1) && convEnc) {
+                    const f = convertFilenameEncoding(file1)
+                    if (f !== undefined) {
+                        file1 = f
+                    }
+                }
+                this.linterDiagnostics.set(vscode.Uri.file(file1), diagsCollection[file])
+            }
+        }
+    }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,7 +17,8 @@ import {Counter} from './components/counter'
 import {TeXMagician} from './components/texmagician'
 import {EnvPair} from './components/envpair'
 import {Section} from './components/section'
-import {Parser as LogParser} from './components/parser/log'
+import {LatexLogParser} from './components/parser/latexlog'
+import {LinterLogParser} from './components/parser/linterlog'
 import {UtensilsParser as PEGParser} from './components/parser/syntax'
 
 import {Completer} from './providers/completion'
@@ -340,7 +341,8 @@ export class Extension {
     readonly viewer: Viewer
     readonly server: Server
     readonly locator: Locator
-    readonly logParser: LogParser
+    readonly latexLogParser: LatexLogParser
+    readonly linterLogParser: LinterLogParser
     readonly pegParser: PEGParser
     readonly completer: Completer
     readonly linter: Linter
@@ -373,7 +375,8 @@ export class Extension {
         this.viewer = new Viewer(this)
         this.server = new Server(this)
         this.locator = new Locator(this)
-        this.logParser = new LogParser(this)
+        this.latexLogParser = new LatexLogParser(this)
+        this.linterLogParser = new LinterLogParser(this)
         this.completer = new Completer(this)
         this.linter = new Linter(this)
         this.cleaner = new Cleaner(this)


### PR DESCRIPTION
Split the log parser into two classes

- `LatexLogParser` for parsing the compiler logs
- `LinterLogParser` for parsing the linter logs

With this PR, adding more parsers(#2324) will be cleaner.