### PR TITLE
Add completion files for ctex-kit

### DIFF
--- a/data/packages/class-ctexart_cmd.json
+++ b/data/packages/class-ctexart_cmd.json
@@ -1,0 +1,122 @@
+{
+  "ctexset{}": {
+    "command": "ctexset{options}",
+    "package": "class-ctexart",
+    "snippet": "ctexset{${1:options}}"
+  },
+  "songti": {
+    "command": "songti",
+    "package": "class-ctexart",
+    "snippet": "songti"
+  },
+  "heiti": {
+    "command": "heiti",
+    "package": "class-ctexart",
+    "snippet": "heiti"
+  },
+  "fangsong": {
+    "command": "fangsong",
+    "package": "class-ctexart",
+    "snippet": "fangsong"
+  },
+  "kaishu": {
+    "command": "kaishu",
+    "package": "class-ctexart",
+    "snippet": "kaishu"
+  },
+  "lishu": {
+    "command": "lishu",
+    "package": "class-ctexart",
+    "snippet": "lishu"
+  },
+  "youyuan": {
+    "command": "youyuan",
+    "package": "class-ctexart",
+    "snippet": "youyuan"
+  },
+  "yahei": {
+    "command": "yahei",
+    "package": "class-ctexart",
+    "snippet": "yahei"
+  },
+  "pingfang": {
+    "command": "pingfang",
+    "package": "class-ctexart",
+    "snippet": "pingfang"
+  },
+  "CTEXthepart": {
+    "command": "CTEXthepart",
+    "package": "class-ctexart",
+    "snippet": "CTEXthepart"
+  },
+  "CTEXthethechapter": {
+    "command": "CTEXthethechapter",
+    "package": "class-ctexart",
+    "snippet": "CTEXthethechapter"
+  },
+  "CTEXthesection": {
+    "command": "CTEXthesection",
+    "package": "class-ctexart",
+    "snippet": "CTEXthesection"
+  },
+  "CTEXthesubsection": {
+    "command": "CTEXthesubsection",
+    "package": "class-ctexart",
+    "snippet": "CTEXthesubsection"
+  },
+  "CTEXthesubsubsection": {
+    "command": "CTEXthesubsubsection",
+    "package": "class-ctexart",
+    "snippet": "CTEXthesubsubsection"
+  },
+  "CTEXtheparagraph": {
+    "command": "CTEXtheparagraph",
+    "package": "class-ctexart",
+    "snippet": "CTEXtheparagraph"
+  },
+  "CTEXthesubparagraph": {
+    "command": "CTEXthesubparagraph",
+    "package": "class-ctexart",
+    "snippet": "CTEXthesubparagraph"
+  },
+  "CTEXifnmae{}{}": {
+    "command": "CTEXifnmae{contents with name}{contents with name}",
+    "package": "class-ctexart",
+    "snippet": "CTEXifnmae{${1:contents with name}}{${2:contents with name}}"
+  },
+  "zihao{}": {
+    "command": "zihao{number}",
+    "package": "class-ctexart",
+    "snippet": "zihao{${1:number}}"
+  },
+  "ziju{}": {
+    "command": "ziju{factor}",
+    "package": "class-ctexart",
+    "snippet": "ziju{${1:factor}}"
+  },
+  "ccwd": {
+    "command": "ccwd",
+    "package": "class-ctexart",
+    "snippet": "ccwd"
+  },
+  "chinese{}": {
+    "command": "chinese{counter}",
+    "package": "class-ctexart",
+    "snippet": "chinese{${1:counter}}"
+  },
+  "CTEXnumber{}{}": {
+    "command": "CTEXnumber{cmd}{number}",
+    "package": "class-ctexart",
+    "snippet": "CTEXnumber{${1:cmd}}{${2:number}}"
+  },
+  "CTEXdigits{}{}": {
+    "command": "CTEXdigits{cmd}{number}",
+    "package": "class-ctexart",
+    "snippet": "CTEXdigits{${1:cmd}}{${2:number}}"
+  },
+  "CTeX": {
+    "command": "CTeX",
+    "package": "class-ctexart",
+    "snippet": "CTeX"
+  }
+}

