### PR TITLE
Change Citation.getEntryDict to Citation.getEntry

### DIFF
--- a/src/components/parser/biblogparser.ts
+++ b/src/components/parser/biblogparser.ts
@@ -90,10 +90,10 @@ export class BibLogParser {
     }
 
     private findKeyLocation(key: string): {file: string, line: number} | undefined {
-        const cites = this.extension.completer.citation.getEntryDict()
-        if (key in cites) {
-            const file = cites[key].file
-            const line = cites[key].position.line + 1
+        const entry = this.extension.completer.citation.getEntry(key)
+        if (entry) {
+            const file = entry.file
+            const line = entry.position.line + 1
             return {file, line}
         } else {
             this.extension.logger.addLogMessage(`Cannot find key when parsing BibTeX log: ${key}`)

--- a/src/providers/completer/citation.ts
+++ b/src/providers/completer/citation.ts
@@ -120,11 +120,10 @@ export class Citation implements IProvider {
         })
     }
 
-    getEntryDict(): {[key: string]: Suggestion} {
+    getEntry(key: string): Suggestion | undefined {
         const suggestions = this.updateAll()
-        const entries: {[key: string]: Suggestion} = {}
-        suggestions.forEach(entry => entries[entry.key] = entry)
-        return entries
+        const entry = suggestions.find((elm) => elm.key === key)
+        return entry
     }
 
     /**

--- a/src/providers/definition.ts
+++ b/src/providers/definition.ts
@@ -56,9 +56,8 @@ export class DefinitionProvider implements vscode.DefinitionProvider {
         if (ref) {
             return new vscode.Location(vscode.Uri.file(ref.file), ref.position)
         }
-        const cites = this.extension.completer.citation.getEntryDict()
-        if (token in cites) {
-            const cite = cites[token]
+        const cite = this.extension.completer.citation.getEntry(token)
+        if (cite) {
             return new vscode.Location( vscode.Uri.file(cite.file), cite.position )
         }
         const command = this.extension.completer.command.definedCmds.get(token)

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -54,11 +54,9 @@ export class HoverProvider implements vscode.HoverProvider {
         const cite = this.extension.completer.citation.getEntry(token)
         if (hovCitation && cite) {
             const range = document.getWordRangeAtPosition(position, /\{.*?\}/)
-            if (cite) {
-                const md = cite.documentation || cite.detail
-                if (md) {
-                    return new vscode.Hover(md, range)
-                }
+            const md = cite.documentation || cite.detail
+            if (md) {
+                return new vscode.Hover(md, range)
             }
         }
         return undefined

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -51,10 +51,9 @@ export class HoverProvider implements vscode.HoverProvider {
             const hover = await this.extension.mathPreview.provideHoverOnRef(document, position, refData, token, ctoken)
             return hover
         }
-        const cites = this.extension.completer.citation.getEntryDict()
-        if (hovCitation && token in cites) {
+        const cite = this.extension.completer.citation.getEntry(token)
+        if (hovCitation && cite) {
             const range = document.getWordRangeAtPosition(position, /\{.*?\}/)
-            const cite = cites[token]
             if (cite) {
                 const md = cite.documentation || cite.detail
                 if (md) {


### PR DESCRIPTION
Change `Citation.getEntryDict` to `Citation.getEntry`. Avoid using object to store citations.