### PR TITLE
Add biber as tool and include outdir for pdflatex

### DIFF
--- a/package.json
+++ b/package.json
@@ -893,9 +893,19 @@
                 "-synctex=1",
                 "-interaction=nonstopmode",
                 "-file-line-error",
+                "-output-directory=%OUTDIR%",
                 "%DOC%"
               ],
               "env": {}
+            },            
+            {
+                "name": "biber",
+                "command": "biber",
+                "args": [
+                    "--output-directory=%OUTDIR%",
+                    "%DOCFILE%"
+                ],
+                "env": {}
             },
             {
               "name": "bibtex",


### PR DESCRIPTION
This PR includes:
- Adding `biber` as a default tool.
- Fixing `pdflatex` command, including support for output directory.

Biber, unlike `bibtext`, supports utf-8 characters and includes more entry types on the `.bib` file. On the other hand, the output directory configuration was not being taken into consideration for the pdflatex command.