### PR TITLE
Stop using fs-extra

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -487,15 +487,6 @@
         "@types/node": "*"
       }
     },
-    "@types/fs-extra": {
-      "version": "9.0.11",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.11.tgz",
-      "integrity": "sha512-mZsifGG4QeQ7hlkhO56u7zt/ycBgGxSVsFI/6lGTU34VtwkiqrrSDgw0+ygs8kFGWcXnFQWMrzF2h7TtDFNixA==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
@@ -1022,11 +1013,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-    },
-    "at-least-node": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -2404,17 +2390,6 @@
         "mime-types": "^2.1.12"
       }
     },
-    "fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-      "requires": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      }
-    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2588,7 +2563,8 @@
     "graceful-fs": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
-      "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q=="
+      "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
+      "dev": true
     },
     "growl": {
       "version": "1.10.5",
@@ -3071,15 +3047,6 @@
       "dev": true,
       "requires": {
         "minimist": "^1.2.0"
-      }
-    },
-    "jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "requires": {
-        "graceful-fs": "^4.1.6",
-        "universalify": "^2.0.0"
       }
     },
     "jsprim": {
@@ -5270,11 +5237,6 @@
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
       "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
       "dev": true
-    },
-    "universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
     },
     "unzipper": {
       "version": "0.10.11",

--- a/package.json
+++ b/package.json
@@ -2071,7 +2071,6 @@
     "@tamuratak/domstubs": "0.1.1",
     "chokidar": "3.5.1",
     "cross-spawn": "7.0.3",
-    "fs-extra": "9.1.0",
     "glob": "7.1.6",
     "iconv-lite": "0.6.2",
     "jimp": "0.16.1",
@@ -2086,7 +2085,6 @@
   },
   "devDependencies": {
     "@types/cross-spawn": "6.0.2",
-    "@types/fs-extra": "9.0.11",
     "@types/glob": "7.1.3",
     "@types/micromatch": "4.0.1",
     "@types/mocha": "8.2.2",

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode'
-import * as fs from 'fs-extra'
+import * as fs from 'fs'
 import * as path from 'path'
 
 import type {Extension} from './main'
@@ -54,7 +54,7 @@ export class Commander {
         this.extension = extension
         this._texdoc = new TeXDoc(extension)
         let extensionSnippets: string
-        fs.readFile(`${this.extension.extensionRoot}/snippets/latex.json`)
+        fs.promises.readFile(`${this.extension.extensionRoot}/snippets/latex.json`)
             .then(data => {extensionSnippets = data.toString()})
             .then(() => {
                 const snipObj: { [key: string]: { body: string } } = JSON.parse(extensionSnippets) as SnippetsLatexJsonType

--- a/src/components/builder.ts
+++ b/src/components/builder.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode'
 import * as path from 'path'
-import * as fs from 'fs-extra'
+import * as fs from 'fs'
 import * as cp from 'child_process'
 import * as cs from 'cross-spawn'
 import * as tmp from 'tmp'
@@ -220,8 +220,8 @@ export class Builder {
                 const fullOutDir = path.resolve(outDir, relativePath)
                 // To avoid issues when fullOutDir is the root dir
                 // Using fs.mkdir() on the root directory even with recursion will result in an error
-                if (! (fs.pathExistsSync(fullOutDir) && fs.statSync(fullOutDir).isDirectory())) {
-                    fs.ensureDirSync(fullOutDir)
+                if (! (fs.existsSync(fullOutDir) && fs.statSync(fullOutDir).isDirectory())) {
+                    fs.mkdirSync(fullOutDir, { recursive: true })
                 }
             })
             this.buildInitiator(rootFile, languageId, recipeName, releaseBuildMutex)

--- a/src/components/cleaner.ts
+++ b/src/components/cleaner.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode'
 import * as path from 'path'
-import * as fs from 'fs-extra'
+import * as fs from 'fs'
 import glob from 'glob'
 import * as cs from 'cross-spawn'
 
@@ -55,10 +55,10 @@ export class Cleaner {
             .map(file => path.resolve(outdir, file))
         ).then(files => Promise.all(
             // Try to unlink the files, returning a Promise for every file
-            files.map(file => fs.unlink(file).then(() => {
+            files.map(file => fs.promises.unlink(file).then(() => {
                 this.extension.logger.addLogMessage(`File cleaned: ${file}`)
                 // If unlinking fails, replace it with an rmdir Promise
-            }, () => fs.rmdir(file).then(() => {
+            }, () => fs.promises.rmdir(file).then(() => {
                 this.extension.logger.addLogMessage(`Folder removed: ${file}`)
             }, () => {
                 this.extension.logger.addLogMessage(`Error removing file: ${file}`)

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode'
 import * as os from 'os'
 import * as path from 'path'
-import * as fs from 'fs-extra'
+import * as fs from 'fs'
 import * as chokidar from 'chokidar'
 import * as micromatch from 'micromatch'
 import type {latexParser} from 'latex-utensils'
@@ -800,7 +800,7 @@ export class Manager {
 
     // This function updates all completers upon tex-file changes.
     private updateCompleterOnChange(file: string) {
-        fs.readFile(file).then(buffer => buffer.toString()).then(content => this.updateCompleter(file, content))
+        fs.promises.readFile(file).then(buffer => buffer.toString()).then(content => this.updateCompleter(file, content))
         this.extension.completer.input.getGraphicsPath(file)
     }
 

--- a/src/components/managerlib/finderutils.ts
+++ b/src/components/managerlib/finderutils.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode'
 import * as path from 'path'
-import * as fs from 'fs-extra'
+import * as fs from 'fs'
 import * as utils from '../../utils/utils'
 
 import type {Extension} from '../../main'

--- a/src/components/managerlib/pathutils.ts
+++ b/src/components/managerlib/pathutils.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode'
 import * as path from 'path'
 import * as cs from 'cross-spawn'
-import * as fs from 'fs-extra'
+import * as fs from 'fs'
 import * as utils from '../../utils/utils'
 
 import type {Extension} from '../../main'

--- a/src/providers/bibtexcompletion.ts
+++ b/src/providers/bibtexcompletion.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode'
-import * as fs from 'fs-extra'
+import * as fs from 'fs'
 
 import * as bibtexUtils from '../utils/bibtexutils'
 import type {Extension} from '../main'

--- a/src/providers/completer/command.ts
+++ b/src/providers/completer/command.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode'
-import * as fs from 'fs-extra'
+import * as fs from 'fs'
 import {latexParser} from 'latex-utensils'
 
 import type {Extension} from '../../main'

--- a/src/providers/completer/commandlib/commandfinder.ts
+++ b/src/providers/completer/commandlib/commandfinder.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode'
-import * as fs from 'fs-extra'
+import * as fs from 'fs'
 import {latexParser} from 'latex-utensils'
 
 import type {Suggestion} from '../command'

--- a/src/providers/completer/documentclass.ts
+++ b/src/providers/completer/documentclass.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode'
-import * as fs from 'fs-extra'
+import * as fs from 'fs'
 
 import type {Extension} from '../../main'
 import type {IProvider} from './interface'

--- a/src/providers/completer/environment.ts
+++ b/src/providers/completer/environment.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode'
-import * as fs from 'fs-extra'
+import * as fs from 'fs'
 import {latexParser} from 'latex-utensils'
 
 import type {Extension} from '../../main'

--- a/src/providers/completer/input.ts
+++ b/src/providers/completer/input.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode'
-import * as fs from 'fs-extra'
+import * as fs from 'fs'
 import * as path from 'path'
 import * as micromatch from 'micromatch'
 import * as utils from '../../utils/utils'

--- a/src/providers/completer/package.ts
+++ b/src/providers/completer/package.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode'
-import * as fs from 'fs-extra'
+import * as fs from 'fs'
 
 import type {Extension} from '../../main'
 import type {IProvider} from './interface'

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode'
-import * as fs from 'fs-extra'
+import * as fs from 'fs'
 
 import type {Extension} from '../main'
 import type {IProvider} from './completer/interface'


### PR DESCRIPTION
Stop using `fs-extra`.  We can use `fs.promises.readFile` instead of `fs-extra.readFile`.

See 

- https://nodejs.org/docs/latest-v12.x/api/fs.html#fs_fs_promises_api
- https://nodejs.org/docs/latest-v12.x/api/fs.html#fs_promise_example