### PR TITLE
Set "virtualWorkspaces": false.

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,9 @@
     "onWebviewPanel:latex-workshop-pdf"
   ],
   "main": "./out/src/main.js",
+  "capabilities": {
+    "virtualWorkspaces": false
+  },
   "contributes": {
     "languages": [
       {


### PR DESCRIPTION
Set `"virtualWorkspaces": false`. See:

- https://github.com/microsoft/vscode/wiki/Virtual-Workspaces
- microsoft/vscode/issues/122836
- https://code.visualstudio.com/updates/v1_56#_define-whether-your-extension-supports-a-virtual-workspace

To support `virtualWorkspaces`, we have to use `vscode.fs` instead of `fs` provided by Node.js, which is related to https://github.com/James-Yu/LaTeX-Workshop/pull/2228#issuecomment-670987337.