### PR TITLE
input.ts: use nul-separated output

### DIFF
--- a/src/providers/completer/input.ts
+++ b/src/providers/completer/input.ts
@@ -32,8 +32,8 @@ export class Input implements IProvider {
                     cp.execSync('which git')
                 }
                 const command = 'git'
-                const args = ['check-ignore', '-z', '--'].concat(files)
-                gitIgnoredFiles = (cp.spawnSync(command, args, {cwd: baseDir})).stdout.toString().split('\x00')
+                const args = ['check-ignore', '-z', '--stdin']
+                gitIgnoredFiles = (cp.spawnSync(command, args, {cwd: baseDir, input: files.join('\x00')})).stdout.toString().split('\x00')
             } catch (ex) { }
         }
         return files.filter(file => {

--- a/src/providers/completer/input.ts
+++ b/src/providers/completer/input.ts
@@ -32,8 +32,8 @@ export class Input implements IProvider {
                     cp.execSync('which git')
                 }
                 const command = 'git'
-                const args = ['check-ignore'].concat(files)
-                gitIgnoredFiles = (cp.spawnSync(command, args, {cwd: baseDir})).stdout.toString().split('\n')
+                const args = ['check-ignore', '-z', '--'].concat(files)
+                gitIgnoredFiles = (cp.spawnSync(command, args, {cwd: baseDir})).stdout.toString().split('\x00')
             } catch (ex) { }
         }
         return files.filter(file => {


### PR DESCRIPTION
Although this shouldn't be exploitable, it is still perfectly possible for someone to have a newline in the filename and get that fed through git. When the extension does a .split('\n') it becomes incorrectly interpreted as two files.