### PR TITLE
Enable resolveJsonModule. 

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -55,6 +55,7 @@
         "no-shadow": "off",
         "@typescript-eslint/no-shadow": "error",
         "@typescript-eslint/no-unsafe-argument": "error",
+        "@typescript-eslint/no-unsafe-assignment": "error",
         "@typescript-eslint/no-unsafe-call": "error",
         "@typescript-eslint/no-unsafe-return": "error",
         "no-unused-expressions": "off",

--- a/dev/createSymbolSvgs.ts
+++ b/dev/createSymbolSvgs.ts
@@ -1,6 +1,8 @@
 import { readFileSync, writeFileSync } from 'fs'
 import * as path from 'path'
 
+type SnippetPanelJsonType = typeof import('../resources/snippetpanel/snippetpanel.json')
+
 type IMathSymbol = {
     name: string,
     keywords?: string,
@@ -42,7 +44,7 @@ function loadSnippets() {
         mathSymbols: {
             [category: string]: IMathSymbol[]
         }
-    } = JSON.parse(readFileSync(snipetsFile, { encoding: 'utf8' }))
+    } = JSON.parse(readFileSync(snipetsFile, { encoding: 'utf8' })) as SnippetPanelJsonType
 
     const mathSymbolPromises: Promise<void>[] = []
     for (const category in snippets.mathSymbols) {

--- a/package.json
+++ b/package.json
@@ -1723,11 +1723,6 @@
           "default": true,
           "markdownDescription": "Display error messages in popup notifications."
         },
