### PR TITLE
Fix typo in hat (@^) snippet

### DIFF
--- a/snippets/latex.json
+++ b/snippets/latex.json
@@ -46,7 +46,7 @@
 	},
 	"hat": {
 		"prefix": "@^",
-		"body": "\\Hat{${1:${TM_SELECTED_TEXT}}}$0",
+		"body": "\\hat{${1:${TM_SELECTED_TEXT}}}$0",
 		"description": "hat"
 	},
 	"bar": {


### PR DESCRIPTION
It seems that this is a typo. At least I can't find a command \Hat in symbols-a4.