### PR TITLE
Treat \left. \right. as bracket pairs

### DIFF
--- a/syntax/syntax-expl3.json
+++ b/syntax/syntax-expl3.json
@@ -7,8 +7,14 @@
 		["[", "]"],
 		["(", ")"],
 		["\\left(", "\\right)"],
+		["\\left(", "\\right."],
+		["\\left.", "\\right)"],
 		["\\left[", "\\right]"],
+		["\\left[", "\\right."],
+		["\\left.", "\\right]"],
 		["\\left\\{", "\\right\\}"],
+		["\\left\\{", "\\right."],
+		["\\left.", "\\right\\}"],
 		["\\left<", "\\right>"]
 	],
 	"autoClosingPairs": [

--- a/syntax/syntax-weave.json
+++ b/syntax/syntax-weave.json
@@ -11,8 +11,14 @@
 		["[", "]"],
 		["(", ")"],
 		["\\left(", "\\right)"],
+		["\\left(", "\\right."],
+		["\\left.", "\\right)"],
 		["\\left[", "\\right]"],
+		["\\left[", "\\right."],
+		["\\left.", "\\right]"],
 		["\\left\\{", "\\right\\}"],
+		["\\left\\{", "\\right."],
+		["\\left.", "\\right\\}"],
 		["\\left<", "\\right>"]
 	],
 	"autoClosingPairs": [

--- a/syntax/syntax.json
+++ b/syntax/syntax.json
@@ -7,8 +7,14 @@
 		["[", "]"],
 		["(", ")"],
 		["\\left(", "\\right)"],
+		["\\left(", "\\right."],
+		["\\left.", "\\right)"],
 		["\\left[", "\\right]"],
+		["\\left[", "\\right."],
+		["\\left.", "\\right]"],
 		["\\left\\{", "\\right\\}"],
+		["\\left\\{", "\\right."],
+		["\\left.", "\\right\\}"],
 		["\\left<", "\\right>"]
 	],
 	"autoClosingPairs": [


### PR DESCRIPTION
Declare the following bracket pairs

```
\left(  \right.
\left.  \right)
\left[  \right.
\left.  \right]
\left\{  \right.
\left.  \right\\}
```

Close #2458
