### PR TITLE
Enable converting ChkTeX outputs' column numbers.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1512,9 +1512,9 @@
           "markdownDescription": "Enable converting ChkTeX outputs' column numbers for non-ASCII characters."
         },
         "latex-workshop.chktex.convertOutput.column.chktexrcTabSize": {
-          "type": "string",
-          "default": "auto",
-          "markdownDescription": "Write the `TabSize` number in `.chktexrc`. If the value is `auto`, LaTeX Workshop will try to read the value from `.chktexrc`. The file in the home directory will not be read."
+          "type": "number",
+          "default": -1,
+          "markdownDescription": "Write the `TabSize` number from `.chktexrc`. The default value \"-1\" means that LaTeX Workshop will try to find `.chktexrc` and to read the value from it."
         },
         "latex-workshop.texcount.path": {
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -1506,6 +1506,16 @@
           "default": 500,
           "markdownDescription": "Defines the delay in milliseconds for chktex to wait after stopped typing.\nThis config only matters when `latex-workshop.chktex.run` is set to `onType`."
         },
+        "latex-workshop.chktex.convertOutput.column.enabled": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Enable converting ChkTeX outputs' column numbers for non-ASCII characters."
+        },
+        "latex-workshop.chktex.convertOutput.column.chktexrcTabSize": {
+          "type": "string",
+          "default": "auto",
+          "markdownDescription": "Write the `TabSize` number in `.chktexrc`. If the value is `auto`, LaTeX Workshop will try to read the value from `.chktexrc`. The file in the home directory will not be read."
+        },
         "latex-workshop.texcount.path": {
           "type": "string",
           "default": "texcount",

--- a/src/components/linter.ts
+++ b/src/components/linter.ts
@@ -193,7 +193,9 @@ export class Linter {
         const reg = /^\s*TabSize\s*=\s*(\d+)\s*$/m
         const match = reg.exec(rcFile)
         if (match) {
-            return Number(match[1])
+            const ret = Number(match[1])
+            this.extension.logger.addLogMessage(`TabSize and .chktexrc: ${ret}, ${filePath}`)
+            return ret
         }
         this.extension.logger.addLogMessage(`TabSize not found in the .chktexrc file: ${filePath}`)
         return

--- a/src/components/linter.ts
+++ b/src/components/linter.ts
@@ -172,7 +172,7 @@ export class Linter {
         let filePath: string | undefined
         if (args.includes('-l')) {
             const idx = args.indexOf('-l')
-            if (idx > 0) {
+            if (idx >= 0) {
                 const rcpath = args[idx+1]
                 if (fs.existsSync(rcpath)) {
                     filePath = rcpath

--- a/src/components/parser/linterlog.ts
+++ b/src/components/parser/linterlog.ts
@@ -8,7 +8,7 @@ import { convertFilenameEncoding } from '../../utils/utils'
 interface LinterLogEntry {
     file: string,
     line: number,
-    position: number,
+    column: number,
     length: number,
     type: string,
     code: number,
@@ -29,19 +29,23 @@ export class LinterLogParser {
         this.extension = extension
     }
 
-    parse(log: string, singleFileOriginalPath?: string) {
+    parse(log: string, singleFileOriginalPath?: string, tabSizeArg?: number) {
         const re = /^(.*?):(\d+):(\d+):(\d+):(.*?):(\d+):(.*?)$/gm
         const linterLog: LinterLogEntry[] = []
         let match = re.exec(log)
         while (match) {
             // This log may be for a single file in memory, in which case we override the
             // path with what is provided
-            const filePath = singleFileOriginalPath ? singleFileOriginalPath : match[1]
+            let filePath = singleFileOriginalPath ? singleFileOriginalPath : match[1]
+            if (!path.isAbsolute(filePath) && this.extension.manager.rootDir !== undefined) {
+                filePath = path.resolve(this.extension.manager.rootDir, filePath)
+            }
+            const line = parseInt(match[2])
+            const column = this.callConvertColumn(parseInt(match[3]), filePath, line, tabSizeArg)
             linterLog.push({
-                file: (!path.isAbsolute(filePath) && this.extension.manager.rootDir !== undefined) ?
-                    path.resolve(this.extension.manager.rootDir, filePath) : filePath,
-                line: parseInt(match[2]),
-                position: parseInt(match[3]),
+                file: filePath,
+                line,
+                column,
                 length: parseInt(match[4]),
                 type: match[5].toLowerCase(),
                 code: parseInt(match[6]),
@@ -61,11 +65,66 @@ export class LinterLogParser {
         this.showLinterDiagnostics(linterLog)
     }
 
+    private callConvertColumn(column: number, filePathArg: string, line: number, tabSizeArg?: number): number {
+        const configuration = vscode.workspace.getConfiguration('latex-workshop')
+        if (!configuration.get('chktex.convertOutput.column.enabled', true)) {
+            return column
+        }
+        const filePath = convertFilenameEncoding(filePathArg)
+        if (!filePath){
+            this.extension.logger.addLogMessage(`Stop converting chktex's column numbers. File not found: ${filePathArg}`)
+            return column
+        }
+        const lineString = fs.readFileSync(filePath).toString().split('\n')[line-1]
+        let tabSize: number | undefined
+        const tabSizeConfig = configuration.get('chktex.convertOutput.column.chktexrcTabSize', 'auto')
+        if (tabSizeConfig !== 'auto') {
+            tabSize = parseInt(tabSizeConfig)
+            if (Number.isNaN(tabSize)) {
+                this.extension.logger.addLogMessage(`Fail to parseInt chktexrcTabSize: ${tabSizeConfig}`)
+                return column
+            }
+        } else {
+            tabSize = tabSizeArg
+        }
+        if (lineString === undefined) {
+            this.extension.logger.addLogMessage(`Stop converting chktex's column numbers. Invalid line number: ${line}`)
+            return column
+        }
+        return this.convertColumn(column, lineString, tabSize)
+    }
+
+    /**
+     * @param colArg One-based value.
+     * @param tabSize The default value used by chktex is 8.
+     * @returns One-based value.
+     */
+    private convertColumn(colArg: number, lineString: string, tabSize = 8): number {
+        const col = colArg - 1
+        const charByteArray = lineString.split('').map((c) => Buffer.byteLength(c))
+        let i = 0
+        let pos = 0
+        while (i < charByteArray.length) {
+            if (col <= pos) {
+                break
+            }
+            if (lineString[i] === '\t') {
+                pos += tabSize
+            } else {
+                pos += charByteArray[i]
+            }
+            i += 1
+        }
+        return i + 1
+    }
+
     private showLinterDiagnostics(linterLog: LinterLogEntry[]) {
         const diagsCollection: { [key: string]: vscode.Diagnostic[] } = {}
         for (const item of linterLog) {
-            const range = new vscode.Range(new vscode.Position(item.line - 1, item.position - 1),
-                new vscode.Position(item.line - 1, item.position - 1 + item.length))
+            const range = new vscode.Range(
+                new vscode.Position(item.line - 1, item.column - 1),
+                new vscode.Position(item.line - 1, item.column - 1 + item.length)
+            )
             const diag = new vscode.Diagnostic(range, item.text, DIAGNOSTIC_SEVERITY[item.type])
             diag.code = item.code
             diag.source = 'ChkTeX'

--- a/src/components/parser/linterlog.ts
+++ b/src/components/parser/linterlog.ts
@@ -77,13 +77,9 @@ export class LinterLogParser {
         }
         const lineString = fs.readFileSync(filePath).toString().split('\n')[line-1]
         let tabSize: number | undefined
-        const tabSizeConfig = configuration.get('chktex.convertOutput.column.chktexrcTabSize', 'auto')
-        if (tabSizeConfig !== 'auto') {
-            tabSize = parseInt(tabSizeConfig)
-            if (Number.isNaN(tabSize)) {
-                this.extension.logger.addLogMessage(`Fail to parseInt chktexrcTabSize: ${tabSizeConfig}`)
-                return column
-            }
+        const tabSizeConfig = configuration.get('chktex.convertOutput.column.chktexrcTabSize', -1)
+        if (tabSizeConfig >= 0) {
+            tabSize = tabSizeConfig
         } else {
             tabSize = tabSizeArg
         }


### PR DESCRIPTION
Enable converting ChkTeX outputs' column numbers. Close #829.

![スクリーンショット 2021-01-14 20 18 53](https://user-images.githubusercontent.com/10665499/104584338-c8007d80-56a5-11eb-8a16-0bd4f6f18bf6.png)

```latex
\documentclass{article}
\usepackage{amsthm,amsmath,amssymb}
\begin{document}

	漢字 $(a$ $(a$ $(a$

	 Ozna─Źimo s $P(x,y$ uvr┼ítavanje 	 字 vrijednosti $(x$ i $(y$ u po─Źetnu jednad┼żbu.

\end{document}
```