--- a/data/packages/class-ctexbeamer_cmd.json
+++ b/data/packages/class-ctexbeamer_cmd.json
@@ -1,0 +1,1787 @@
+{
+  "ctexset{}": {
+    "command": "ctexset{options}",
+    "package": "class-ctexbeamer",
+    "snippet": "ctexset{${1:options}}"
+  },
+  "songti": {
+    "command": "songti",
+    "package": "class-ctexbeamer",
+    "snippet": "songti"
+  },
+  "heiti": {
+    "command": "heiti",
+    "package": "class-ctexbeamer",
+    "snippet": "heiti"
+  },
+  "fangsong": {
+    "command": "fangsong",
+    "package": "class-ctexbeamer",
+    "snippet": "fangsong"
+  },
+  "kaishu": {
+    "command": "kaishu",
+    "package": "class-ctexbeamer",
+    "snippet": "kaishu"
+  },
+  "lishu": {
+    "command": "lishu",
+    "package": "class-ctexbeamer",
+    "snippet": "lishu"
+  },
+  "youyuan": {
+    "command": "youyuan",
+    "package": "class-ctexbeamer",
+    "snippet": "youyuan"
+  },
+  "yahei": {
+    "command": "yahei",
+    "package": "class-ctexbeamer",
+    "snippet": "yahei"
+  },
+  "pingfang": {
+    "command": "pingfang",
+    "package": "class-ctexbeamer",
+    "snippet": "pingfang"
+  },
+  "CTEXthepart": {
+    "command": "CTEXthepart",
+    "package": "class-ctexbeamer",
+    "snippet": "CTEXthepart"
+  },
+  "CTEXthethechapter": {
+    "command": "CTEXthethechapter",
+    "package": "class-ctexbeamer",
+    "snippet": "CTEXthethechapter"
+  },
+  "CTEXthesection": {
+    "command": "CTEXthesection",
+    "package": "class-ctexbeamer",
+    "snippet": "CTEXthesection"
+  },
+  "CTEXthesubsection": {
+    "command": "CTEXthesubsection",
+    "package": "class-ctexbeamer",
+    "snippet": "CTEXthesubsection"
+  },
+  "CTEXthesubsubsection": {
+    "command": "CTEXthesubsubsection",
+    "package": "class-ctexbeamer",
+    "snippet": "CTEXthesubsubsection"
+  },
+  "CTEXtheparagraph": {
+    "command": "CTEXtheparagraph",
+    "package": "class-ctexbeamer",
+    "snippet": "CTEXtheparagraph"
+  },
+  "CTEXthesubparagraph": {
+    "command": "CTEXthesubparagraph",
+    "package": "class-ctexbeamer",
+    "snippet": "CTEXthesubparagraph"
+  },
+  "CTEXifnmae{}{}": {
+    "command": "CTEXifnmae{contents with name}{contents with name}",
+    "package": "class-ctexbeamer",
+    "snippet": "CTEXifnmae{${1:contents with name}}{${2:contents with name}}"
+  },
+  "zihao{}": {
+    "command": "zihao{number}",
+    "package": "class-ctexbeamer",
+    "snippet": "zihao{${1:number}}"
+  },
+  "ziju{}": {
+    "command": "ziju{factor}",
+    "package": "class-ctexbeamer",
+    "snippet": "ziju{${1:factor}}"
+  },
+  "ccwd": {
+    "command": "ccwd",
+    "package": "class-ctexbeamer",
+    "snippet": "ccwd"
+  },
+  "chinese{}": {
+    "command": "chinese{counter}",
+    "package": "class-ctexbeamer",
+    "snippet": "chinese{${1:counter}}"
+  },
+  "CTEXnumber{}{}": {
+    "command": "CTEXnumber{cmd}{number}",
+    "package": "class-ctexbeamer",
+    "snippet": "CTEXnumber{${1:cmd}}{${2:number}}"
+  },
+  "CTEXdigits{}{}": {
+    "command": "CTEXdigits{cmd}{number}",
+    "package": "class-ctexbeamer",
+    "snippet": "CTEXdigits{${1:cmd}}{${2:number}}"
+  },
+  "CTeX": {
+    "command": "CTeX",
+    "package": "class-ctexbeamer",
+    "snippet": "CTeX"
+  },
+  "movie[]{}{}": {
+    "command": "movie[options]{poster text}{movie filename}",
+    "package": "class-ctexbeamer",
+    "snippet": "movie[${3:options}]{${1:poster text}}{${2:movie filename}}"
+  },
+  "movie{}{}": {
+    "command": "movie{poster text}{movie filename}",
+    "package": "class-ctexbeamer",
+    "snippet": "movie{${1:poster text}}{${2:movie filename}}"
+  },
+  "hyperlinkmovie[]{}{}": {
+    "command": "hyperlinkmovie[options]{movie label}{text}",
+    "package": "class-ctexbeamer",
+    "snippet": "hyperlinkmovie[${3:options}]{${1:movie label}}{${2:text}}"
+  },
+  "hyperlinkmovie{}{}": {
+    "command": "hyperlinkmovie{movie label}{text}",
+    "package": "class-ctexbeamer",
+    "snippet": "hyperlinkmovie{${1:movie label}}{${2:text}}"
+  },
+  "animate": {
+    "command": "animate",
+    "package": "class-ctexbeamer",
+    "snippet": "animate"
+  },
+  "animate<>": {
+    "command": "animate<overlay specification>",
+    "package": "class-ctexbeamer",
+    "snippet": "animate<${1:overlay specification}>"
+  },
+  "animatevalue<start slide - end slide>{}{}{}": {
+    "command": "animatevalue<start slide - end slide>{name}{start value}{end value}",
+    "package": "class-ctexbeamer",
+    "snippet": "animatevalue<start slide - end slide>{${1:name}}{${2:start value}}{${3:end value}}"
+  },
+  "animatevalue{}{}{}": {
+    "command": "animatevalue{name}{start value}{end value}",
+    "package": "class-ctexbeamer",
+    "snippet": "animatevalue{${1:name}}{${2:start value}}{${3:end value}}"
+  },
+  "multiinclude[][]{}": {
+    "command": "multiinclude[<default overlay specification>][options]{base file name}",
+    "package": "class-ctexbeamer",
+    "snippet": "multiinclude[${2:<default overlay specification>}][${3:options}]{${1:base file name}}"
+  },
+  "multiinclude[]{}": {
+    "command": "multiinclude[options]{base file name}",
+    "package": "class-ctexbeamer",
+    "snippet": "multiinclude[${2:options}]{${1:base file name}}"
+  },
+  "multiinclude{}": {
+    "command": "multiinclude{base file name}",
+    "package": "class-ctexbeamer",
+    "snippet": "multiinclude{${1:base file name}}"
+  },
+  "sound[]{}{}": {
+    "command": "sound[options]{sound poster text}{sound filename}",
+    "package": "class-ctexbeamer",
+    "snippet": "sound[${3:options}]{${1:sound poster text}}{${2:sound filename}}"
+  },
+  "sound{}{}": {
+    "command": "sound{sound poster text}{sound filename}",
+    "package": "class-ctexbeamer",
+    "snippet": "sound{${1:sound poster text}}{${2:sound filename}}"
+  },
+  "hyperlinksound[]{}{}": {
+    "command": "hyperlinksound[options]{sound label}{text}",
+    "package": "class-ctexbeamer",
+    "snippet": "hyperlinksound[${3:options}]{${1:sound label}}{${2:text}}"
+  },
+  "hyperlinksound{}{}": {
+    "command": "hyperlinksound{sound label}{text}",
+    "package": "class-ctexbeamer",
+    "snippet": "hyperlinksound{${1:sound label}}{${2:text}}"
+  },
+  "hyperlinkmute{}": {
+    "command": "hyperlinkmute{text}",
+    "package": "class-ctexbeamer",
+    "snippet": "hyperlinkmute{${1:text}}"
+  },
+  "transblindshorizontal<>[]": {
+    "command": "transblindshorizontal<overlay specification>[options]",
+    "package": "class-ctexbeamer",
+    "snippet": "transblindshorizontal<${2:overlay specification}>[${1:options}]"
+  },
+  "transblindshorizontal<>": {
+    "command": "transblindshorizontal<overlay specification>",
+    "package": "class-ctexbeamer",
+    "snippet": "transblindshorizontal<${1:overlay specification}>"
+  },
+  "transblindshorizontal[]": {
+    "command": "transblindshorizontal[options]",
+    "package": "class-ctexbeamer",
+    "snippet": "transblindshorizontal[${1:options}]"
+  },
+  "transblindshorizontal": {
+    "command": "transblindshorizontal",
+    "package": "class-ctexbeamer",
+    "snippet": "transblindshorizontal"
+  },
+  "transblindsvertical<>[]": {
+    "command": "transblindsvertical<overlay specification>[options]",
+    "package": "class-ctexbeamer",
+    "snippet": "transblindsvertical<${2:overlay specification}>[${1:options}]"
+  },
+  "transblindsvertical<>": {
+    "command": "transblindsvertical<overlay specification>",
+    "package": "class-ctexbeamer",
+    "snippet": "transblindsvertical<${1:overlay specification}>"
+  },
+  "transblindsvertical[]": {
+    "command": "transblindsvertical[options]",
+    "package": "class-ctexbeamer",
+    "snippet": "transblindsvertical[${1:options}]"
+  },
+  "transblindsvertical": {
+    "command": "transblindsvertical",
+    "package": "class-ctexbeamer",
+    "snippet": "transblindsvertical"
+  },
+  "transboxin<>[]": {
+    "command": "transboxin<overlay specification>[options]",
+    "package": "class-ctexbeamer",
+    "snippet": "transboxin<${2:overlay specification}>[${1:options}]"
+  },
+  "transboxin<>": {
+    "command": "transboxin<overlay specification>",
+    "package": "class-ctexbeamer",
+    "snippet": "transboxin<${1:overlay specification}>"
+  },
+  "transboxin[]": {
+    "command": "transboxin[options]",
+    "package": "class-ctexbeamer",
+    "snippet": "transboxin[${1:options}]"
+  },
+  "transboxin": {
+    "command": "transboxin",
+    "package": "class-ctexbeamer",
+    "snippet": "transboxin"
+  },
+  "transboxout<>[]": {
+    "command": "transboxout<overlay specification>[options]",
+    "package": "class-ctexbeamer",
+    "snippet": "transboxout<${2:overlay specification}>[${1:options}]"
+  },
+  "transboxout<>": {
+    "command": "transboxout<overlay specification>",
+    "package": "class-ctexbeamer",
+    "snippet": "transboxout<${1:overlay specification}>"
+  },
+  "transboxout[]": {
+    "command": "transboxout[options]",
+    "package": "class-ctexbeamer",
+    "snippet": "transboxout[${1:options}]"
+  },
+  "transboxout": {
+    "command": "transboxout",
+    "package": "class-ctexbeamer",
+    "snippet": "transboxout"
+  },
+  "transdissolve<>[]": {
+    "command": "transdissolve<overlay specification>[options]",
+    "package": "class-ctexbeamer",
+    "snippet": "transdissolve<${2:overlay specification}>[${1:options}]"
+  },
+  "transdissolve<>": {
+    "command": "transdissolve<overlay specification>",
+    "package": "class-ctexbeamer",
+    "snippet": "transdissolve<${1:overlay specification}>"
+  },
+  "transdissolve[]": {
+    "command": "transdissolve[options]",
+    "package": "class-ctexbeamer",
+    "snippet": "transdissolve[${1:options}]"
+  },
+  "transdissolve": {
+    "command": "transdissolve",
+    "package": "class-ctexbeamer",
+    "snippet": "transdissolve"
+  },
+  "transglitter<>[]": {
+    "command": "transglitter<overlay specification>[options]",
+    "package": "class-ctexbeamer",
+    "snippet": "transglitter<${2:overlay specification}>[${1:options}]"
+  },
+  "transglitter<>": {
+    "command": "transglitter<overlay specification>",
+    "package": "class-ctexbeamer",
+    "snippet": "transglitter<${1:overlay specification}>"
+  },
+  "transglitter[]": {
+    "command": "transglitter[options]",
+    "package": "class-ctexbeamer",
+    "snippet": "transglitter[${1:options}]"
+  },
+  "transglitter": {
+    "command": "transglitter",
+    "package": "class-ctexbeamer",
+    "snippet": "transglitter"
+  },
+  "transsplitverticalin<>[]": {
+    "command": "transsplitverticalin<overlay specification>[options]",
+    "package": "class-ctexbeamer",
+    "snippet": "transsplitverticalin<${2:overlay specification}>[${1:options}]"
+  },
+  "transsplitverticalin<>": {
+    "command": "transsplitverticalin<overlay specification>",
+    "package": "class-ctexbeamer",
+    "snippet": "transsplitverticalin<${1:overlay specification}>"
+  },
+  "transsplitverticalin[]": {
+    "command": "transsplitverticalin[options]",
+    "package": "class-ctexbeamer",
+    "snippet": "transsplitverticalin[${1:options}]"
+  },
+  "transsplitverticalin": {
+    "command": "transsplitverticalin",
+    "package": "class-ctexbeamer",
+    "snippet": "transsplitverticalin"
+  },
+  "transsplitverticalout<>[]": {
+    "command": "transsplitverticalout<overlay specification>[options]",
+    "package": "class-ctexbeamer",
+    "snippet": "transsplitverticalout<${2:overlay specification}>[${1:options}]"
+  },
+  "transsplitverticalout<>": {
+    "command": "transsplitverticalout<overlay specification>",
+    "package": "class-ctexbeamer",
+    "snippet": "transsplitverticalout<${1:overlay specification}>"
+  },
+  "transsplitverticalout[]": {
+    "command": "transsplitverticalout[options]",
+    "package": "class-ctexbeamer",
+    "snippet": "transsplitverticalout[${1:options}]"
+  },
+  "transsplitverticalout": {
+    "command": "transsplitverticalout",
+    "package": "class-ctexbeamer",
+    "snippet": "transsplitverticalout"
+  },
+  "transsplithorizontalin<>[]": {
+    "command": "transsplithorizontalin<overlay specification>[options]",
+    "package": "class-ctexbeamer",
+    "snippet": "transsplithorizontalin<${2:overlay specification}>[${1:options}]"
+  },
+  "transsplithorizontalin<>": {
+    "command": "transsplithorizontalin<overlay specification>",
+    "package": "class-ctexbeamer",
+    "snippet": "transsplithorizontalin<${1:overlay specification}>"
+  },
+  "transsplithorizontalin[]": {
+    "command": "transsplithorizontalin[options]",
+    "package": "class-ctexbeamer",
+    "snippet": "transsplithorizontalin[${1:options}]"
+  },
+  "transsplithorizontalin": {
+    "command": "transsplithorizontalin",
+    "package": "class-ctexbeamer",
+    "snippet": "transsplithorizontalin"
+  },
+  "transsplithorizontalout<>[]": {
+    "command": "transsplithorizontalout<overlay specification>[options]",
+    "package": "class-ctexbeamer",
+    "snippet": "transsplithorizontalout<${2:overlay specification}>[${1:options}]"
+  },
+  "transsplithorizontalout<>": {
+    "command": "transsplithorizontalout<overlay specification>",
+    "package": "class-ctexbeamer",
+    "snippet": "transsplithorizontalout<${1:overlay specification}>"
+  },
+  "transsplithorizontalout[]": {
+    "command": "transsplithorizontalout[options]",
+    "package": "class-ctexbeamer",
+    "snippet": "transsplithorizontalout[${1:options}]"
+  },
+  "transsplithorizontalout": {
+    "command": "transsplithorizontalout",
+    "package": "class-ctexbeamer",
+    "snippet": "transsplithorizontalout"
+  },
+  "transwipe<>[]": {
+    "command": "transwipe<overlay specification>[options]",
+    "package": "class-ctexbeamer",
+    "snippet": "transwipe<${2:overlay specification}>[${1:options}]"
+  },
+  "transwipe<>": {
+    "command": "transwipe<overlay specification>",
+    "package": "class-ctexbeamer",
+    "snippet": "transwipe<${1:overlay specification}>"
+  },
+  "transwipe[]": {
+    "command": "transwipe[options]",
+    "package": "class-ctexbeamer",
+    "snippet": "transwipe[${1:options}]"
+  },
+  "transwipe": {
+    "command": "transwipe",
+    "package": "class-ctexbeamer",
+    "snippet": "transwipe"
+  },
+  "transduration<>{}": {
+    "command": "transduration<overlay specification>{number of seconds}",
+    "package": "class-ctexbeamer",
+    "snippet": "transduration<${2:overlay specification}>{${1:number of seconds}}"
+  },
+  "transduration{}": {
+    "command": "transduration{number of seconds}",
+    "package": "class-ctexbeamer",
+    "snippet": "transduration{${1:number of seconds}}"
+  },
+  "usebeamercolor*[]{}": {
+    "command": "usebeamercolor*[fg or bg]{beamer-color name}",
+    "package": "class-ctexbeamer",
+    "snippet": "usebeamercolor*[${2:fg or bg}]{${1:beamer-color name}}"
+  },
+  "usebeamercolor*{}": {
+    "command": "usebeamercolor*{beamer-color name}",
+    "package": "class-ctexbeamer",
+    "snippet": "usebeamercolor*{${1:beamer-color name}}"
+  },
+  "usebeamercolor[]{}": {
+    "command": "usebeamercolor[fg or bg]{beamer-color name}",
+    "package": "class-ctexbeamer",
+    "snippet": "usebeamercolor[${2:fg or bg}]{${1:beamer-color name}}"
+  },
+  "usebeamercolor{}": {
+    "command": "usebeamercolor{beamer-color name}",
+    "package": "class-ctexbeamer",
+    "snippet": "usebeamercolor{${1:beamer-color name}}"
+  },
+  "ifbeamercolorempty[]{}{}{}": {
+    "command": "ifbeamercolorempty[fg or bg]{beamer-color name}{if undefined}{if defined}",
+    "package": "class-ctexbeamer",
+    "snippet": "ifbeamercolorempty[${4:fg or bg}]{${1:beamer-color name}}{${2:if undefined}}{${3:if defined}}"
+  },
+  "ifbeamercolorempty{}{}{}": {
+    "command": "ifbeamercolorempty{beamer-color name}{if undefined}{if defined}",
+    "package": "class-ctexbeamer",
+    "snippet": "ifbeamercolorempty{${1:beamer-color name}}{${2:if undefined}}{${3:if defined}}"
+  },
+  "setbeamercolor*{}{}": {
+    "command": "setbeamercolor*{beamer-color name}{options}",
+    "package": "class-ctexbeamer",
+    "snippet": "setbeamercolor*{${1:beamer-color name}}{${2:options}}"
+  },
+  "setbeamercolor{}{}": {
+    "command": "setbeamercolor{beamer-color name}{options}",
+    "package": "class-ctexbeamer",
+    "snippet": "setbeamercolor{${1:beamer-color name}}{${2:options}}"
+  },
+  "setbeamercovered{}": {
+    "command": "setbeamercovered{options}",
+    "package": "class-ctexbeamer",
+    "snippet": "setbeamercovered{${1:options}}"
+  },
+  "opaqueness{}": {
+    "command": "opaqueness{percentage of opaqueness}",
+    "package": "class-ctexbeamer",
+    "snippet": "opaqueness{${1:percentage of opaqueness}}"
+  },
+  "opaqueness<>{}": {
+    "command": "opaqueness<overlay specification>{percentage of opaqueness}",
+    "package": "class-ctexbeamer",
+    "snippet": "opaqueness<${2:overlay specification}>{${1:percentage of opaqueness}}"
+  },
+  "usebeamertemplate{}": {
+    "command": "usebeamertemplate{element name}",
+    "package": "class-ctexbeamer",
+    "snippet": "usebeamertemplate{${1:element name}}"
+  },
+  "usebeamertemplate*{}": {
+    "command": "usebeamertemplate*{element name}",
+    "package": "class-ctexbeamer",
+    "snippet": "usebeamertemplate*{${1:element name}}"
+  },
+  "usebeamertemplate**{}": {
+    "command": "usebeamertemplate**{element name}",
+    "package": "class-ctexbeamer",
+    "snippet": "usebeamertemplate**{${1:element name}}"
+  },
+  "usebeamertemplate***{}": {
+    "command": "usebeamertemplate***{element name}",
+    "package": "class-ctexbeamer",
+    "snippet": "usebeamertemplate***{${1:element name}}"
+  },
+  "ifbeamertemplateempty{}{}{}": {
+    "command": "ifbeamertemplateempty{beamer template name}{executed if empty}{executed otherwise}",
+    "package": "class-ctexbeamer",
+    "snippet": "ifbeamertemplateempty{${1:beamer template name}}{${2:executed if empty}}{${3:executed otherwise}}"
+  },
+  "expandbeamertemplate{}": {
+    "command": "expandbeamertemplate{beamer template name}",
+    "package": "class-ctexbeamer",
+    "snippet": "expandbeamertemplate{${1:beamer template name}}"
+  },
+  "setbeamertemplate{}[]{}": {
+    "command": "setbeamertemplate{element name}[predefined option]{args}",
+    "package": "class-ctexbeamer",
+    "snippet": "setbeamertemplate{${1:element name}}[${2:predefined option}]{${3:args}}"
+  },
+  "setbeamertemplate{}{}": {
+    "command": "setbeamertemplate{element name}{args}",
+    "package": "class-ctexbeamer",
+    "snippet": "setbeamertemplate{${1:element name}}{${2:args}}"
+  },
+  "addtobeamertemplate{}{}{}": {
+    "command": "addtobeamertemplate{element name}{pre-text}{post-text}",
+    "package": "class-ctexbeamer",
+    "snippet": "addtobeamertemplate{${1:element name}}{${2:pre-text}}{${3:post-text}}"
+  },
+  "defbeamertemplate<>*{}{}[][]{}[]{}": {
+    "command": "defbeamertemplate<mode specification>*{element name}{predefined option}[argument number][default optional argument]{predefined text}[action]{action command}",
+    "package": "class-ctexbeamer",
+    "snippet": "defbeamertemplate<${8:mode specification}>*{${1:element name}}{${2:predefined option}}[${3:argument number}][${4:default optional argument}]{${5:predefined text}}[${6:action}]{${7:action command}}"
+  },
+  "defbeamertemplate<>*{}{}[]{}[]{}": {
+    "command": "defbeamertemplate<mode specification>*{element name}{predefined option}[default optional argument]{predefined text}[action]{action command}",
+    "package": "class-ctexbeamer",
+    "snippet": "defbeamertemplate<${7:mode specification}>*{${1:element name}}{${2:predefined option}}[${3:default optional argument}]{${4:predefined text}}[${5:action}]{${6:action command}}"
+  },
+  "defbeamertemplate<>*{}{}{}[]{}": {
+    "command": "defbeamertemplate<mode specification>*{element name}{predefined option}{predefined text}[action]{action command}",
+    "package": "class-ctexbeamer",
+    "snippet": "defbeamertemplate<${6:mode specification}>*{${1:element name}}{${2:predefined option}}{${3:predefined text}}[${4:action}]{${5:action command}}"
+  },
+  "defbeamertemplate<>*{}{}[][]{}": {
+    "command": "defbeamertemplate<mode specification>*{element name}{predefined option}[argument number][default optional argument]{predefined text}",
+    "package": "class-ctexbeamer",
+    "snippet": "defbeamertemplate<${6:mode specification}>*{${1:element name}}{${2:predefined option}}[${3:argument number}][${4:default optional argument}]{${5:predefined text}}"
+  },
+  "defbeamertemplate<>*{}{}[]{}": {
+    "command": "defbeamertemplate<mode specification>*{element name}{predefined option}[argument number]{predefined text}",
+    "package": "class-ctexbeamer",
+    "snippet": "defbeamertemplate<${5:mode specification}>*{${1:element name}}{${2:predefined option}}[${3:argument number}]{${4:predefined text}}"
+  },
+  "defbeamertemplate<>*{}{}{}": {
+    "command": "defbeamertemplate<mode specification>*{element name}{predefined option}{predefined text}",
+    "package": "class-ctexbeamer",
+    "snippet": "defbeamertemplate<${4:mode specification}>*{${1:element name}}{${2:predefined option}}{${3:predefined text}}"
+  },
+  "defbeamertemplate{}{}[][]{}[]{}": {
+    "command": "defbeamertemplate{element name}{predefined option}[argument number][default optional argument]{predefined text}[action]{action command}",
+    "package": "class-ctexbeamer",
+    "snippet": "defbeamertemplate{${1:element name}}{${2:predefined option}}[${3:argument number}][${4:default optional argument}]{${5:predefined text}}[${6:action}]{${7:action command}}"
+  },
+  "defbeamertemplate{}{}[]{}[]{}": {
+    "command": "defbeamertemplate{element name}{predefined option}[default optional argument]{predefined text}[action]{action command}",
+    "package": "class-ctexbeamer",
+    "snippet": "defbeamertemplate{${1:element name}}{${2:predefined option}}[${3:default optional argument}]{${4:predefined text}}[${5:action}]{${6:action command}}"
+  },
+  "defbeamertemplate{}{}{}[]{}": {
+    "command": "defbeamertemplate{element name}{predefined option}{predefined text}[action]{action command}",
+    "package": "class-ctexbeamer",
+    "snippet": "defbeamertemplate{${1:element name}}{${2:predefined option}}{${3:predefined text}}[${4:action}]{${5:action command}}"
+  },
+  "defbeamertemplate{}{}[][]{}": {
+    "command": "defbeamertemplate{element name}{predefined option}[argument number][default optional argument]{predefined text}",
+    "package": "class-ctexbeamer",
+    "snippet": "defbeamertemplate{${1:element name}}{${2:predefined option}}[${3:argument number}][${4:default optional argument}]{${5:predefined text}}"
+  },
+  "defbeamertemplate{}{}[]{}": {
+    "command": "defbeamertemplate{element name}{predefined option}[argument number]{predefined text}",
+    "package": "class-ctexbeamer",
+    "snippet": "defbeamertemplate{${1:element name}}{${2:predefined option}}[${3:argument number}]{${4:predefined text}}"
+  },
+  "defbeamertemplate{}{}{}": {
+    "command": "defbeamertemplate{element name}{predefined option}{predefined text}",
+    "package": "class-ctexbeamer",
+    "snippet": "defbeamertemplate{${1:element name}}{${2:predefined option}}{${3:predefined text}}"
+  },
+  "defbeamertemplatealias{}{}{}": {
+    "command": "defbeamertemplatealias{element name}{new predefined option name}{existing predefined option name}",
+    "package": "class-ctexbeamer",
+    "snippet": "defbeamertemplatealias{${1:element name}}{${2:new predefined option name}}{${3:existing predefined option name}}"
+  },
+  "defbeamertemplateparent{}[]{} [][]{}": {
+    "command": "defbeamertemplateparent{parent template name}[predefined option name]{child template list} [argument number][default optional argument]{arguments for children}",
+    "package": "class-ctexbeamer",
+    "snippet": "defbeamertemplateparent{${1:parent template name}}[${2:predefined option name}]{${3:child template list}} [${4:argument number}][${5:default optional argument}]{${6:arguments for children}}"
+  },
+  "defbeamertemplateparent{}{} [][]{}": {
+    "command": "defbeamertemplateparent{parent template name}{child template list} [argument number][default optional argument]{arguments for children}",
+    "package": "class-ctexbeamer",
+    "snippet": "defbeamertemplateparent{${1:parent template name}}{${2:child template list}} [${3:argument number}][${4:default optional argument}]{${5:arguments for children}}"
+  },
+  "defbeamertemplateparent{}{} []{}": {
+    "command": "defbeamertemplateparent{parent template name}{child template list} [default optional argument]{arguments for children}",
+    "package": "class-ctexbeamer",
+    "snippet": "defbeamertemplateparent{${1:parent template name}}{${2:child template list}} [${3:default optional argument}]{${4:arguments for children}}"
+  },
+  "defbeamertemplateparent{}{} {}": {
+    "command": "defbeamertemplateparent{parent template name}{child template list} {arguments for children}",
+    "package": "class-ctexbeamer",
+    "snippet": "defbeamertemplateparent{${1:parent template name}}{${2:child template list}} {${3:arguments for children}}"
+  },
+  "usebeamerfont*{}": {
+    "command": "usebeamerfont*{beamer-font name}",
+    "package": "class-ctexbeamer",
+    "snippet": "usebeamerfont*{${1:beamer-font name}}"
+  },
+  "usebeamerfont{}": {
+    "command": "usebeamerfont{beamer-font name}",
+    "package": "class-ctexbeamer",
+    "snippet": "usebeamerfont{${1:beamer-font name}}"
+  },
+  "setbeamerfont*{}{}": {
+    "command": "setbeamerfont*{beamer-font name}{attributes}",
+    "package": "class-ctexbeamer",
+    "snippet": "setbeamerfont*{${1:beamer-font name}}{${2:attributes}}"
+  },
+  "setbeamerfont{}{}": {
+    "command": "setbeamerfont{beamer-font name}{attributes}",
+    "package": "class-ctexbeamer",
+    "snippet": "setbeamerfont{${1:beamer-font name}}{${2:attributes}}"
+  },
+  "insertnavigation": {
+    "command": "insertnavigation",
+    "package": "class-ctexbeamer",
+    "snippet": "insertnavigation"
+  },
+  "insertpagenumber": {
+    "command": "insertpagenumber",
+    "package": "class-ctexbeamer",
+    "snippet": "insertpagenumber"
+  },
+  "insertsection": {
+    "command": "insertsection",
+    "package": "class-ctexbeamer",
+    "snippet": "insertsection"
+  },
+  "insertsectionnavigation": {
+    "command": "insertsectionnavigation",
+    "package": "class-ctexbeamer",
+    "snippet": "insertsectionnavigation"
+  },
+  "insertsectionnavigationhorizontal": {
+    "command": "insertsectionnavigationhorizontal",
+    "package": "class-ctexbeamer",
+    "snippet": "insertsectionnavigationhorizontal"
+  },
+  "insertshortauthor": {
+    "command": "insertshortauthor",
+    "package": "class-ctexbeamer",
+    "snippet": "insertshortauthor"
+  },
+  "insertshortdate": {
+    "command": "insertshortdate",
+    "package": "class-ctexbeamer",
+    "snippet": "insertshortdate"
+  },
+  "insertshortinstitute": {
+    "command": "insertshortinstitute",
+    "package": "class-ctexbeamer",
+    "snippet": "insertshortinstitute"
+  },
+  "insertshortpart": {
+    "command": "insertshortpart",
+    "package": "class-ctexbeamer",
+    "snippet": "insertshortpart"
+  },
+  "insertshorttitle": {
+    "command": "insertshorttitle",
+    "package": "class-ctexbeamer",
+    "snippet": "insertshorttitle"
+  },
+  "insertshortsubtitle": {
+    "command": "insertshortsubtitle",
+    "package": "class-ctexbeamer",
+    "snippet": "insertshortsubtitle"
+  },
+  "insertsubsection": {
+    "command": "insertsubsection",
+    "package": "class-ctexbeamer",
+    "snippet": "insertsubsection"
+  },
+  "insertsubsectionnavigation": {
+    "command": "insertsubsectionnavigation",
+    "package": "class-ctexbeamer",
+    "snippet": "insertsubsectionnavigation"
+  },
+  "insertsubsectionnavigationhorizontal": {
+    "command": "insertsubsectionnavigationhorizontal",
+    "package": "class-ctexbeamer",
+    "snippet": "insertsubsectionnavigationhorizontal"
+  },
+  "insertverticalnavigation": {
+    "command": "insertverticalnavigation",
+    "package": "class-ctexbeamer",
+    "snippet": "insertverticalnavigation"
+  },
+  "insertframenumber": {
+    "command": "insertframenumber",
+    "package": "class-ctexbeamer",
+    "snippet": "insertframenumber"
+  },
+  "inserttotalframenumber": {
+    "command": "inserttotalframenumber",
+    "package": "class-ctexbeamer",
+    "snippet": "inserttotalframenumber"
+  },
+  "insertframestartpage": {
+    "command": "insertframestartpage",
+    "package": "class-ctexbeamer",
+    "snippet": "insertframestartpage"
+  },
+  "insertframeendpage": {
+    "command": "insertframeendpage",
+    "package": "class-ctexbeamer",
+    "snippet": "insertframeendpage"
+  },
+  "insertsubsectionstartpage": {
+    "command": "insertsubsectionstartpage",
+    "package": "class-ctexbeamer",
+    "snippet": "insertsubsectionstartpage"
+  },
+  "insertsubsectionendpage": {
+    "command": "insertsubsectionendpage",
+    "package": "class-ctexbeamer",
+    "snippet": "insertsubsectionendpage"
+  },
+  "insertsectionstartpage": {
+    "command": "insertsectionstartpage",
+    "package": "class-ctexbeamer",
+    "snippet": "insertsectionstartpage"
+  },
+  "insertsectionendpage": {
+    "command": "insertsectionendpage",
+    "package": "class-ctexbeamer",
+    "snippet": "insertsectionendpage"
+  },
+  "insertpartstartpage": {
+    "command": "insertpartstartpage",
+    "package": "class-ctexbeamer",
+    "snippet": "insertpartstartpage"
+  },
+  "insertpartendpage": {
+    "command": "insertpartendpage",
+    "package": "class-ctexbeamer",
+    "snippet": "insertpartendpage"
+  },
+  "insertpresentationstartpage": {
+    "command": "insertpresentationstartpage",
+    "package": "class-ctexbeamer",
+    "snippet": "insertpresentationstartpage"
+  },
+  "insertpresentationendpage": {
+    "command": "insertpresentationendpage",
+    "package": "class-ctexbeamer",
+    "snippet": "insertpresentationendpage"
+  },
+  "insertappendixstartpage": {
+    "command": "insertappendixstartpage",
+    "package": "class-ctexbeamer",
+    "snippet": "insertappendixstartpage"
+  },
+  "insertappendixendpage": {
+    "command": "insertappendixendpage",
+    "package": "class-ctexbeamer",
+    "snippet": "insertappendixendpage"
+  },
+  "insertdocumentstartpage": {
+    "command": "insertdocumentstartpage",
+    "package": "class-ctexbeamer",
+    "snippet": "insertdocumentstartpage"
+  },
+  "insertdocumentendpage": {
+    "command": "insertdocumentendpage",
+    "package": "class-ctexbeamer",
+    "snippet": "insertdocumentendpage"
+  },
+  "setbeamersize{}": {
+    "command": "setbeamersize{options}",
+    "package": "class-ctexbeamer",
+    "snippet": "setbeamersize{${1:options}}"
+  },
+  "insertsectionhead": {
+    "command": "insertsectionhead",
+    "package": "class-ctexbeamer",
+    "snippet": "insertsectionhead"
+  },
+  "insertsectionheadnumber": {
+    "command": "insertsectionheadnumber",
+    "package": "class-ctexbeamer",
+    "snippet": "insertsectionheadnumber"
+  },
+  "insertpartheadnumber": {
+    "command": "insertpartheadnumber",
+    "package": "class-ctexbeamer",
+    "snippet": "insertpartheadnumber"
+  },
+  "insertsubsectionhead": {
+    "command": "insertsubsectionhead",
+    "package": "class-ctexbeamer",
+    "snippet": "insertsubsectionhead"
+  },
+  "insertsubsectionheadnumber": {
+    "command": "insertsubsectionheadnumber",
+    "package": "class-ctexbeamer",
+    "snippet": "insertsubsectionheadnumber"
+  },
+  "insertslidenavigationsymbol": {
+    "command": "insertslidenavigationsymbol",
+    "package": "class-ctexbeamer",
+    "snippet": "insertslidenavigationsymbol"
+  },
+  "insertframenavigationsymbol": {
+    "command": "insertframenavigationsymbol",
+    "package": "class-ctexbeamer",
+    "snippet": "insertframenavigationsymbol"
+  },
+  "insertsubsectionnavigationsymbol": {
+    "command": "insertsubsectionnavigationsymbol",
+    "package": "class-ctexbeamer",
+    "snippet": "insertsubsectionnavigationsymbol"
+  },
+  "insertsectionnavigationsymbol": {
+    "command": "insertsectionnavigationsymbol",
+    "package": "class-ctexbeamer",
+    "snippet": "insertsectionnavigationsymbol"
+  },
+  "insertdocnavigationsymbol": {
+    "command": "insertdocnavigationsymbol",
+    "package": "class-ctexbeamer",
+    "snippet": "insertdocnavigationsymbol"
+  },
+  "insertbackfindforwardnavigationsymbol": {
+    "command": "insertbackfindforwardnavigationsymbol",
+    "package": "class-ctexbeamer",
+    "snippet": "insertbackfindforwardnavigationsymbol"
+  },
+  "insertenumlabel": {
+    "command": "insertenumlabel",
+    "package": "class-ctexbeamer",
+    "snippet": "insertenumlabel"
+  },
+  "insertsubsubenumlabel": {
+    "command": "insertsubsubenumlabel",
+    "package": "class-ctexbeamer",
+    "snippet": "insertsubsubenumlabel"
+  },
+  "insertdescriptionitem": {
+    "command": "insertdescriptionitem",
+    "package": "class-ctexbeamer",
+    "snippet": "insertdescriptionitem"
+  },
+  "inserttheoremheadfont": {
+    "command": "inserttheoremheadfont",
+    "package": "class-ctexbeamer",
+    "snippet": "inserttheoremheadfont"
+  },
+  "inserttheoremname": {
+    "command": "inserttheoremname",
+    "package": "class-ctexbeamer",
+    "snippet": "inserttheoremname"
+  },
+  "inserttheoremnumber": {
+    "command": "inserttheoremnumber",
+    "package": "class-ctexbeamer",
+    "snippet": "inserttheoremnumber"
+  },
+  "inserttheoremaddition": {
+    "command": "inserttheoremaddition",
+    "package": "class-ctexbeamer",
+    "snippet": "inserttheoremaddition"
+  },
+  "inserttheorempunctuation": {
+    "command": "inserttheorempunctuation",
+    "package": "class-ctexbeamer",
+    "snippet": "inserttheorempunctuation"
+  },
+  "insertcaption": {
+    "command": "insertcaption",
+    "package": "class-ctexbeamer",
+    "snippet": "insertcaption"
+  },
+  "insertcaptionname": {
+    "command": "insertcaptionname",
+    "package": "class-ctexbeamer",
+    "snippet": "insertcaptionname"
+  },
+  "insertcaptionnumber": {
+    "command": "insertcaptionnumber",
+    "package": "class-ctexbeamer",
+    "snippet": "insertcaptionnumber"
+  },
+  "insertfootnotetext": {
+    "command": "insertfootnotetext",
+    "package": "class-ctexbeamer",
+    "snippet": "insertfootnotetext"
+  },
+  "insertfootnotemark": {
+    "command": "insertfootnotemark",
+    "package": "class-ctexbeamer",
+    "snippet": "insertfootnotemark"
+  },
+  "insertnote": {
+    "command": "insertnote",
+    "package": "class-ctexbeamer",
+    "snippet": "insertnote"
+  },
+  "insertslideintonotes": {
+    "command": "insertslideintonotes",
+    "package": "class-ctexbeamer",
+    "snippet": "insertslideintonotes"
+  },
+  "logo{}": {
+    "command": "logo{logo text}",
+    "package": "class-ctexbeamer",
+    "snippet": "logo{${1:logo text}}"
+  },
+  "insertlogo": {
+    "command": "insertlogo",
+    "package": "class-ctexbeamer",
+    "snippet": "insertlogo"
+  },
+  "frametitle<>[]{}": {
+    "command": "frametitle<overlay specification>[short frame title]{frame title text}",
+    "package": "class-ctexbeamer",
+    "snippet": "frametitle<${3:overlay specification}>[${2:short frame title}]{${1:frame title text}}"
+  },
+  "frametitle<>{}": {
+    "command": "frametitle<overlay specification>{frame title text}",
+    "package": "class-ctexbeamer",
+    "snippet": "frametitle<${2:overlay specification}>{${1:frame title text}}"
+  },
+  "frametitle[]{}": {
+    "command": "frametitle[short frame title]{frame title text}",
+    "package": "class-ctexbeamer",
+    "snippet": "frametitle[${2:short frame title}]{${1:frame title text}}"
+  },
+  "frametitle{}": {
+    "command": "frametitle{frame title text}",
+    "package": "class-ctexbeamer",
+    "snippet": "frametitle{${1:frame title text}}"
+  },
+  "framesubtitle<>{}": {
+    "command": "framesubtitle<overlay specification>{frame subtitle text}",
+    "package": "class-ctexbeamer",
+    "snippet": "framesubtitle<${2:overlay specification}>{${1:frame subtitle text}}"
+  },
+  "framesubtitle{}": {
+    "command": "framesubtitle{frame subtitle text}",
+    "package": "class-ctexbeamer",
+    "snippet": "framesubtitle{${1:frame subtitle text}}"
+  },
+  "titlepage": {
+    "command": "titlepage",
+    "package": "class-ctexbeamer",
+    "snippet": "titlepage"
+  },
+  "title[]{}": {
+    "command": "title[short title]{title}",
+    "package": "class-ctexbeamer",
+    "snippet": "title[${2:short title}]{${1:title}}"
+  },
+  "title{}": {
+    "command": "title{title}",
+    "package": "class-ctexbeamer",
+    "snippet": "title{${1:title}}"
+  },
+  "subtitle[]{}": {
+    "command": "subtitle[short subtitle]{subtitle}",
+    "package": "class-ctexbeamer",
+    "snippet": "subtitle[${2:short subtitle}]{${1:subtitle}}"
+  },
+  "subtitle{}": {
+    "command": "subtitle{subtitle}",
+    "package": "class-ctexbeamer",
+    "snippet": "subtitle{${1:subtitle}}"
+  },
+  "author[]{}": {
+    "command": "author[short author names]{author names}",
+    "package": "class-ctexbeamer",
+    "snippet": "author[${2:short author names}]{${1:author names}}"
+  },
+  "author{}": {
+    "command": "author{author names}",
+    "package": "class-ctexbeamer",
+    "snippet": "author{${1:author names}}"
+  },
+  "institute[]{}": {
+    "command": "institute[short institute]{institute}",
+    "package": "class-ctexbeamer",
+    "snippet": "institute[${2:short institute}]{${1:institute}}"
+  },
+  "institute{}": {
+    "command": "institute{institute}",
+    "package": "class-ctexbeamer",
+    "snippet": "institute{${1:institute}}"
+  },
+  "date[]{}": {
+    "command": "date[short date]{date}",
+    "package": "class-ctexbeamer",
+    "snippet": "date[${2:short date}]{${1:date}}"
+  },
+  "date{}": {
+    "command": "date{date}",
+    "package": "class-ctexbeamer",
+    "snippet": "date{${1:date}}"
+  },
+  "titlegraphic{}": {
+    "command": "titlegraphic{text}",
+    "package": "class-ctexbeamer",
+    "snippet": "titlegraphic{${1:text}}"
+  },
+  "subject{}": {
+    "command": "subject{text}",
+    "package": "class-ctexbeamer",
+    "snippet": "subject{${1:text}}"
+  },
+  "keywords{}": {
+    "command": "keywords{text}",
+    "package": "class-ctexbeamer",
+    "snippet": "keywords{${1:text}}"
+  },
+  "section<>[]{}": {
+    "command": "section<mode specification>[short section name]{section name}",
+    "package": "class-ctexbeamer",
+    "snippet": "section<${3:mode specification}>[${2:short section name}]{${1:section name}}"
+  },
+  "section<>{}": {
+    "command": "section<mode specification>{section name}",
+    "package": "class-ctexbeamer",
+    "snippet": "section<${2:mode specification}>{${1:section name}}"
+  },
+  "section{}": {
+    "command": "section{section name}",
+    "package": "class-ctexbeamer",
+    "snippet": "section{${1:section name}}"
+  },
+  "section<>*[]{}": {
+    "command": "section<mode specification>*[short section name]{section name}",
+    "package": "class-ctexbeamer",
+    "snippet": "section<${3:mode specification}>*[${2:short section name}]{${1:section name}}"
+  },
+  "section<>*{}": {
+    "command": "section<mode specification>*{section name}",
+    "package": "class-ctexbeamer",
+    "snippet": "section<${2:mode specification}>*{${1:section name}}"
+  },
+  "section*[]{}": {
+    "command": "section*[short section name]{section name}",
+    "package": "class-ctexbeamer",
+    "snippet": "section*[${2:short section name}]{${1:section name}}"
+  },
+  "section*{}": {
+    "command": "section*{section name}",
+    "package": "class-ctexbeamer",
+    "snippet": "section*{${1:section name}}"
+  },
+  "subsection<>[]{}": {
+    "command": "subsection<mode specification>[short section name]{section name}",
+    "package": "class-ctexbeamer",
+    "snippet": "subsection<${3:mode specification}>[${2:short section name}]{${1:section name}}"
+  },
+  "subsection<>{}": {
+    "command": "subsection<mode specification>{section name}",
+    "package": "class-ctexbeamer",
+    "snippet": "subsection<${2:mode specification}>{${1:section name}}"
+  },
+  "subsection{}": {
+    "command": "subsection{section name}",
+    "package": "class-ctexbeamer",
+    "snippet": "subsection{${1:section name}}"
+  },
+  "subsection<>*[]{}": {
+    "command": "subsection<mode specification>*[short section name]{section name}",
+    "package": "class-ctexbeamer",
+    "snippet": "subsection<${3:mode specification}>*[${2:short section name}]{${1:section name}}"
+  },
+  "subsection<>*{}": {
+    "command": "subsection<mode specification>*{section name}",
+    "package": "class-ctexbeamer",
+    "snippet": "subsection<${2:mode specification}>*{${1:section name}}"
+  },
+  "subsection*[]{}": {
+    "command": "subsection*[short section name]{section name}",
+    "package": "class-ctexbeamer",
+    "snippet": "subsection*[${2:short section name}]{${1:section name}}"
+  },
+  "subsection*{}": {
+    "command": "subsection*{section name}",
+    "package": "class-ctexbeamer",
+    "snippet": "subsection*{${1:section name}}"
+  },
+  "subsubsection<>[]{}": {
+    "command": "subsubsection<mode specification>[short section name]{section name}",
+    "package": "class-ctexbeamer",
+    "snippet": "subsubsection<${3:mode specification}>[${2:short section name}]{${1:section name}}"
+  },
+  "subsubsection<>{}": {
+    "command": "subsubsection<mode specification>{section name}",
+    "package": "class-ctexbeamer",
+    "snippet": "subsubsection<${2:mode specification}>{${1:section name}}"
+  },
+  "subsubsection{}": {
+    "command": "subsubsection{section name}",
+    "package": "class-ctexbeamer",
+    "snippet": "subsubsection{${1:section name}}"
+  },
+  "subsubsection<>*[]{}": {
+    "command": "subsubsection<mode specification>*[short section name]{section name}",
+    "package": "class-ctexbeamer",
+    "snippet": "subsubsection<${3:mode specification}>*[${2:short section name}]{${1:section name}}"
+  },
+  "subsubsection<>*{}": {
+    "command": "subsubsection<mode specification>*{section name}",
+    "package": "class-ctexbeamer",
+    "snippet": "subsubsection<${2:mode specification}>*{${1:section name}}"
+  },
+  "subsubsection*[]{}": {
+    "command": "subsubsection*[short section name]{section name}",
+    "package": "class-ctexbeamer",
+    "snippet": "subsubsection*[${2:short section name}]{${1:section name}}"
+  },
+  "subsubsection*{}": {
+    "command": "subsubsection*{section name}",
+    "package": "class-ctexbeamer",
+    "snippet": "subsubsection*{${1:section name}}"
+  },
+  "AtBeginSection[]{}": {
+    "command": "AtBeginSection[special star text]{text}",
+    "package": "class-ctexbeamer",
+    "snippet": "AtBeginSection[${2:special star text}]{${1:text}}"
+  },
+  "AtBeginSection{}": {
+    "command": "AtBeginSection{text}",
+    "package": "class-ctexbeamer",
+    "snippet": "AtBeginSection{${1:text}}"
+  },
+  "AtBeginSubsection[]{}": {
+    "command": "AtBeginSubsection[special star text]{text}",
+    "package": "class-ctexbeamer",
+    "snippet": "AtBeginSubsection[${2:special star text}]{${1:text}}"
+  },
+  "AtBeginSubsection{}": {
+    "command": "AtBeginSubsection{text}",
+    "package": "class-ctexbeamer",
+    "snippet": "AtBeginSubsection{${1:text}}"
+  },
+  "AtBeginSubsubsection[]{}": {
+    "command": "AtBeginSubsubsection[special star text]{text}",
+    "package": "class-ctexbeamer",
+    "snippet": "AtBeginSubsubsection[${2:special star text}]{${1:text}}"
+  },
+  "AtBeginSubsubsection{}": {
+    "command": "AtBeginSubsubsection{text}",
+    "package": "class-ctexbeamer",
+    "snippet": "AtBeginSubsubsection{${1:text}}"
+  },
+  "part<>[]{}": {
+    "command": "part<mode specification>[short part name]{part name}",
+    "package": "class-ctexbeamer",
+    "snippet": "part<${3:mode specification}>[${2:short part name}]{${1:part name}}"
+  },
+  "part<>{}": {
+    "command": "part<mode specification>{part name}",
+    "package": "class-ctexbeamer",
+    "snippet": "part<${2:mode specification}>{${1:part name}}"
+  },
+  "part{}": {
+    "command": "part{part name}",
+    "package": "class-ctexbeamer",
+    "snippet": "part{${1:part name}}"
+  },
+  "partpage": {
+    "command": "partpage",
+    "package": "class-ctexbeamer",
+    "snippet": "partpage"
+  },
+  "AtBeginPart{}": {
+    "command": "AtBeginPart{text}",
+    "package": "class-ctexbeamer",
+    "snippet": "AtBeginPart{${1:text}}"
+  },
+  "lecture[]{}{}": {
+    "command": "lecture[short lecture name]{lecture name}{lecture label}",
+    "package": "class-ctexbeamer",
+    "snippet": "lecture[${3:short lecture name}]{${1:lecture name}}{${2:lecture label}}"
+  },
+  "lecture{}{}": {
+    "command": "lecture{lecture name}{lecture label}",
+    "package": "class-ctexbeamer",
+    "snippet": "lecture{${1:lecture name}}{${2:lecture label}}"
+  },
+  "includeonlylecture{}": {
+    "command": "includeonlylecture{lecture label}",
+    "package": "class-ctexbeamer",
+    "snippet": "includeonlylecture{${1:lecture label}}"
+  },
+  "AtBeginLecture{}": {
+    "command": "AtBeginLecture{text}",
+    "package": "class-ctexbeamer",
+    "snippet": "AtBeginLecture{${1:text}}"
+  },
+  "tableofcontents[]": {
+    "command": "tableofcontents[comma-separated option list]",
+    "package": "class-ctexbeamer",
+    "snippet": "tableofcontents[${1:comma-separated option list}]"
+  },
+  "bibitem<>[]{}": {
+    "command": "bibitem<overlay specification>[citation text]{label name}",
+    "package": "class-ctexbeamer",
+    "snippet": "bibitem<${3:overlay specification}>[${2:citation text}]{${1:label name}}"
+  },
+  "bibitem<>{}": {
+    "command": "bibitem<overlay specification>{label name}",
+    "package": "class-ctexbeamer",
+    "snippet": "bibitem<${2:overlay specification}>{${1:label name}}"
+  },
+  "bibitem{}": {
+    "command": "bibitem{label name}",
+    "package": "class-ctexbeamer",
+    "snippet": "bibitem{${1:label name}}"
+  },
+  "appendix<>": {
+    "command": "appendix<mode specification>",
+    "package": "class-ctexbeamer",
+    "snippet": "appendix<${1:mode specification}>"
+  },
+  "hypertarget<>{}{}": {
+    "command": "hypertarget<overlay specification>{target name}{text}",
+    "package": "class-ctexbeamer",
+    "snippet": "hypertarget<${3:overlay specification}>{${1:target name}}{${2:text}}"
+  },
+  "hypertarget{}{}": {
+    "command": "hypertarget{target name}{text}",
+    "package": "class-ctexbeamer",
+    "snippet": "hypertarget{${1:target name}}{${2:text}}"
+  },
+  "beamerbutton{}": {
+    "command": "beamerbutton{button text}",
+    "package": "class-ctexbeamer",
+    "snippet": "beamerbutton{${1:button text}}"
+  },
+  "beamergotobutton{}": {
+    "command": "beamergotobutton{button text}",
+    "package": "class-ctexbeamer",
+    "snippet": "beamergotobutton{${1:button text}}"
+  },
+  "beamerskipbutton{}": {
+    "command": "beamerskipbutton{button text}",
+    "package": "class-ctexbeamer",
+    "snippet": "beamerskipbutton{${1:button text}}"
+  },
+  "beamerreturnbutton{}": {
+    "command": "beamerreturnbutton{button text}",
+    "package": "class-ctexbeamer",
+    "snippet": "beamerreturnbutton{${1:button text}}"
+  },
+  "hyperlink<>{}{}<>": {
+    "command": "hyperlink<overlay specification>{target name}{link text}<overlay specification>",
+    "package": "class-ctexbeamer",
+    "snippet": "hyperlink<${3:overlay specification}>{${1:target name}}{${2:link text}}<${4:overlay specification}>"
+  },
+  "hyperlink{}{}<>": {
+    "command": "hyperlink{target name}{link text}<overlay specification>",
+    "package": "class-ctexbeamer",
+    "snippet": "hyperlink{${1:target name}}{${2:link text}}<${3:overlay specification}>"
+  },
+  "hyperlink{}{}": {
+    "command": "hyperlink{target name}{link text}",
+    "package": "class-ctexbeamer",
+    "snippet": "hyperlink{${1:target name}}{${2:link text}}"
+  },
+  "hyperlinkslideprev<>{}": {
+    "command": "hyperlinkslideprev<overlay specification>{link text}",
+    "package": "class-ctexbeamer",
+    "snippet": "hyperlinkslideprev<${2:overlay specification}>{${1:link text}}"
+  },
+  "hyperlinkslideprev{}": {
+    "command": "hyperlinkslideprev{link text}",
+    "package": "class-ctexbeamer",
+    "snippet": "hyperlinkslideprev{${1:link text}}"
+  },
+  "hyperlinkslidenext<>{}": {
+    "command": "hyperlinkslidenext<overlay specification>{link text}",
+    "package": "class-ctexbeamer",
+    "snippet": "hyperlinkslidenext<${2:overlay specification}>{${1:link text}}"
+  },
+  "hyperlinkslidenext{}": {
+    "command": "hyperlinkslidenext{link text}",
+    "package": "class-ctexbeamer",
+    "snippet": "hyperlinkslidenext{${1:link text}}"
+  },
+  "hyperlinkframestart<>{}": {
+    "command": "hyperlinkframestart<overlay specification>{link text}",
+    "package": "class-ctexbeamer",
+    "snippet": "hyperlinkframestart<${2:overlay specification}>{${1:link text}}"
+  },
+  "hyperlinkframestart{}": {
+    "command": "hyperlinkframestart{link text}",
+    "package": "class-ctexbeamer",
+    "snippet": "hyperlinkframestart{${1:link text}}"
+  },
+  "hyperlinkframeend<>{}": {
+    "command": "hyperlinkframeend<overlay specification>{link text}",
+    "package": "class-ctexbeamer",
+    "snippet": "hyperlinkframeend<${2:overlay specification}>{${1:link text}}"
+  },
+  "hyperlinkframeend{}": {
+    "command": "hyperlinkframeend{link text}",
+    "package": "class-ctexbeamer",
+    "snippet": "hyperlinkframeend{${1:link text}}"
+  },
+  "hyperlinkframestartnext<>{}": {
+    "command": "hyperlinkframestartnext<overlay specification>{link text}",
+    "package": "class-ctexbeamer",
+    "snippet": "hyperlinkframestartnext<${2:overlay specification}>{${1:link text}}"
+  },
+  "hyperlinkframestartnext{}": {
+    "command": "hyperlinkframestartnext{link text}",
+    "package": "class-ctexbeamer",
+    "snippet": "hyperlinkframestartnext{${1:link text}}"
+  },
+  "hyperlinkframeendprev<>{}": {
+    "command": "hyperlinkframeendprev<overlay specification>{link text}",
+    "package": "class-ctexbeamer",
+    "snippet": "hyperlinkframeendprev<${2:overlay specification}>{${1:link text}}"
+  },
+  "hyperlinkframeendprev{}": {
+    "command": "hyperlinkframeendprev{link text}",
+    "package": "class-ctexbeamer",
+    "snippet": "hyperlinkframeendprev{${1:link text}}"
+  },
+  "hyperlinkpresentationstart<>{}": {
+    "command": "hyperlinkpresentationstart<overlay specification>{link text}",
+    "package": "class-ctexbeamer",
+    "snippet": "hyperlinkpresentationstart<${2:overlay specification}>{${1:link text}}"
+  },
+  "hyperlinkpresentationstart{}": {
+    "command": "hyperlinkpresentationstart{link text}",
+    "package": "class-ctexbeamer",
+    "snippet": "hyperlinkpresentationstart{${1:link text}}"
+  },
+  "hyperlinkpresentationend<>{}": {
+    "command": "hyperlinkpresentationend<overlay specification>{link text}",
+    "package": "class-ctexbeamer",
+    "snippet": "hyperlinkpresentationend<${2:overlay specification}>{${1:link text}}"
+  },
+  "hyperlinkpresentationend{}": {
+    "command": "hyperlinkpresentationend{link text}",
+    "package": "class-ctexbeamer",
+    "snippet": "hyperlinkpresentationend{${1:link text}}"
+  },
+  "hyperlinkappendixstart<>{}": {
+    "command": "hyperlinkappendixstart<overlay specification>{link text}",
+    "package": "class-ctexbeamer",
+    "snippet": "hyperlinkappendixstart<${2:overlay specification}>{${1:link text}}"
+  },
+  "hyperlinkappendixstart{}": {
+    "command": "hyperlinkappendixstart{link text}",
+    "package": "class-ctexbeamer",
+    "snippet": "hyperlinkappendixstart{${1:link text}}"
+  },
+  "hyperlinkappendixend<>{}": {
+    "command": "hyperlinkappendixend<overlay specification>{link text}",
+    "package": "class-ctexbeamer",
+    "snippet": "hyperlinkappendixend<${2:overlay specification}>{${1:link text}}"
+  },
+  "hyperlinkappendixend{}": {
+    "command": "hyperlinkappendixend{link text}",
+    "package": "class-ctexbeamer",
+    "snippet": "hyperlinkappendixend{${1:link text}}"
+  },
+  "hyperlinkdocumentstart<>{}": {
+    "command": "hyperlinkdocumentstart<overlay specification>{link text}",
+    "package": "class-ctexbeamer",
+    "snippet": "hyperlinkdocumentstart<${2:overlay specification}>{${1:link text}}"
+  },
+  "hyperlinkdocumentstart{}": {
+    "command": "hyperlinkdocumentstart{link text}",
+    "package": "class-ctexbeamer",
+    "snippet": "hyperlinkdocumentstart{${1:link text}}"
+  },
+  "hyperlinkdocumentend<>{}": {
+    "command": "hyperlinkdocumentend<overlay specification>{link text}",
+    "package": "class-ctexbeamer",
+    "snippet": "hyperlinkdocumentend<${2:overlay specification}>{${1:link text}}"
+  },
+  "hyperlinkdocumentend{}": {
+    "command": "hyperlinkdocumentend{link text}",
+    "package": "class-ctexbeamer",
+    "snippet": "hyperlinkdocumentend{${1:link text}}"
+  },
+  "againframe<>[][]{}": {
+    "command": "againframe<overlay specification>[<default overlay specification>][options]{name}",
+    "package": "class-ctexbeamer",
+    "snippet": "againframe<${4:overlay specification}>[${2:<default overlay specification>}][${3:options}]{${1:name}}"
+  },
+  "againframe<>[]{}": {
+    "command": "againframe<overlay specification>[options]{name}",
+    "package": "class-ctexbeamer",
+    "snippet": "againframe<${3:overlay specification}>[${2:options}]{${1:name}}"
+  },
+  "againframe<>{}": {
+    "command": "againframe<overlay specification>{name}",
+    "package": "class-ctexbeamer",
+    "snippet": "againframe<${2:overlay specification}>{${1:name}}"
+  },
+  "againframe[][]{}": {
+    "command": "againframe[<default overlay specification>][options]{name}",
+    "package": "class-ctexbeamer",
+    "snippet": "againframe[${2:<default overlay specification>}][${3:options}]{${1:name}}"
+  },
+  "againframe[]{}": {
+    "command": "againframe[options]{name}",
+    "package": "class-ctexbeamer",
+    "snippet": "againframe[${2:options}]{${1:name}}"
+  },
+  "againframe{}": {
+    "command": "againframe{name}",
+    "package": "class-ctexbeamer",
+    "snippet": "againframe{${1:name}}"
+  },
+  "framezoom<><>[]()()": {
+    "command": "framezoom<button overlay specification><zoomed overlay specification>[options](upper left x,upper left y)(zoom area width,zoom area depth)",
+    "package": "class-ctexbeamer",
+    "snippet": "framezoom<${2:button overlay specification}><${3:zoomed overlay specification}>[${1:options}](${4:upper left x,upper left y})(${5:zoom area width,zoom area depth})"
+  },
+  "framezoom<><>()()": {
+    "command": "framezoom<button overlay specification><zoomed overlay specification>(upper left x,upper left y)(zoom area width,zoom area depth)",
+    "package": "class-ctexbeamer",
+    "snippet": "framezoom<${1:button overlay specification}><${2:zoomed overlay specification}>(${3:upper left x,upper left y})(${4:zoom area width,zoom area depth})"
+  },
+  "structure<>{}": {
+    "command": "structure<overlay specification>{text}",
+    "package": "class-ctexbeamer",
+    "snippet": "structure<${2:overlay specification}>{${1:text}}"
+  },
+  "structure{}": {
+    "command": "structure{text}",
+    "package": "class-ctexbeamer",
+    "snippet": "structure{${1:text}}"
+  },
+  "alert<>{}": {
+    "command": "alert<overlay specification>{highlighted text}",
+    "package": "class-ctexbeamer",
+    "snippet": "alert<${2:overlay specification}>{${1:highlighted text}}"
+  },
+  "alert{}": {
+    "command": "alert{highlighted text}",
+    "package": "class-ctexbeamer",
+    "snippet": "alert{${1:highlighted text}}"
+  },
+  "newtheorem*{}[]{}[]": {
+    "command": "newtheorem*{environment name}[numbered same as]{head text}[number within]",
+    "package": "class-ctexbeamer",
+    "snippet": "newtheorem*{${1:environment name}}[${2:numbered same as}]{${3:head text}}[${4:number within}]"
+  },
+  "newtheorem*{}{}[]": {
+    "command": "newtheorem*{environment name}{head text}[number within]",
+    "package": "class-ctexbeamer",
+    "snippet": "newtheorem*{${1:environment name}}{${2:head text}}[${3:number within}]"
+  },
+  "newtheorem*{}{}": {
+    "command": "newtheorem*{environment name}{head text}",
+    "package": "class-ctexbeamer",
+    "snippet": "newtheorem*{${1:environment name}}{${2:head text}}"
+  },
+  "newtheorem{}[]{}[]": {
+    "command": "newtheorem{environment name}[numbered same as]{head text}[number within]",
+    "package": "class-ctexbeamer",
+    "snippet": "newtheorem{${1:environment name}}[${2:numbered same as}]{${3:head text}}[${4:number within}]"
+  },
+  "footnote<>[]{}": {
+    "command": "footnote<overlay specification>[options]{text}",
+    "package": "class-ctexbeamer",
+    "snippet": "footnote<${3:overlay specification}>[${2:options}]{${1:text}}"
+  },
+  "footnote<>{}": {
+    "command": "footnote<overlay specification>{text}",
+    "package": "class-ctexbeamer",
+    "snippet": "footnote<${2:overlay specification}>{${1:text}}"
+  },
+  "footnote{}": {
+    "command": "footnote{text}",
+    "package": "class-ctexbeamer",
+    "snippet": "footnote{${1:text}}"
+  },
+  "setjobnamebeamerversion{}": {
+    "command": "setjobnamebeamerversion{filename without extension}",
+    "package": "class-ctexbeamer",
+    "snippet": "setjobnamebeamerversion{${1:filename without extension}}"
+  },
+  "includeslide[]{}": {
+    "command": "includeslide[options]{label name}",
+    "package": "class-ctexbeamer",
+    "snippet": "includeslide[${2:options}]{${1:label name}}"
+  },
+  "includeslide{}": {
+    "command": "includeslide{label name}",
+    "package": "class-ctexbeamer",
+    "snippet": "includeslide{${1:label name}}"
+  },
+  "mode<>{}": {
+    "command": "mode<mode specification>{text}",
+    "package": "class-ctexbeamer",
+    "snippet": "mode<${2:mode specification}>{${1:text}}"
+  },
+  "mode{}": {
+    "command": "mode{text}",
+    "package": "class-ctexbeamer",
+    "snippet": "mode{${1:text}}"
+  },
+  "mode<>": {
+    "command": "mode<mode specification>",
+    "package": "class-ctexbeamer",
+    "snippet": "mode<${1:mode specification}>"
+  },
+  "mode*": {
+    "command": "mode*",
+    "package": "class-ctexbeamer",
+    "snippet": "mode*"
+  },
+  "mode": {
+    "command": "mode",
+    "package": "class-ctexbeamer",
+    "snippet": "mode"
+  },
+  "note<>[]{}": {
+    "command": "note<overlay specification>[options]{note text}",
+    "package": "class-ctexbeamer",
+    "snippet": "note<${3:overlay specification}>[${2:options}]{${1:note text}}"
+  },
+  "note<>{}": {
+    "command": "note<overlay specification>{note text}",
+    "package": "class-ctexbeamer",
+    "snippet": "note<${2:overlay specification}>{${1:note text}}"
+  },
+  "note[]{}": {
+    "command": "note[options]{note text}",
+    "package": "class-ctexbeamer",
+    "snippet": "note[${2:options}]{${1:note text}}"
+  },
+  "note{}": {
+    "command": "note{note text}",
+    "package": "class-ctexbeamer",
+    "snippet": "note{${1:note text}}"
+  },
+  "AtBeginNote{}": {
+    "command": "AtBeginNote{text}",
+    "package": "class-ctexbeamer",
+    "snippet": "AtBeginNote{${1:text}}"
+  },
+  "AtEndNote{}": {
+    "command": "AtEndNote{text}",
+    "package": "class-ctexbeamer",
+    "snippet": "AtEndNote{${1:text}}"
+  },
+  "pause[]": {
+    "command": "pause[number]",
+    "package": "class-ctexbeamer",
+    "snippet": "pause[${1:number}]"
+  },
+  "pause": {
+    "command": "pause",
+    "package": "class-ctexbeamer",
+    "snippet": "pause"
+  },
+  "onslide<>{}": {
+    "command": "onslide<overlay specification>{text}",
+    "package": "class-ctexbeamer",
+    "snippet": "onslide<${2:overlay specification}>{${1:text}}"
+  },
+  "onslide+<>{}": {
+    "command": "onslide+<overlay specification>{text}",
+    "package": "class-ctexbeamer",
+    "snippet": "onslide+<${2:overlay specification}>{${1:text}}"
+  },
+  "onslide*<>{}": {
+    "command": "onslide*<overlay specification>{text}",
+    "package": "class-ctexbeamer",
+    "snippet": "onslide*<${2:overlay specification}>{${1:text}}"
+  },
+  "onslide<>": {
+    "command": "onslide<overlay specification>",
+    "package": "class-ctexbeamer",
+    "snippet": "onslide<${1:overlay specification}>"
+  },
+  "onslide": {
+    "command": "onslide",
+    "package": "class-ctexbeamer",
+    "snippet": "onslide"
+  },
+  "only<>{}<>": {
+    "command": "only<overlay specification>{text}<overlay specification>",
+    "package": "class-ctexbeamer",
+    "snippet": "only<${2:overlay specification}>{${1:text}}<${3:overlay specification}>"
+  },
+  "only{}<>": {
+    "command": "only{text}<overlay specification>",
+    "package": "class-ctexbeamer",
+    "snippet": "only{${1:text}}<${2:overlay specification}>"
+  },
+  "only{}": {
+    "command": "only{text}",
+    "package": "class-ctexbeamer",
+    "snippet": "only{${1:text}}"
+  },
+  "uncover<>{}": {
+    "command": "uncover<overlay specification>{text}",
+    "package": "class-ctexbeamer",
+    "snippet": "uncover<${2:overlay specification}>{${1:text}}"
+  },
+  "uncover{}": {
+    "command": "uncover{text}",
+    "package": "class-ctexbeamer",
+    "snippet": "uncover{${1:text}}"
+  },
+  "visible<>{}": {
+    "command": "visible<overlay specification>{text}",
+    "package": "class-ctexbeamer",
+    "snippet": "visible<${2:overlay specification}>{${1:text}}"
+  },
+  "visible{}": {
+    "command": "visible{text}",
+    "package": "class-ctexbeamer",
+    "snippet": "visible{${1:text}}"
+  },
+  "invisible<>{}": {
+    "command": "invisible<overlay specification>{text}",
+    "package": "class-ctexbeamer",
+    "snippet": "invisible<${2:overlay specification}>{${1:text}}"
+  },
+  "invisible{}": {
+    "command": "invisible{text}",
+    "package": "class-ctexbeamer",
+    "snippet": "invisible{${1:text}}"
+  },
+  "alt<>{}{}<>": {
+    "command": "alt<overlay specification>{default text}{alternative text}<overlay specification>",
+    "package": "class-ctexbeamer",
+    "snippet": "alt<${3:overlay specification}>{${1:default text}}{${2:alternative text}}<${4:overlay specification}>"
+  },
+  "alt{}{}<>": {
+    "command": "alt{default text}{alternative text}<overlay specification>",
+    "package": "class-ctexbeamer",
+    "snippet": "alt{${1:default text}}{${2:alternative text}}<${3:overlay specification}>"
+  },
+  "alt{}{}": {
+    "command": "alt{default text}{alternative text}",
+    "package": "class-ctexbeamer",
+    "snippet": "alt{${1:default text}}{${2:alternative text}}"
+  },
+  "temporal{}{}{}": {
+    "command": "temporal{before slide text}{default text}{after slide text}",
+    "package": "class-ctexbeamer",
+    "snippet": "temporal{${1:before slide text}}{${2:default text}}{${3:after slide text}}"
+  },
+  "temporal<>{}{}{}": {
+    "command": "temporal<overlay specification>{before slide text}{default text}{after slide text}",
+    "package": "class-ctexbeamer",
+    "snippet": "temporal<${4:overlay specification}>{${1:before slide text}}{${2:default text}}{${3:after slide text}}"
+  },
+  "item<>[]<>": {
+    "command": "item<alert specification>[item label]<alert specification>",
+    "package": "class-ctexbeamer",
+    "snippet": "item<${2:alert specification}>[${1:item label}]<${3:alert specification}>"
+  },
+  "item<><>": {
+    "command": "item<alert specification><alert specification>",
+    "package": "class-ctexbeamer",
+    "snippet": "item<${1:alert specification}><${2:alert specification}>"
+  },
+  "item[]<>": {
+    "command": "item[item label]<alert specification>",
+    "package": "class-ctexbeamer",
+    "snippet": "item[${1:item label}]<${2:alert specification}>"
+  },
+  "label<>{}": {
+    "command": "label<overlay specification>{label name}",
+    "package": "class-ctexbeamer",
+    "snippet": "label<${2:overlay specification}>{${1:label name}}"
+  },
+  "resetcounteronoverlays{}": {
+    "command": "resetcounteronoverlays{counter name}",
+    "package": "class-ctexbeamer",
+    "snippet": "resetcounteronoverlays{${1:counter name}}"
+  },
+  "resetcountonoverlays{}": {
+    "command": "resetcountonoverlays{count register name}",
+    "package": "class-ctexbeamer",
+    "snippet": "resetcountonoverlays{${1:count register name}}"
+  },
+  "action<>{}": {
+    "command": "action<action specification>{text}",
+    "package": "class-ctexbeamer",
+    "snippet": "action<${2:action specification}>{${1:text}}"
+  },
+  "action{}": {
+    "command": "action{text}",
+    "package": "class-ctexbeamer",
+    "snippet": "action{${1:text}}"
+  },
+  "beamerdefaultoverlayspecification{}": {
+    "command": "beamerdefaultoverlayspecification{default overlay specification}",
+    "package": "class-ctexbeamer",
+    "snippet": "beamerdefaultoverlayspecification{${1:default overlay specification}}"
+  },
+  "usetheme[]{}": {
+    "command": "usetheme[options]{name list}",
+    "package": "class-ctexbeamer",
+    "snippet": "usetheme[${2:options}]{${1:name list}}"
+  },
+  "usetheme{}": {
+    "command": "usetheme{name list}",
+    "package": "class-ctexbeamer",
+    "snippet": "usetheme{${1:name list}}"
+  },
+  "usecolortheme[]{}": {
+    "command": "usecolortheme[options]{name list}",
+    "package": "class-ctexbeamer",
+    "snippet": "usecolortheme[${2:options}]{${1:name list}}"
+  },
+  "usecolortheme{}": {
+    "command": "usecolortheme{name list}",
+    "package": "class-ctexbeamer",
+    "snippet": "usecolortheme{${1:name list}}"
+  },
+  "usefonttheme[]{}": {
+    "command": "usefonttheme[options]{name}",
+    "package": "class-ctexbeamer",
+    "snippet": "usefonttheme[${2:options}]{${1:name}}"
+  },
+  "usefonttheme{}": {
+    "command": "usefonttheme{name}",
+    "package": "class-ctexbeamer",
+    "snippet": "usefonttheme{${1:name}}"
+  },
+  "useinnertheme[]{}": {
+    "command": "useinnertheme[options]{name}",
+    "package": "class-ctexbeamer",
+    "snippet": "useinnertheme[${2:options}]{${1:name}}"
+  },
+  "useinnertheme{}": {
+    "command": "useinnertheme{name}",
+    "package": "class-ctexbeamer",
+    "snippet": "useinnertheme{${1:name}}"
+  },
+  "useoutertheme[]{}": {
+    "command": "useoutertheme[options]{name}",
+    "package": "class-ctexbeamer",
+    "snippet": "useoutertheme[${2:options}]{${1:name}}"
+  },
+  "useoutertheme{}": {
+    "command": "useoutertheme{name}",
+    "package": "class-ctexbeamer",
+    "snippet": "useoutertheme{${1:name}}"
+  },
+  "addheadbox{}{}": {
+    "command": "addheadbox{beamer color}{box template}",
+    "package": "class-ctexbeamer",
+    "snippet": "addheadbox{${1:beamer color}}{${2:box template}}"
+  },
+  "addfootbox{}{}": {
+    "command": "addfootbox{beamer color}{box template}",
+    "package": "class-ctexbeamer",
+    "snippet": "addfootbox{${1:beamer color}}{${2:box template}}"
+  },
+  "includeonlyframes{}": {
+    "command": "includeonlyframes{frame label list}",
+    "package": "class-ctexbeamer",
+    "snippet": "includeonlyframes{${1:frame label list}}"
+  }
+}

