### PR TITLE
Sort bibtex fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -2002,6 +2002,19 @@
           "default": true,
           "markdownDescription": "Align equal signs when calling VSCode format on a .bib file."
         },
+        "latex-workshop.bibtex-fields.sort.enabled": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Sort fields inside each entry according. It also implies aligning fields. The sorting order is defined by `latex-workshop.bibtex-fields.order`."
+        },
+        "latex-workshop.bibtex-fields.order": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "markdownDescription": "When `latex-workshop.bibtex-fields.sort.enabled` is true, sort entries according the order defined here and then alphabetically for not listed fields."
+        },
         "latex-workshop.mathpreviewpanel.editorGroup": {
           "type": "string",
           "default": "below",

--- a/src/providers/bibtexcompletion.ts
+++ b/src/providers/bibtexcompletion.ts
@@ -42,6 +42,7 @@ export class BibtexCompleter implements vscode.CompletionItemProvider {
             sortFields: config.get('bibtex-fields.sort.enabled') as boolean,
             fieldsOrder: config.get('bibtex-fields.order') as string[]
         }
+        this.extension.logger.addLogMessage(`Bibtex format config: ${JSON.stringify(bibtexFormat)}`)
 
         const maxLengths: {[key: string]: number} = this.computeMaxLengths(entries, optFields)
         const entriesList: string[] = []

--- a/src/providers/bibtexcompletion.ts
+++ b/src/providers/bibtexcompletion.ts
@@ -38,7 +38,9 @@ export class BibtexCompleter implements vscode.CompletionItemProvider {
             right: leftright[1],
             trailingComma: config.get('bibtex-format.trailingComma') as boolean,
             sort: config.get('bibtex-format.sortby') as string[],
-            alignOnEqual: config.get('bibtex-format.align-equal.enabled') as boolean
+            alignOnEqual: config.get('bibtex-format.align-equal.enabled') as boolean,
+            sortFields: config.get('bibtex-fields.sort.enabled') as boolean,
+            fieldsOrder: config.get('bibtex-fields.order') as string[]
         }
 
         const maxLengths: {[key: string]: number} = this.computeMaxLengths(entries, optFields)

--- a/src/providers/bibtexformatter.ts
+++ b/src/providers/bibtexformatter.ts
@@ -73,6 +73,7 @@ export class BibtexFormatter {
             sortFields: config.get('bibtex-fields.sort.enabled') as boolean,
             fieldsOrder: config.get('bibtex-fields.order') as string[]
         }
+        this.extension.logger.addLogMessage(`Bibtex format config: ${JSON.stringify(configuration)}`)
         const lineOffset = range ? range.start.line : 0
         const columnOffset = range ? range.start.character : 0
 

--- a/src/providers/bibtexformatter.ts
+++ b/src/providers/bibtexformatter.ts
@@ -69,7 +69,9 @@ export class BibtexFormatter {
             right: leftright[1],
             trailingComma: config.get('bibtex-format.trailingComma') as boolean,
             sort: config.get('bibtex-format.sortby') as string[],
-            alignOnEqual: config.get('bibtex-format.align-equal.enabled') as boolean
+            alignOnEqual: config.get('bibtex-format.align-equal.enabled') as boolean,
+            sortFields: config.get('bibtex-fields.sort.enabled') as boolean,
+            fieldsOrder: config.get('bibtex-fields.order') as string[]
         }
         const lineOffset = range ? range.start.line : 0
         const columnOffset = range ? range.start.character : 0


### PR DESCRIPTION
Close #2490

Sorting fields is enabled by `latex-workshop.bibtex-fields.sort.enabled`. This is only taken into account when also aligning fields. The order is defined by `latex-workshop.bibtex-fields.order` and then alphabetically for not listed fields.


