### PR TITLE
 Make sure to wait for findRoot to return before proceeding.

### DIFF
--- a/src/components/locator.ts
+++ b/src/components/locator.ts
@@ -136,7 +136,6 @@ export class Locator {
             return
         }
         if (!pdfFile) {
-            this.extension.manager.findRoot()
             pdfFile = this.extension.manager.tex2pdf(rootFile)
         }
         if (vscode.window.activeTextEditor.document.lineCount === line &&

--- a/src/main.ts
+++ b/src/main.ts
@@ -171,9 +171,6 @@ export function activate(context: vscode.ExtensionContext) {
         if (extension.manager.hasTexId(e.languageId)) {
             obsoleteConfigCheck(extension)
             await extension.manager.findRoot()
-
-            extension.structureProvider.refresh()
-            extension.structureProvider.update()
         }
 
         if (e.languageId === 'pdf') {

--- a/src/main.ts
+++ b/src/main.ts
@@ -166,11 +166,11 @@ export function activate(context: vscode.ExtensionContext) {
         }
     }))
 
-    context.subscriptions.push(vscode.workspace.onDidOpenTextDocument((e: vscode.TextDocument) => {
+    context.subscriptions.push(vscode.workspace.onDidOpenTextDocument(async (e: vscode.TextDocument) => {
         // This function will be called when a new text is opened, or an inactive editor is reactivated after vscode reload
         if (extension.manager.hasTexId(e.languageId)) {
             obsoleteConfigCheck(extension)
-            extension.manager.findRoot()
+            await extension.manager.findRoot()
 
             extension.structureProvider.refresh()
             extension.structureProvider.update()
@@ -209,7 +209,7 @@ export function activate(context: vscode.ExtensionContext) {
     }))
 
     let isLaTeXActive = false
-    context.subscriptions.push(vscode.window.onDidChangeActiveTextEditor((e: vscode.TextEditor | undefined) => {
+    context.subscriptions.push(vscode.window.onDidChangeActiveTextEditor(async (e: vscode.TextEditor | undefined) => {
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         if (vscode.window.visibleTextEditors.filter(editor => extension.manager.hasTexId(editor.document.languageId)).length > 0) {
             extension.logger.status.show()
@@ -225,7 +225,7 @@ export function activate(context: vscode.ExtensionContext) {
         }
 
         if (e && extension.manager.hasTexId(e.document.languageId)) {
-            extension.manager.findRoot()
+            await extension.manager.findRoot()
             extension.linter.lintRootFileIfEnabled()
         } else {
             isLaTeXActive = false
@@ -273,8 +273,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     context.subscriptions.push(vscode.window.registerWebviewViewProvider('latex-snippet-view', new SnippetViewProvider(extension), {webviewOptions: {retainContextWhenHidden: true}}))
 
-    extension.manager.findRoot()
-    extension.linter.lintRootFileIfEnabled()
+    extension.manager.findRoot().then(() => extension.linter.lintRootFileIfEnabled())
     obsoleteConfigCheck(extension)
     conflictExtensionCheck()
     checkDeprecatedFeatures(extension)


### PR DESCRIPTION
This PR is closes #2571.

Before calling `linter.lintRootFileIfEnabled`, we have to make sure that `manager.findRoot` has finished.