### PR TITLE
sets: use whenever possible sets instead of arrays

### DIFF
--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -38,7 +38,7 @@ interface Content {
             environment?: EnvEntry[],
             bibitem?: CiteEntry[],
             command?: CmdEntry[],
-            package?: string[]
+            package?: Set<string>
         },
         /**
          * The sub-files of the LaTeX file. They should be tex or plain files.

--- a/src/components/texdoc.ts
+++ b/src/components/texdoc.ts
@@ -66,14 +66,14 @@ export class TeXDoc {
     }
 
     texdocUsepackages() {
-        let names: string[] = []
+        const names: Set<string> = new Set()
         for (const tex of this.extension.manager.getIncludedTeX()) {
             const content = this.extension.manager.cachedContent[tex]
             const pkgs = content && content.element.package
             if (!pkgs) {
                 continue
             }
-            names = names.concat(pkgs)
+            pkgs.forEach(pkg => names.add(pkg))
         }
         const packagenames = Array.from(new Set(names))
         const items: vscode.QuickPickItem[] = packagenames.map( name => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -305,13 +305,13 @@ export function activate(context: vscode.ExtensionContext) {
         completer: {
             command: {
                 usedPackages: () => {
-                    let allPkgs: string[] = []
+                    const allPkgs: Set<string> = new Set()
                     extension.manager.getIncludedTeX().forEach(tex => {
                         const pkgs = extension.manager.cachedContent[tex].element.package
                         if (pkgs === undefined) {
                             return
                         }
-                        allPkgs = allPkgs.concat(pkgs)
+                        pkgs.forEach(pkg => allPkgs.add(pkg))
                     })
                     return allPkgs
                 }

--- a/src/providers/completer/command.ts
+++ b/src/providers/completer/command.ts
@@ -248,12 +248,10 @@ export class Command implements IProvider {
                     }
                     let filePkgs = this.extension.manager.cachedContent[file].element.package
                     if (!filePkgs) {
-                        filePkgs = []
+                        filePkgs = new Set()
                         this.extension.manager.cachedContent[file].element.package = filePkgs
                     }
-                    if (!filePkgs.includes(pkg)) {
-                        filePkgs.push(pkg)
-                    }
+                    filePkgs.add(pkg)
                 })
             }
         }
@@ -280,12 +278,10 @@ export class Command implements IProvider {
                             }
                             let pkgs = this.extension.manager.cachedContent[file].element.package
                             if (!pkgs) {
-                                pkgs = []
+                                pkgs = new Set<string>()
                                 this.extension.manager.cachedContent[file].element.package = pkgs
                             }
-                            if (!pkgs.includes(pkg)) {
-                                pkgs.push(pkg)
-                            }
+                            pkgs.add(pkg)
                         })
                     }
                 })


### PR DESCRIPTION
Due to the lag problem commented at #2637 (and the simple solution proposed) new future bugs and performance issues can be approached using `Set`s.

Using those data structures allows having unique items inside them so when trying to add a duplicated one won't be an issue. In addition, most of the operations are ![order](https://render.githubusercontent.com/render/math?math=O\left(1\right)) such as insertions, deletions and searches. The main "problem" is that sets are unordered so then any kind of displaying won't have always the same distribution (an approach, if needed, would be converting the `Set` to an `Array` and then sortering, if necessary).

With this PR, some operations can be simplified by just using sets, allowing cleaner code alongside faster and efficient operations