--- a/data/packages/class-ctexbeamer_env.json
+++ b/data/packages/class-ctexbeamer_env.json
@@ -1,0 +1,230 @@
+{
+  "frame": {
+    "name": "frame",
+    "detail": "frame",
+    "snippet": "",
+    "package": "class-ctexbeamer"
+  },
+  "frame<>": {
+    "name": "frame",
+    "detail": "frame<overlay specification>",
+    "snippet": "<${1:overlay specification}>",
+    "package": "class-ctexbeamer"
+  },
+  "frame<>[]": {
+    "name": "frame",
+    "detail": "frame<overlay specification>[<default overlay specification>]",
+    "snippet": "<${2:overlay specification}>[${1:<default overlay specification>}]",
+    "package": "class-ctexbeamer"
+  },
+  "frame<>[][]": {
+    "name": "frame",
+    "detail": "frame<overlay specification>[<default overlay specification>][options]",
+    "snippet": "<${3:overlay specification}>[${1:<default overlay specification>}][${2:options}]",
+    "package": "class-ctexbeamer"
+  },
+  "frame<>[][]{}": {
+    "name": "frame",
+    "detail": "frame<overlay specification>[<default overlay specification>][options]{title}",
+    "snippet": "<${4:overlay specification}>[${2:<default overlay specification>}][${3:options}]{${1:title}}",
+    "package": "class-ctexbeamer"
+  },
+  "frame<>[][]{}{}": {
+    "name": "frame",
+    "detail": "frame<overlay specification>[<default overlay specification>][options]{title}{subtitle}",
+    "snippet": "<${5:overlay specification}>[${3:<default overlay specification>}][${4:options}]{${1:title}}{${2:subtitle}}",
+    "package": "class-ctexbeamer"
+  },
+  "frame[]": {
+    "name": "frame",
+    "detail": "frame[options]",
+    "snippet": "[${1:options}]",
+    "package": "class-ctexbeamer"
+  },
+  "frame[][]": {
+    "name": "frame",
+    "detail": "frame[<default overlay specification>][options]",
+    "snippet": "[${1:<default overlay specification>}][${2:options}]",
+    "package": "class-ctexbeamer"
+  },
+  "frame[][]{}": {
+    "name": "frame",
+    "detail": "frame[<default overlay specification>][options]{title}",
+    "snippet": "[${2:<default overlay specification>}][${3:options}]{${1:title}}",
+    "package": "class-ctexbeamer"
+  },
+  "frame[][]{}{}": {
+    "name": "frame",
+    "detail": "frame[<default overlay specification>][options]{title}{subtitle}",
+    "snippet": "[${3:<default overlay specification>}][${4:options}]{${1:title}}{${2:subtitle}}",
+    "package": "class-ctexbeamer"
+  },
+  "frame[]{}": {
+    "name": "frame",
+    "detail": "frame[options]{title}",
+    "snippet": "[${2:options}]{${1:title}}",
+    "package": "class-ctexbeamer"
+  },
+  "frame[]{}{}": {
+    "name": "frame",
+    "detail": "frame[options]{title}{subtitle}",
+    "snippet": "[${3:options}]{${1:title}}{${2:subtitle}}",
+    "package": "class-ctexbeamer"
+  },
+  "frame{}": {
+    "name": "frame",
+    "detail": "frame{subtitle}",
+    "snippet": "{${1:subtitle}}",
+    "package": "class-ctexbeamer"
+  },
+  "structureenv<>": {
+    "name": "structureenv",
+    "detail": "structureenv<overlay specification>",
+    "snippet": "<${1:overlay specification}>",
+    "package": "class-ctexbeamer"
+  },
+  "structureenv": {
+    "name": "structureenv",
+    "detail": "structureenv",
+    "snippet": "",
+    "package": "class-ctexbeamer"
+  },
+  "alertenv<>": {
+    "name": "alertenv",
+    "detail": "alertenv<overlay specification>",
+    "snippet": "<${1:overlay specification}>",
+    "package": "class-ctexbeamer"
+  },
+  "alertenv": {
+    "name": "alertenv",
+    "detail": "alertenv",
+    "snippet": "",
+    "package": "class-ctexbeamer"
+  },
+  "block<>{}<>": {
+    "name": "block",
+    "detail": "block<action specification>{block title}<action specification>",
+    "snippet": "<${2:action specification}>{${1:block title}}<${3:action specification}>",
+    "package": "class-ctexbeamer"
+  },
+  "alertblock<>{}<>": {
+    "name": "alertblock",
+    "detail": "alertblock<action specification>{block title}<action specification>",
+    "snippet": "<${2:action specification}>{${1:block title}}<${3:action specification}>",
+    "package": "class-ctexbeamer"
+  },
+  "exampleblock<>{}<>": {
+    "name": "exampleblock",
+    "detail": "exampleblock<action specification>{block title}<overlay specification>",
+    "snippet": "<${2:action specification}>{${1:block title}}<${3:overlay specification}>",
+    "package": "class-ctexbeamer"
+  },
+  "beamercolorbox[]{}": {
+    "name": "beamercolorbox",
+    "detail": "beamercolorbox[options]{beamer color}",
+    "snippet": "[${2:options}]{${1:beamer color}}",
+    "package": "class-ctexbeamer"
+  },
+  "beamercolorbox{}": {
+    "name": "beamercolorbox",
+    "detail": "beamercolorbox{beamer color}",
+    "snippet": "{${1:beamer color}}",
+    "package": "class-ctexbeamer"
+  },
+  "beamerboxesrounded[]{}": {
+    "name": "beamerboxesrounded",
+    "detail": "beamerboxesrounded[options]{head}",
+    "snippet": "[${2:options}]{${1:head}}",
+    "package": "class-ctexbeamer"
+  },
+  "beamerboxesrounded{}": {
+    "name": "beamerboxesrounded",
+    "detail": "beamerboxesrounded{head}",
+    "snippet": "{${1:head}}",
+    "package": "class-ctexbeamer"
+  },
+  "columns[]": {
+    "name": "columns",
+    "detail": "columns[options]",
+    "snippet": "[${1:options}]",
+    "package": "class-ctexbeamer"
+  },
+  "columns": {
+    "name": "columns",
+    "detail": "columns",
+    "snippet": "",
+    "package": "class-ctexbeamer"
+  },
+  "column[]{}": {
+    "name": "column",
+    "detail": "column[placement]{column width}",
+    "snippet": "[${2:placement}]{${1:column width}}",
+    "package": "class-ctexbeamer"
+  },
+  "column{}": {
+    "name": "column",
+    "detail": "column{column width}",
+    "snippet": "{${1:column width}}",
+    "package": "class-ctexbeamer"
+  },
+  "semiverbatim": {
+    "name": "semiverbatim",
+    "detail": "semiverbatim",
+    "snippet": "",
+    "package": "class-ctexbeamer"
+  },
+  "abstract<>": {
+    "name": "abstract",
+    "detail": "abstract<action specification>",
+    "snippet": "<${1:action specification}>",
+    "package": "class-ctexbeamer"
+  },
+  "onlyenv<>": {
+    "name": "onlyenv",
+    "detail": "onlyenv<overlay specification>",
+    "snippet": "<${1:overlay specification}>",
+    "package": "class-ctexbeamer"
+  },
+  "onlyenv": {
+    "name": "onlyenv",
+    "detail": "onlyenv",
+    "snippet": "",
+    "package": "class-ctexbeamer"
+  },
+  "altenv<>{}{}{}{}<>": {
+    "name": "altenv",
+    "detail": "altenv<overlay specification>{begin text}{end text}{alternate begin text}{alternate end text}<overlay specification>",
+    "snippet": "<${5:overlay specification}>{${1:begin text}}{${2:end text}}{${3:alternate begin text}}{${4:alternate end text}}<${6:overlay specification}>",
+    "package": "class-ctexbeamer"
+  },
+  "altenv{}{}{}{}<>": {
+    "name": "altenv",
+    "detail": "altenv{begin text}{end text}{alternate begin text}{alternate end text}<overlay specification>",
+    "snippet": "{${1:begin text}}{${2:end text}}{${3:alternate begin text}}{${4:alternate end text}}<${5:overlay specification}>",
+    "package": "class-ctexbeamer"
+  },
+  "overlayarea{}{}": {
+    "name": "overlayarea",
+    "detail": "overlayarea{area width}{area height}",
+    "snippet": "{${1:area width}}{${2:area height}}",
+    "package": "class-ctexbeamer"
+  },
+  "overprint[]": {
+    "name": "overprint",
+    "detail": "overprint[area width]",
+    "snippet": "[${1:area width}]",
+    "package": "class-ctexbeamer"
+  },
+  "overprint": {
+    "name": "overprint",
+    "detail": "overprint",
+    "snippet": "",
+    "package": "class-ctexbeamer"
+  },
+  "actionenv<>": {
+    "name": "actionenv",
+    "detail": "actionenv<action specification>",
+    "snippet": "<${1:action specification}>",
+    "package": "class-ctexbeamer"
+  }
+}

