### PR TITLE
Enable autofix on multiline maths

### DIFF
--- a/src/providers/codeactions.ts
+++ b/src/providers/codeactions.ts
@@ -178,12 +178,16 @@ export class CodeActions {
         const regex = new RegExp('^' + oldDelim.replace(/\$/g, '\\$') + '$')
         const regexResult = regex.exec(text)
         if (!regexResult) {
-            const pat = new RegExp(oldDelim.replace(/\$/g, '\\$') + '(?!\\$)')
-            const endPos = this.extension.mathPreview.texMathEnvFinder.findEndPair(document, pat, endRange.start)
-            if (!endPos) {
+            if (oldDelim === '$$') {
+                const pat = new RegExp(oldDelim.replace(/\$/g, '\\$') + '(?!\\$)')
+                const endPos = this.extension.mathPreview.texMathEnvFinder.findEndPair(document, pat, endRange.start)
+                if (!endPos) {
+                    return
+                }
+                endRange = new vs.Range(endPos.translate(0, - oldDelimLength), endPos)
+            } else {
                 return
             }
-            endRange = new vs.Range(endPos.translate(0, - oldDelimLength), endPos)
         }
         const edit = new vs.WorkspaceEdit()
         edit.replace(document.uri, endRange, endDelim)

--- a/src/providers/codeactions.ts
+++ b/src/providers/codeactions.ts
@@ -169,7 +169,7 @@ export class CodeActions {
         return this.replaceRangeWithString(document, range, replacementString.repeat(range.end.character - range.start.character))
     }
 
-    private replaceMathDelimitersInRange(document: vs.TextDocument, range: vs.Range, oldDelim: string, startDelim: string, endDelim: string) {
+    private replaceMathDelimitersInRange(document: vs.TextDocument, range: vs.Range, oldDelim: '$' | '$$', startDelim: string, endDelim: string) {
         const oldDelimLength = oldDelim.length
         let endRange = range.with(range.end.translate(0, - oldDelimLength), range.end)
         const text = document.getText(endRange)

--- a/src/providers/codeactions.ts
+++ b/src/providers/codeactions.ts
@@ -175,11 +175,9 @@ export class CodeActions {
         const text = document.getText(endRange)
         // Check if the end position really contains the end delimiter.
         // This is not the case when the opening and closing delimiters are on different lines
-        const regex = new RegExp('^' + oldDelim.replace(/\$/g, '\\$') + '$')
-        const regexResult = regex.exec(text)
-        if (!regexResult) {
+        if (text !== oldDelim) {
             if (oldDelim === '$$') {
-                const pat = new RegExp(oldDelim.replace(/\$/g, '\\$') + '(?!\\$)')
+                const pat = /(?<!\\)\$\$/
                 const endPos = this.extension.mathPreview.texMathEnvFinder.findEndPair(document, pat, endRange.start)
                 if (!endPos) {
                     return

--- a/src/providers/preview/mathpreview.ts
+++ b/src/providers/preview/mathpreview.ts
@@ -23,7 +23,7 @@ export class MathPreview {
     private readonly mj: MathJaxPool
     private readonly cursorRenderer: CursorRenderer
     private readonly newCommandFinder: NewCommandFinder
-    private readonly texMathEnvFinder: TeXMathEnvFinder
+    readonly texMathEnvFinder: TeXMathEnvFinder
     private readonly hoverPreviewOnRefProvider: HoverPreviewOnRefProvider
     private readonly mputils: MathPreviewUtils
 

--- a/src/providers/preview/mathpreviewlib/texmathenvfinder.ts
+++ b/src/providers/preview/mathpreviewlib/texmathenvfinder.ts
@@ -90,7 +90,7 @@ export class TeXMathEnvFinder {
     //  \begin{...}                \end{...}
     //             ^
     //             startPos1
-    private findEndPair(document: vscode.TextDocument | TextDocumentLike, endPat: RegExp, startPos1: vscode.Position): vscode.Position | undefined {
+    findEndPair(document: vscode.TextDocument | TextDocumentLike, endPat: RegExp, startPos1: vscode.Position): vscode.Position | undefined {
         const currentLine = document.lineAt(startPos1).text.substring(startPos1.character)
         const l = this.removeComment(currentLine)
         let m = l.match(endPat)


### PR DESCRIPTION
Related to #499.

Autofix `$ $` to `\( \)` and `$$ $$` to `\[ \]` works for multiline expressions