### PR TITLE
Use mutex for file watcher

### DIFF
--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -783,7 +783,7 @@ export class Manager {
     }
 
     private createFileWatcher() {
-        this.extension.logger.addLogMessage(`Creating a new file watcher for ${this.rootFile}`)
+        this.extension.logger.addLogMessage('Creating a new file watcher.')
         this.extension.logger.addLogMessage(`watcherOptions: ${JSON.stringify(this.watcherOptions)}`)
         const fileWatcher = chokidar.watch([], this.watcherOptions)
         this.registerListeners(fileWatcher)


### PR DESCRIPTION
Close #2720 and #2688.

- Use mutex for file watcher.
- Make `Manager.fileWatcher` readonly.
- Use `Set` for `Manager.filesWatched`.

We don't have to call `chokidar.watch` every time `rootFile` changes. Calling `Manager.fileWatcher.close()` and `Manager.registerListeners` is enough.

https://github.com/James-Yu/LaTeX-Workshop/blob/0667017e67319226fec042555a16a36980af28a5/src/components/manager.ts#L773-L777