### PR TITLE
Migration to supporting virtual workspaces.

### DIFF
--- a/src/components/lwfs.ts
+++ b/src/components/lwfs.ts
@@ -1,0 +1,15 @@
+import * as vscode from 'vscode'
+import type {Extension} from '../main'
+
+export class LwFileSystem {
+    readonly extension: Extension
+
+    constructor(extension: Extension) {
+        this.extension = extension
+    }
+
+    isLocalUri(uri: vscode.Uri): boolean {
+        return uri.scheme === 'file'
+    }
+
+}

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -160,10 +160,14 @@ export class Manager {
             if (ret.type === 'filePath') {
                 return ret.filePath
             } else {
-                return ret.uri.fsPath
+                if (ret.uri.scheme === 'file') {
+                    return ret.uri.fsPath
+                } else {
+                    return
+                }
             }
         } else {
-            return undefined
+            return
         }
     }
 

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -163,6 +163,7 @@ export class Manager {
                 if (ret.uri.scheme === 'file') {
                     return ret.uri.fsPath
                 } else {
+                    this.extension.logger.addLogMessage(`The file cannot be used as the root file: ${ret.uri.toString(true)}`)
                     return
                 }
             }
@@ -326,6 +327,7 @@ export class Manager {
             return undefined
         }
         if (!this.extension.lwfs.isLocalUri(vscode.window.activeTextEditor.document.uri)) {
+            this.extension.logger.addLogMessage(`The active document cannot be used as the root file: ${vscode.window.activeTextEditor.document.uri.toString(true)}`)
             return undefined
         }
         if (this.getIncludedTeX().includes(vscode.window.activeTextEditor.document.fileName)) {
@@ -339,6 +341,7 @@ export class Manager {
             return undefined
         }
         if (!this.extension.lwfs.isLocalUri(vscode.window.activeTextEditor.document.uri)) {
+            this.extension.logger.addLogMessage(`The active document cannot be used as the root file: ${vscode.window.activeTextEditor.document.uri.toString(true)}`)
             return undefined
         }
         const regex = /\\begin{document}/m
@@ -375,6 +378,7 @@ export class Manager {
             const candidates: string[] = []
             for (const file of files) {
                 if (!this.extension.lwfs.isLocalUri(file)) {
+                    this.extension.logger.addLogMessage(`Skip the file: ${file.toString(true)}`)
                     continue
                 }
                 const flsChildren = this.getTeXChildrenFromFls(file.fsPath)

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import * as utils from './utils/utils'
 import {Commander} from './commander'
 import {LaTeXCommander} from './components/commander'
 import {Logger} from './components/logger'
+import {LwFileSystem} from './components/lwfs'
 import {Manager, BuildEvents} from './components/manager'
 import {Builder} from './components/builder'
 import {Viewer} from './components/viewer'
@@ -329,6 +330,7 @@ export class Extension {
     packageInfo: { version?: string } = {}
     readonly extensionRoot: string
     readonly logger: Logger
+    readonly lwfs: LwFileSystem
     readonly commander: Commander
     readonly configuration: Configuration
     readonly manager: Manager
@@ -365,6 +367,7 @@ export class Extension {
         this.logger.addLogMessage(`$PATH: ${process.env.PATH}`)
         this.logger.addLogMessage(`$SHELL: ${process.env.SHELL}`)
         this.configuration = new Configuration(this)
+        this.lwfs = new LwFileSystem(this)
         this.commander = new Commander(this)
         this.manager = new Manager(this)
         this.builder = new Builder(this)


### PR DESCRIPTION
VS Code's ecosystem begins requiring us to adapt to the [virtual workspace](https://github.com/microsoft/vscode/wiki/Virtual-Workspaces). To support it, we have to rewrite the code based on Node.js's `fs` module to the one based on `vscode.workspace.fs`. We should gradually support it. Not at once.

This PR is the first step of the adaption. In this PR, we don't support the virtual workspace at all. We just prepare for it.

### Introducing `Manager.rootFileUri`

When we make some feature to adapt to the virtual workspace, we rewrite the code with `Manager.rootFileUri` instead of `Manager.rootFile`.

We have changed the type of values stored in `Manager.rootFiles` from `string` to `RootFileType`. `Manager.rootFile` can work with the root file saved through `Manager.rootFileUri`.

https://github.com/James-Yu/LaTeX-Workshop/blob/98364b48752064805b36e6fd97f001a9130c484a/src/components/manager.ts#L157-L172

### Making the root file `undefined` if the active document is not on the local filesystem. 

At this moment, we don't support the virtual workspace. So, it should be `undefined`.

### Adding `src/components/lwfs.ts`

`vscode.workspace.fs` cannot read files outside the current workspace even if they are on the local filesystem. So, we have to treat the local filesystem specially. We will add methods to `src/components/lwfs.ts` and use them for the purpose.

### Changing `workspaceRootDir` to `workspaceRootDirUri`

Store `workspaceRootDir` as a URI string.

### Testing 

I have published an [extension](https://marketplace.visualstudio.com/items?itemName=tamuratak.vscode-localfsprovider) to test supporting the virtual workspace. It implements a filesystem provider with Node.js's `fs` module. With the extension, we can open local files in the virtual workspace with a URI beginning with`localfs://`. Please execute `LocalFS: Setup Workspace`.

We can also use [MemFS](https://marketplace.visualstudio.com/items?itemName=jrieken.vscode-memfs) by the member of the VS Code dev team.

We can also sue Remote Repositories.

- https://code.visualstudio.com/updates/v1_56#_remote-repositories-remotehub
- https://github.com/microsoft/vscode/wiki/Virtual-Workspaces#run-your-extension-against-a-virtual-workspace