--- a/data/packages/class-ctexbook_cmd.json
+++ b/data/packages/class-ctexbook_cmd.json
@@ -1,0 +1,137 @@
+{
+  "frontmatter": {
+    "command": "frontmatter",
+    "package": "class-ctexbook",
+    "snippet": "frontmatter"
+  },
+  "mainmatter": {
+    "command": "mainmatter",
+    "package": "class-ctexbook",
+    "snippet": "mainmatter"
+  },
+  "backmatter": {
+    "command": "backmatter",
+    "package": "class-ctexbook",
+    "snippet": "backmatter"
+  },
+  "ctexset{}": {
+    "command": "ctexset{options}",
+    "package": "class-ctexbook",
+    "snippet": "ctexset{${1:options}}"
+  },
+  "songti": {
+    "command": "songti",
+    "package": "class-ctexbook",
+    "snippet": "songti"
+  },
+  "heiti": {
+    "command": "heiti",
+    "package": "class-ctexbook",
+    "snippet": "heiti"
+  },
+  "fangsong": {
+    "command": "fangsong",
+    "package": "class-ctexbook",
+    "snippet": "fangsong"
+  },
+  "kaishu": {
+    "command": "kaishu",
+    "package": "class-ctexbook",
+    "snippet": "kaishu"
+  },
+  "lishu": {
+    "command": "lishu",
+    "package": "class-ctexbook",
+    "snippet": "lishu"
+  },
+  "youyuan": {
+    "command": "youyuan",
+    "package": "class-ctexbook",
+    "snippet": "youyuan"
+  },
+  "yahei": {
+    "command": "yahei",
+    "package": "class-ctexbook",
+    "snippet": "yahei"
+  },
+  "pingfang": {
+    "command": "pingfang",
+    "package": "class-ctexbook",
+    "snippet": "pingfang"
+  },
+  "CTEXthepart": {
+    "command": "CTEXthepart",
+    "package": "class-ctexbook",
+    "snippet": "CTEXthepart"
+  },
+  "CTEXthethechapter": {
+    "command": "CTEXthethechapter",
+    "package": "class-ctexbook",
+    "snippet": "CTEXthethechapter"
+  },
+  "CTEXthesection": {
+    "command": "CTEXthesection",
+    "package": "class-ctexbook",
+    "snippet": "CTEXthesection"
+  },
+  "CTEXthesubsection": {
+    "command": "CTEXthesubsection",
+    "package": "class-ctexbook",
+    "snippet": "CTEXthesubsection"
+  },
+  "CTEXthesubsubsection": {
+    "command": "CTEXthesubsubsection",
+    "package": "class-ctexbook",
+    "snippet": "CTEXthesubsubsection"
+  },
+  "CTEXtheparagraph": {
+    "command": "CTEXtheparagraph",
+    "package": "class-ctexbook",
+    "snippet": "CTEXtheparagraph"
+  },
+  "CTEXthesubparagraph": {
+    "command": "CTEXthesubparagraph",
+    "package": "class-ctexbook",
+    "snippet": "CTEXthesubparagraph"
+  },
+  "CTEXifnmae{}{}": {
+    "command": "CTEXifnmae{contents with name}{contents with name}",
+    "package": "class-ctexbook",
+    "snippet": "CTEXifnmae{${1:contents with name}}{${2:contents with name}}"
+  },
+  "zihao{}": {
+    "command": "zihao{number}",
+    "package": "class-ctexbook",
+    "snippet": "zihao{${1:number}}"
+  },
+  "ziju{}": {
+    "command": "ziju{factor}",
+    "package": "class-ctexbook",
+    "snippet": "ziju{${1:factor}}"
+  },
+  "ccwd": {
+    "command": "ccwd",
+    "package": "class-ctexbook",
+    "snippet": "ccwd"
+  },
+  "chinese{}": {
+    "command": "chinese{counter}",
+    "package": "class-ctexbook",
+    "snippet": "chinese{${1:counter}}"
+  },
+  "CTEXnumber{}{}": {
+    "command": "CTEXnumber{cmd}{number}",
+    "package": "class-ctexbook",
+    "snippet": "CTEXnumber{${1:cmd}}{${2:number}}"
+  },
+  "CTEXdigits{}{}": {
+    "command": "CTEXdigits{cmd}{number}",
+    "package": "class-ctexbook",
+    "snippet": "CTEXdigits{${1:cmd}}{${2:number}}"
+  },
+  "CTeX": {
+    "command": "CTeX",
+    "package": "class-ctexbook",
+    "snippet": "CTeX"
+  }
+}

