### PR TITLE
Enable @typescript-eslint/no-floating-promises

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -50,6 +50,7 @@
         "@typescript-eslint/semi": ["error", "never", { "beforeStatementContinuationChars": "always" }],
         "@typescript-eslint/type-annotation-spacing": ["error", { "before": false, "after": true, "overrides": { "arrow": { "before": true, "after": true }}}],
         "@typescript-eslint/consistent-type-assertions": ["error", { "assertionStyle": "as", "objectLiteralTypeAssertions": "never" }],
+        "@typescript-eslint/no-floating-promises": "error",
         "@typescript-eslint/no-invalid-void-type": "error",
         "@typescript-eslint/no-misused-promises": [ "error", { "checksVoidReturn": false } ],
         "no-shadow": "off",

--- a/dev/createSymbolSvgs.ts
+++ b/dev/createSymbolSvgs.ts
@@ -14,7 +14,7 @@ type IMathSymbol = {
 }
 
 let mathJax: typeof import('mathjax-node')
-import('mathjax-node')
+void import('mathjax-node')
     .then(mj => {
         mathJax = mj
         mj.config({

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -125,16 +125,15 @@ export class Commander {
             return
         }
         if (recipe) {
-            this.build(false, undefined, undefined, recipe)
-            return
+            return this.build(false, undefined, undefined, recipe)
         }
-        vscode.window.showQuickPick(recipes.map(candidate => candidate.name), {
+        return vscode.window.showQuickPick(recipes.map(candidate => candidate.name), {
             placeHolder: 'Please Select a LaTeX Recipe'
         }).then(selected => {
             if (!selected) {
                 return
             }
-            this.build(false, undefined, undefined, selected)
+            return this.build(false, undefined, undefined, selected)
         })
     }
 
@@ -168,34 +167,31 @@ export class Commander {
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         const tabEditorGroup = configuration.get('view.pdf.tab.editorGroup') as string
         if (mode === 'browser') {
-            this.extension.viewer.openBrowser(pickedRootFile)
-            return
+            return this.extension.viewer.openBrowser(pickedRootFile)
         } else if (mode === 'tab') {
-            this.extension.viewer.openTab(pickedRootFile, true, tabEditorGroup)
-            return
+            return this.extension.viewer.openTab(pickedRootFile, true, tabEditorGroup)
         } else if (mode === 'external') {
             this.extension.viewer.openExternal(pickedRootFile)
             return
         } else if (mode === 'set') {
-            this.setViewer()
-            return
+            return this.setViewer()
         }
         const promise = (configuration.get('view.pdf.viewer') as string === 'none') ? this.setViewer(): Promise.resolve()
-        promise.then(() => {
+        void promise.then(() => {
             if (!pickedRootFile) {
                 return
             }
             switch (configuration.get('view.pdf.viewer')) {
-                case 'browser':
-                    this.extension.viewer.openBrowser(pickedRootFile)
-                    break
+                case 'browser': {
+                    return this.extension.viewer.openBrowser(pickedRootFile)
+                }
                 case 'tab':
-                default:
-                    this.extension.viewer.openTab(pickedRootFile, true, tabEditorGroup)
-                    break
-                case 'external':
-                    this.extension.viewer.openExternal(pickedRootFile)
-                    break
+                default: {
+                    return this.extension.viewer.openTab(pickedRootFile, true, tabEditorGroup)
+                }
+                case 'external': {
+                    return this.extension.viewer.openExternal(pickedRootFile)
+                }
             }
         })
     }
@@ -215,7 +211,7 @@ export class Commander {
         if (uri === undefined || !uri.fsPath.endsWith('.pdf')) {
             return
         }
-        this.extension.viewer.openTab(uri.fsPath, false, 'current', false)
+        return this.extension.viewer.openTab(uri.fsPath, false, 'current', false)
     }
 
     synctex() {
@@ -286,12 +282,12 @@ export class Commander {
         if (!vscode.window.activeTextEditor || !this.extension.manager.hasTexId(vscode.window.activeTextEditor.document.languageId) ||
             this.extension.manager.rootFile === vscode.window.activeTextEditor.document.fileName) {
             if (this.extension.manager.rootFile) {
-                this.extension.counter.count(this.extension.manager.rootFile)
+                void this.extension.counter.count(this.extension.manager.rootFile)
             } else {
                 this.extension.logger.addLogMessage('WORDCOUNT: No rootFile defined.')
             }
         } else {
-            this.extension.counter.count(vscode.window.activeTextEditor.document.fileName, false)
+            void this.extension.counter.count(vscode.window.activeTextEditor.document.fileName, false)
         }
     }
 
@@ -308,9 +304,9 @@ export class Commander {
         this.extension.logger.addLogMessage(`GOTOSECTION command invoked. Target ${filePath}, line ${lineNumber}`)
         const activeEditor = vscode.window.activeTextEditor
 
-        vscode.workspace.openTextDocument(filePath).then((doc) => {
-            vscode.window.showTextDocument(doc).then(() => {
-                vscode.commands.executeCommand('revealLine', {lineNumber, at: 'center'})
+        void vscode.workspace.openTextDocument(filePath).then((doc) => {
+            void vscode.window.showTextDocument(doc).then(() => {
+                void vscode.commands.executeCommand('revealLine', {lineNumber, at: 'center'})
                 if (activeEditor) {
                     activeEditor.selection = new vscode.Selection(new vscode.Position(lineNumber, 0), new vscode.Position(lineNumber, 0))
                 }
@@ -325,16 +321,16 @@ export class Commander {
         .then(option => {
             switch (option) {
                 case 'Web browser':
-                    configuration.update('view.pdf.viewer', 'browser', true)
-                    vscode.window.showInformationMessage('By default, PDF will be viewed with web browser. This setting can be changed at "latex-workshop.view.pdf.viewer".')
+                    void configuration.update('view.pdf.viewer', 'browser', true)
+                    void vscode.window.showInformationMessage('By default, PDF will be viewed with web browser. This setting can be changed at "latex-workshop.view.pdf.viewer".')
                     break
                 case 'VSCode tab':
-                    configuration.update('view.pdf.viewer', 'tab', true)
-                    vscode.window.showInformationMessage('By default, PDF will be viewed with VSCode tab. This setting can be changed at "latex-workshop.view.pdf.viewer".')
+                    void configuration.update('view.pdf.viewer', 'tab', true)
+                    void vscode.window.showInformationMessage('By default, PDF will be viewed with VSCode tab. This setting can be changed at "latex-workshop.view.pdf.viewer".')
                     break
                 case 'External viewer':
-                    configuration.update('view.pdf.viewer', 'external', true)
-                    vscode.window.showInformationMessage('By default, PDF will be viewed with external viewer. This setting can be changed at "latex-workshop.view.pdf.viewer".')
+                    void configuration.update('view.pdf.viewer', 'external', true)
+                    void vscode.window.showInformationMessage('By default, PDF will be viewed with external viewer. This setting can be changed at "latex-workshop.view.pdf.viewer".')
                     break
                 default:
                     break
@@ -387,12 +383,12 @@ export class Commander {
         if (!vscode.window.activeTextEditor || !this.extension.manager.hasTexId(vscode.window.activeTextEditor.document.languageId)) {
             return
         }
-        this.extension.envPair.closeEnv()
+        return this.extension.envPair.closeEnv()
     }
 
     actions() {
         this.extension.logger.addLogMessage('ACTIONS command invoked.')
-        vscode.commands.executeCommand('workbench.view.extension.latex').then(() => vscode.commands.executeCommand('workbench.action.focusActiveEditorGroup'))
+        return vscode.commands.executeCommand('workbench.view.extension.latex').then(() => vscode.commands.executeCommand('workbench.action.focusActiveEditorGroup'))
     }
 
     /**
@@ -406,8 +402,9 @@ export class Commander {
         }
         const entry = this.snippets.get(name)
         if (entry) {
-            editor.insertSnippet(entry)
+            return editor.insertSnippet(entry)
         }
+        return
     }
 
     /**
@@ -423,9 +420,9 @@ export class Commander {
         }
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         if (!configuration.get('bind.enter.key')) {
-            return editor.edit(() => {
+            return editor.edit(() =>
                 vscode.commands.executeCommand('type', { source: 'keyboard', text: '\n' })
-            })
+            )
         }
         if (modifiers === 'alt') {
             return vscode.commands.executeCommand('editor.action.insertLineAfter')
@@ -436,9 +433,9 @@ export class Commander {
 
         // if the cursor is not followed by only spaces/eol, insert a plain newline
         if (line.text.substr(cursorPos.character).split(' ').length - 1 !== line.range.end.character - cursorPos.character) {
-            return editor.edit(() => {
+            return editor.edit(() =>
                 vscode.commands.executeCommand('type', { source: 'keyboard', text: '\n' })
-            })
+            )
         }
 
         // if the line only consists of \item or \item[], delete its content
@@ -470,9 +467,9 @@ export class Commander {
                          .then(() => { editor.selection = new vscode.Selection(newCursorPos, newCursorPos) })
                          .then(() => { editor.revealRange(editor.selection) })
         }
-        return editor.edit(() => {
+        return editor.edit(() =>
             vscode.commands.executeCommand('type', { source: 'keyboard', text: '\n' })
-        })
+        )
     }
 
     /**
@@ -606,7 +603,7 @@ export class Commander {
             return
         }
         const ast = await this.extension.pegParser.parseLatex(vscode.window.activeTextEditor.document.getText())
-        vscode.workspace.openTextDocument({content: JSON.stringify(ast, null, 2), language: 'json'}).then(doc => vscode.window.showTextDocument(doc))
+        return vscode.workspace.openTextDocument({content: JSON.stringify(ast, null, 2), language: 'json'}).then(doc => vscode.window.showTextDocument(doc))
     }
 
     async devParseBib() {
@@ -614,7 +611,7 @@ export class Commander {
             return
         }
         const ast = await this.extension.pegParser.parseBibtex(vscode.window.activeTextEditor.document.getText())
-        vscode.workspace.openTextDocument({content: JSON.stringify(ast, null, 2), language: 'json'}).then(doc => vscode.window.showTextDocument(doc))
+        return vscode.workspace.openTextDocument({content: JSON.stringify(ast, null, 2), language: 'json'}).then(doc => vscode.window.showTextDocument(doc))
     }
 
     texdoc(pkg?: string) {
@@ -635,7 +632,7 @@ export class Commander {
     }
 
     openMathPreviewPanel() {
-        this.extension.mathPreviewPanel.open()
+        return this.extension.mathPreviewPanel.open()
     }
 
     closeMathPreviewPanel() {

--- a/src/components/counter.ts
+++ b/src/components/counter.ts
@@ -48,13 +48,13 @@ export class Counter {
 
         proc.on('error', err => {
             this.extension.logger.addLogMessage(`Cannot count words: ${err.message}, ${stderr}`)
-            this.extension.logger.showErrorMessage('TeXCount failed. Please refer to LaTeX Workshop Output for details.')
+            void this.extension.logger.showErrorMessage('TeXCount failed. Please refer to LaTeX Workshop Output for details.')
         })
 
         proc.on('exit', exitCode => {
             if (exitCode !== 0) {
                 this.extension.logger.addLogMessage(`Cannot count words, code: ${exitCode}, ${stderr}`)
-                this.extension.logger.showErrorMessage('TeXCount failed. Please refer to LaTeX Workshop Output for details.')
+                void this.extension.logger.showErrorMessage('TeXCount failed. Please refer to LaTeX Workshop Output for details.')
             } else {
                 const words = /Words in text: ([0-9]*)/g.exec(stdout)
                 const floats = /Number of floats\/tables\/figures: ([0-9]*)/g.exec(stdout)
@@ -63,7 +63,7 @@ export class Counter {
                     if (floats && parseInt(floats[1]) > 0) {
                         floatMsg = `and ${floats[1]} float${parseInt(floats[1]) > 1 ? 's' : ''} (tables, figures, etc.) `
                     }
-                    vscode.window.showInformationMessage(`There are ${words[1]} words ${floatMsg}in the ${merge ? 'LaTeX project' : 'opened LaTeX file'}.`)
+                    void vscode.window.showInformationMessage(`There are ${words[1]} words ${floatMsg}in the ${merge ? 'LaTeX project' : 'opened LaTeX file'}.`)
                 }
                 this.extension.logger.addLogMessage(`TeXCount log:\n${stdout}`)
             }

--- a/src/components/envpair.ts
+++ b/src/components/envpair.ts
@@ -240,7 +240,7 @@ export class EnvPair {
             return // bad match
         }
 
-        vscode.workspace.applyEdit(edit).then(success => {
+        void vscode.workspace.applyEdit(edit).then(success => {
             if (success) {
                 switch (action) {
                     case 'cursor':
@@ -297,7 +297,7 @@ export class EnvPair {
             }
         }
 
-        vscode.workspace.applyEdit(edit).then(success => {
+        void vscode.workspace.applyEdit(edit).then(success => {
             if (success) {
                 const beginEnvPos = beginEnv.pos.translate(0, -1)
                 const endEnvPos = endEnv.pos.translate(0, envNameLength + beginEnv.type.length)

--- a/src/components/linter.ts
+++ b/src/components/linter.ts
@@ -74,7 +74,7 @@ export class Linter {
     lintRootFileIfEnabled() {
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         if (configuration.get('chktex.enabled') as boolean) {
-            this.lintRootFile()
+            void this.lintRootFile()
         }
     }
 
@@ -86,7 +86,7 @@ export class Linter {
             if (this.linterTimeout) {
                 clearTimeout(this.linterTimeout)
             }
-            this.linterTimeout = setTimeout(() => { this.lintActiveFile() }, interval)
+            this.linterTimeout = setTimeout(() => this.lintActiveFile(), interval)
         }
     }
 

--- a/src/components/locator.ts
+++ b/src/components/locator.ts
@@ -161,7 +161,7 @@ export class Locator {
                 }
             }
         } else {
-            this.invokeSyncTeXCommandForward(line, character, filePath, pdfFile).then( (record) => {
+            void this.invokeSyncTeXCommandForward(line, character, filePath, pdfFile).then( (record) => {
                 if (pdfFile) {
                     this.extension.viewer.syncTeX(pdfFile, record)
                 }
@@ -340,9 +340,9 @@ export class Locator {
             }
             const pos = new vscode.Position(row, col)
 
-            vscode.window.showTextDocument(doc, viewColumn).then((editor) => {
+            vscode.window.showTextDocument(doc, viewColumn).then( async (editor) => {
                 editor.selection = new vscode.Selection(pos, pos)
-                vscode.commands.executeCommand('revealLine', {lineNumber: row, at: 'center'})
+                await vscode.commands.executeCommand('revealLine', {lineNumber: row, at: 'center'})
                 this.animateToNotify(editor, pos)
             }, (r) => this.extension.logger.logOnRejected(r))
         }, (r) => this.extension.logger.logOnRejected(r))

--- a/src/components/logger.ts
+++ b/src/components/logger.ts
@@ -63,18 +63,18 @@ export class Logger {
         switch (severity) {
             case 'info':
                 if (configuration.get('message.information.show')) {
-                    vscode.window.showInformationMessage(message)
+                    void vscode.window.showInformationMessage(message)
                 }
                 break
             case 'warning':
                 if (configuration.get('message.warning.show')) {
-                    vscode.window.showWarningMessage(message)
+                    void vscode.window.showWarningMessage(message)
                 }
                 break
             case 'error':
             default:
                 if (configuration.get('message.error.show')) {
-                    vscode.window.showErrorMessage(message)
+                    void vscode.window.showErrorMessage(message)
                 }
                 break
         }

--- a/src/components/managerlib/bibwatcher.ts
+++ b/src/components/managerlib/bibwatcher.ts
@@ -35,10 +35,10 @@ export class BibWatcher {
         this.bibWatcher.on('unlink', (file: string) => this.onWatchedBibDeleted(file))
     }
 
-    private onWatchedBibChanged(file: string) {
+    private async onWatchedBibChanged(file: string) {
         this.extension.logger.addLogMessage(`Bib file watcher - file changed: ${file}`)
-        this.extension.completer.citation.parseBibFile(file)
-        this.extension.manager.buildOnFileChanged(file, true)
+        await this.extension.completer.citation.parseBibFile(file)
+        await this.extension.manager.buildOnFileChanged(file, true)
     }
 
     private onWatchedBibDeleted(file: string) {
@@ -50,12 +50,12 @@ export class BibWatcher {
         this.extension.completer.citation.removeEntriesInFile(file)
     }
 
-    watchBibFile(bibPath: string) {
+    async watchBibFile(bibPath: string) {
         if (this.bibWatcher && !this.bibsWatched.includes(bibPath)) {
             this.extension.logger.addLogMessage(`Added to bib file watcher: ${bibPath}`)
             this.bibWatcher.add(bibPath)
             this.bibsWatched.push(bibPath)
-            this.extension.completer.citation.parseBibFile(bibPath)
+            await this.extension.completer.citation.parseBibFile(bibPath)
         }
     }
 

--- a/src/components/mathpreviewpanel.ts
+++ b/src/components/mathpreviewpanel.ts
@@ -88,10 +88,10 @@ export class MathPreviewPanel {
     initializePanel(panel: vscode.WebviewPanel) {
         const disposable = vscode.Disposable.from(
             vscode.workspace.onDidChangeTextDocument( (event) => {
-                this.extension.mathPreviewPanel.update({type: 'edit', event})
+                void this.extension.mathPreviewPanel.update({type: 'edit', event})
             }),
             vscode.window.onDidChangeTextEditorSelection( (event) => {
-                this.extension.mathPreviewPanel.update({type: 'selection', event})
+                void this.extension.mathPreviewPanel.update({type: 'selection', event})
             })
         )
         this.panel = panel
@@ -103,12 +103,12 @@ export class MathPreviewPanel {
         })
         panel.onDidChangeViewState((ev) => {
             if (ev.webviewPanel.visible) {
-                this.update()
+                void this.update()
             }
         })
         panel.webview.onDidReceiveMessage(() => {
             this.extension.logger.addLogMessage('Math preview panel: initialized')
-            this.update()
+            void this.update()
         })
     }
 
@@ -123,7 +123,7 @@ export class MathPreviewPanel {
         if (this.panel) {
             this.close()
         } else {
-            this.open()
+            void this.open()
         }
     }
 

--- a/src/components/section.ts
+++ b/src/components/section.ts
@@ -107,7 +107,7 @@ export class Section {
             }
         }
 
-        vscode.workspace.applyEdit(edit).then(success => {
+        void vscode.workspace.applyEdit(edit).then(success => {
             if (success) {
                 editor.selections = newSelections
             }

--- a/src/components/snippetpanel.ts
+++ b/src/components/snippetpanel.ts
@@ -65,11 +65,11 @@ export class SnippetPanel {
                 editor.insertSnippet(new vscode.SnippetString(message.snippet.replace(/\\\n/g, '\\n'))).then(
                     () => {},
                     err => {
-                        vscode.window.showWarningMessage(`Unable to insert symbol, ${err}`)
+                        void vscode.window.showWarningMessage(`Unable to insert symbol, ${err}`)
                     }
                 )
             } else {
-                vscode.window.showWarningMessage('Unable get document to insert symbol into')
+                void vscode.window.showWarningMessage('Unable get document to insert symbol into')
             }
         }
     }

--- a/src/components/texdoc.ts
+++ b/src/components/texdoc.ts
@@ -31,18 +31,18 @@ export class TeXDoc {
 
         proc.on('error', err => {
             this.extension.logger.addLogMessage(`Cannot run texdoc: ${err.message}, ${stderr}`)
-            this.extension.logger.showErrorMessage('Texdoc failed. Please refer to LaTeX Workshop Output for details.')
+            void this.extension.logger.showErrorMessage('Texdoc failed. Please refer to LaTeX Workshop Output for details.')
         })
 
         proc.on('exit', exitCode => {
             if (exitCode !== 0) {
                 this.extension.logger.addLogMessage(`Cannot find documentation for ${pkg}.`)
-                this.extension.logger.showErrorMessage('Texdoc failed. Please refer to LaTeX Workshop Output for details.')
+                void this.extension.logger.showErrorMessage('Texdoc failed. Please refer to LaTeX Workshop Output for details.')
             } else {
                 const regex = new RegExp(`(no documentation found)|(Documentation for ${pkg} could not be found)`)
                 if (stdout.match(regex) || stderr.match(regex)) {
                     this.extension.logger.addLogMessage(`Cannot find documentation for ${pkg}.`)
-                    this.extension.logger.showErrorMessage(`Cannot find documentation for ${pkg}.`)
+                    void this.extension.logger.showErrorMessage(`Cannot find documentation for ${pkg}.`)
                 } else {
                     this.extension.logger.addLogMessage(`Opening documentation for ${pkg}.`)
                 }
@@ -57,7 +57,7 @@ export class TeXDoc {
             this.runTexdoc(pkg)
             return
         }
-        vscode.window.showInputBox({value: '', prompt: 'Package name'}).then(selectedPkg => {
+        void vscode.window.showInputBox({value: '', prompt: 'Package name'}).then(selectedPkg => {
             if (!selectedPkg) {
                 return
             }
@@ -79,7 +79,7 @@ export class TeXDoc {
         const items: vscode.QuickPickItem[] = packagenames.map( name => {
             return { label: name }
         })
-        vscode.window.showQuickPick(items).then(selectedPkg => {
+        void vscode.window.showQuickPick(items).then(selectedPkg => {
             if (!selectedPkg) {
                 return
             }

--- a/src/components/texmagician.ts
+++ b/src/components/texmagician.ts
@@ -37,11 +37,11 @@ export class TeXMagician {
 
     addTexRoot() {
         // taken from here: https://github.com/DonJayamanne/listFilesVSCode/blob/master/src/extension.ts (MIT licensed, should be fine)
-        vscode.workspace.findFiles('**/*.{tex}').then(files => {
+        void vscode.workspace.findFiles('**/*.{tex}').then(files => {
             const displayFiles = files.map(file => {
                 return { description: file.fsPath, label: this.getFileName(file.fsPath), filePath: file.fsPath }
             })
-            vscode.window.showQuickPick(displayFiles).then(val => {
+            void vscode.window.showQuickPick(displayFiles).then(val => {
                 const editor = vscode.window.activeTextEditor
                 if (!(val && editor)) {
                     return
@@ -58,7 +58,7 @@ export class TeXMagician {
                 const uri = editor.document.uri
                 const edit = new vscode.WorkspaceEdit()
                 edit.set(uri, edits)
-                vscode.workspace.applyEdit(edit)
+                void vscode.workspace.applyEdit(edit)
             })
         })
     }

--- a/src/components/viewer.ts
+++ b/src/components/viewer.ts
@@ -179,7 +179,7 @@ export class Viewer {
      *
      * @param sourceFile The path of a LaTeX file.
      */
-    openBrowser(sourceFile: string) {
+    async openBrowser(sourceFile: string) {
         const url = this.checkViewer(sourceFile, true)
         if (!url) {
             return
@@ -188,10 +188,10 @@ export class Viewer {
         this.createClients(pdfFile)
 
         try {
-            vscode.env.openExternal(vscode.Uri.parse(url))
+            await vscode.env.openExternal(vscode.Uri.parse(url))
             this.extension.logger.addLogMessage(`Open PDF viewer for ${pdfFile}`)
         } catch (e) {
-            vscode.window.showInputBox({
+            void vscode.window.showInputBox({
                 prompt: 'Unable to open browser. Please copy and visit this link.',
                 value: url
             })
@@ -440,7 +440,7 @@ export class Viewer {
                 break
             }
             case 'reverse_synctex': {
-                this.extension.locator.locate(data, data.path)
+                void this.extension.locator.locate(data, data.path)
                 break
             }
             case 'ping': {

--- a/src/providers/bibtexformatter.ts
+++ b/src/providers/bibtexformatter.ts
@@ -39,13 +39,13 @@ export class BibtexFormatter {
             edit.replace(doc.uri, e.range, e.newText)
         })
 
-        vscode.workspace.applyEdit(edit).then(success => {
+        void vscode.workspace.applyEdit(edit).then(success => {
             if (success) {
                 this.duplicatesDiagnostics.set(doc.uri, this.diags)
                 const t1 = performance.now()
                 this.extension.logger.addLogMessage(`BibTeX action successful. Took ${t1 - t0} ms.`)
             } else {
-                this.extension.logger.showErrorMessage('Something went wrong while processing the bibliography.')
+                void this.extension.logger.showErrorMessage('Something went wrong while processing the bibliography.')
             }
         })
 
@@ -81,7 +81,7 @@ export class BibtexFormatter {
             if (error instanceof(Error)) {
                 this.extension.logger.addLogMessage('Bibtex parser failed.')
                 this.extension.logger.addLogMessage(error.message)
-                this.extension.logger.showErrorMessage('Bibtex parser failed with error: ' + error.message)
+                void this.extension.logger.showErrorMessage('Bibtex parser failed with error: ' + error.message)
             }
             return undefined
         })

--- a/src/providers/codeactions.ts
+++ b/src/providers/codeactions.ts
@@ -77,22 +77,22 @@ export class CodeActions implements vs.CodeActionProvider {
             case 39:
             case 42:
                 // In all these cases remove all proceeding whitespace.
-                this.replaceWhitespaceOnLineBefore(document, range.end, '')
+                void this.replaceWhitespaceOnLineBefore(document, range.end, '')
                 break
             case 4:
             case 5:
             case 28:
                 // In all these cases just clear what ChkTeX highlighted.
-                this.replaceRangeWithString(document, range, '')
+                void this.replaceRangeWithString(document, range, '')
                 break
             case 1:
-                this.replaceWhitespaceOnLineBefore(document, range.end.translate(0, -1), '{}')
+                void this.replaceWhitespaceOnLineBefore(document, range.end.translate(0, -1), '{}')
                 break
             case 2:
-                this.replaceWhitespaceOnLineBefore(document, range.end, '~')
+                void this.replaceWhitespaceOnLineBefore(document, range.end, '~')
                 break
             case 6:
-                this.replaceWhitespaceOnLineBefore(document, range.end.translate(0, -1), '\\/')
+                void this.replaceWhitespaceOnLineBefore(document, range.end.translate(0, -1), '\\/')
                 break
             case 11:
                 // add a space after so we don't accidentally join with the following word.
@@ -101,32 +101,32 @@ export class CodeActions implements vs.CodeActionProvider {
                     break
                 }
                 fixString = regexResult[0] + ' '
-                this.replaceRangeWithString(document, range, fixString)
+                void this.replaceRangeWithString(document, range, fixString)
                 break
             case 12:
-                this.replaceRangeWithString(document, range, '\\ ')
+                void this.replaceRangeWithString(document, range, '\\ ')
                 break
             case 13:
-                this.replaceWhitespaceOnLineBefore(document, range.end.translate(0, -1), '\\@')
+                void this.replaceWhitespaceOnLineBefore(document, range.end.translate(0, -1), '\\@')
                 break
             case 18:
                 if (isOpeningQuote(document, range)) {
-                    this.replaceRangeWithRepeatedString(document, range, '``')
+                    void this.replaceRangeWithRepeatedString(document, range, '``')
                 } else {
-                    this.replaceRangeWithRepeatedString(document, range, "''")
+                    void this.replaceRangeWithRepeatedString(document, range, "''")
                 }
                 break
             case 32:
-                this.replaceRangeWithRepeatedString(document, range, '`')
+                void this.replaceRangeWithRepeatedString(document, range, '`')
                 break
             case 33:
-                this.replaceRangeWithRepeatedString(document, range, "'")
+                void this.replaceRangeWithRepeatedString(document, range, "'")
                 break
             case 34:
                 if (isOpeningQuote(document, range)) {
-                    this.replaceRangeWithRepeatedString(document, range, '`')
+                    void this.replaceRangeWithRepeatedString(document, range, '`')
                 } else {
-                    this.replaceRangeWithRepeatedString(document, range, "'")
+                    void this.replaceRangeWithRepeatedString(document, range, "'")
                 }
                 break
             case 35:
@@ -135,13 +135,13 @@ export class CodeActions implements vs.CodeActionProvider {
                     break
                 }
                 fixString = regexResult[1]
-                this.replaceRangeWithString(document, range, fixString)
+                void this.replaceRangeWithString(document, range, fixString)
                 break
             case 45:
-                this.replaceMathDelimitersInRange(document, range, '$$', '\\[', '\\]')
+                void this.replaceMathDelimitersInRange(document, range, '$$', '\\[', '\\]')
                 break
             case 46:
-                this.replaceMathDelimitersInRange(document, range, '$', '\\(', '\\)')
+                void this.replaceMathDelimitersInRange(document, range, '$', '\\(', '\\)')
                 break
             default:
                 break

--- a/src/providers/completer/citation.ts
+++ b/src/providers/completer/citation.ts
@@ -90,7 +90,7 @@ export class Citation implements IProvider {
     }
 
     browser(_args?: {document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken, context: vscode.CompletionContext}) {
-        vscode.window.showQuickPick(this.updateAll(this.getIncludedBibs(this.extension.manager.rootFile)).map(item => {
+        void vscode.window.showQuickPick(this.updateAll(this.getIncludedBibs(this.extension.manager.rootFile)).map(item => {
             return {
                 label: item.fields.title ? item.fields.title : '',
                 description: `${item.key}`,
@@ -114,8 +114,8 @@ export class Citation implements IProvider {
                     const commaStart = content.lastIndexOf(',') + 1
                     start = editor.document.positionAt(curlyStart > commaStart ? curlyStart : commaStart)
                 }
-                editor.edit(edit => edit.replace(new vscode.Range(start, editor.selection.start), selected.description || ''))
-                      .then(() => editor.selection = new vscode.Selection(editor.selection.end, editor.selection.end))
+                void editor.edit(edit => edit.replace(new vscode.Range(start, editor.selection.start), selected.description || ''))
+                           .then(() => editor.selection = new vscode.Selection(editor.selection.end, editor.selection.end))
             }
         })
     }

--- a/src/providers/completer/commandlib/surround.ts
+++ b/src/providers/completer/commandlib/surround.ts
@@ -25,7 +25,7 @@ export class SurroundCommand {
                 })
             }
         })
-        vscode.window.showQuickPick(candidate, {
+        void vscode.window.showQuickPick(candidate, {
             placeHolder: 'Press ENTER to surround previous selection with selected command',
             matchOnDetail: false,
             matchOnDescription: false
@@ -33,7 +33,7 @@ export class SurroundCommand {
             if (selected === undefined) {
                 return
             }
-            editor.edit( editBuilder => {
+            void editor.edit( editBuilder => {
                 for (const selection of editor.selections) {
                     const selectedContent = editor.document.getText(selection)
                     const selectedCommand = '\\' + selected.command

--- a/src/providers/latexformatter.ts
+++ b/src/providers/latexformatter.ts
@@ -62,7 +62,7 @@ export class LaTexFormatter {
                 if (!latexindentPresent) {
                     this.extension.logger.addLogMessage(`Can not find latexindent in PATH: ${this.formatter}`)
                     this.extension.logger.addLogMessage(`PATH: ${process.env.PATH}`)
-                    this.extension.logger.showErrorMessage('Can not find latexindent in PATH.')
+                    void this.extension.logger.showErrorMessage('Can not find latexindent in PATH.')
                     return []
                 }
             }
@@ -181,14 +181,14 @@ export class LaTexFormatter {
             worker.stdout.on('data', (chunk: Buffer | string) => stdoutBuffer.push(chunk.toString()))
             worker.stderr.on('data', (chunk: Buffer | string) => stderrBuffer.push(chunk.toString()))
             worker.on('error', err => {
-                this.extension.logger.showErrorMessage('Formatting failed. Please refer to LaTeX Workshop Output for details.')
+                void this.extension.logger.showErrorMessage('Formatting failed. Please refer to LaTeX Workshop Output for details.')
                 this.extension.logger.addLogMessage(`Formatting failed: ${err.message}`)
                 this.extension.logger.addLogMessage(`stderr: ${stderrBuffer.join('')}`)
                 resolve([])
             })
             worker.on('close', code => {
                 if (code !== 0) {
-                    this.extension.logger.showErrorMessage('Formatting failed. Please refer to LaTeX Workshop Output for details.')
+                    void this.extension.logger.showErrorMessage('Formatting failed. Please refer to LaTeX Workshop Output for details.')
                     this.extension.logger.addLogMessage(`Formatting failed with exit code ${code}`)
                     this.extension.logger.addLogMessage(`stderr: ${stderrBuffer.join('')}`)
                     return resolve([])

--- a/src/providers/snippetview.ts
+++ b/src/providers/snippetview.ts
@@ -53,11 +53,11 @@ export class SnippetViewProvider implements vscode.WebviewViewProvider {
                 editor.insertSnippet(new vscode.SnippetString(message.snippet.replace(/\\\n/g, '\\n'))).then(
                     () => {},
                     err => {
-                        vscode.window.showWarningMessage(`Unable to insert symbol, ${err}`)
+                        void vscode.window.showWarningMessage(`Unable to insert symbol, ${err}`)
                     }
                 )
             } else {
-                vscode.window.showWarningMessage('Unable get document to insert symbol into')
+                void vscode.window.showWarningMessage('Unable get document to insert symbol into')
             }
         }
     }

--- a/src/providers/structure.ts
+++ b/src/providers/structure.ts
@@ -371,7 +371,8 @@ export class StructureTreeView {
         const f = e.textEditor.document.fileName
         const currentNode = this.traverseSectionTree(this._treeDataProvider.ds, f, line)
         if (currentNode) {
-            this._viewer.reveal(currentNode, {select: true})
+            return this._viewer.reveal(currentNode, {select: true})
         }
+        return
     }
 }

--- a/test/build.test.ts
+++ b/test/build.test.ts
@@ -22,8 +22,9 @@ suite('Build TeX files test suite', () => {
     suiteSetup(() => {
         const config = vscode.workspace.getConfiguration()
         if (process.env['LATEXWORKSHOP_CI_ENABLE_DOCKER']) {
-            config.update('latex-workshop.docker.enabled', true, vscode.ConfigurationTarget.Global)
+            return config.update('latex-workshop.docker.enabled', true, vscode.ConfigurationTarget.Global)
         }
+        return
     })
 
     //
@@ -616,7 +617,7 @@ suite('Build TeX files test suite', () => {
             const doc = await vscode.workspace.openTextDocument(texFilePath)
             await vscode.window.showTextDocument(doc)
             await waitLatexWorkshopActivated()
-            execCommandThenPick(
+            await execCommandThenPick(
                 () => vscode.commands.executeCommand('latex-workshop.build'),
                 () => vscode.commands.executeCommand('workbench.action.acceptSelectedQuickOpenItem')
             )
@@ -633,7 +634,7 @@ suite('Build TeX files test suite', () => {
             const doc = await vscode.workspace.openTextDocument(texFilePath)
             await vscode.window.showTextDocument(doc)
             await waitLatexWorkshopActivated()
-            execCommandThenPick(
+            await execCommandThenPick(
                 () => vscode.commands.executeCommand('latex-workshop.build'),
                 async () => {
                     await vscode.commands.executeCommand('workbench.action.quickOpenSelectNext')

--- a/test/completion.test.ts
+++ b/test/completion.test.ts
@@ -18,8 +18,9 @@ suite('Completion test suite', () => {
     suiteSetup(() => {
         const config = vscode.workspace.getConfiguration()
         if (process.env['LATEXWORKSHOP_CI_ENABLE_DOCKER']) {
-            config.update('latex-workshop.docker.enabled', true, vscode.ConfigurationTarget.Global)
+            return config.update('latex-workshop.docker.enabled', true, vscode.ConfigurationTarget.Global)
         }
+        return
     })
 
     runTestWithFixture('fixture001', 'basic completion', async () => {

--- a/test/rootfile.test.ts
+++ b/test/rootfile.test.ts
@@ -17,8 +17,9 @@ suite('RootFile test suite', () => {
     suiteSetup(() => {
         const config = vscode.workspace.getConfiguration()
         if (process.env['LATEXWORKSHOP_CI_ENABLE_DOCKER']) {
-            config.update('latex-workshop.docker.enabled', true, vscode.ConfigurationTarget.Global)
+            return config.update('latex-workshop.docker.enabled', true, vscode.ConfigurationTarget.Global)
         }
+        return
     })
 
     runTestWithFixture('fixture001', 'import package', async () => {

--- a/test/runTest.ts
+++ b/test/runTest.ts
@@ -77,4 +77,4 @@ async function main() {
     }
 }
 
-main()
+void main()

--- a/test/viewer.test.ts
+++ b/test/viewer.test.ts
@@ -21,8 +21,9 @@ suite('PDF Viewer test suite', () => {
     suiteSetup(() => {
         const config = vscode.workspace.getConfiguration()
         if (process.env['LATEXWORKSHOP_CI_ENABLE_DOCKER']) {
-            config.update('latex-workshop.docker.enabled', true, vscode.ConfigurationTarget.Global)
+            return config.update('latex-workshop.docker.enabled', true, vscode.ConfigurationTarget.Global)
         }
+        return
     })
 
     //

--- a/viewer/latexworkshop.ts
+++ b/viewer/latexworkshop.ts
@@ -76,7 +76,7 @@ class LateXWorkshopPdfViewer implements ILatexWorkshopPdfViewer {
         this.startConnectionKeeper()
         this.startRebroadcastingKeyboardEvent()
         this.startSendingState()
-        this.startReceivingPanelManagerResponse()
+        void this.startReceivingPanelManagerResponse()
 
         this.pdfFileRendered = new Promise((resolve) => {
             this.onDidRenderPdfFile(() => resolve(), {once: true})
@@ -108,7 +108,7 @@ class LateXWorkshopPdfViewer implements ILatexWorkshopPdfViewer {
             cb()
             PDFViewerApplication.eventBus.off('documentloaded', cb0)
         }
-        this.getEventBus().then(eventBus => {
+        void this.getEventBus().then(eventBus => {
             eventBus.on('documentloaded', cb0)
         })
         return { dispose: () => PDFViewerApplication.eventBus.off('documentloaded', cb0) }
@@ -121,7 +121,7 @@ class LateXWorkshopPdfViewer implements ILatexWorkshopPdfViewer {
                 PDFViewerApplication.eventBus.off('pagesinit', cb0)
             }
         }
-        this.getEventBus().then(eventBus => {
+        void this.getEventBus().then(eventBus => {
             eventBus.on('pagesinit', cb0)
         })
         return { dispose: () => PDFViewerApplication.eventBus.off('pagesinit', cb0) }
@@ -134,7 +134,7 @@ class LateXWorkshopPdfViewer implements ILatexWorkshopPdfViewer {
                 PDFViewerApplication.eventBus.off('pagerendered', cb0)
             }
         }
-        this.getEventBus().then(eventBus => {
+        void this.getEventBus().then(eventBus => {
             eventBus.on('pagerendered', cb0)
         })
         return { dispose: () => PDFViewerApplication.eventBus.off('pagerendered', cb0) }
@@ -194,7 +194,7 @@ class LateXWorkshopPdfViewer implements ILatexWorkshopPdfViewer {
             // We have to wait for currentScaleValue set above to be effected
             // especially for cases of non-number scales.
             // https://github.com/James-Yu/LaTeX-Workshop/issues/1870
-            this.pdfFileRendered.then(() => {
+            void this.pdfFileRendered.then(() => {
                 if (state.trim === undefined) {
                     return
                 }
@@ -278,7 +278,7 @@ class LateXWorkshopPdfViewer implements ILatexWorkshopPdfViewer {
                     // https://github.com/James-Yu/LaTeX-Workshop/issues/1871
                     PDFViewerApplicationOptions.set('spreadModeOnLoad', pack.spreadMode)
 
-                    PDFViewerApplication.open(`${utils.pdfFilePrefix}${this.encodedPdfFilePath}`).then( () => {
+                    void PDFViewerApplication.open(`${utils.pdfFilePrefix}${this.encodedPdfFilePath}`).then( () => {
                         // reset the document title to the original value to avoid duplication
                         document.title = this.documentTitle
                         // ensure that trimming is invoked if needed.
@@ -305,7 +305,7 @@ class LateXWorkshopPdfViewer implements ILatexWorkshopPdfViewer {
                         PDFViewerApplication.pdfCursorTools.handTool.deactivate()
                     }
                     if (!this.isRestoredWithSerializer) {
-                        this.restorePdfViewerState(data)
+                        void this.restorePdfViewerState(data)
                     }
                     if (data.invertMode.enabled) {
                         const { brightness, grayscale, hueRotate, invert, sepia } = data.invertMode
@@ -569,7 +569,7 @@ class LateXWorkshopPdfViewer implements ILatexWorkshopPdfViewer {
         }, true)
         const events = ['scroll', 'scalechanged', 'zoomin', 'zoomout', 'zoomreset', 'scrollmodechanged', 'spreadmodechanged', 'pagenumberchanged']
         for (const ev of events) {
-            this.getEventBus().then(eventBus => {
+            void this.getEventBus().then(eventBus => {
                 eventBus.on(ev, () => {
                     this.sendCurrentStateToPanelManager()
                 })
@@ -588,7 +588,7 @@ class LateXWorkshopPdfViewer implements ILatexWorkshopPdfViewer {
             switch (data.type) {
                 case 'restore_state': {
                     this.isRestoredWithSerializer = true
-                    this.restorePdfViewerState(data.state)
+                    void this.restorePdfViewerState(data.state)
                     break
                 }
                 default: {


### PR DESCRIPTION
Enable `@typescript-eslint/no-floating-promises`

- https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-floating-promises.md

The usage is the following:

- If we have to await a promise, we use `await` or `return` for the promise.
- If we don't have to await a promise, we set `void` before the promise.

See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/void

We should await `clean`. Otherwise, newly generated files would be cleaned during the next build.

https://github.com/James-Yu/LaTeX-Workshop/blob/524d6325b5f7781e4696de3dc28d3ca4a3d2f3cd/src/components/builder.ts#L167-L176


https://github.com/James-Yu/LaTeX-Workshop/blob/524d6325b5f7781e4696de3dc28d3ca4a3d2f3cd/src/components/builder.ts#L332-L349
