### PR TITLE
Change the default of view.pdf.invertMode.enabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -1414,7 +1414,7 @@
             "compat",
             "never"
           ],
-          "default": "compat",
+          "default": "auto",
           "markdownDescription": "Enable the CSS invert filter.",
           "enumDescriptions": [
             "Enable the invert filter when using a dark theme.",


### PR DESCRIPTION
For `view.pdf.invertMode.enabled`, the current default is `compat`: this is invoked, if `invert > 0`.
But the user most certainly wants to switch to the inverted mode (with filter `invert`) immediately when selecting a new _theme_.
That is, the default `auto` is natural (and not the specific value of the variable `invert`).