--- a/data/packages/class-ctexrep_cmd.json
+++ b/data/packages/class-ctexrep_cmd.json
@@ -1,0 +1,137 @@
+{
+  "frontmatter": {
+    "command": "frontmatter",
+    "package": "class-ctexrep",
+    "snippet": "frontmatter"
+  },
+  "mainmatter": {
+    "command": "mainmatter",
+    "package": "class-ctexrep",
+    "snippet": "mainmatter"
+  },
+  "backmatter": {
+    "command": "backmatter",
+    "package": "class-ctexrep",
+    "snippet": "backmatter"
+  },
+  "ctexset{}": {
+    "command": "ctexset{options}",
+    "package": "class-ctexrep",
+    "snippet": "ctexset{${1:options}}"
+  },
+  "songti": {
+    "command": "songti",
+    "package": "class-ctexrep",
+    "snippet": "songti"
+  },
+  "heiti": {
+    "command": "heiti",
+    "package": "class-ctexrep",
+    "snippet": "heiti"
+  },
+  "fangsong": {
+    "command": "fangsong",
+    "package": "class-ctexrep",
+    "snippet": "fangsong"
+  },
+  "kaishu": {
+    "command": "kaishu",
+    "package": "class-ctexrep",
+    "snippet": "kaishu"
+  },
+  "lishu": {
+    "command": "lishu",
+    "package": "class-ctexrep",
+    "snippet": "lishu"
+  },
+  "youyuan": {
+    "command": "youyuan",
+    "package": "class-ctexrep",
+    "snippet": "youyuan"
+  },
+  "yahei": {
+    "command": "yahei",
+    "package": "class-ctexrep",
+    "snippet": "yahei"
+  },
+  "pingfang": {
+    "command": "pingfang",
+    "package": "class-ctexrep",
+    "snippet": "pingfang"
+  },
+  "CTEXthepart": {
+    "command": "CTEXthepart",
+    "package": "class-ctexrep",
+    "snippet": "CTEXthepart"
+  },
+  "CTEXthethechapter": {
+    "command": "CTEXthethechapter",
+    "package": "class-ctexrep",
+    "snippet": "CTEXthethechapter"
+  },
+  "CTEXthesection": {
+    "command": "CTEXthesection",
+    "package": "class-ctexrep",
+    "snippet": "CTEXthesection"
+  },
+  "CTEXthesubsection": {
+    "command": "CTEXthesubsection",
+    "package": "class-ctexrep",
+    "snippet": "CTEXthesubsection"
+  },
+  "CTEXthesubsubsection": {
+    "command": "CTEXthesubsubsection",
+    "package": "class-ctexrep",
+    "snippet": "CTEXthesubsubsection"
+  },
+  "CTEXtheparagraph": {
+    "command": "CTEXtheparagraph",
+    "package": "class-ctexrep",
+    "snippet": "CTEXtheparagraph"
+  },
+  "CTEXthesubparagraph": {
+    "command": "CTEXthesubparagraph",
+    "package": "class-ctexrep",
+    "snippet": "CTEXthesubparagraph"
+  },
+  "CTEXifnmae{}{}": {
+    "command": "CTEXifnmae{contents with name}{contents with name}",
+    "package": "class-ctexrep",
+    "snippet": "CTEXifnmae{${1:contents with name}}{${2:contents with name}}"
+  },
+  "zihao{}": {
+    "command": "zihao{number}",
+    "package": "class-ctexrep",
+    "snippet": "zihao{${1:number}}"
+  },
+  "ziju{}": {
+    "command": "ziju{factor}",
+    "package": "class-ctexrep",
+    "snippet": "ziju{${1:factor}}"
+  },
+  "ccwd": {
+    "command": "ccwd",
+    "package": "class-ctexrep",
+    "snippet": "ccwd"
+  },
+  "chinese{}": {
+    "command": "chinese{counter}",
+    "package": "class-ctexrep",
+    "snippet": "chinese{${1:counter}}"
+  },
+  "CTEXnumber{}{}": {
+    "command": "CTEXnumber{cmd}{number}",
+    "package": "class-ctexrep",
+    "snippet": "CTEXnumber{${1:cmd}}{${2:number}}"
+  },
+  "CTEXdigits{}{}": {
+    "command": "CTEXdigits{cmd}{number}",
+    "package": "class-ctexrep",
+    "snippet": "CTEXdigits{${1:cmd}}{${2:number}}"
+  },
+  "CTeX": {
+    "command": "CTeX",
+    "package": "class-ctexrep",
+    "snippet": "CTeX"
+  }
+}

