### PR TITLE
2671-strip-verbatim

### DIFF
--- a/package.json
+++ b/package.json
@@ -1000,6 +1000,14 @@
           "default": [],
           "markdownDescription": "List of directories where to look for extra input `.tex` files. \nAbsolute paths are required. You may also need to set the environment variable `TEXINPUTS` properly for the LaTeX compiler to find the `.tex` files, see the `env` parameter of [recipes](https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#latex-recipes)."
         },
+        "latex-workshop.latex.verbatimEnvs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": ["verbatim", "lstlisting", "minted"],
+          "markdownDescription": "List environments with verbatim-like content. These environments are stripped off the `.tex` files before any parsing occurs. Note that this variable has no effect on syntax highlighting."
+        },
         "latex-workshop.kpsewhich.path": {
           "type": "string",
           "default": "kpsewhich",

--- a/src/components/envpair.ts
+++ b/src/components/envpair.ts
@@ -43,7 +43,7 @@ export class EnvPair {
     }
 
     private tokenizeLine(document: vscode.TextDocument, pos: vscode.Position): MatchEnv | null {
-        const line = utils.stripComments(document.lineAt(pos).text)
+        const line = utils.stripCommentsAndVerbatim(document.lineAt(pos).text)
         const ind = pos.character
         if (ind > line.length) {
             return null
@@ -105,7 +105,7 @@ export class EnvPair {
             return this.delimiters[key].end
         })
         while (true) {
-            line = utils.stripComments(line)
+            line = utils.stripCommentsAndVerbatim(line)
             let allMatches = regexpAllMatches(line, patRegexp)
             if (dir === -1) {
                 allMatches = allMatches.reverse()

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -357,7 +357,7 @@ export class Manager {
             return undefined
         }
         const regex = /\\begin{document}/m
-        const content = utils.stripComments(vscode.window.activeTextEditor.document.getText())
+        const content = utils.stripCommentsAndVerbatim(vscode.window.activeTextEditor.document.getText())
         const result = content.match(regex)
         if (result) {
             const rootSubFile = this.finderUtils.findSubFiles(content)
@@ -398,7 +398,7 @@ export class Manager {
                     this.extension.logger.addLogMessage(`Found root file from '.fls': ${file.fsPath}`)
                     return file.fsPath
                 }
-                const content = utils.stripComments(fs.readFileSync(file.fsPath).toString())
+                const content = utils.stripCommentsAndVerbatim(fs.readFileSync(file.fsPath).toString())
                 const result = content.match(regex)
                 if (result) {
                     // Can be a root
@@ -488,7 +488,7 @@ export class Manager {
             }
             return this.cachedContent[cachedFile].content
         }
-        const fileContent = utils.stripComments(fs.readFileSync(file).toString())
+        const fileContent = utils.stripCommentsAndVerbatim(fs.readFileSync(file).toString())
         this.setCachedContent(file, {content: fileContent, element: {}, children: [], bibs: []})
         return fileContent
     }
@@ -548,7 +548,7 @@ export class Manager {
      */
     private getTeXChildren(file: string, baseFile: string, children: string[], content?: string): string[] {
         if (content === undefined) {
-            content = utils.stripComments(fs.readFileSync(file).toString())
+            content = utils.stripCommentsAndVerbatim(fs.readFileSync(file).toString())
         }
 
         // Update children of current file
@@ -865,7 +865,7 @@ export class Manager {
             this.extension.logger.addLogMessage(`Cannot parse a TeX file: ${file}`)
             this.extension.logger.addLogMessage('Fall back to regex-based completion.')
             // Do the update with old style.
-            const contentNoComment = utils.stripComments(content)
+            const contentNoComment = utils.stripCommentsAndVerbatim(content)
             this.extension.completer.reference.update(file, undefined, undefined, contentNoComment)
             this.extension.completer.glossary.update(file, undefined, contentNoComment)
             this.extension.completer.environment.update(file, undefined, undefined, contentNoComment)

--- a/src/main.ts
+++ b/src/main.ts
@@ -231,7 +231,7 @@ export function activate(context: vscode.ExtensionContext): ReturnType<typeof ge
             return
         }
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
-        const content = utils.stripComments(e.document.getText())
+        const content = utils.stripCommentsAndVerbatim(e.document.getText())
         extension.manager.getCachedContent(e.document.fileName).content = content
         if (configuration.get('intellisense.update.aggressive.enabled')) {
             if (updateCompleter) {

--- a/src/providers/completer/input.ts
+++ b/src/providers/completer/input.ts
@@ -26,7 +26,7 @@ export class Input implements IProvider {
     }
 
     getGraphicsPath(filePath: string) {
-        const content = utils.stripComments(fs.readFileSync(filePath, 'utf-8'))
+        const content = utils.stripCommentsAndVerbatim(fs.readFileSync(filePath, 'utf-8'))
         const regex = /\\graphicspath{[\s\n]*((?:{[^{}]*}[\s\n]*)*)}/g
         let result: string[] | null
         do {

--- a/src/providers/preview/mathpreviewlib/newcommandfinder.ts
+++ b/src/providers/preview/mathpreviewlib/newcommandfinder.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode'
 import * as fs from 'fs'
 import {latexParser} from 'latex-utensils'
-import {stripComments} from '../../../utils/utils'
+import {stripCommentsAndVerbatim} from '../../../utils/utils'
 import * as path from 'path'
 
 import type {Extension} from '../../../main'
@@ -97,7 +97,7 @@ export class NewCommandFinder {
         } catch (e) {
             commands = []
             const regex = /(\\(?:(?:(?:(?:re)?new|provide)command|DeclareMathOperator)(\*)?{\\[a-zA-Z]+}(?:\[[^[\]{}]*\])*{.*})|\\(?:def\\[a-zA-Z]+(?:#[0-9])*{.*})|\\DeclarePairedDelimiter{\\[a-zA-Z]+}{[^{}]*}{[^{}]*})/gm
-            const noCommentContent = stripComments(content)
+            const noCommentContent = stripCommentsAndVerbatim(content)
             let result: RegExpExecArray | null
             do {
                 result = regex.exec(noCommentContent)

--- a/src/providers/preview/mathpreviewlib/texmathenvfinder.ts
+++ b/src/providers/preview/mathpreviewlib/texmathenvfinder.ts
@@ -88,7 +88,7 @@ export class TeXMathEnvFinder {
     //             startPos1
     findEndPair(document: vscode.TextDocument | TextDocumentLike, endPat: RegExp, startPos1: vscode.Position): vscode.Position | undefined {
         const currentLine = document.lineAt(startPos1).text.substring(startPos1.character)
-        const l = utils.stripComments(currentLine)
+        const l = utils.stripCommentsAndVerbatim(currentLine)
         let m = l.match(endPat)
         if (m && m.index !== undefined) {
             return new vscode.Position(startPos1.line, startPos1.character + m.index + m[0].length)
@@ -96,7 +96,7 @@ export class TeXMathEnvFinder {
 
         let lineNum = startPos1.line + 1
         while (lineNum <= document.lineCount) {
-            m = utils.stripComments(document.lineAt(lineNum).text).match(endPat)
+            m = utils.stripCommentsAndVerbatim(document.lineAt(lineNum).text).match(endPat)
             if (m && m.index !== undefined) {
                 return new vscode.Position(lineNum, m.index + m[0].length)
             }
@@ -110,7 +110,7 @@ export class TeXMathEnvFinder {
     //  return pos                 endPos1
     private findBeginPair(document: vscode.TextDocument | TextDocumentLike, beginPat: RegExp, endPos1: vscode.Position, limit: number): vscode.Position | undefined {
         const currentLine = document.lineAt(endPos1).text.substr(0, endPos1.character)
-        let l = utils.stripComments(currentLine)
+        let l = utils.stripCommentsAndVerbatim(currentLine)
         let m = l.match(beginPat)
         if (m && m.index !== undefined) {
             return new vscode.Position(endPos1.line, m.index)
@@ -119,7 +119,7 @@ export class TeXMathEnvFinder {
         let i = 0
         while (lineNum >= 0 && i < limit) {
             l = document.lineAt(lineNum).text
-            l = utils.stripComments(l)
+            l = utils.stripCommentsAndVerbatim(l)
             m = l.match(beginPat)
             if (m && m.index !== undefined) {
                 return new vscode.Position(lineNum, m.index)

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -40,7 +40,10 @@ export function stripComments(text: string): string {
 export function stripCommentsAndVerbatim(text: string): string {
     let content = stripComments(text)
     content = content.replace(/\\verb\*?([^a-zA-Z0-9]).*?\1/, '')
-    const verbatimPattern = '\\\\begin{verbatim}.*?\\\\end{verbatim}'
+    const configuration = vscode.workspace.getConfiguration('latex-workshop')
+    const verbatimEnvs = configuration.get('latex.verbatimEnvs') as string[]
+    const verbatimAlt = verbatimEnvs.join('|')
+    const verbatimPattern = `\\\\begin{(${verbatimAlt})}.*?\\\\end{\\1}`
     const reg = RegExp(verbatimPattern, 'gms')
     // Remove verbatim envs. It fails with nested verbatim envs.
     content = content.replace(reg, (match, ..._args) => {
@@ -64,7 +67,7 @@ export function getLongestBalancedString(s: string): string {
                 nested++
                 break
             case '}':
-                nested --
+                nested--
                 break
             case '\\':
                 // skip an escaped character

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -39,9 +39,10 @@ export function stripComments(text: string): string {
  */
 export function stripCommentsAndVerbatim(text: string): string {
     let content = stripComments(text)
-    content = content.replace(/\\verb\*?([^a-zA-Z0-9]).*\1/, '')
-    const verbatimPattern = '\\\\begin{verbatim}.*\\\\end{verbatim}'
+    content = content.replace(/\\verb\*?([^a-zA-Z0-9]).*?\1/, '')
+    const verbatimPattern = '\\\\begin{verbatim}.*?\\\\end{verbatim}'
     const reg = RegExp(verbatimPattern, 'gms')
+    // Remove verbatim envs. It fails with nested verbatim envs.
     content = content.replace(reg, (match, ..._args) => {
         const len = Math.max(match.split('\n').length, 1)
         return '\n'.repeat(len - 1)


### PR DESCRIPTION
Close #2671

- Make sure to remove any verbatim parts before scanning the `.tex` content. For the moment, it breaks if there are nested verbatim environments.
- Make the list of verbatim-like environments configurable.

Once this PR is merged, I will investigate how the `content` property can be removed from `manager. cachedContent`.