### PR TITLE
Remove duplicate commands in data/commands.json 

### DIFF
--- a/data/commands.json
+++ b/data/commands.json
@@ -108,10 +108,6 @@
     "snippet": "{${1}\\\\}",
     "detail": "curly brackets \\{ ... \\}"
   },
-  "title": {
-    "command": "title",
-    "snippet": "title{${1:text}}"
-  },
   "part": {
     "command": "part",
     "snippet": "part{${1}}"
@@ -783,18 +779,6 @@
     "command": "appendixname",
     "snippet": "appendixname"
   },
-  "arabic": {
-    "command": "arabic",
-    "snippet": "arabic{${1:counter}}"
-  },
-  "ensuremath": {
-    "command": "ensuremath",
-    "snippet": "ensuremath{${1:text}}"
-  },
-  "bibitem": {
-    "command": "bibitem",
-    "snippet": "bibitem{${1:citekey}}"
-  },
   "bibitem[]{}": {
     "command": "bibitem[label]{citekey}",
     "snippet": "bibitem[${2:label}]{${1:citekey}}"
@@ -803,21 +787,9 @@
     "command": "caption[short]{title}",
     "snippet": "caption[${2:short}]{${1:title}}"
   },
-  "chapter*": {
-    "command": "chapter*",
-    "snippet": "chapter*{${1:title}}"
-  },
   "chapter[]{}": {
     "command": "chapter[short]{title}",
     "snippet": "chapter[${2:short}]{${1:title}}"
-  },
-  "chaptermark": {
-    "command": "chaptermark",
-    "snippet": "chaptermark{${1:code}}"
-  },
-  "chaptername": {
-    "command": "chaptername",
-    "snippet": "chaptername{${1:name}}"
   },
   "cite[]{}": {
     "command": "cite[text]{keylist}",
@@ -835,10 +807,6 @@
     "command": "contentsline{type}{text}{page}",
     "snippet": "contentsline{${1:type}}{${2:text}}{${3:page}}"
   },
