### PR TITLE
Fix auto build on save with subfiles

### DIFF
--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -781,22 +781,36 @@ export class Manager {
         this.pdfWatcher.watchPdfFile(pdfPath)
     }
 
-    buildOnFileChanged(file: string, bibChanged: boolean = false) {
-        const configuration = vscode.workspace.getConfiguration('latex-workshop')
-        if (configuration.get('latex.autoBuild.run') as string !== BuildEvents.onFileChange) {
-            return
-        }
+    private autoBuild(file: string, bibChanged: boolean ) {
         if (this.extension.builder.disableBuildAfterSave) {
             this.extension.logger.addLogMessage('Auto Build Run is temporarily disabled during a second.')
             return
         }
         this.extension.logger.addLogMessage(`Auto build started detecting the change of a file: ${file}`)
+        const configuration = vscode.workspace.getConfiguration('latex-workshop')
         if (!bibChanged && this.localRootFile && configuration.get('latex.rootFile.useSubFile')) {
             this.extension.commander.build(true, this.localRootFile, this.rootFileLanguageId)
         } else {
             this.extension.commander.build(true, this.rootFile, this.rootFileLanguageId)
         }
     }
+
+    buildOnFileChanged(file: string, bibChanged: boolean = false) {
+        const configuration = vscode.workspace.getConfiguration('latex-workshop')
+        if (configuration.get('latex.autoBuild.run') as string !== BuildEvents.onFileChange) {
+            return
+        }
+        this.autoBuild(file, bibChanged)
+    }
+
+    buildOnSave(file: string) {
+        const configuration = vscode.workspace.getConfiguration('latex-workshop')
+        if (configuration.get('latex.autoBuild.run') as string !== BuildEvents.onSave) {
+            return
+        }
+        this.autoBuild(file, false)
+    }
+
 
     // This function updates all completers upon tex-file changes.
     private updateCompleterOnChange(file: string) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -159,7 +159,7 @@ export function activate(context: vscode.ExtensionContext) {
                     return
                 }
                 extension.logger.addLogMessage(`Auto build started on saving file: ${e.fileName}`)
-                extension.commander.build(true)
+                extension.manager.buildOnSave(e.fileName)
             }
         }
     }))

--- a/test/build.test.ts
+++ b/test/build.test.ts
@@ -248,7 +248,7 @@ suite('Build TeX files test suite', () => {
         })
     })
 
-    runTestWithFixture('fixture031', 'auto build with subfiles', async () => {
+    runTestWithFixture('fixture031', 'auto build with subfiles and onFileChange', async () => {
         const fixtureDir = getFixtureDir()
         const texFileName = 's.tex'
         const pdfFileName = 's.pdf'
@@ -283,7 +283,7 @@ suite('Build TeX files test suite', () => {
         })
     })
 
-    runTestWithFixture('fixture033', 'auto build main.tex when editing s.tex', async () => {
+    runTestWithFixture('fixture033', 'auto build main.tex when editing s.tex with onFileChange', async () => {
         const fixtureDir = getFixtureDir()
         const texFileName = 's.tex'
         const pdfFileName = 'main.pdf'
@@ -416,6 +416,43 @@ suite('Build TeX files test suite', () => {
         await sleep(5000)
         assert.ok( !fs.existsSync(pdfFilePath) )
     })
+
+    runTestWithFixture('fixture039', 'auto build with subfiles and onSave', async () => {
+        const fixtureDir = getFixtureDir()
+        const texFileName = 's.tex'
+        const pdfFileName = 's.pdf'
+        const pdfFilePath = path.join(fixtureDir, 'sub', pdfFileName)
+        await assertPdfIsGenerated(pdfFilePath, async () => {
+            const texFilePath = vscode.Uri.file(path.join(fixtureDir, 'sub', texFileName))
+            const doc = await vscode.workspace.openTextDocument(texFilePath)
+            const editor = await vscode.window.showTextDocument(doc)
+            await waitLatexWorkshopActivated()
+            await waitRootFileFound()
+            await editor.edit((builder) => {
+                builder.insert(new vscode.Position(2, 0), ' ')
+            })
+            await doc.save()
+        })
+    }, () => isDockerEnabled())
+
+    runTestWithFixture('fixture03a', 'auto build main.tex when editing s.tex with onSave', async () => {
+        const fixtureDir = getFixtureDir()
+        const texFileName = 's.tex'
+        const pdfFileName = 'main.pdf'
+        const pdfFilePath = path.join(fixtureDir, pdfFileName)
+        await assertPdfIsGenerated(pdfFilePath, async () => {
+            const texFilePath = vscode.Uri.file(path.join(fixtureDir, 'sub', texFileName))
+            const doc = await vscode.workspace.openTextDocument(texFilePath)
+            const editor = await vscode.window.showTextDocument(doc)
+            await waitLatexWorkshopActivated()
+            await waitRootFileFound()
+            await editor.edit((builder) => {
+                builder.insert(new vscode.Position(2, 0), ' ')
+            })
+            await doc.save()
+        })
+    })
+
 
     //
     // Multi-file project build tests

--- a/test/fixtures/build/fixture039/.vscode/settings.json
+++ b/test/fixtures/build/fixture039/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "latex-workshop.latex.rootFile.useSubFile": true,
+    "latex-workshop.latex.autoBuild.run": "onSave"
+}

--- a/test/fixtures/build/fixture039/main.tex
+++ b/test/fixtures/build/fixture039/main.tex
@@ -1,0 +1,6 @@
+\documentclass{article}
+\usepackage{subfiles}
+\begin{document}
+main main main
+\subfile{sub/s}
+\end{document}

--- a/test/fixtures/build/fixture039/sub/s.tex
+++ b/test/fixtures/build/fixture039/sub/s.tex
@@ -1,0 +1,4 @@
+\documentclass[../main.tex]{subfiles}
+\begin{document}
+sub sub sub
+\end{document}

--- a/test/fixtures/build/fixture03a/.vscode/settings.json
+++ b/test/fixtures/build/fixture03a/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "latex-workshop.latex.rootFile.useSubFile": false,
+    "latex-workshop.latex.autoBuild.run": "onSave"
+}

--- a/test/fixtures/build/fixture03a/main.tex
+++ b/test/fixtures/build/fixture03a/main.tex
@@ -1,0 +1,6 @@
+\documentclass{article}
+\usepackage{subfiles}
+\begin{document}
+main main main
+\subfile{sub/s}
+\end{document}

--- a/test/fixtures/build/fixture03a/sub/s.tex
+++ b/test/fixtures/build/fixture03a/sub/s.tex
@@ -1,0 +1,4 @@
+\documentclass[../main.tex]{subfiles}
+\begin{document}
+sub sub sub
+\end{document}


### PR DESCRIPTION
Close #2662

With `latex-workshop.latex.autoBuild.run=onSave`, automatic building did not respect `latex-workshop.latex.rootFile.useSubFile`.    For automatic build, we must not directly call `commander.build`.  

This PR adds more tests with `latex-workshop.latex.autoBuild.run=onSave` on top of `latex-workshop.latex.autoBuild.run=onFileChange` and refactors automatic building.