### PR TITLE
Add a configurable clean command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1185,6 +1185,36 @@
           ],
           "markdownDescription": "Files to clean.\nThis property must be an array of strings. File globs such as *.removeme, something?.aux can be used."
         },
+        "latex-workshop.latex.clean.command": {
+          "type": "string",
+          "default": "latexmk",
+          "markdownDescription": "The command to be used to remove temporary files when `latex-workshop.latex.clean.method` is set to `cleanMethod`."
+        },
+        "latex-workshop.latex.clean.args": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "-c",
+            "%TEX%"
+          ],
+          "markdownDescription": "The arguments of `latex-workshop.latex.clean.command`. The `%TEX%` placeholder is the full path of the tex file from which the clean command is called."
+        },
+
+        "latex-workshop.latex.clean.method": {
+          "type": "string",
+          "default": "glob",
+          "enum": [
+            "glob",
+            "cleanCommand"
+          ],
+          "markdownEnumDescriptions": [
+            "Clean all the files located in `latex-workshop.latex.outDir` and matching the glob patterns listed in `latex-workshop.latex.clean.fileTypes`.",
+            "Run `latex-workshop.latex.clean.command` to clean temporary files."
+          ],
+          "markdownDescription": "Define the method used by the `clean` command to remove temporary files."
+        },
         "latex-workshop.latex.option.maxPrintLine.enabled": {
           "type": "boolean",
           "default": true,

--- a/src/components/cleaner.ts
+++ b/src/components/cleaner.ts
@@ -28,17 +28,15 @@ export class Cleaner {
         switch (cleanMethod) {
             case 'glob':
                 return this.cleanGlob(rootFile)
-                break
             case 'cleanCommand':
                 return this.cleanCommand(rootFile)
-                break
             default:
                 this.extension.logger.addLogMessage(`Unknown cleaning method: ${cleanMethod}`)
                 return
         }
     }
 
-    async cleanGlob(rootFile: string): Promise<void> {
+    private cleanGlob(rootFile: string): Promise<void> {
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         let globs = configuration.get('latex.clean.fileTypes') as string[]
         const outdir = path.resolve(path.dirname(rootFile), this.extension.manager.getOutDir(rootFile))
@@ -88,7 +86,7 @@ export class Cleaner {
         })
     }
 
-    cleanCommand(rootFile: string): Promise<void> {
+    private cleanCommand(rootFile: string): Promise<void> {
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         const command = configuration.get('latex.clean.command') as string
         let args = configuration.get('latex.clean.args') as string[]

--- a/src/components/cleaner.ts
+++ b/src/components/cleaner.ts
@@ -115,6 +115,7 @@ export class Cleaner {
                 } else {
                     this.extension.logger.addLogMessage(`The clean command failed with exit code ${exitCode}`)
                     this.extension.logger.addLogMessage(`Clean command stderr: ${stderr}`)
+                    reject(stderr)
                 }
             })
 

--- a/src/components/cleaner.ts
+++ b/src/components/cleaner.ts
@@ -95,7 +95,7 @@ export class Cleaner {
             args = args.map(arg => arg.replace('%TEX%', rootFile))
         }
         this.extension.logger.addLogMessage(`Clean temporary files using: ${command}, ${args}`)
-        return new Promise((resolve, reject) => {
+        return new Promise((resolve, _reject) => {
             const proc = cs.spawn(command, args, {cwd: path.dirname(rootFile), detached: true})
             let stderr = ''
             proc.stderr.on('data', newStderr => {
@@ -106,15 +106,14 @@ export class Cleaner {
                 if (err instanceof Error) {
                     this.extension.logger.logError(err)
                 }
-                reject(err)
+                resolve()
             })
             proc.on('exit', exitCode => {
-                if (exitCode === 0) {
-                    resolve()
-                } else {
+                if (exitCode !== 0) {
                     this.extension.logger.addLogMessage(`The clean command failed with exit code ${exitCode}`)
                     this.extension.logger.addLogMessage(`Clean command stderr: ${stderr}`)
                 }
+                resolve()
             })
 
         })

--- a/src/components/cleaner.ts
+++ b/src/components/cleaner.ts
@@ -96,14 +96,12 @@ export class Cleaner {
             args = args.map(arg => arg.replace('%TEX%', rootFile))
         }
         this.extension.logger.addLogMessage(`Clean temporary files using: ${command}, ${args}`)
-        const proc = cs.spawn(command, args, {cwd: path.dirname(rootFile), detached: true})
-
-        let stderr = ''
-        proc.stderr.on('data', newStderr => {
-            stderr += newStderr
-        })
-
-        return new Promise( (resolve, reject) => {
+        return new Promise((resolve, reject) => {
+            const proc = cs.spawn(command, args, {cwd: path.dirname(rootFile), detached: true})
+            let stderr = ''
+            proc.stderr.on('data', newStderr => {
+                stderr += newStderr
+            })
             proc.on('error', err => {
                 this.extension.logger.addLogMessage(`Cannot run ${command}: ${err.message}, ${stderr}`)
                 if (err instanceof Error) {

--- a/src/components/cleaner.ts
+++ b/src/components/cleaner.ts
@@ -20,6 +20,7 @@ export class Cleaner {
             }
             rootFile = this.extension.manager.rootFile
             if (! rootFile) {
+                this.extension.logger.addLogMessage('Cannot determine the root file to be cleaned.')
                 return
             }
         }
@@ -113,7 +114,6 @@ export class Cleaner {
                 } else {
                     this.extension.logger.addLogMessage(`The clean command failed with exit code ${exitCode}`)
                     this.extension.logger.addLogMessage(`Clean command stderr: ${stderr}`)
-                    reject(stderr)
                 }
             })
 

--- a/src/components/cleaner.ts
+++ b/src/components/cleaner.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode'
 import * as path from 'path'
 import * as fs from 'fs-extra'
 import glob from 'glob'
+import * as cs from 'cross-spawn'
 
 import type {Extension} from '../main'
 
@@ -22,6 +23,22 @@ export class Cleaner {
                 return
             }
         }
+        const configuration = vscode.workspace.getConfiguration('latex-workshop')
+        const cleanMethod = configuration.get('latex.clean.method') as string
+        switch (cleanMethod) {
+            case 'glob':
+                return this.cleanGlob(rootFile)
+                break
+            case 'cleanCommand':
+                return this.cleanCommand(rootFile)
+                break
+            default:
+                this.extension.logger.addLogMessage(`Unknown cleaning method: ${cleanMethod}`)
+                return
+        }
+    }
+
+    async cleanGlob(rootFile: string): Promise<void> {
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         let globs = configuration.get('latex.clean.fileTypes') as string[]
         const outdir = path.resolve(path.dirname(rootFile), this.extension.manager.getOutDir(rootFile))
@@ -69,5 +86,41 @@ export class Cleaner {
                 }
             })
         })
+    }
+
+    cleanCommand(rootFile: string): Promise<void> {
+        const configuration = vscode.workspace.getConfiguration('latex-workshop')
+        const command = configuration.get('latex.clean.command') as string
+        let args = configuration.get('latex.clean.args') as string[]
+        if (args) {
+            args = args.map(arg => arg.replace('%TEX%', rootFile))
+        }
+        this.extension.logger.addLogMessage(`Clean temporary files using: ${command}, ${args}`)
+        const proc = cs.spawn(command, args, {cwd: path.dirname(rootFile), detached: true})
+
+        let stderr = ''
+        proc.stderr.on('data', newStderr => {
+            stderr += newStderr
+        })
+
+        return new Promise( (resolve, reject) => {
+            proc.on('error', err => {
+                this.extension.logger.addLogMessage(`Cannot run ${command}: ${err.message}, ${stderr}`)
+                if (err instanceof Error) {
+                    this.extension.logger.logError(err)
+                }
+                reject(err)
+            })
+            proc.on('exit', exitCode => {
+                if (exitCode === 0) {
+                    resolve()
+                } else {
+                    this.extension.logger.addLogMessage(`The clean command failed with exit code ${exitCode}`)
+                    this.extension.logger.addLogMessage(`Clean command stderr: ${stderr}`)
+                }
+            })
+
+        })
+
     }
 }


### PR DESCRIPTION
Close #2451

This PR introduces a fully configurable `clean` command and add three new configuration variables

- `latex-workshop.latex.clean.method` can be `glob` (default) or `cleanCommand`. 
    - With `glob`, clean all the files located in `latex-workshop.latex.outDir` and matching the glob patterns listed in `latex-workshop.latex.clean.fileTypes`.
   - With `cleanCommand`, run `latex-workshop.latex.clean.command` to clean temporary files.
- `latex-workshop.latex.clean.command`
- `latex-workshop.latex.clean.args`