### PR TITLE
Stop exposing Manager.cachedContent.

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -301,13 +301,11 @@ export function activate(context: vscode.ExtensionContext) {
             findRoot: () => extension.manager.findRoot(),
             rootDir: () => extension.manager.rootDir,
             rootFile: () => extension.manager.rootFile,
-            setEnvVar: () => extension.manager.setEnvVar(),
-            cachedContent: () => extension.manager.cachedContent
+            setEnvVar: () => extension.manager.setEnvVar()
         },
         completer: {
             command: {
                 usedPackages: () => {
-                    console.warn('`completer.command.usedPackages` is deprecated. Consider use `manager.cachedContent`.')
                     let allPkgs: string[] = []
                     extension.manager.getIncludedTeX().forEach(tex => {
                         const pkgs = extension.manager.cachedContent[tex].element.package


### PR DESCRIPTION
Stop exposing `Manager.cachedContent`. We should not expose internal implementation.

LaTeX-Utilities does not use the API.

https://github.com/tecosaur/LaTeX-Utilities/blob/7deced79c590ba5c9354721231aad907555d3d54/src/main.ts#L214-L239