### PR TITLE
Adopt a more lazy approach to read tex content

### DIFF
--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -846,7 +846,7 @@ export class Manager {
 
     // This function updates all completers upon tex-file changes.
     private updateCompleterOnChange(file: string) {
-        fs.promises.readFile(file).then(buffer => buffer.toString()).then(content => this.updateCompleter(file, content))
+        this.updateCompleter(file, this.getDirtyContent(file))
         this.extension.completer.input.getGraphicsPath(file)
     }
 

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -139,6 +139,13 @@ export class Manager {
         }
     }
 
+    updateCachedContent(document: vscode.TextDocument) {
+        const cache = this.getCachedContent(document.fileName)
+        if (cache !== undefined) {
+            cache.content = document.getText()
+        }
+    }
+
     /**
      * Returns the output directory developed according to the input tex path
      * and 'latex.outDir' config. If `texPath` is `undefined`, the default root

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -29,7 +29,7 @@ interface Content {
          * The dirty (under editing) content of the LaTeX file if opened in vscode,
          * the content on disk otherwise.
          */
-        content: string | null,
+        content: string | undefined,
         /**
          * Completion item and other items for the LaTeX file.
          */
@@ -135,7 +135,7 @@ export class Manager {
 
     private invalidateCachedContent(filePath: string) {
         if (filePath in this.cachedContent) {
-            this.cachedContent[filePath].content = null
+            this.cachedContent[filePath].content = undefined
         }
     }
 

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -495,7 +495,7 @@ export class Manager {
                 return cache.content
             }
         }
-        const fileContent = utils.stripCommentsAndVerbatim(fs.readFileSync(file).toString())
+        const fileContent = fs.readFileSync(file).toString()
         this.setCachedContent(file, {content: fileContent, element: {}, children: [], bibs: []})
         return fileContent
     }
@@ -534,7 +534,7 @@ export class Manager {
             this.fileWatcher.add(file)
             this.filesWatched.push(file)
         }
-        const content = this.getDirtyContent(file)
+        const content = utils.stripCommentsAndVerbatim(this.getDirtyContent(file))
         this.cachedContent[file].children = []
         this.cachedContent[file].bibs = []
         this.parseInputFiles(content, file, baseFile)
