### PR TITLE
Support <<child='...'>>= for .rnw file inclusion 

### DIFF
--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -16,7 +16,7 @@ import type {Suggestion as GlossEntry} from 'src/providers/completer/glossary'
 import {PdfWatcher} from './managerlib/pdfwatcher'
 import {BibWatcher} from './managerlib/bibwatcher'
 import {FinderUtils} from './managerlib/finderutils'
-import {PathUtils} from './managerlib/pathutils'
+import {PathUtils, PathRegExp} from './managerlib/pathutils'
 import type {MatchPath} from './managerlib/pathutils'
 import {IntellisenseWatcher} from './managerlib/intellisensewatcher'
 
@@ -529,16 +529,14 @@ export class Manager {
         // Update children of current file
         if (this.cachedContent[file] === undefined) {
             this.cachedContent[file] = {content, element: {}, bibs: [], children: []}
-            // We must create copies of the regexp to handle lastIndex properly
-            const inputRegex = new RegExp(this.pathUtils.inputRegex)
-            const childRegex = new RegExp(this.pathUtils.childRegex)
+            const pathRegexp = new PathRegExp()
             while (true) {
-                const result: MatchPath | undefined = this.pathUtils.exec(inputRegex, childRegex, content)
+                const result: MatchPath | undefined = pathRegexp.exec(content)
                 if (!result) {
                     break
                 }
 
-                const inputFile = this.pathUtils.parseInputFilePath(result, file, baseFile)
+                const inputFile = pathRegexp.parseInputFilePath(result, file, baseFile)
 
                 if (!inputFile ||
                     !fs.existsSync(inputFile) ||
@@ -575,15 +573,13 @@ export class Manager {
     }
 
     private parseInputFiles(content: string, currentFile: string, baseFile: string) {
-        // We must create copies of the regexp to handle lastIndex properly
-        const inputRegex = new RegExp(this.pathUtils.inputRegex)
-        const childRegex = new RegExp(this.pathUtils.childRegex)
+        const pathRegexp = new PathRegExp()
         while (true) {
-            const result: MatchPath | undefined = this.pathUtils.exec(inputRegex, childRegex, content)
+            const result: MatchPath | undefined = pathRegexp.exec(content)
             if (!result) {
                 break
             }
-            const inputFile = this.pathUtils.parseInputFilePath(result, currentFile, baseFile)
+            const inputFile = pathRegexp.parseInputFilePath(result, currentFile, baseFile)
 
             if (!inputFile ||
                 !fs.existsSync(inputFile) ||

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -529,8 +529,12 @@ export class Manager {
         if (this.cachedContent[file] === undefined) {
             this.cachedContent[file] = {content, element: {}, bibs: [], children: []}
             const inputReg = this.pathUtils.inputRegex
+            const childReg = this.pathUtils.childRegex
             while (true) {
-                const result = inputReg.exec(content)
+                let result = inputReg.exec(content)
+                if (!result) {
+                    result = childReg.exec(content)
+                }
                 if (!result) {
                     break
                 }

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -528,7 +528,7 @@ export class Manager {
         // Update children of current file
         if (this.cachedContent[file] === undefined) {
             this.cachedContent[file] = {content, element: {}, bibs: [], children: []}
-            const inputReg = /(?:(?:\\(?:input|InputIfFileExists|include|SweaveInput|subfile|(?:(?:sub)?(?:import|inputfrom|includefrom)\*?{([^}]*)}))(?:\[[^[\]{}]*\])?){([^}]*)})|(?:<<(?:[^,]*,)*\s*child='([^']*)'\s*(?:,[^,]*)*>>=)/g
+            const inputReg = this.pathUtils.inputRegex
             while (true) {
                 const result = inputReg.exec(content)
                 if (!result) {
@@ -572,7 +572,7 @@ export class Manager {
     }
 
     private parseInputFiles(content: string, currentFile: string, baseFile: string) {
-        const inputReg = /(?:(?:\\(?:input|InputIfFileExists|include|SweaveInput|subfile|(?:(?:sub)?(?:import|inputfrom|includefrom)\*?{([^}]*)}))(?:\[[^[\]{}]*\])?){([^}]*)})|(?:<<(?:[^,]*,)*\s*child='([^']*)'\s*(?:,[^,]*)*>>=)/g
+        const inputReg = this.pathUtils.inputRegex
         while (true) {
             const result = inputReg.exec(content)
             if (!result) {

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -17,6 +17,7 @@ import {PdfWatcher} from './managerlib/pdfwatcher'
 import {BibWatcher} from './managerlib/bibwatcher'
 import {FinderUtils} from './managerlib/finderutils'
 import {PathUtils} from './managerlib/pathutils'
+import type {MatchPath} from './managerlib/pathutils'
 import {IntellisenseWatcher} from './managerlib/intellisensewatcher'
 
 /**
@@ -531,10 +532,7 @@ export class Manager {
             const inputReg = this.pathUtils.inputRegex
             const childReg = this.pathUtils.childRegex
             while (true) {
-                let result = inputReg.exec(content)
-                if (!result) {
-                    result = childReg.exec(content)
-                }
+                const result: MatchPath | undefined = this.pathUtils.exec(inputReg, childReg, content)
                 if (!result) {
                     break
                 }
@@ -577,12 +575,12 @@ export class Manager {
 
     private parseInputFiles(content: string, currentFile: string, baseFile: string) {
         const inputReg = this.pathUtils.inputRegex
+        const childReg = this.pathUtils.childRegex
         while (true) {
-            const result = inputReg.exec(content)
+            const result: MatchPath | undefined = this.pathUtils.exec(inputReg, childReg, content)
             if (!result) {
                 break
             }
-
             const inputFile = this.pathUtils.parseInputFilePath(result, currentFile, baseFile)
 
             if (!inputFile ||

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -528,7 +528,7 @@ export class Manager {
         // Update children of current file
         if (this.cachedContent[file] === undefined) {
             this.cachedContent[file] = {content, element: {}, bibs: [], children: []}
-            const inputReg = /(?:\\(?:input|InputIfFileExists|include|SweaveInput|subfile|(?:(?:sub)?(?:import|inputfrom|includefrom)\*?{([^}]*)}))(?:\[[^[\]{}]*\])?){([^}]*)}/g
+            const inputReg = /(?:(?:\\(?:input|InputIfFileExists|include|SweaveInput|subfile|(?:(?:sub)?(?:import|inputfrom|includefrom)\*?{([^}]*)}))(?:\[[^[\]{}]*\])?){([^}]*)})|(?:<<(?:[^,]*,)*\s*child='([^']*)'\s*(?:,[^,]*)*>>=)/g
             while (true) {
                 const result = inputReg.exec(content)
                 if (!result) {
@@ -572,7 +572,7 @@ export class Manager {
     }
 
     private parseInputFiles(content: string, currentFile: string, baseFile: string) {
-        const inputReg = /(?:\\(?:input|InputIfFileExists|include|SweaveInput|subfile|(?:(?:sub)?(?:import|inputfrom|includefrom)\*?{([^}]*)}))(?:\[[^[\]{}]*\])?){([^}]*)}/g
+        const inputReg = /(?:(?:\\(?:input|InputIfFileExists|include|SweaveInput|subfile|(?:(?:sub)?(?:import|inputfrom|includefrom)\*?{([^}]*)}))(?:\[[^[\]{}]*\])?){([^}]*)})|(?:<<(?:[^,]*,)*\s*child='([^']*)'\s*(?:,[^,]*)*>>=)/g
         while (true) {
             const result = inputReg.exec(content)
             if (!result) {

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -529,10 +529,11 @@ export class Manager {
         // Update children of current file
         if (this.cachedContent[file] === undefined) {
             this.cachedContent[file] = {content, element: {}, bibs: [], children: []}
-            const inputReg = this.pathUtils.inputRegex
-            const childReg = this.pathUtils.childRegex
+            // We must create copies of the regexp to handle lastIndex properly
+            const inputRegex = new RegExp(this.pathUtils.inputRegex)
+            const childRegex = new RegExp(this.pathUtils.childRegex)
             while (true) {
-                const result: MatchPath | undefined = this.pathUtils.exec(inputReg, childReg, content)
+                const result: MatchPath | undefined = this.pathUtils.exec(inputRegex, childRegex, content)
                 if (!result) {
                     break
                 }
@@ -574,10 +575,11 @@ export class Manager {
     }
 
     private parseInputFiles(content: string, currentFile: string, baseFile: string) {
-        const inputReg = this.pathUtils.inputRegex
-        const childReg = this.pathUtils.childRegex
+        // We must create copies of the regexp to handle lastIndex properly
+        const inputRegex = new RegExp(this.pathUtils.inputRegex)
+        const childRegex = new RegExp(this.pathUtils.childRegex)
         while (true) {
-            const result: MatchPath | undefined = this.pathUtils.exec(inputReg, childReg, content)
+            const result: MatchPath | undefined = this.pathUtils.exec(inputRegex, childRegex, content)
             if (!result) {
                 break
             }

--- a/src/components/managerlib/finderutils.ts
+++ b/src/components/managerlib/finderutils.ts
@@ -16,7 +16,7 @@ export class FinderUtils {
         if (!vscode.window.activeTextEditor) {
             return undefined
         }
-        const regex = /^(?:%\s*!\s*T[Ee]X\sroot\s*=\s*(.*\.tex)$)/m
+        const regex = /^(?:%\s*!\s*T[Ee]X\sroot\s*=\s*(.*\.(?:tex|[jrsRS]nw|[rR]tex|jtexw))$)/m
         let content = vscode.window.activeTextEditor.document.getText()
 
         let result = content.match(regex)

--- a/src/components/managerlib/pathutils.ts
+++ b/src/components/managerlib/pathutils.ts
@@ -19,34 +19,27 @@ export interface MatchPath {
     index: number
 }
 
-export class PathUtils {
-    private readonly extension: Extension
-    readonly inputRegex: RegExp
-    readonly childRegex: RegExp
+export class PathRegExp {
+    private readonly inputRegexp: RegExp
+    private readonly childRegexp: RegExp
 
-    constructor(extension: Extension) {
-        this.extension = extension
-        this.inputRegex = /\\(?:input|InputIfFileExists|include|SweaveInput|subfile|(?:(?:sub)?(?:import|inputfrom|includefrom)\*?{([^}]*)}))(?:\[[^[\]{}]*\])?{([^}]*)}/g
-        this.childRegex = /<<(?:[^,]*,)*\s*child='([^']*)'\s*(?:,[^,]*)*>>=/g
+    constructor() {
+        this.inputRegexp = /\\(?:input|InputIfFileExists|include|SweaveInput|subfile|(?:(?:sub)?(?:import|inputfrom|includefrom)\*?{([^}]*)}))(?:\[[^[\]{}]*\])?{([^}]*)}/g
+        this.childRegexp = /<<(?:[^,]*,)*\s*child='([^']*)'\s*(?:,[^,]*)*>>=/g
     }
 
-    private get rootDir() {
-        return this.extension.manager.rootDir
-    }
-
-    private getOutDir(texFile: string) {
-        return this.extension.manager.getOutDir(texFile)
+    resetLastIndex() {
+        this.inputRegexp.lastIndex = 0
+        this.childRegexp.lastIndex = 0
     }
 
     /**
      * Return the matched input or child path. If there is no match, return undefined
      *
-     * @param inputReg a copy of this.inputRegex. We must use a copy to properly handle the .lastIndex property of RegExp.
-     * @param childReg a copy of this.childRegex. We must use a copy to properly handle the .lastIndex property of RegExp.
      * @param content the string to match the regex on
      */
-    exec(inputReg: RegExp, childReg: RegExp, content: string): MatchPath | undefined {
-        let result = inputReg.exec(content)
+    exec(content: string): MatchPath | undefined {
+        let result = this.inputRegexp.exec(content)
         if (result) {
             return {
                 type: MatchType.Input,
@@ -56,7 +49,7 @@ export class PathUtils {
                 index: result.index
             }
         }
-        result = childReg.exec(content)
+        result = this.childRegexp.exec(content)
         if (result) {
             return {
                 type: MatchType.Child,
@@ -93,6 +86,27 @@ export class PathUtils {
             }
         }
         return undefined
+    }
+
+}
+
+export class PathUtils {
+    private readonly extension: Extension
+    readonly inputRegex: RegExp
+    readonly childRegex: RegExp
+
+    constructor(extension: Extension) {
+        this.extension = extension
+        this.inputRegex = /\\(?:input|InputIfFileExists|include|SweaveInput|subfile|(?:(?:sub)?(?:import|inputfrom|includefrom)\*?{([^}]*)}))(?:\[[^[\]{}]*\])?{([^}]*)}/g
+        this.childRegex = /<<(?:[^,]*,)*\s*child='([^']*)'\s*(?:,[^,]*)*>>=/g
+    }
+
+    private get rootDir() {
+        return this.extension.manager.rootDir
+    }
+
+    private getOutDir(texFile: string) {
+        return this.extension.manager.getOutDir(texFile)
     }
 
     /**

--- a/src/components/managerlib/pathutils.ts
+++ b/src/components/managerlib/pathutils.ts
@@ -23,12 +23,18 @@ export class PathUtils {
 
     parseInputFilePath(regResult: RegExpExecArray, currentFile: string, rootFile: string): string | undefined {
         const texDirs = vscode.workspace.getConfiguration('latex-workshop').get('latex.texDirs') as string[]
-        if (regResult[0].startsWith('\\subimport') || regResult[0].startsWith('\\subinputfrom') || regResult[0].startsWith('\\subincludefrom')) {
-            return utils.resolveFile([path.dirname(currentFile)], path.join(regResult[1], regResult[2]))
-        } else if (regResult[0].startsWith('\\import') || regResult[0].startsWith('\\inputfrom') || regResult[0].startsWith('\\includefrom')) {
-            return utils.resolveFile([regResult[1], path.join(path.dirname(rootFile), regResult[1])], regResult[2])
+        if (regResult[3]) {
+            /* Case <<child='...'>>= for Rnw files */
+            return utils.resolveFile([path.dirname(currentFile), path.dirname(rootFile), ...texDirs], regResult[3])
         } else {
-            return utils.resolveFile([path.dirname(currentFile), path.dirname(rootFile), ...texDirs], regResult[2])
+            /* Standard LaTeX input case */
+            if (regResult[0].startsWith('\\subimport') || regResult[0].startsWith('\\subinputfrom') || regResult[0].startsWith('\\subincludefrom')) {
+                return utils.resolveFile([path.dirname(currentFile)], path.join(regResult[1], regResult[2]))
+            } else if (regResult[0].startsWith('\\import') || regResult[0].startsWith('\\inputfrom') || regResult[0].startsWith('\\includefrom')) {
+                return utils.resolveFile([regResult[1], path.join(path.dirname(rootFile), regResult[1])], regResult[2])
+            } else {
+                return utils.resolveFile([path.dirname(currentFile), path.dirname(rootFile), ...texDirs], regResult[2])
+            }
         }
     }
 

--- a/src/components/managerlib/pathutils.ts
+++ b/src/components/managerlib/pathutils.ts
@@ -6,6 +6,19 @@ import * as utils from '../../utils/utils'
 
 import type {Extension} from '../../main'
 
+export enum MatchType {
+    Input,
+    Child
+}
+
+export interface MatchPath {
+    type: MatchType,
+    path: string,
+    directory: string,
+    matchedString: string,
+    index: number
+}
+
 export class PathUtils {
     private readonly extension: Extension
     readonly inputRegex: RegExp
@@ -26,27 +39,60 @@ export class PathUtils {
     }
 
     /**
+     * Return the matched input or child path. If there is no match, return undefined
+     *
+     * @param inputReg a copy of this.inputRegex. We must use a copy to properly handle the .lastIndex property of RegExp.
+     * @param childReg a copy of this.childRegex. We must use a copy to properly handle the .lastIndex property of RegExp.
+     * @param content the string to match the regex on
+     */
+    exec(inputReg: RegExp, childReg: RegExp, content: string): MatchPath | undefined {
+        let result = inputReg.exec(content)
+        if (result) {
+            return {
+                type: MatchType.Input,
+                path: result[2],
+                directory: result[1],
+                matchedString: result[0],
+                index: result.index
+            }
+        }
+        result = childReg.exec(content)
+        if (result) {
+            return {
+                type: MatchType.Child,
+                path: result[1],
+                directory: '',
+                matchedString: result[0],
+                index: result.index
+            }
+        }
+        return undefined
+    }
+    /**
      * Compute the resolved file path from matches of this.inputReg or this.childReg
      *
      * @param regResult is the the result of this.inputReg.exec() or this.childReg.exec()
      * @param currentFile is the name of file in which the match has been obtained
      * @param rootFile
      */
-    parseInputFilePath(regResult: RegExpExecArray, currentFile: string, rootFile: string): string | undefined {
+    parseInputFilePath(match: MatchPath, currentFile: string, rootFile: string): string | undefined {
         const texDirs = vscode.workspace.getConfiguration('latex-workshop').get('latex.texDirs') as string[]
         /* match of this.childReg */
-        if (regResult[0].startsWith('<<')) {
-            return utils.resolveFile([path.dirname(currentFile), path.dirname(rootFile), ...texDirs], regResult[1])
+        if (match.type === MatchType.Child) {
+            return utils.resolveFile([path.dirname(currentFile), path.dirname(rootFile), ...texDirs], match.path)
         }
 
         /* match of this.inputReg */
-        if (regResult[0].startsWith('\\subimport') || regResult[0].startsWith('\\subinputfrom') || regResult[0].startsWith('\\subincludefrom')) {
-            return utils.resolveFile([path.dirname(currentFile)], path.join(regResult[1], regResult[2]))
-        } else if (regResult[0].startsWith('\\import') || regResult[0].startsWith('\\inputfrom') || regResult[0].startsWith('\\includefrom')) {
-            return utils.resolveFile([regResult[1], path.join(path.dirname(rootFile), regResult[1])], regResult[2])
-        } else {
-            return utils.resolveFile([path.dirname(currentFile), path.dirname(rootFile), ...texDirs], regResult[2])
+        if (match.type === MatchType.Input) {
+            if (match.matchedString.startsWith('\\subimport') || match.matchedString.startsWith('\\subinputfrom') || match.matchedString.startsWith('\\subincludefrom')) {
+                return utils.resolveFile([path.dirname(currentFile)], path.join(match.directory, match.path))
+            } else if (match.matchedString.startsWith('\\import') || match.matchedString.startsWith('\\inputfrom') || match.matchedString.startsWith('\\includefrom')) {
+                return utils.resolveFile([match.directory, path.join(path.dirname(rootFile), match.directory)], match.path)
+            } else {
+                return utils.resolveFile([path.dirname(currentFile), path.dirname(rootFile), ...texDirs], match.path)
+            }
         }
+        return undefined
     }
 
     /**

--- a/src/components/managerlib/pathutils.ts
+++ b/src/components/managerlib/pathutils.ts
@@ -8,9 +8,11 @@ import type {Extension} from '../../main'
 
 export class PathUtils {
     private readonly extension: Extension
+    readonly inputRegex: RegExp
 
     constructor(extension: Extension) {
         this.extension = extension
+        this.inputRegex = /(?:(?:\\(?:input|InputIfFileExists|include|SweaveInput|subfile|(?:(?:sub)?(?:import|inputfrom|includefrom)\*?{([^}]*)}))(?:\[[^[\]{}]*\])?){([^}]*)})|(?:<<(?:[^,]*,)*\s*child='([^']*)'\s*(?:,[^,]*)*>>=)/g
     }
 
     private get rootDir() {

--- a/src/components/managerlib/pathutils.ts
+++ b/src/components/managerlib/pathutils.ts
@@ -9,10 +9,12 @@ import type {Extension} from '../../main'
 export class PathUtils {
     private readonly extension: Extension
     readonly inputRegex: RegExp
+    readonly childRegex: RegExp
 
     constructor(extension: Extension) {
         this.extension = extension
-        this.inputRegex = /(?:(?:\\(?:input|InputIfFileExists|include|SweaveInput|subfile|(?:(?:sub)?(?:import|inputfrom|includefrom)\*?{([^}]*)}))(?:\[[^[\]{}]*\])?){([^}]*)})|(?:<<(?:[^,]*,)*\s*child='([^']*)'\s*(?:,[^,]*)*>>=)/g
+        this.inputRegex = /\\(?:input|InputIfFileExists|include|SweaveInput|subfile|(?:(?:sub)?(?:import|inputfrom|includefrom)\*?{([^}]*)}))(?:\[[^[\]{}]*\])?{([^}]*)}/g
+        this.childRegex = /<<(?:[^,]*,)*\s*child='([^']*)'\s*(?:,[^,]*)*>>=/g
     }
 
     private get rootDir() {
@@ -23,20 +25,27 @@ export class PathUtils {
         return this.extension.manager.getOutDir(texFile)
     }
 
+    /**
+     * Compute the resolved file path from matches of this.inputReg or this.childReg
+     *
+     * @param regResult is the the result of this.inputReg.exec() or this.childReg.exec()
+     * @param currentFile is the name of file in which the match has been obtained
+     * @param rootFile
+     */
     parseInputFilePath(regResult: RegExpExecArray, currentFile: string, rootFile: string): string | undefined {
         const texDirs = vscode.workspace.getConfiguration('latex-workshop').get('latex.texDirs') as string[]
-        if (regResult[3]) {
-            /* Case <<child='...'>>= for Rnw files */
-            return utils.resolveFile([path.dirname(currentFile), path.dirname(rootFile), ...texDirs], regResult[3])
+        /* match of this.childReg */
+        if (regResult[0].startsWith('<<')) {
+            return utils.resolveFile([path.dirname(currentFile), path.dirname(rootFile), ...texDirs], regResult[1])
+        }
+
+        /* match of this.inputReg */
+        if (regResult[0].startsWith('\\subimport') || regResult[0].startsWith('\\subinputfrom') || regResult[0].startsWith('\\subincludefrom')) {
+            return utils.resolveFile([path.dirname(currentFile)], path.join(regResult[1], regResult[2]))
+        } else if (regResult[0].startsWith('\\import') || regResult[0].startsWith('\\inputfrom') || regResult[0].startsWith('\\includefrom')) {
+            return utils.resolveFile([regResult[1], path.join(path.dirname(rootFile), regResult[1])], regResult[2])
         } else {
-            /* Standard LaTeX input case */
-            if (regResult[0].startsWith('\\subimport') || regResult[0].startsWith('\\subinputfrom') || regResult[0].startsWith('\\subincludefrom')) {
-                return utils.resolveFile([path.dirname(currentFile)], path.join(regResult[1], regResult[2]))
-            } else if (regResult[0].startsWith('\\import') || regResult[0].startsWith('\\inputfrom') || regResult[0].startsWith('\\includefrom')) {
-                return utils.resolveFile([regResult[1], path.join(path.dirname(rootFile), regResult[1])], regResult[2])
-            } else {
-                return utils.resolveFile([path.dirname(currentFile), path.dirname(rootFile), ...texDirs], regResult[2])
-            }
+            return utils.resolveFile([path.dirname(currentFile), path.dirname(rootFile), ...texDirs], regResult[2])
         }
     }
 

--- a/src/providers/structure.ts
+++ b/src/providers/structure.ts
@@ -101,8 +101,9 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
         })
         pattern += ')(\\*)?(?:\\[[^\\[\\]\\{\\}]*\\])?{(.*)}'
 
-        const childReg = this.pathUtils.childRegex
-        const inputReg = this.pathUtils.inputRegex
+        // We must create copies of the regexp to handle lastIndex properly.
+        const inputRegex = new RegExp(this.pathUtils.inputRegex)
+        const childRegex = new RegExp(this.pathUtils.childRegex)
         const headingReg = RegExp(pattern, 'm')
         const envNames = this.showFloats ? ['figure', 'frame', 'table'] : ['frame']
         const envReg = RegExp(`(?:\\\\(begin|end)(?:\\[[^[\\]]*\\])?){(?:(${envNames.join('|')})\\*?)}`, 'm')
@@ -111,8 +112,8 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
         const lines = content.split('\n')
         for (let lineNumber = 0; lineNumber < lines.length; lineNumber++) {
             const line = lines[lineNumber]
-            inputReg.lastIndex = 0
-            childReg.lastIndex = 0
+            inputRegex.lastIndex = 0
+            childRegex.lastIndex = 0
             let result = envReg.exec(line)
             if (result && result[1] === 'begin') {
                 envStack.push({name: result[2], start: lineNumber, end: lineNumber})
@@ -140,7 +141,7 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
 
             // inputs part
             if (imports) {
-                const matchPath: MatchPath | undefined = this.pathUtils.exec(inputReg, childReg, line)
+                const matchPath: MatchPath | undefined = this.pathUtils.exec(inputRegex, childRegex, line)
                 if (matchPath) {
                     // zoom into this file
                     // resolve the path


### PR DESCRIPTION
To fully support the use of `<<child='...'>>=` for `.rnw` file inclusion, we need to integrate it to

- [x] the rootFile detection mechanism
- [x] the structure provider
- [x] magic comments : accept files with a non `.tex` extension

Close #2607