### PR TITLE
Fix a regexp which might causes ReDoS

### DIFF
--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -142,7 +142,7 @@ export class Completer implements vscode.CompletionItemProvider {
         let provider: IProvider | undefined
         switch (type) {
             case 'citation':
-                reg = /(?:\\[a-zA-Z]*[Cc]ite[a-zA-Z]*\*?(?:\([^[)]*\)){0,2}(?:(?:\[[^[\]]*\])*(?:{[^{}]*})?)*{([^}]*)$)|(?:\\bibentry{([^}]*)$)/
+                reg = /(?:\\[a-zA-Z]*[Cc]ite[a-zA-Z]*\*?(?:\([^[)]*\)){0,2}(?:\[[^[\]]*\]|{[^{}]*})*{([^}]*)$)|(?:\\bibentry{([^}]*)$)/
                 provider = this.citation
                 break
             case 'reference':


### PR DESCRIPTION
CodeQL warns the following regular expression might cause the regular expression denial of service. https://en.wikipedia.org/wiki/ReDoS

```regexp
(?:(?:\[[^[\]]*\])*(?:{[^{}]*})?)*
```

This PR fixes it by changing to the following:

```regexp
(?:\[[^[\]]*\]|{[^{}]*})*
```