--- a/data/packages/ctex_cmd.json
+++ b/data/packages/ctex_cmd.json
@@ -1,0 +1,122 @@
+{
+  "ctexset{}": {
+    "command": "ctexset{options}",
+    "package": "ctex",
+    "snippet": "ctexset{${1:options}}"
+  },
+  "songti": {
+    "command": "songti",
+    "package": "ctex",
+    "snippet": "songti"
+  },
+  "heiti": {
+    "command": "heiti",
+    "package": "ctex",
+    "snippet": "heiti"
+  },
+  "fangsong": {
+    "command": "fangsong",
+    "package": "ctex",
+    "snippet": "fangsong"
+  },
+  "kaishu": {
+    "command": "kaishu",
+    "package": "ctex",
+    "snippet": "kaishu"
+  },
+  "lishu": {
+    "command": "lishu",
+    "package": "ctex",
+    "snippet": "lishu"
+  },
+  "youyuan": {
+    "command": "youyuan",
+    "package": "ctex",
+    "snippet": "youyuan"
+  },
+  "yahei": {
+    "command": "yahei",
+    "package": "ctex",
+    "snippet": "yahei"
+  },
+  "pingfang": {
+    "command": "pingfang",
+    "package": "ctex",
+    "snippet": "pingfang"
+  },
+  "CTEXthepart": {
+    "command": "CTEXthepart",
+    "package": "ctex",
+    "snippet": "CTEXthepart"
+  },
+  "CTEXthethechapter": {
+    "command": "CTEXthethechapter",
+    "package": "ctex",
+    "snippet": "CTEXthethechapter"
+  },
+  "CTEXthesection": {
+    "command": "CTEXthesection",
+    "package": "ctex",
+    "snippet": "CTEXthesection"
+  },
+  "CTEXthesubsection": {
+    "command": "CTEXthesubsection",
+    "package": "ctex",
+    "snippet": "CTEXthesubsection"
+  },
+  "CTEXthesubsubsection": {
+    "command": "CTEXthesubsubsection",
+    "package": "ctex",
+    "snippet": "CTEXthesubsubsection"
+  },
+  "CTEXtheparagraph": {
+    "command": "CTEXtheparagraph",
+    "package": "ctex",
+    "snippet": "CTEXtheparagraph"
+  },
+  "CTEXthesubparagraph": {
+    "command": "CTEXthesubparagraph",
+    "package": "ctex",
+    "snippet": "CTEXthesubparagraph"
+  },
+  "CTEXifnmae{}{}": {
+    "command": "CTEXifnmae{contents with name}{contents with name}",
+    "package": "ctex",
+    "snippet": "CTEXifnmae{${1:contents with name}}{${2:contents with name}}"
+  },
+  "zihao{}": {
+    "command": "zihao{number}",
+    "package": "ctex",
+    "snippet": "zihao{${1:number}}"
+  },
+  "ziju{}": {
+    "command": "ziju{factor}",
+    "package": "ctex",
+    "snippet": "ziju{${1:factor}}"
+  },
+  "ccwd": {
+    "command": "ccwd",
+    "package": "ctex",
+    "snippet": "ccwd"
+  },
+  "chinese{}": {
+    "command": "chinese{counter}",
+    "package": "ctex",
+    "snippet": "chinese{${1:counter}}"
+  },
+  "CTEXnumber{}{}": {
+    "command": "CTEXnumber{cmd}{number}",
+    "package": "ctex",
+    "snippet": "CTEXnumber{${1:cmd}}{${2:number}}"
+  },
+  "CTEXdigits{}{}": {
+    "command": "CTEXdigits{cmd}{number}",
+    "package": "ctex",
+    "snippet": "CTEXdigits{${1:cmd}}{${2:number}}"
+  },
+  "CTeX": {
+    "command": "CTeX",
+    "package": "ctex",
+    "snippet": "CTeX"
+  }
+}