-  "contentsname": {
-    "command": "contentsname",
-    "snippet": "contentsname{${1:name}}"
-  },
   "ddots": {
     "command": "ddots",
     "snippet": "ddots",
@@ -847,14 +815,6 @@
   "documentclass[]{}": {
     "command": "documentclass[options]{style}",
     "snippet": "documentclass[${2:options}]{${1:style}}"
-  },
-  "fbox": {
-    "command": "fbox",
-    "snippet": "fbox{${1:text}}"
-  },
-  "figurename": {
-    "command": "figurename",
-    "snippet": "figurename{${1:name}}"
   },
   "footnotemark": {
     "command": "footnotemark",
@@ -868,10 +828,6 @@
     "command": "footnotetext[number]{text}",
     "snippet": "footnotetext[${2:number}]{${1:text}}"
   },
-  "footnotetext": {
-    "command": "footnotetext",
-    "snippet": "footnotetext{${1:text}}"
-  },
   "footnote[]{}": {
     "command": "footnote[number]{text}",
     "snippet": "footnote[${2:number}]{${1:text}}"
@@ -879,10 +835,6 @@
   "glossaryentry{}{}": {
     "command": "glossaryentry{text}{pagenum}",
     "snippet": "glossaryentry{${1:text}}{${2:pagenum}}"
-  },
-  "glossary": {
-    "command": "glossary",
-    "snippet": "glossary{${1:text}}"
   },
   "hlinefill": {
     "command": "hlinefill",
@@ -892,18 +844,6 @@
     "command": "includegraphics[options]{name}",
     "snippet": "includegraphics[${2:options}]{${1:name}}",
     "postAction": "editor.action.triggerSuggest"
-  },
-  "includeonly": {
-    "command": "includeonly",
-    "snippet": "includeonly{${1:filelist}}"
-  },
-  "indexname": {
-    "command": "indexname",
-    "snippet": "indexname{${1:name}}"
-  },
-  "index": {
-    "command": "index",
-    "snippet": "index{${1:entry}}"
   },
   "inputlineno": {
     "command": "inputlineno",
@@ -961,10 +901,6 @@
     "command": "markright{righthead}",
     "snippet": "markright{${1:righthead}}"
   },
-  "mbox": {
-    "command": "mbox",
-    "snippet": "mbox{${1:text}}"
-  },
   "newline": {
     "command": "newline",
     "snippet": "newline"
@@ -984,10 +920,6 @@
   "newtheorem{}{}[]": {
     "command": "newtheorem{envname}{caption}[within]",
     "snippet": "newtheorem{${1:envname}}{${2:caption}}[${3:within}]"
-  },
-  "nocite": {
-    "command": "nocite",
-    "snippet": "nocite{${1:keylist}}"
   },
   "nolinebreak": {
     "command": "nolinebreak",
@@ -1009,18 +941,6 @@
     "command": "underbrace{text}",
     "snippet": "underbrace{${1:text}}"
   },
-  "overbrace": {
-    "command": "overbrace",
-    "snippet": "overbrace{${1:text}}",
-    "detail": "⏞",
-    "documentation": "TOP CURLY BRACKET"
-  },
-  "overline": {
-    "command": "overline",
-    "snippet": "overline{${1:text}}",
-    "detail": " ̅",
-    "documentation": "overbar embellishment"
-  },
   "pagebreak[]": {
     "command": "pagebreak[number]",
     "snippet": "pagebreak[${1:number}]"
@@ -1028,14 +948,6 @@
   "pagename": {
     "command": "pagename",
     "snippet": "pagename"
-  },
-  "pagenumbering": {
-    "command": "pagenumbering",
-    "snippet": "pagenumbering{${1:numstyle}}"
-  },
-  "paragraph*": {
-    "command": "paragraph*",
-    "snippet": "paragraph*{${1:title}}"
   },
   "paragraph[]{}": {
     "command": "paragraph[short]{title}",
@@ -1049,10 +961,6 @@
     "command": "parbox{width}{text}",
     "snippet": "parbox{${1:width}}{${2:text}}"
   },
-  "part*": {
-    "command": "part*",
-    "snippet": "part*{${1:title}}"
-  },
   "part[]{}": {
     "command": "part[short]{title}",
     "snippet": "part[${2:short}]{${1:title}}"
@@ -1060,10 +968,6 @@
   "rule[]{}{}": {
     "command": "rule[lift]{width}{thickness}",
     "snippet": "rule[${3:lift}]{${1:width}}{${2:thickness}}"
-  },
-  "section*": {
-    "command": "section*",
-    "snippet": "section*{${1:title}}"
   },
   "section[]{}": {
     "command": "section[short]{title}",
@@ -1073,37 +977,17 @@
     "command": "stackrel{above}{under}",
     "snippet": "stackrel{${1:above}}{${2:under}}"
   },
-  "subparagraph*": {
-    "command": "subparagraph*",
-    "snippet": "subparagraph*{${1:title}}"
-  },
   "subparagraph[]{}": {
     "command": "subparagraph[short]{title}",
     "snippet": "subparagraph[${2:short}]{${1:title}}"
-  },
-  "subsection*": {
-    "command": "subsection*",
-    "snippet": "subsection*{${1:title}}"
   },
   "subsection[]{}": {
     "command": "subsection[short]{title}",
     "snippet": "subsection[${2:short}]{${1:title}}"
   },
-  "subsubsection*": {
-    "command": "subsubsection*",
-    "snippet": "subsubsection*{${1:title}}"
-  },
   "subsubsection[]{}": {
     "command": "subsubsection[short]{title}",
     "snippet": "subsubsection[${2:short}]{${1:title}}"
-  },
-  "thanks": {
-    "command": "thanks",
-    "snippet": "thanks{${1:text}}"
-  },
-  "thispagestyle": {
-    "command": "thispagestyle",
-    "snippet": "thispagestyle{${1:empty/plain/headings/myheadings}}"
   },
   "usepackage[]{}": {
     "command": "usepackage[options]{package}",
@@ -1128,10 +1012,6 @@
   "providecommand{}[]{}": {
     "command": "providecommand{cmd}[args]{def}",
     "snippet": "providecommand{${1:cmd}}[${2:args}]{${3:def}}"
-  },
-  "providecommand": {
-    "command": "providecommand",
-    "snippet": "providecommand{${1:cmd}}{${2:def}}"
   },
   "newenvironment{}[][]{}{}": {
     "command": "newenvironment{nam}[args][default]{begdef}{enddef}",


### PR DESCRIPTION
Remove duplicate commands in ` data/commands.json`. They are also defined in `data/packages/latex-document_cmd.json`.

We can find them with `jq`.

```
jq -s add data/commands.json data/packages/latex-document_cmd.json | jq 'to_entries | map(.value | .snippet) |  sort | group_by(.) | map(select(length>1) | .[0])'
```