### PR TITLE
Should catch errors of kill commands.

### DIFF
--- a/src/components/builder.ts
+++ b/src/components/builder.ts
@@ -55,18 +55,19 @@ export class Builder {
         if (proc) {
             const pid = proc.pid
             try {
+                this.extension.logger.addLogMessage(`Kill child processes of the current process. PPID: ${pid}`)
                 if (process.platform === 'linux' || process.platform === 'darwin') {
-                    cp.execSync(`pkill -P ${pid}`)
+                    cp.execSync(`pkill -P ${pid}`, { timeout: 100 })
                 } else if (process.platform === 'win32') {
-                    cp.execSync(`taskkill /F /T /PID ${pid}`)
+                    cp.execSync(`taskkill /F /T /PID ${pid}`, { timeout: 100 })
                 }
             } catch (e) {
                 if (e instanceof Error) {
-                    this.extension.logger.addLogMessage(`Error when killing child processes of the current build process. ${e.message}`)
+                    this.extension.logger.addLogMessage(`Error when killing child processes of the current process. ${e.message}`)
                 }
             } finally {
                 proc.kill()
-                this.extension.logger.addLogMessage(`Kill the current process. PID: ${pid}.`)
+                this.extension.logger.addLogMessage(`Kill the current process. PID: ${pid}`)
             }
         } else {
             this.extension.logger.addLogMessage('LaTeX build process to kill is not found.')

--- a/src/components/builder.ts
+++ b/src/components/builder.ts
@@ -54,13 +54,20 @@ export class Builder {
         const proc = this.currentProcess
         if (proc) {
             const pid = proc.pid
-            if (process.platform === 'linux' || process.platform === 'darwin') {
-                cp.execSync(`pkill -P ${pid}`)
-            } else if (process.platform === 'win32') {
-                cp.execSync(`taskkill /F /T /PID ${pid}`)
+            try {
+                if (process.platform === 'linux' || process.platform === 'darwin') {
+                    cp.execSync(`pkill -P ${pid}`)
+                } else if (process.platform === 'win32') {
+                    cp.execSync(`taskkill /F /T /PID ${pid}`)
+                }
+            } catch (e) {
+                if (e instanceof Error) {
+                    this.extension.logger.addLogMessage(`Error when killing child processes of the current build process. ${e.message}`)
+                }
+            } finally {
+                proc.kill()
+                this.extension.logger.addLogMessage(`Kill the current process. PID: ${pid}.`)
             }
-            proc.kill()
-            this.extension.logger.addLogMessage(`Kill the current process. PID: ${pid}.`)
         } else {
             this.extension.logger.addLogMessage('LaTeX build process to kill is not found.')
         }

--- a/src/components/builder.ts
+++ b/src/components/builder.ts
@@ -57,9 +57,9 @@ export class Builder {
             try {
                 this.extension.logger.addLogMessage(`Kill child processes of the current process. PPID: ${pid}`)
                 if (process.platform === 'linux' || process.platform === 'darwin') {
-                    cp.execSync(`pkill -P ${pid}`, { timeout: 100 })
+                    cp.execSync(`pkill -P ${pid}`, { timeout: 1000 })
                 } else if (process.platform === 'win32') {
-                    cp.execSync(`taskkill /F /T /PID ${pid}`, { timeout: 100 })
+                    cp.execSync(`taskkill /F /T /PID ${pid}`, { timeout: 1000 })
                 }
             } catch (e) {
                 if (e instanceof Error) {


### PR DESCRIPTION
We should catch errors of kill commands. Otherwise, `proc.kill()` might not be executed.

`execSync` throws an error when the build process does not have a child process.

- https://nodejs.org/docs/latest-v12.x/api/child_process.html#child_process_child_process_execsync_command_options

Version: 1.52.1
Commit: ea3859d4ba2f3e577a159bc91e3074c5d85c0523
Date: 2020-12-16T16:30:02.420Z
Electron: 9.3.5
Chrome: 83.0.4103.122
Node.js: 12.14.1
V8: 8.3.110.13-electron.0
OS: Darwin x64 18.7.0

macOS Mojave 10.14.6
