### PR TITLE
Configure align on equal signs for bibtex formatter

### DIFF
--- a/package.json
+++ b/package.json
@@ -2002,6 +2002,11 @@
           "default": false,
           "markdownDescription": "Sort content when calling VSCode format on a .bib file."
         },
+        "latex-workshop.bibtex-format.align-equal.enabled": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Align equal signs when calling VSCode format on a .bib file."
+        },
         "latex-workshop.mathpreviewpanel.editorGroup": {
           "type": "string",
           "default": "below",

--- a/src/providers/bibtexcompletion.ts
+++ b/src/providers/bibtexcompletion.ts
@@ -32,7 +32,8 @@ export class BibtexCompleter implements vscode.CompletionItemProvider {
             left: leftright[0],
             right: leftright[1],
             trailingComma: config.get('bibtex-format.trailingComma') as boolean,
-            sort: config.get('bibtex-format.sortby') as string[]
+            sort: config.get('bibtex-format.sortby') as string[],
+            alignOnEqual: config.get('bibtex-format.align-equal.enabled') as boolean
         }
 
         const maxLengths: {[key: string]: number} = this.computeMaxLengths(entries, optFields)

--- a/src/providers/bibtexformatter.ts
+++ b/src/providers/bibtexformatter.ts
@@ -63,7 +63,8 @@ export class BibtexFormatter {
             left: leftright[0],
             right: leftright[1],
             trailingComma: config.get('bibtex-format.trailingComma') as boolean,
-            sort: config.get('bibtex-format.sortby') as string[]
+            sort: config.get('bibtex-format.sortby') as string[],
+            alignOnEqual: config.get('bibtex-format.align-equal.enabled') as boolean
         }
         const lineOffset = range ? range.start.line : 0
         const columnOffset = range ? range.start.character : 0

--- a/src/utils/bibtexutils.ts
+++ b/src/utils/bibtexutils.ts
@@ -6,7 +6,8 @@ export interface BibtexFormatConfig {
     right: string,
     case: 'UPPERCASE' | 'lowercase',
     trailingComma: boolean,
-    sort: string[]
+    sort: string[],
+    alignOnEqual: boolean
 }
 
 /**
@@ -100,13 +101,18 @@ export function bibtexFormat(entry: bibtexParser.Entry, config: BibtexFormatConf
 
     // Find the longest field name in entry
     let maxFieldLength = 0
-    entry.content.forEach(field => {
-        maxFieldLength = Math.max(maxFieldLength, field.name.length)
-    })
+    if (config.alignOnEqual) {
+        entry.content.forEach(field => {
+            maxFieldLength = Math.max(maxFieldLength, field.name.length)
+        })
+    }
 
     entry.content.forEach(field => {
         s += ',\n' + config.tab + (config.case === 'lowercase' ? field.name : field.name.toUpperCase())
-        s += ' '.repeat(maxFieldLength - field.name.length) + ' = '
+        if (config.alignOnEqual) {
+            s += ' '.repeat(maxFieldLength - field.name.length)
+        }
+        s += ' = '
         s += fieldToString(field.value, config.left, config.right)
     })
 


### PR DESCRIPTION
This PR adds a new configuration variable `latex-workshop.bibtex-format.align-equal.enabled` to decide whether the bibtex formatter should align the equal signs.

Close #2481