--- a/data/packages/xeCJK_cmd.json
+++ b/data/packages/xeCJK_cmd.json
@@ -1,0 +1,257 @@
+{
+  "xeCJKsetup{}": {
+    "command": "xeCJKsetup{options}",
+    "package": "xeCJK",
+    "snippet": "xeCJKsetup{${1:options}}"
+  },
+  "setCJKmainfont{}": {
+    "command": "setCJKmainfont{font name}",
+    "package": "xeCJK",
+    "snippet": "setCJKmainfont{${1:font name}}"
+  },
+  "setCJKmainfont{}[]": {
+    "command": "setCJKmainfont{font name}[font features]",
+    "package": "xeCJK",
+    "snippet": "setCJKmainfont{${1:font name}}[${2:font features}]"
+  },
+  "setCJKsansfont{}": {
+    "command": "setCJKsansfont{font name}",
+    "package": "xeCJK",
+    "snippet": "setCJKsansfont{${1:font name}}"
+  },
+  "setCJKsansfont{}[]": {
+    "command": "setCJKsansfont{font name}[font features]",
+    "package": "xeCJK",
+    "snippet": "setCJKsansfont{${1:font name}}[${2:font features}]"
+  },
+  "setCJKmonofont{}": {
+    "command": "setCJKmonofont{font name}",
+    "package": "xeCJK",
+    "snippet": "setCJKmonofont{${1:font name}}"
+  },
+  "setCJKmonofont{}[]": {
+    "command": "setCJKmonofont{font name}[font features]",
+    "package": "xeCJK",
+    "snippet": "setCJKmonofont{${1:font name}}[${2:font features}]"
+  },
+  "setCJKfamilyfont{}{}": {
+    "command": "setCJKfamilyfont{family}{font name}",
+    "package": "xeCJK",
+    "snippet": "setCJKfamilyfont{${1:family}}{${2:font name}}"
+  },
+  "setCJKfamilyfont{}{}[]": {
+    "command": "setCJKfamilyfont{family}{font name}[font features]",
+    "package": "xeCJK",
+    "snippet": "setCJKfamilyfont{${1:family}}{${2:font name}}[${3:font features}]"
+  },
+  "CJKfamily{}": {
+    "command": "CJKfamily{family}",
+    "package": "xeCJK",
+    "snippet": "CJKfamily{${1:family}}"
+  },
+  "CJKfamily+{}": {
+    "command": "CJKfamily+{family}",
+    "package": "xeCJK",
+    "snippet": "CJKfamily+{${1:family}}"
+  },
+  "CJKfamily-{}": {
+    "command": "CJKfamily-{family}",
+    "package": "xeCJK",
+    "snippet": "CJKfamily-{${1:family}}"
+  },
+  "newCJKfontfamily{}{}": {
+    "command": "newCJKfontfamily{cmd}{font name}",
+    "package": "xeCJK",
+    "snippet": "newCJKfontfamily{${1:cmd}}{${2:font name}}"
+  },
+  "newCJKfontfamily{}{}[]": {
+    "command": "newCJKfontfamily{cmd}{font name}[font features]",
+    "package": "xeCJK",
+    "snippet": "newCJKfontfamily{${1:cmd}}{${2:font name}}[${3:font features}]"
+  },
+  "newCJKfontfamily[]{}{}": {
+    "command": "newCJKfontfamily[family]{cmd}{font name}",
+    "package": "xeCJK",
+    "snippet": "newCJKfontfamily[${3:family}]{${1:cmd}}{${2:font name}}"
+  },
+  "newCJKfontfamily[]{}[]{}": {
+    "command": "newCJKfontfamily[family]{cmd}[font features]{font name}",
+    "package": "xeCJK",
+    "snippet": "newCJKfontfamily[${3:family}]{${1:cmd}}[${4:font features}]{${2:font name}}"
+  },
+  "CJKfontspec{}": {
+    "command": "CJKfontspec{font name}",
+    "package": "xeCJK",
+    "snippet": "CJKfontspec{${1:font name}}"
+  },
+  "CJKfontspec{}[]": {
+    "command": "CJKfontspec{font name}[font features]",
+    "package": "xeCJK",
+    "snippet": "CJKfontspec{${1:font name}}[${2:font features}]"
+  },
+  "defaultCJKfontfeatures{}": {
+    "command": "defaultCJKfontfeatures{font features}",
+    "package": "xeCJK",
+    "snippet": "defaultCJKfontfeatures{${1:font features}}"
+  },
+  "addCJKfontfeatures{}": {
+    "command": "addCJKfontfeatures{font features}",
+    "package": "xeCJK",
+    "snippet": "addCJKfontfeatures{${1:font features}}"
+  },
+  "addCJKfontfeatures*{}": {
+    "command": "addCJKfontfeatures*{font features}",
+    "package": "xeCJK",
+    "snippet": "addCJKfontfeatures*{${1:font features}}"
+  },
+  "addCJKfontfeatures[]{}": {
+    "command": "addCJKfontfeatures[blocks]{font features}",
+    "package": "xeCJK",
+    "snippet": "addCJKfontfeatures[${2:blocks}]{${1:font features}}"
+  },
+  "addCJKfontfeatures*[]{}": {
+    "command": "addCJKfontfeatures*[blocks]{font features}",
+    "package": "xeCJK",
+    "snippet": "addCJKfontfeatures*[${2:blocks}]{${1:font features}}"
+  },
+  "CJKrmdefault": {
+    "command": "CJKrmdefault",
+    "package": "xeCJK",
+    "snippet": "CJKrmdefault"
+  },
+  "CJKsfdefault": {
+    "command": "CJKsfdefault",
+    "package": "xeCJK",
+    "snippet": "CJKsfdefault"
+  },
+  "CJKttdefault": {
+    "command": "CJKttdefault",
+    "package": "xeCJK",
+    "snippet": "CJKttdefault"
+  },
+  "CJKfamilydefault": {
+    "command": "CJKfamilydefault",
+    "package": "xeCJK",
+    "snippet": "CJKfamilydefault"
+  },
+  "setCJKmathfont{}": {
+    "command": "setCJKmathfont{font name}",
+    "package": "xeCJK",
+    "snippet": "setCJKmathfont{${1:font name}}"
+  },
+  "setCJKmathfont{}[]": {
+    "command": "setCJKmathfont{font name}[font features]",
+    "package": "xeCJK",
+    "snippet": "setCJKmathfont{${1:font name}}[${2:font features}]"
+  },
+  "setCJKfallbackfamilyfont{}{}": {
+    "command": "setCJKfallbackfamilyfont{family}{font name}",
+    "package": "xeCJK",
+    "snippet": "setCJKfallbackfamilyfont{${1:family}}{${2:font name}}"
+  },
+  "setCJKfallbackfamilyfont{}{}[]": {
+    "command": "setCJKfallbackfamilyfont{family}{font name}[font features]",
+    "package": "xeCJK",
+    "snippet": "setCJKfallbackfamilyfont{${1:family}}{${2:font name}}[${3:font features}]"
+  },
+  "xeCJKDeclareSubCJKBlock{}{}": {
+    "command": "xeCJKDeclareSubCJKBlock{block}{block range}",
+    "package": "xeCJK",
+    "snippet": "xeCJKDeclareSubCJKBlock{${1:block}}{${2:block range}}"
+  },
+  "xeCJKDeclareSubCJKBlock*{}{}": {
+    "command": "xeCJKDeclareSubCJKBlock*{block}{block range}",
+    "package": "xeCJK",
+    "snippet": "xeCJKDeclareSubCJKBlock*{${1:block}}{${2:block range}}"
+  },
+  "xeCJKCancelSubCJKBlock{}": {
+    "command": "xeCJKCancelSubCJKBlock{blocks}",
+    "package": "xeCJK",
+    "snippet": "xeCJKCancelSubCJKBlock{${1:blocks}}"
+  },
+  "xeCJKCancelSubCJKBlock*{}": {
+    "command": "xeCJKCancelSubCJKBlock*{blocks}",
+    "package": "xeCJK",
+    "snippet": "xeCJKCancelSubCJKBlock*{${1:blocks}}"
+  },
+  "xeCJKRestoreSubCJKBlock{}": {
+    "command": "xeCJKRestoreSubCJKBlock{blocks}",
+    "package": "xeCJK",
+    "snippet": "xeCJKRestoreSubCJKBlock{${1:blocks}}"
+  },
+  "xeCJKRestoreSubCJKBlock*{}": {
+    "command": "xeCJKRestoreSubCJKBlock*{blocks}",
+    "package": "xeCJK",
+    "snippet": "xeCJKRestoreSubCJKBlock*{${1:blocks}}"
+  },
+  "xeCJKDeclareCharClass{}{}": {
+    "command": "xeCJKDeclareCharClass{class}{class range}",
+    "package": "xeCJK",
+    "snippet": "xeCJKDeclareCharClass{${1:class}}{${2:class range}}"
+  },
+  "xeCJKDeclareCharClass*{}{}": {
+    "command": "xeCJKDeclareCharClass*{class}{class range}",
+    "package": "xeCJK",
+    "snippet": "xeCJKDeclareCharClass*{${1:class}}{${2:class range}}"
+  },
+  "xeCJKResetCharClass": {
+    "command": "xeCJKResetCharClass",
+    "package": "xeCJK",
+    "snippet": "xeCJKResetCharClass"
+  },
+  "xeCJKResetPunctClass": {
+    "command": "xeCJKResetPunctClass",
+    "package": "xeCJK",
+    "snippet": "xeCJKResetPunctClass"
+  },
+  "normalspacechars{}": {
+    "command": "normalspacechars{char list}",
+    "package": "xeCJK",
+    "snippet": "normalspacechars{${1:char list}}"
+  },
+  "xeCJKsetwidth{}{}": {
+    "command": "xeCJKsetwidth{punt list}{length}",
+    "package": "xeCJK",
+    "snippet": "xeCJKsetwidth{${1:punt list}}{${2:length}}"
+  },
+  "xeCJKsetwidth*{}{}": {
+    "command": "xeCJKsetwidth*{punt list}{length}",
+    "package": "xeCJK",
+    "snippet": "xeCJKsetwidth*{${1:punt list}}{${2:length}}"
+  },
+  "xeCJKsetkern{}{}{}": {
+    "command": "xeCJKsetkern{first punct}{second punct}{length}",
+    "package": "xeCJK",
+    "snippet": "xeCJKsetkern{${1:first punct}}{${2:second punct}}{${3:length}}"
+  },
+  "xeCJKDeclarePunctStyle{}{}": {
+    "command": "xeCJKDeclarePunctStyle{style}{keyvals}",
+    "package": "xeCJK",
+    "snippet": "xeCJKDeclarePunctStyle{${1:style}}{${2:keyvals}}"
+  },
+  "xeCJKEditPunctStyle{}{}": {
+    "command": "xeCJKEditPunctStyle{style}{keyvals}",
+    "package": "xeCJK",
+    "snippet": "xeCJKEditPunctStyle{${1:style}}{${2:keyvals}}"
+  },
+  "xeCJKVerbAddon": {
+    "command": "xeCJKVerbAddon",
+    "package": "xeCJK",
+    "snippet": "xeCJKVerbAddon"
+  },
+  "xeCJKOffVerbAddon": {
+    "command": "xeCJKOffVerbAddon",
+    "package": "xeCJK",
+    "snippet": "xeCJKOffVerbAddon"
+  },
+  "xeCJKnobreak": {
+    "command": "xeCJKnobreak",
+    "package": "xeCJK",
+    "snippet": "xeCJKnobreak"
+  },
+  "xeCJKShipoutHook": {
+    "command": "xeCJKShipoutHook",
+    "package": "xeCJK",
+    "snippet": "xeCJKShipoutHook"
+  }
+}

