### PR TITLE
Handle killing of build process properly

### DIFF
--- a/data/commands.json
+++ b/data/commands.json
@@ -336,8 +336,8 @@
     "command": "nonumber",
     "detail": "Insert nonumber, shortcut @,"
   },
-  "kill": {
-    "command": "kill"
+  "stop": {
+    "command": "stop"
   },
   "tiny": {
     "command": "tiny"

--- a/package.json
+++ b/package.json
@@ -348,8 +348,8 @@
         "category": "LaTeX Workshop"
       },
       {
-        "command": "latex-workshop.kill",
-        "title": "Kill LaTeX compiler process",
+        "command": "latex-workshop.stop",
+        "title": "Stop current build",
         "category": "LaTeX Workshop"
       },
       {

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -204,9 +204,9 @@ export class Commander {
         this.extension.viewer.refreshExistingViewer()
     }
 
-    kill() {
-        this.extension.logger.addLogMessage('KILL command invoked.')
-        this.extension.builder.kill()
+    stop() {
+        this.extension.logger.addLogMessage('STOP command invoked.')
+        this.extension.builder.stop()
     }
 
     pdf(uri: vscode.Uri | undefined) {

--- a/src/components/builder.ts
+++ b/src/components/builder.ts
@@ -48,9 +48,9 @@ export class Builder {
     }
 
     /**
-     * Kill the current build process.
+     * Stop the current build process.
      */
-    async kill() {
+    async stop() {
         if (this.currentProcess) {
             const envVarsPosix: ProcessEnv = {PATH: '/bin:/usr/bin'}
             const envVarsWindows: ProcessEnv = {PATH: '%SystemRoot%\\system32;%SystemRoot%;%SystemRoot%\\System32\\Wbem'}
@@ -253,7 +253,7 @@ export class Builder {
                     title: 'Running build process',
                     cancellable: true
                 }, (progress, token) => {
-                    token.onCancellationRequested(this.kill.bind(this))
+                    token.onCancellationRequested(this.stop.bind(this))
                     this.extension.buildInfo.buildStarted(progress)
                     const p = new Promise<void>(resolve => {
                         this.extension.buildInfo.setResolveToken(resolve)

--- a/src/components/commander.ts
+++ b/src/components/commander.ts
@@ -20,7 +20,7 @@ export class LaTeXCommander implements vscode.TreeDataProvider<LaTeXCommand> {
         this.commands.push(buildCommand)
         const recipes = configuration.get('latex.recipes') as {name: string}[]
         buildCommand.children.push(new LaTeXCommand('Clean up auxiliary files', None, {command: 'latex-workshop.clean', title: ''}, 'clear-all'))
-        buildCommand.children.push(new LaTeXCommand('Terminate current compilation', None, {command: 'latex-workshop.kill', title: ''}, 'debug-stop'))
+        buildCommand.children.push(new LaTeXCommand('Stop current build', None, {command: 'latex-workshop.stop', title: ''}, 'debug-stop'))
         if (recipes) {
             recipes.forEach(recipe => {
                 buildCommand.children.push(new LaTeXCommand(`Recipe: ${recipe.name}`, None, {command: 'latex-workshop.recipes', title: '', arguments: [recipe.name]}, 'debug-start'))

--- a/src/main.ts
+++ b/src/main.ts
@@ -67,7 +67,7 @@ function registerLatexWorkshopCommands(extension: Extension) {
     vscode.commands.registerCommand('latex-workshop.viewInBrowser', () => extension.commander.view('browser'))
     vscode.commands.registerCommand('latex-workshop.viewExternal', () => extension.commander.view('external'))
     vscode.commands.registerCommand('latex-workshop.setViewer', () => extension.commander.view('set'))
-    vscode.commands.registerCommand('latex-workshop.kill', () => extension.commander.kill())
+    vscode.commands.registerCommand('latex-workshop.stop', () => extension.commander.stop())
     vscode.commands.registerCommand('latex-workshop.synctex', () => extension.commander.synctex())
     vscode.commands.registerCommand('latex-workshop.texdoc', (pkg) => extension.commander.texdoc(pkg))
     vscode.commands.registerCommand('latex-workshop.texdocUsepackages', () => extension.commander.texdocUsepackages())


### PR DESCRIPTION
Fixes issue #2484. I've tested on macOS Big Sur, of course, and it's working nicely. I've also slightly modified the Windows method. On all platforms now, it should try a graceful termination before a hard kill (after a one second timeout).

I also took the liberty to rename the "Kill" commmand, but obviously you can choose to not use that commit. See the commit log for the reason, however.

CC @jlelong