### PR TITLE
Remove quote escaping for bst language

### DIFF
--- a/syntax/BibTeX-style.tmLanguage.json
+++ b/syntax/BibTeX-style.tmLanguage.json
@@ -101,17 +101,6 @@
         }
       ]
     },
-    "string": {
-      "name": "string.quoted.double.bst",
-      "begin": "\\\"",
-      "end": "\\\"",
-      "patterns": [
-        {
-          "name": "constant.character.escape.bst",
-          "match": "(?<!\\\\)\\\\\\\""
-        }
-      ]
-    },
     "number": {
       "name": "constant.numeric.bst",
       "match": "\\#-?\\d+\\b"


### PR DESCRIPTION
An earlier issue (#2429) mentioned the syntax of the bst. I find the fix is actually incorrect because BibTeX does not process quote escaping at all. Thus the `string.quoted.double.bst` should be removed. Besides, the original mistake was added by me.

The following is an example.

`test.bst`:
```
ENTRY { field }{}{}

FUNCTION {main}
{ "a\" top$ }

READ

EXECUTE{main}
```

`test.aux`:
```latex
\citation{*}
\bibstyle{test}
\bibdata{test}
```

`test.bib` is empty.

Then `bibtex test` gives:
```
This is BibTeX, Version 0.99d (TeX Live 2021)
The top-level auxiliary file: test.aux
The style file: test.bst
Database file #1: test.bib
a\
```

If the `"a\"` is changed to `"a\""`, some errors will be raised:
```
This is BibTeX, Version 0.99d (TeX Live 2021)
The top-level auxiliary file: test.aux
The style file: test.bst
""" can't follow a literal---line 4 of file test.bst
Database file #1: test.bib
You can't pop an empty literal stack
while executing---line 8 of file test.bst
Empty literal
(There were 2 error messages)
```
