### PR TITLE
Add placeholder %SEP% and %DELIM%

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -65,7 +65,7 @@ export function getLongestBalancedString(s: string): string {
                 nested++
                 break
             case '}':
-                nested --
+                nested--
                 break
             case '\\':
                 // skip an escaped character
@@ -198,12 +198,12 @@ export function replaceArgumentPlaceholders(rootFile: string, tmpDir: string): (
                     .replace(/%DOCFILE%/g, docfile)
                     .replace(/%DIR%/g, docker ? './' : dir)
                     .replace(/%DIR_W32%/g, docker ? './' : dirW32)
+                    .replace(/%SEP%/g, docker ? '/' : path.sep)
+                    .replace(/%DELIM%/g, docker ? ':' : path.delimiter)
                     .replace(/%TMPDIR%/g, tmpDir)
-
         }
         const outDirW32 = path.normalize(expandPlaceHolders(configuration.get('latex.outDir') as string))
         const outDir = outDirW32.split(path.sep).join('/')
         return expandPlaceHolders(arg).replace(/%OUTDIR%/g, outDir).replace(/%OUTDIR_W32%/g, outDirW32)
-
     }
 }


### PR DESCRIPTION
When I set `outDir` to a value different from `%DIR%`, I need to set the environment variable `BIBINPUTS="%OUTDIR:"` for `bibtex`. But the field delimiter is `';'` on Windows (on Unix-like systems is `':'`).

I want to add new placeholder `%DELIM%` to keep my `settings.json` consistent on different machines.

```json
{
    "name": "bibtex",
    "command": "bibtex",
    "args": [
        "out/%DOCFILE%"
    ],
    "env": {
        "BIBINPUTS": "%OUTDIR%:"
    }
}

// Change to
{
    "name": "bibtex",
    "command": "bibtex",
    "args": [
        "out/%DOCFILE%"
    ],
    "env": {
        "BIBINPUTS": "%OUTDIR%%DELIM%"
    }
}
```