### PR TITLE
Accept any number of spaces for bibtex indentation given as a string

### DIFF
--- a/package.json
+++ b/package.json
@@ -1946,13 +1946,8 @@
         },
         "latex-workshop.bibtex-format.tab": {
           "type": "string",
-          "enum": [
-            "2 spaces",
-            "4 spaces",
-            "tab"
-          ],
           "default": "2 spaces",
-          "description": "Indentation for each field."
+          "markdownDescription": "Indentation for each field. The string can `\"tab\"` or of the form `\"X spaces\"` or simply `\"X\"` where `X` is a number"
         },
         "latex-workshop.bibtex-format.surround": {
           "type": "string",

--- a/src/providers/bibtexcompletion.ts
+++ b/src/providers/bibtexcompletion.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode'
 import * as fs from 'fs-extra'
 
-import type * as bibtexUtils from '../utils/bibtexutils'
+import * as bibtexUtils from '../utils/bibtexutils'
 import type {Extension} from '../main'
 
 export class BibtexCompleter implements vscode.CompletionItemProvider {
@@ -25,9 +25,14 @@ export class BibtexCompleter implements vscode.CompletionItemProvider {
         const entriesReplacements = vscode.workspace.getConfiguration('latex-workshop').get('intellisense.bibtexJSON.replace') as {[key: string]: string[]}
         const config = vscode.workspace.getConfiguration('latex-workshop')
         const leftright = config.get('bibtex-format.surround') === 'Curly braces' ? [ '{', '}' ] : [ '"', '"']
-        const tabs = { '2 spaces': '  ', '4 spaces': '    ', 'tab': '\t' }
+        let tabs: string | undefined = bibtexUtils.getBibtexFormatTab(config)
+        if (tabs === undefined) {
+            this.extension.logger.addLogMessage(`Wrong value for bibtex-format.tab: ${config.get('bibtex-format.tab')}`)
+            this.extension.logger.addLogMessage('Setting bibtex-format.tab to \'2 spaces\'')
+            tabs = '  '
+        }
         const bibtexFormat: bibtexUtils.BibtexFormatConfig = {
-            tab: tabs[config.get('bibtex-format.tab') as ('2 spaces' | '4 spaces' | 'tab')],
+            tab: tabs,
             case: config.get('bibtex-format.case') as ('UPPERCASE' | 'lowercase'),
             left: leftright[0],
             right: leftright[1],

--- a/src/providers/bibtexformatter.ts
+++ b/src/providers/bibtexformatter.ts
@@ -56,9 +56,14 @@ export class BibtexFormatter {
         const config = vscode.workspace.getConfiguration('latex-workshop')
         const handleDuplicates = config.get('bibtex-format.handleDuplicates') as 'Ignore Duplicates' | 'Highlight Duplicates' | 'Comment Duplicates'
         const leftright = config.get('bibtex-format.surround') === 'Curly braces' ? [ '{', '}' ] : [ '"', '"']
-        const tabs = { '2 spaces': '  ', '4 spaces': '    ', 'tab': '\t' }
+        let tabs: string | undefined = bibtexUtils.getBibtexFormatTab(config)
+        if (tabs === undefined) {
+            this.extension.logger.addLogMessage(`Wrong value for bibtex-format.tab: ${config.get('bibtex-format.tab')}`)
+            this.extension.logger.addLogMessage('Setting bibtex-format.tab to \'2 spaces\'')
+            tabs = '  '
+        }
         const configuration: bibtexUtils.BibtexFormatConfig = {
-            tab: tabs[config.get('bibtex-format.tab') as ('2 spaces' | '4 spaces' | 'tab')],
+            tab: tabs,
             case: config.get('bibtex-format.case') as ('UPPERCASE' | 'lowercase'),
             left: leftright[0],
             right: leftright[1],

--- a/src/utils/bibtexutils.ts
+++ b/src/utils/bibtexutils.ts
@@ -1,3 +1,4 @@
+import * as vscode from 'vscode'
 import type {bibtexParser} from 'latex-utensils'
 
 export interface BibtexFormatConfig {
@@ -8,6 +9,27 @@ export interface BibtexFormatConfig {
     trailingComma: boolean,
     sort: string[],
     alignOnEqual: boolean
+}
+
+/**
+ * Read the indentation from vscode configuration
+ *
+ * @param config VSCode workspace configuration
+ * @return the indentation as a string or undefined if the configuration variable is not correct
+ */
+export function getBibtexFormatTab(config: vscode.WorkspaceConfiguration): string | undefined {
+    const tab = config.get('bibtex-format.tab') as string
+    if (tab === 'tab') {
+        return '\t'
+    } else {
+        const res = /^(\d+)( spaces)?$/.exec(tab)
+        if (res) {
+            const nSpaces = parseInt(res[1], 10)
+            return ' '.repeat(nSpaces)
+        } else {
+            return undefined
+        }
+    }
 }
 
 /**


### PR DESCRIPTION
Related to the discussion in #2481.

The variable `latex-workshop.bibtex-format.tab` can be `"tab"`, `"X spaces"` or `"X"`
where `X` is a number.

This change is transparent for users who customized this variable.