### PR TITLE
Set "untrustedWorkspaces": {  "supported": false }

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,10 @@
   ],
   "main": "./out/src/main.js",
   "capabilities": {
-    "virtualWorkspaces": false
+    "virtualWorkspaces": false,
+    "untrustedWorkspaces": {
+      "supported": false
+    }
   },
   "contributes": {
     "languages": [


### PR DESCRIPTION
Set 

```json
"untrustedWorkspaces": {
    "supported": false
}
```

The extension will be disabled in untrusted workspaces.

- https://code.visualstudio.com/updates/v1_56#_workspace-trust-extension-api
- https://github.com/microsoft/vscode/issues/120251

To support enbling LaTeX Workshop in untrusted workspaces, we have to disable magic comments and other features in untrusted workspaces.