@@ -846,8 +846,9 @@ export class Manager {
 
     // This function updates all completers upon tex-file changes.
     private updateCompleterOnChange(file: string) {
-        this.updateCompleter(file, this.getDirtyContent(file))
-        this.extension.completer.input.getGraphicsPath(file)
+        const content = this.getDirtyContent(file)
+        this.updateCompleter(file, content)
+        this.extension.completer.input.getGraphicsPath(content)
     }
 
     /**

--- a/src/components/section.ts
+++ b/src/components/section.ts
@@ -121,8 +121,7 @@ export class Section {
      * @param pos the current position in the document
      * @param doc the text document
      */
-    private searchLevelUp(levels: string[], pos: vscode.Position, doc: vscode.TextDocument): MatchSection | undefined{
-
+    private searchLevelUp(levels: string[], pos: vscode.Position, doc: vscode.TextDocument): MatchSection | undefined {
         const range = new vscode.Range(new vscode.Position(0, 0), pos.translate(-1, 0))
         const content = stripCommentsAndVerbatim(doc.getText(range)).split('\n')
         const pattern = '\\\\(' + levels.join('|') + ')\\*?(?:\\[.+?\\])?\\{.*?\\}'
@@ -146,7 +145,6 @@ export class Section {
      * @param doc the text document
      */
     private searchLevelDown(levels: string[], pos: vscode.Position, doc: vscode.TextDocument): vscode.Position {
-
         const range = new vscode.Range(pos, new vscode.Position(doc.lineCount, 0))
         const content = stripCommentsAndVerbatim(doc.getText(range)).split('\n')
         const pattern = '\\\\(?:(' + levels.join('|') + ')\\*?(?:\\[.+?\\])?\\{.*?\\})|appendix|\\\\end{document}'

--- a/src/main.ts
+++ b/src/main.ts
@@ -231,7 +231,8 @@ export function activate(context: vscode.ExtensionContext): ReturnType<typeof ge
             return
         }
         extension.linter.lintActiveFileIfEnabledAfterInterval()
-        if (extension.manager.getCachedContent(e.document.fileName) === undefined) {
+        const cache = extension.manager.getCachedContent(e.document.fileName)
+        if (cache === undefined) {
             return
         }
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
@@ -241,10 +242,7 @@ export function activate(context: vscode.ExtensionContext): ReturnType<typeof ge
             }
             updateCompleter = setTimeout(() => {
                 const content = utils.stripCommentsAndVerbatim(e.document.getText())
-                const cache = extension.manager.getCachedContent(e.document.fileName)
-                if (cache !== undefined) {
-                    cache.content = content
-                }
+                cache.content = content
                 const file = e.document.uri.fsPath
                 extension.manager.parseFileAndSubs(file, extension.manager.rootFile)
                 extension.manager.updateCompleter(file, content)

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,6 @@ import * as vscode from 'vscode'
 import * as path from 'path'
 import * as process from 'process'
 
-import * as utils from './utils/utils'
 import {Commander} from './commander'
 import {LaTeXCommander} from './components/commander'
 import {Logger} from './components/logger'
@@ -191,7 +190,7 @@ export function activate(context: vscode.ExtensionContext): ReturnType<typeof ge
 
     context.subscriptions.push(vscode.workspace.onDidSaveTextDocument( (e: vscode.TextDocument) => {
         if (extension.manager.hasTexId(e.languageId)) {
-            const content = utils.stripCommentsAndVerbatim(e.getText())
+            const content = e.getText()
             const cache = extension.manager.getCachedContent(e.fileName)
             if (cache !== undefined) {
                 cache.content = content
@@ -241,7 +240,7 @@ export function activate(context: vscode.ExtensionContext): ReturnType<typeof ge
                 clearTimeout(updateCompleter)
             }
             updateCompleter = setTimeout(() => {
-                const content = utils.stripCommentsAndVerbatim(e.document.getText())
+                const content = e.document.getText()
                 cache.content = content
                 const file = e.document.uri.fsPath
                 extension.manager.parseFileAndSubs(file, extension.manager.rootFile)

--- a/src/main.ts
+++ b/src/main.ts
@@ -190,11 +190,7 @@ export function activate(context: vscode.ExtensionContext): ReturnType<typeof ge
 
     context.subscriptions.push(vscode.workspace.onDidSaveTextDocument( (e: vscode.TextDocument) => {
         if (extension.manager.hasTexId(e.languageId)) {
-            const content = e.getText()
-            const cache = extension.manager.getCachedContent(e.fileName)
-            if (cache !== undefined) {
-                cache.content = content
-            }
+            extension.manager.updateCachedContent(e)
             extension.linter.lintRootFileIfEnabled()
             extension.structureProvider.refresh()
             extension.structureProvider.update()
@@ -240,8 +236,8 @@ export function activate(context: vscode.ExtensionContext): ReturnType<typeof ge
                 clearTimeout(updateCompleter)
             }
             updateCompleter = setTimeout(() => {
+                extension.manager.updateCachedContent(e.document)
                 const content = e.document.getText()
-                cache.content = content
                 const file = e.document.uri.fsPath
                 extension.manager.parseFileAndSubs(file, extension.manager.rootFile)
                 extension.manager.updateCompleter(file, content)

--- a/src/providers/completer/input.ts
+++ b/src/providers/completer/input.ts
@@ -5,6 +5,7 @@ import * as micromatch from 'micromatch'
 
 import type {Extension} from '../../main'
 import type {IProvider} from './interface'
+import {stripCommentsAndVerbatim} from '../../utils/utils'
 
 const ignoreFiles = ['**/.vscode', '**/.vscodeignore', '**/.gitignore']
 
@@ -24,12 +25,17 @@ export class Input implements IProvider {
         })
     }
 
-    getGraphicsPath(filePath: string) {
-        const content = this.extension.manager.getDirtyContent(filePath)
+    /**
+     * Set the graphics path
+     *
+     * @param content the content to be parsed for graphicspath
+     */
+    getGraphicsPath(content: string) {
         const regex = /\\graphicspath{[\s\n]*((?:{[^{}]*}[\s\n]*)*)}/g
+        const noVerbContent = stripCommentsAndVerbatim(content)
         let result: string[] | null
         do {
-            result = regex.exec(content)
+            result = regex.exec(noVerbContent)
             if (result) {
                 for (const dir of result[1].split(/\{|\}/).filter(s => s.replace(/^\s*$/, ''))) {
                     if (this.graphicsPath.includes(dir)) {

--- a/src/providers/completer/input.ts
+++ b/src/providers/completer/input.ts
@@ -2,7 +2,6 @@ import * as vscode from 'vscode'
 import * as fs from 'fs'
 import * as path from 'path'
 import * as micromatch from 'micromatch'
-import * as utils from '../../utils/utils'
 
 import type {Extension} from '../../main'
 import type {IProvider} from './interface'
@@ -26,7 +25,7 @@ export class Input implements IProvider {
     }
 
     getGraphicsPath(filePath: string) {
-        const content = utils.stripCommentsAndVerbatim(fs.readFileSync(filePath, 'utf-8'))
+        const content = this.extension.manager.getDirtyContent(filePath)
         const regex = /\\graphicspath{[\s\n]*((?:{[^{}]*}[\s\n]*)*)}/g
         let result: string[] | null
         do {

--- a/src/providers/preview/mathpreviewlib/newcommandfinder.ts
+++ b/src/providers/preview/mathpreviewlib/newcommandfinder.ts
@@ -74,7 +74,7 @@ export class NewCommandFinder {
             if (cache === undefined) {
                 continue
             }
-            const content = cache.content
+            const content = this.extension.manager.getDirtyContent(tex)
             commands = commands.concat(await this.findNewCommand(content))
         }
         return commandsInConfigFile + '\n' + this.postProcessNewCommands(commands.join(''))

--- a/src/providers/preview/mathpreviewlib/newcommandfinder.ts
+++ b/src/providers/preview/mathpreviewlib/newcommandfinder.ts
@@ -75,6 +75,9 @@ export class NewCommandFinder {
                 continue
             }
             const content = this.extension.manager.getDirtyContent(tex)
+            if (content === undefined) {
+                continue
+            }
             commands = commands.concat(await this.findNewCommand(content))
         }
         return commandsInConfigFile + '\n' + this.postProcessNewCommands(commands.join(''))

--- a/src/providers/structure.ts
+++ b/src/providers/structure.ts
@@ -81,6 +81,9 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
         }
 
         let content = this.extension.manager.getDirtyContent(filePath)
+        if (!content) {
+            return children
+        }
         content = utils.stripCommentsAndVerbatim(content)
         const endPos = content.search(/\\end{document}/gm)
         if (endPos > -1) {

--- a/src/providers/structure.ts
+++ b/src/providers/structure.ts
@@ -1,5 +1,4 @@
 import * as vscode from 'vscode'
-import * as fs from 'fs'
 
 import type { Extension } from '../main'
 import * as utils from '../utils/utils'
@@ -81,7 +80,7 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
             return rootStack.length === 0
         }
 
-        let content = fs.readFileSync(filePath, 'utf-8')
+        let content = this.extension.manager.getDirtyContent(filePath)
         content = utils.stripCommentsAndVerbatim(content)
         const endPos = content.search(/\\end{document}/gm)
         if (endPos > -1) {


### PR DESCRIPTION
Following https://github.com/James-Yu/LaTeX-Workshop/issues/2671#issuecomment-835562749, I have had a closer look at how `cachedContent[file].content` is set/used. 

- If `file` is opened in a vscode `editor`, the content is read using `TextDocument.getText`, which uses an internal cache mechanism https://github.com/Microsoft/vscode/blob/166efae36645bc787afc8bbfb12d8ac5adda8ead/src/vs/editor/common/model/mirrorTextModel.ts#L58-L80

     The cached gets invalidated when a change event is fired. Hence, calling `getText` repeatedly is harmless as long as the editor (buffer) is not modified.
- If the file is not opened inside vscode, the file content is read via `fs.readFile`. I doubt that this function uses an internal cache and we call it several times in a row with no reason. For instance, https://github.com/James-Yu/LaTeX-Workshop/blob/de2bd02bc45d4b2c7615fcc8e13a12bac57632bc/src/components/manager.ts#L776-L784

    - In `this.parseFileAndSubs`, we call `this.getDirtyContent(file, true)`, which reads the content from disk
    - The following line,`this.updateCompleterOnChange(file)` calls `fs.promises.readFile(file)` again. https://github.com/James-Yu/LaTeX-Workshop/blob/de2bd02bc45d4b2c7615fcc8e13a12bac57632bc/src/components/manager.ts#L841-L844 and `this.extension.completer.input.getGraphicsPath` reads the file from disk once more https://github.com/James-Yu/LaTeX-Workshop/blob/71f66741ce3bcd9c52a0a44e8d69d0146951bf2d/src/providers/completer/input.ts#L28-L29
 

This PR  implements a lazy update of `cachedContent[file].content` (or at least lazier than it used to be) and uses `getDirtyContent` to access a `tex` buffer/file content instead of directly calling `fs.readFile`.

