### PR TITLE
Fix typo, highlight `\iftrue`, not `\ftrue`

### DIFF
--- a/syntax/TeX.tmLanguage.json
+++ b/syntax/TeX.tmLanguage.json
@@ -14,7 +14,7 @@
           "name": "punctuation.definition.keyword.tex"
         }
       },
-      "match": "(\\\\)(backmatter|else|fi|frontmatter|ftrue|mainmatter|if(case|cat|dim|eof|false|hbox|hmode|inner|mmode|num|odd|undefined|vbox|vmode|void|x)?)\\b",
+      "match": "(\\\\)(backmatter|else|fi|frontmatter|mainmatter|if(case|cat|dim|eof|false|hbox|hmode|inner|mmode|num|odd|true|undefined|vbox|vmode|void|x)?)\\b",
       "name": "keyword.control.tex"
     },
     {


### PR DESCRIPTION
This PR will fix a typo found in syntax file for TeX language, in which the TeX primitive should be `\iftrue`, not `\ftrue`. Note the missing leading `i`.