--- a/data/packages/xeCJKfntef_cmd.json
+++ b/data/packages/xeCJKfntef_cmd.json
@@ -1,0 +1,232 @@
+{
+  "CJKunderline{}": {
+    "command": "CJKunderline{contents}",
+    "package": "xeCJKfntef",
+    "snippet": "CJKunderline{${1:contents}}"
+  },
+  "CJKunderline*{}": {
+    "command": "CJKunderline*{contents}",
+    "package": "xeCJKfntef",
+    "snippet": "CJKunderline*{${1:contents}}"
+  },
+  "CJKunderline-{}": {
+    "command": "CJKunderline-{contents}",
+    "package": "xeCJKfntef",
+    "snippet": "CJKunderline-{${1:contents}}"
+  },
+  "CJKunderline[]{}": {
+    "command": "CJKunderline[options]{contents}",
+    "package": "xeCJKfntef",
+    "snippet": "CJKunderline[${2:options}]{${1:contents}}"
+  },
+  "CJKunderline*[]{}": {
+    "command": "CJKunderline*[options]{contents}",
+    "package": "xeCJKfntef",
+    "snippet": "CJKunderline*[${2:options}]{${1:contents}}"
+  },
+  "CJKunderline-[]{}": {
+    "command": "CJKunderline-[options]{contents}",
+    "package": "xeCJKfntef",
+    "snippet": "CJKunderline-[${2:options}]{${1:contents}}"
+  },
+  "CJKunderdblline{}": {
+    "command": "CJKunderdblline{contents}",
+    "package": "xeCJKfntef",
+    "snippet": "CJKunderdblline{${1:contents}}"
+  },
+  "CJKunderdblline*{}": {
+    "command": "CJKunderdblline*{contents}",
+    "package": "xeCJKfntef",
+    "snippet": "CJKunderdblline*{${1:contents}}"
+  },
+  "CJKunderdblline-{}": {
+    "command": "CJKunderdblline-{contents}",
+    "package": "xeCJKfntef",
+    "snippet": "CJKunderdblline-{${1:contents}}"
+  },
+  "CJKunderdblline[]{}": {
+    "command": "CJKunderdblline[options]{contents}",
+    "package": "xeCJKfntef",
+    "snippet": "CJKunderdblline[${2:options}]{${1:contents}}"
+  },
+  "CJKunderdblline*[]{}": {
+    "command": "CJKunderdblline*[options]{contents}",
+    "package": "xeCJKfntef",
+    "snippet": "CJKunderdblline*[${2:options}]{${1:contents}}"
+  },
+  "CJKunderdblline-[]{}": {
+    "command": "CJKunderdblline-[options]{contents}",
+    "package": "xeCJKfntef",
+    "snippet": "CJKunderdblline-[${2:options}]{${1:contents}}"
+  },
+  "CJKunderwave{}": {
+    "command": "CJKunderwave{contents}",
+    "package": "xeCJKfntef",
+    "snippet": "CJKunderwave{${1:contents}}"
+  },
+  "CJKunderwave*{}": {
+    "command": "CJKunderwave*{contents}",
+    "package": "xeCJKfntef",
+    "snippet": "CJKunderwave*{${1:contents}}"
+  },
+  "CJKunderwave-{}": {
+    "command": "CJKunderwave-{contents}",
+    "package": "xeCJKfntef",
+    "snippet": "CJKunderwave-{${1:contents}}"
+  },
+  "CJKunderwave[]{}": {
+    "command": "CJKunderwave[options]{contents}",
+    "package": "xeCJKfntef",
+    "snippet": "CJKunderwave[${2:options}]{${1:contents}}"
+  },
+  "CJKunderwave*[]{}": {
+    "command": "CJKunderwave*[options]{contents}",
+    "package": "xeCJKfntef",
+    "snippet": "CJKunderwave*[${2:options}]{${1:contents}}"
+  },
+  "CJKunderwave-[]{}": {
+    "command": "CJKunderwave-[options]{contents}",
+    "package": "xeCJKfntef",
+    "snippet": "CJKunderwave-[${2:options}]{${1:contents}}"
+  },
+  "CJKsout{}": {
+    "command": "CJKsout{contents}",
+    "package": "xeCJKfntef",
+    "snippet": "CJKsout{${1:contents}}"
+  },
+  "CJKsout*{}": {
+    "command": "CJKsout*{contents}",
+    "package": "xeCJKfntef",
+    "snippet": "CJKsout*{${1:contents}}"
+  },
+  "CJKsout-{}": {
+    "command": "CJKsout-{contents}",
+    "package": "xeCJKfntef",
+    "snippet": "CJKsout-{${1:contents}}"
+  },
+  "CJKsout[]{}": {
+    "command": "CJKsout[options]{contents}",
+    "package": "xeCJKfntef",
+    "snippet": "CJKsout[${2:options}]{${1:contents}}"
+  },
+  "CJKsout*[]{}": {
+    "command": "CJKsout*[options]{contents}",
+    "package": "xeCJKfntef",
+    "snippet": "CJKsout*[${2:options}]{${1:contents}}"
+  },
+  "CJKsout-[]{}": {
+    "command": "CJKsout-[options]{contents}",
+    "package": "xeCJKfntef",
+    "snippet": "CJKsout-[${2:options}]{${1:contents}}"
+  },
+  "CJKxout{}": {
+    "command": "CJKxout{contents}",
+    "package": "xeCJKfntef",
+    "snippet": "CJKxout{${1:contents}}"
+  },
+  "CJKxout*{}": {
+    "command": "CJKxout*{contents}",
+    "package": "xeCJKfntef",
+    "snippet": "CJKxout*{${1:contents}}"
+  },
+  "CJKxout-{}": {
+    "command": "CJKxout-{contents}",
+    "package": "xeCJKfntef",
+    "snippet": "CJKxout-{${1:contents}}"
+  },
+  "CJKxout[]{}": {
+    "command": "CJKxout[options]{contents}",
+    "package": "xeCJKfntef",
+    "snippet": "CJKxout[${2:options}]{${1:contents}}"
+  },
+  "CJKxout*[]{}": {
+    "command": "CJKxout*[options]{contents}",
+    "package": "xeCJKfntef",
+    "snippet": "CJKxout*[${2:options}]{${1:contents}}"
+  },
+  "CJKxout-[]{}": {
+    "command": "CJKxout-[options]{contents}",
+    "package": "xeCJKfntef",
+    "snippet": "CJKxout-[${2:options}]{${1:contents}}"
+  },
+  "CJKunderdot{}": {
+    "command": "CJKunderdot{contents}",
+    "package": "xeCJKfntef",
+    "snippet": "CJKunderdot{${1:contents}}"
+  },
+  "CJKunderdot[]{}": {
+    "command": "CJKunderdot[options]{contents}",
+    "package": "xeCJKfntef",
+    "snippet": "CJKunderdot[${2:options}]{${1:contents}}"
+  },
+  "CJKunderanyline{}{}{}": {
+    "command": "CJKunderanyline{depth}{underlined contents}{text}",
+    "package": "xeCJKfntef",
+    "snippet": "CJKunderanyline{${1:depth}}{${2:underlined contents}}{${3:text}}"
+  },
+  "CJKunderanyline*{}{}{}": {
+    "command": "CJKunderanyline*{depth}{underlined contents}{text}",
+    "package": "xeCJKfntef",
+    "snippet": "CJKunderanyline*{${1:depth}}{${2:underlined contents}}{${3:text}}"
+  },
+  "CJKunderanyline-{}{}{}": {
+    "command": "CJKunderanyline-{depth}{underlined contents}{text}",
+    "package": "xeCJKfntef",
+    "snippet": "CJKunderanyline-{${1:depth}}{${2:underlined contents}}{${3:text}}"
+  },
+  "CJKunderanyline[]{}{}{}": {
+    "command": "CJKunderanyline[options]{depth}{underlined contents}{text}",
+    "package": "xeCJKfntef",
+    "snippet": "CJKunderanyline[${4:options}]{${1:depth}}{${2:underlined contents}}{${3:text}}"
+  },
+  "CJKunderanyline*[]{}{}{}": {
+    "command": "CJKunderanyline*[options]{depth}{underlined contents}{text}",
+    "package": "xeCJKfntef",
+    "snippet": "CJKunderanyline*[${4:options}]{${1:depth}}{${2:underlined contents}}{${3:text}}"
+  },
+  "CJKunderanyline-[]{}{}{}": {
+    "command": "CJKunderanyline-[options]{depth}{underlined contents}{text}",
+    "package": "xeCJKfntef",
+    "snippet": "CJKunderanyline-[${4:options}]{${1:depth}}{${2:underlined contents}}{${3:text}}"
+  },
+  "CJKunderanysymbol{}{}{}": {
+    "command": "CJKunderanysymbol{depth}{symbol}{contents}",
+    "package": "xeCJKfntef",
+    "snippet": "CJKunderanysymbol{${1:depth}}{${2:symbol}}{${3:contents}}"
+  },
+  "CJKunderanysymbol[]{}{}{}": {
+    "command": "CJKunderanysymbol[options]{depth}{symbol}{contents}",
+    "package": "xeCJKfntef",
+    "snippet": "CJKunderanysymbol[${4:options}]{${1:depth}}{${2:symbol}}{${3:contents}}"
+  },
+  "xeCJKfntefon": {
+    "command": "xeCJKfntefon",
+    "package": "xeCJKfntef",
+    "snippet": "xeCJKfntefon"
+  },
+  "xeCJKfntefon*": {
+    "command": "xeCJKfntefon*",
+    "package": "xeCJKfntef",
+    "snippet": "xeCJKfntefon*"
+  },
+  "xeCJKfntefon-": {
+    "command": "xeCJKfntefon-",
+    "package": "xeCJKfntef",
+    "snippet": "xeCJKfntefon-"
+  },
+  "xeCJKfntefon[]": {
+    "command": "xeCJKfntefon[options]",
+    "package": "xeCJKfntef",
+    "snippet": "xeCJKfntefon[${1:options}]"
+  },
+  "xeCJKfntefon*[]": {
+    "command": "xeCJKfntefon*[options]",
+    "package": "xeCJKfntef",
+    "snippet": "xeCJKfntefon*[${1:options}]"
+  },
+  "xeCJKfntefon-[]": {
+    "command": "xeCJKfntefon-[options]",
+    "package": "xeCJKfntef",
+    "snippet": "xeCJKfntefon-[${1:options}]"
+  }
+}

--- a/data/packages/xeCJKfntef_env.json
+++ b/data/packages/xeCJKfntef_env.json
@@ -1,0 +1,14 @@
+{
+  "CJKfiletwosides{}": {
+    "name": "CJKfiletwosides",
+    "detail": "CJKfiletwosides{width}",
+    "snippet": "{${1:width}}",
+    "package": "xeCJKfntef"
+  },
+  "CJKfiletwosides[]{}": {
+    "name": "CJKfiletwosides",
+    "detail": "CJKfiletwosides[position]{width}",
+    "snippet": "[${2:position}]{${1:width}}",
+    "package": "xeCJKfntef"
+  }
+}

--- a/data/packages/zhnumber_cmd.json
+++ b/data/packages/zhnumber_cmd.json
@@ -1,0 +1,107 @@
+{
+  "zhnumber{}": {
+    "command": "zhnumber{number}",
+    "package": "zhnumber",
+    "snippet": "zhnumber{${1:number}}"
+  },
+  "zhnumber[]{}": {
+    "command": "zhnumber[options]{number}",
+    "package": "zhnumber",
+    "snippet": "zhnumber[${2:options}]{${1:number}}"
+  },
+  "zhdigits{}": {
+    "command": "zhdigits{number}",
+    "package": "zhnumber",
+    "snippet": "zhdigits{${1:number}}"
+  },
+  "zhdigits*{}": {
+    "command": "zhdigits*{number}",
+    "package": "zhnumber",
+    "snippet": "zhdigits*{${1:number}}"
+  },
+  "zhdigits*[]{}": {
+    "command": "zhdigits*[options]{number}",
+    "package": "zhnumber",
+    "snippet": "zhdigits*[${2:options}]{${1:number}}"
+  },
+  "zhnum{}": {
+    "command": "zhnum{counter}",
+    "package": "zhnumber",
+    "snippet": "zhnum{${1:counter}}"
+  },
+  "zhnum[]{}": {
+    "command": "zhnum[options]{counter}",
+    "package": "zhnumber",
+    "snippet": "zhnum[${2:options}]{${1:counter}}"
+  },
+  "zhdig{}": {
+    "command": "zhdig{counter}",
+    "package": "zhnumber",
+    "snippet": "zhdig{${1:counter}}"
+  },
+  "zhdig[]{}": {
+    "command": "zhdig[options]{counter}",
+    "package": "zhnumber",
+    "snippet": "zhdig[${2:options}]{${1:counter}}"
+  },
+  "zhweekday{}": {
+    "command": "zhweekday{yyyy/mm/dd}",
+    "package": "zhnumber",
+    "snippet": "zhweekday{${1:yyyy/mm/dd}}"
+  },
+  "zhdate{}": {
+    "command": "zhdate{yyyy/mm/dd}",
+    "package": "zhnumber",
+    "snippet": "zhdate{${1:yyyy/mm/dd}}"
+  },
+  "zhdate*{}": {
+    "command": "zhdate*{yyyy/mm/dd}",
+    "package": "zhnumber",
+    "snippet": "zhdate*{${1:yyyy/mm/dd}}"
+  },
+  "zhtoday": {
+    "command": "zhtoday",
+    "package": "zhnumber",
+    "snippet": "zhtoday"
+  },
+  "zhtime{}": {
+    "command": "zhtime{hh:mm}",
+    "package": "zhnumber",
+    "snippet": "zhtime{${1:hh:mm}}"
+  },
+  "zhcurrtime": {
+    "command": "zhcurrtime",
+    "package": "zhnumber",
+    "snippet": "zhcurrtime"
+  },
+  "zhtiangan{}": {
+    "command": "zhtiangan{number}",
+    "package": "zhnumber",
+    "snippet": "zhtiangan{${1:number}}"
+  },
+  "zhdizhi{}": {
+    "command": "zhdizhi{number}",
+    "package": "zhnumber",
+    "snippet": "zhdizhi{${1:number}}"
+  },
+  "zhganzhi{}": {
+    "command": "zhganzhi{number}",
+    "package": "zhnumber",
+    "snippet": "zhganzhi{${1:number}}"
+  },
+  "zhganzhinian{}": {
+    "command": "zhganzhinian{year}",
+    "package": "zhnumber",
+    "snippet": "zhganzhinian{${1:year}}"
+  },
+  "zhnumExtendScaleMap[]{}": {
+    "command": "zhnumExtendScaleMap[character]{character1, character2, ..., charactern}",
+    "package": "zhnumber",
+    "snippet": "zhnumExtendScaleMap[${2:character}]{${1:character1, character2, ..., charactern}}"
+  },
+  "zhnumsetup{}": {
+    "command": "zhnumsetup{options}",
+    "package": "zhnumber",
+    "snippet": "zhnumsetup{${1:options}}"
+  }
+}


### PR DESCRIPTION
These are completion files for several packages from ctex-kit. They are generated from <https://github.com/zepinglee/LaTeX-cwl/tree/completion-ctex> which is not merged to [LaTeX-cwl](https://github.com/LaTeXing/LaTeX-cwl) yet (https://github.com/LaTeXing/LaTeX-cwl/pull/17).

Is there a way to specify inclusions for the completion feature? This is the situation of `ctexart.cls`, `ctexbook.cls`, and `ctexrep.cls` which provide (almost) same commands as `ctex.sty` does. It is convenient for maintaining to have one set of commands in `ctex_cmd.json` and specify inclusion in `ctex*.cls`.