-        "latex-workshop.message.update.show": {
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Display LaTeX Workshop update message on new versions."
-        },
         "latex-workshop.message.log.show": {
           "type": "boolean",
           "default": true,

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -5,6 +5,7 @@ import * as path from 'path'
 import type {Extension} from './main'
 import {getLongestBalancedString} from './utils/utils'
 import {TeXDoc} from './components/texdoc'
+type SnippetsLatexJsonType = typeof import('../snippets/latex.json')
 
 async function quickPickRootFile(rootFile: string, localRootFile: string): Promise<string | undefined> {
     const configuration = vscode.workspace.getConfiguration('latex-workshop')
@@ -56,7 +57,7 @@ export class Commander {
         fs.readFile(`${this.extension.extensionRoot}/snippets/latex.json`)
             .then(data => {extensionSnippets = data.toString()})
             .then(() => {
-                const snipObj: { [key: string]: { body: string } } = JSON.parse(extensionSnippets)
+                const snipObj: { [key: string]: { body: string } } = JSON.parse(extensionSnippets) as SnippetsLatexJsonType
                 Object.keys(snipObj).forEach(key => {
                     this.snippets[key] = new vscode.SnippetString(snipObj[key]['body'])
                 })

--- a/src/components/builder.ts
+++ b/src/components/builder.ts
@@ -501,7 +501,7 @@ export class Builder {
         /**
          * Use JSON.parse and JSON.stringify for a deep copy.
          */
-        steps = JSON.parse(JSON.stringify(steps))
+        steps = JSON.parse(JSON.stringify(steps)) as StepCommand[]
 
         const docker = configuration.get('docker.enabled')
         steps.forEach(step => {

--- a/src/components/duplicatelabels.ts
+++ b/src/components/duplicatelabels.ts
@@ -26,7 +26,7 @@ export class DuplicateLabels {
             this.extension.logger.addLogMessage(`Cannot check for duplicate labels in a file not in manager: ${file}.`)
             return []
         }
-        const labelsCount: Map<string, number> = new Map()
+        const labelsCount = new Map<string, number>()
         this.extension.manager.getIncludedTeX().forEach(cachedFile => {
             const cachedRefs = this.extension.manager.cachedContent[cachedFile].element.reference
             if (cachedRefs === undefined) {

--- a/src/components/linter.ts
+++ b/src/components/linter.ts
@@ -122,7 +122,7 @@ export class Linter {
             stdout = await this.processWrapper('active file', command, args.concat(requiredArgs).filter(arg => arg !== ''), {cwd: path.dirname(filePath)}, content)
         } catch (err) {
             if ('stdout' in err) {
-                stdout = err.stdout
+                stdout = err.stdout as string
             } else {
                 return
             }
@@ -157,7 +157,7 @@ export class Linter {
             stdout = await this.processWrapper('root file', command, args.concat(requiredArgs).filter(arg => arg !== ''), {cwd: path.dirname(this.extension.manager.rootFile)})
         } catch (err) {
             if ('stdout' in err) {
-                stdout = err.stdout
+                stdout = err.stdout as string
             } else {
                 return
             }

--- a/src/components/viewer.ts
+++ b/src/components/viewer.ts
@@ -87,7 +87,7 @@ class PdfViewerPanelSerializer implements vscode.WebviewPanelSerializer {
 
 export class Viewer {
     private readonly extension: Extension
-    private readonly webviewPanels: Map<string, Set<PdfViewerPanel>> = new Map()
+    private readonly webviewPanels = new Map<string, Set<PdfViewerPanel>>()
     readonly clients: {[key: string]: Set<Client>} = {}
     readonly pdfViewerPanelSerializer: PdfViewerPanelSerializer
 
@@ -374,7 +374,7 @@ export class Viewer {
      * @param msg A message from the viewer in JSON fromat.
      */
     handler(websocket: ws, msg: string) {
-        const data: ClientRequest = JSON.parse(msg)
+        const data = JSON.parse(msg) as ClientRequest
         if (data.type !== 'ping') {
             this.extension.logger.addLogMessage(`Handle data type: ${data.type}`)
         }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,4 @@
 import * as vscode from 'vscode'
-import * as path from 'path'
-import * as fs from 'fs'
 
 import type {Extension} from './main'
 
@@ -114,41 +112,4 @@ export function checkDeprecatedFeatures(extension: Extension) {
         extension.logger.addLogMessage(msg)
         extension.logger.displayStatus('check', 'statusBar.foreground', markdownMsg, 'warning')
     }
-}
-
-export function newVersionMessage(extensionPath: string, extension: Extension) {
-    fs.readFile(`${extensionPath}${path.sep}package.json`, (err, data) => {
-        if (err) {
-            extension.logger.addLogMessage('Cannot read package information.')
-            return
-        }
-        extension.packageInfo = JSON.parse(data.toString())
-        extension.logger.addLogMessage(`LaTeX Workshop version: ${extension.packageInfo.version}`)
-        if (fs.existsSync(`${extensionPath}${path.sep}VERSION`) &&
-            fs.readFileSync(`${extensionPath}${path.sep}VERSION`).toString() === extension.packageInfo.version) {
-            return
-        }
-        fs.writeFileSync(`${extensionPath}${path.sep}VERSION`, extension.packageInfo.version)
-        const configuration = vscode.workspace.getConfiguration('latex-workshop')
-        if (!(configuration.get('message.update.show') as boolean)) {
-            return
-        }
-        vscode.window.showInformationMessage(`LaTeX Workshop updated to version ${extension.packageInfo.version}.`,
-            'Change log', 'Star the project', 'Disable this message')
-        .then(option => {
-            switch (option) {
-                case 'Change log':
-                    vscode.env.openExternal(vscode.Uri.parse('https://github.com/James-Yu/LaTeX-Workshop/blob/master/CHANGELOG.md'))
-                    break
-                case 'Star the project':
-                    vscode.env.openExternal(vscode.Uri.parse('https://github.com/James-Yu/LaTeX-Workshop'))
-                    break
-                case 'Disable this message':
-                    configuration.update('message.update.show', false, true)
-                    break
-                default:
-                    break
-            }
-        })
-    })
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,7 +40,7 @@ import { SnippetPanel } from './components/snippetpanel'
 import { BibtexFormatter, BibtexFormatterProvider } from './providers/bibtexformatter'
 import {SnippetViewProvider} from './providers/snippetview'
 
-import {checkDeprecatedFeatures, newVersionMessage, obsoleteConfigCheck} from './config'
+import {checkDeprecatedFeatures, obsoleteConfigCheck} from './config'
 
 function conflictExtensionCheck() {
     function check(extensionID: string, name: string, suggestion: string) {
@@ -274,7 +274,6 @@ export function activate(context: vscode.ExtensionContext) {
     obsoleteConfigCheck(extension)
     conflictExtensionCheck()
     checkDeprecatedFeatures(extension)
-    newVersionMessage(context.extensionPath, extension)
 
     // If VS Code started with PDF files, we must explicitly execute `commander.pdf` for the PDF files.
     vscode.window.visibleTextEditors.forEach(editor => {

--- a/src/providers/bibtexcompletion.ts
+++ b/src/providers/bibtexcompletion.ts
@@ -4,6 +4,9 @@ import * as fs from 'fs-extra'
 import * as bibtexUtils from '../utils/bibtexutils'
 import type {Extension} from '../main'
 
+type DataBibtexJsonType = typeof import('../../data/bibtex-entries.json')
+type DataBibtexOptionalJsonType = typeof import('../../data/bibtex-optional-entries.json')
+
 export class BibtexCompleter implements vscode.CompletionItemProvider {
     private readonly extension: Extension
     private readonly entryItems: vscode.CompletionItem[] = []
@@ -20,8 +23,8 @@ export class BibtexCompleter implements vscode.CompletionItemProvider {
     }
 
     private loadDefaultItems() {
-        const entries: { [key: string]: string[] } = JSON.parse(fs.readFileSync(`${this.extension.extensionRoot}/data/bibtex-entries.json`, {encoding: 'utf8'}))
-        const optFields: { [key: string]: string[] } = JSON.parse(fs.readFileSync(`${this.extension.extensionRoot}/data/bibtex-optional-entries.json`, {encoding: 'utf8'}))
+        const entries: { [key: string]: string[] } = JSON.parse(fs.readFileSync(`${this.extension.extensionRoot}/data/bibtex-entries.json`, {encoding: 'utf8'})) as DataBibtexJsonType
+        const optFields: { [key: string]: string[] } = JSON.parse(fs.readFileSync(`${this.extension.extensionRoot}/data/bibtex-optional-entries.json`, {encoding: 'utf8'})) as DataBibtexOptionalJsonType
         const entriesReplacements = vscode.workspace.getConfiguration('latex-workshop').get('intellisense.bibtexJSON.replace') as {[key: string]: string[]}
         const config = vscode.workspace.getConfiguration('latex-workshop')
         const leftright = config.get('bibtex-format.surround') === 'Curly braces' ? [ '{', '}' ] : [ '"', '"']

--- a/src/providers/completer/command.ts
+++ b/src/providers/completer/command.ts
@@ -8,9 +8,11 @@ import type {IProvider} from './interface'
 import {CommandFinder, isTriggerSuggestNeeded, resolveCmdEnvFile} from './commandlib/commandfinder'
 import {SurroundCommand} from './commandlib/surround'
 
+type DataUnimathSymbolsJsonType = typeof import('../../../data/unimathsymbols.json')
+
 export interface CmdItemEntry {
     command: string, // frame
-    snippet: string,
+    snippet?: string,
     package?: string,
     label?: string, // \\begin{frame} ... \\end{frame}
     detail?: string,
@@ -106,7 +108,7 @@ export class Command implements IProvider {
         // Insert unimathsymbols
         if (configuration.get('intellisense.unimathsymbols.enabled')) {
             if (this.defaultSymbols.length === 0) {
-                const symbols: { [key: string]: CmdItemEntry } = JSON.parse(fs.readFileSync(`${this.extension.extensionRoot}/data/unimathsymbols.json`).toString())
+                const symbols: { [key: string]: CmdItemEntry } = JSON.parse(fs.readFileSync(`${this.extension.extensionRoot}/data/unimathsymbols.json`).toString()) as DataUnimathSymbolsJsonType
                 Object.keys(symbols).forEach(key => {
                     this.defaultSymbols.push(this.entryCmdToCompletion(key, symbols[key]))
                 })
@@ -343,7 +345,7 @@ export class Command implements IProvider {
             this.packageCmds[pkg] = []
             if (filePath !== undefined) {
                 try {
-                    const cmds: {[key: string]: CmdItemEntry} = JSON.parse(fs.readFileSync(filePath).toString())
+                    const cmds = JSON.parse(fs.readFileSync(filePath).toString()) as {[key: string]: CmdItemEntry}
                     Object.keys(cmds).forEach(key => {
                         if (isCmdItemEntry(cmds[key])) {
                             this.packageCmds[pkg].push(this.entryCmdToCompletion(key, cmds[key]))

--- a/src/providers/completer/documentclass.ts
+++ b/src/providers/completer/documentclass.ts
@@ -4,6 +4,8 @@ import * as fs from 'fs-extra'
 import type {Extension} from '../../main'
 import type {IProvider} from './interface'
 
+type DataClassnamesJsonType = typeof import('../../../data/classnames.json')
+
 type ClassItemEntry = {
     command: string,
     detail: string,
@@ -34,7 +36,7 @@ export class DocumentClass implements IProvider {
 
     private provide(): vscode.CompletionItem[] {
         if (this.suggestions.length === 0) {
-            const allClasses: {[key: string]: ClassItemEntry} = JSON.parse(fs.readFileSync(`${this.extension.extensionRoot}/data/classnames.json`).toString())
+            const allClasses: {[key: string]: ClassItemEntry} = JSON.parse(fs.readFileSync(`${this.extension.extensionRoot}/data/classnames.json`).toString()) as DataClassnamesJsonType
             this.initialize(allClasses)
         }
         return this.suggestions

--- a/src/providers/completer/environment.ts
+++ b/src/providers/completer/environment.ts
@@ -6,6 +6,8 @@ import type {Extension} from '../../main'
 import type {IProvider} from './interface'
 import {resolveCmdEnvFile} from './commandlib/commandfinder'
 
+type DataEnvsJsonType = typeof import('../../../data/environments.json')
+
 export interface EnvItemEntry {
     name: string, // Name of the environment, what comes inside \begin{...}
     snippet?: string, // To be inserted after \begin{..}
@@ -233,7 +235,7 @@ export class Environment implements IProvider {
             return {}
         }
         try {
-            const envs: {[key: string]: EnvItemEntry} = JSON.parse(fs.readFileSync(filePath).toString())
+            const envs: {[key: string]: EnvItemEntry} = JSON.parse(fs.readFileSync(filePath).toString()) as DataEnvsJsonType
             Object.keys(envs).forEach(key => {
                 if (! isEnvItemEntry(envs[key])) {
                     this.extension.logger.addLogMessage(`Cannot parse intellisense file: ${filePath}`)

--- a/src/providers/completer/package.ts
+++ b/src/providers/completer/package.ts
@@ -4,6 +4,8 @@ import * as fs from 'fs-extra'
 import type {Extension} from '../../main'
 import type {IProvider} from './interface'
 
+type DataPackagesJsonType = typeof import('../../../data/packagenames.json')
+
 type PackageItemEntry = {
     command: string,
     detail: string,
@@ -34,7 +36,7 @@ export class Package implements IProvider {
 
     private provide(): vscode.CompletionItem[] {
         if (this.suggestions.length === 0) {
-            const pkgs: {[key: string]: PackageItemEntry} = JSON.parse(fs.readFileSync(`${this.extension.extensionRoot}/data/packagenames.json`).toString())
+            const pkgs: {[key: string]: PackageItemEntry} = JSON.parse(fs.readFileSync(`${this.extension.extensionRoot}/data/packagenames.json`).toString()) as DataPackagesJsonType
             this.initialize(pkgs)
         }
         return this.suggestions

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -15,6 +15,10 @@ import {Input} from './completer/input'
 import {Glossary} from './completer/glossary'
 import type {ReferenceDocType} from './completer/reference'
 
+type DataEnvsJsonType = typeof import('../../data/environments.json')
+type DataCmdsJsonType = typeof import('../../data/commands.json')
+type DataLatexMathSymbolsJsonType = typeof import('../../data/packages/latex-mathsymbols_cmd.json')
+
 export class Completer implements vscode.CompletionItemProvider {
     private readonly extension: Extension
     readonly citation: Citation
@@ -47,9 +51,9 @@ export class Completer implements vscode.CompletionItemProvider {
         const defaultEnvs = fs.readFileSync(`${this.extension.extensionRoot}/data/environments.json`, {encoding: 'utf8'})
         const defaultCommands = fs.readFileSync(`${this.extension.extensionRoot}/data/commands.json`, {encoding: 'utf8'})
         const defaultLaTeXMathSymbols = fs.readFileSync(`${this.extension.extensionRoot}/data/packages/latex-mathsymbols_cmd.json`, {encoding: 'utf8'})
-        const env: { [key: string]: EnvItemEntry } = JSON.parse(defaultEnvs)
-        const cmds = JSON.parse(defaultCommands)
-        const maths: { [key: string]: CmdItemEntry } = JSON.parse(defaultLaTeXMathSymbols)
+        const env: { [key: string]: EnvItemEntry } = JSON.parse(defaultEnvs) as DataEnvsJsonType
+        const cmds = JSON.parse(defaultCommands) as DataCmdsJsonType
+        const maths: { [key: string]: CmdItemEntry } = JSON.parse(defaultLaTeXMathSymbols) as DataLatexMathSymbolsJsonType
         for (const key of Object.keys(maths)) {
             if (key.match(/\{.*?\}/)) {
                 const ent = maths[key]
@@ -99,7 +103,7 @@ export class Completer implements vscode.CompletionItemProvider {
             if (typeof item.documentation !== 'string') {
                 return item
             }
-            const data: ReferenceDocType = JSON.parse(item.documentation)
+            const data = JSON.parse(item.documentation) as ReferenceDocType
             const sug = {
                 file: data.file,
                 position: new vscode.Position(data.position.line, data.position.character)

--- a/src/providers/preview/pdfrenderer_worker.ts
+++ b/src/providers/preview/pdfrenderer_worker.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 import * as domstubs from '@tamuratak/domstubs'
 import * as fs from 'fs'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
         "noUnusedLocals": true,
         "noUnusedParameters": true,
         "outDir": "out",
+        "resolveJsonModule": true,
         "rootDir": ".",
         "skipLibCheck": true,
         "sourceMap": true,

--- a/viewer/latexworkshop.ts
+++ b/viewer/latexworkshop.ts
@@ -209,7 +209,7 @@ class LateXWorkshopPdfViewer implements ILatexWorkshopPdfViewer {
             this.send(pack)
         })
         this.socket.addEventListener('message', (event: MessageEvent<string>) => {
-            const data: ServerResponse = JSON.parse(event.data)
+            const data = JSON.parse(event.data) as ServerResponse
             switch (data.type) {
                 case 'synctex': {
                     // use the offsetTop of the actual page, much more accurate than multiplying the offsetHeight of the first page
@@ -509,7 +509,7 @@ class LateXWorkshopPdfViewer implements ILatexWorkshopPdfViewer {
     private async startReceivingPanelManagerResponse() {
         await this.pdfViewerStarted
         window.addEventListener('message', (e) => {
-            const data: PanelManagerResponse = e.data
+            const data = e.data as PanelManagerResponse
             if (!data.type) {
                 console.log('LateXWorkshopPdfViewer received a message of unknown type: ' + JSON.stringify(data))
                 return


### PR DESCRIPTION

- Enable resolveJsonModule. We can statically check objects read from JSON files. See https://www.typescriptlang.org/tsconfig#resolveJsonModule
- Enable "@typescript-eslint/no-unsafe-assignment": "error"
- Remove newVersionMessage.

For example, if we unintentionally edit `snippets/latex.json`,

```diff
diff --git a/snippets/latex.json b/snippets/latex.json
index a2ba085d..e058c700 100644
--- a/snippets/latex.json
+++ b/snippets/latex.json
@@ -1,7 +1,6 @@
 {
        "item": {
                "prefix": "item",
-               "body": "\n\\item ",
                "description": "\\item on a newline"
        },
        "subscript": {
```

then, the following compile error occurs:

```
$ npm run compile

> latex-workshop@8.16.1 compile /Users/tamura/src/github/LaTeX-Workshop
> tsc -p tsconfig.json && tsc -p viewer/tsconfig.json

src/commander.ts:60:23 - error TS2322: Type '{ item: { prefix: string; description: string; }; subscript: { prefix: string; body: string; description: string; }; superscript: { prefix: string; body: string; description: string; }; etc: { prefix: string; body: string; description: string; }; ... 106 more ...; subparagraph: { ...; }; }' is not assignable to type '{ [key: string]: { body: string; }; }'.
  Property '"item"' is incompatible with index signature.
    Property 'body' is missing in type '{ prefix: string; description: string; }' but required in type '{ body: string; }'.

60                 const snipObj: { [key: string]: { body: string } } = JSON.parse(extensionSnippets) as SnippetsLatexJsonType
                         ~~~~~~~

  src/commander.ts:60:51
    60                 const snipObj: { [key: string]: { body: string } } = JSON.parse(extensionSnippets) as SnippetsLatexJsonType
                                                         ~~~~
    'body' is declared here.


Found 1 error.
```

We can see that the error message states that the `body` property is missing.
