### PR TITLE
Enable access to Web-View from remote machines

### DIFF
--- a/src/components/server.ts
+++ b/src/components/server.ts
@@ -20,7 +20,7 @@ export class Server {
         this.httpServer = http.createServer((request, response) => this.handler(request, response))
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         const viewerPort = configuration.get('viewer.pdf.internal.port') as number
-        this.httpServer.listen(viewerPort, '127.0.0.1', undefined, () => {
+        this.httpServer.listen(viewerPort, '0.0.0.0', undefined, () => {
             const {address, port} = this.httpServer.address() as AddressInfo
             this.port = port
             if (address.includes(':')) {


### PR DESCRIPTION
Is there a reason that the Web-Viewer is listening to 127.0.0.1?
To enable access from remote machines I found it useful to instead listen to 0.0.0.0