### PR TITLE
Use await in Manager.parseFlsFile

### DIFF
--- a/src/components/builder.ts
+++ b/src/components/builder.ts
@@ -373,7 +373,7 @@ export class Builder {
         }
         this.extension.viewer.refreshExistingViewer(rootFile)
         this.extension.completer.reference.setNumbersFromAuxFile(rootFile)
-        this.extension.manager.parseFlsFile(rootFile)
+        await this.extension.manager.parseFlsFile(rootFile)
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         if (configuration.get('view.pdf.viewer') === 'external' && configuration.get('synctex.afterBuild.enabled')) {
             const pdfFile = this.extension.manager.tex2pdf(rootFile)

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -570,7 +570,7 @@ export class Manager {
         await this.parseBibFiles(content, file)
         // We need to parse the fls to discover file dependencies when defined by TeX macro
         // It happens a lot with subfiles, https://tex.stackexchange.com/questions/289450/path-of-figures-in-different-directories-with-subfile-latex
-        this.parseFlsFile(file)
+        await this.parseFlsFile(file)
     }
 
     /**
@@ -689,7 +689,7 @@ export class Manager {
      *
      * @param texFile The path of a LaTeX file.
      */
-    parseFlsFile(texFile: string) {
+    async parseFlsFile(texFile: string) {
         this.extension.logger.addLogMessage('Parse fls file.')
         const flsFile = this.pathUtils.getFlsFilePath(texFile)
         if (flsFile === undefined) {
@@ -699,7 +699,7 @@ export class Manager {
         const outDir = this.getOutDir(texFile)
         const ioFiles = this.pathUtils.parseFlsContent(fs.readFileSync(flsFile).toString(), rootDir)
 
-        ioFiles.input.forEach(async (inputFile: string) => {
+        for (const inputFile of ioFiles.input) {
             // Drop files that are also listed as OUTPUT or should be ignored
             if (ioFiles.output.includes(inputFile) ||
                 this.isExcluded(inputFile) ||
@@ -721,15 +721,15 @@ export class Manager {
                 // Watch non-tex files.
                 await this.addToFileWatcher(inputFile)
             }
-        })
+        }
 
-        ioFiles.output.forEach((outputFile: string) => {
+        for (const outputFile of ioFiles.output) {
             if (path.extname(outputFile) === '.aux' && fs.existsSync(outputFile)) {
                 this.extension.logger.addLogMessage(`Parse aux file: ${outputFile}`)
-                void this.parseAuxFile(fs.readFileSync(outputFile).toString(),
-                                       path.dirname(outputFile).replace(outDir, rootDir))
+                await this.parseAuxFile(fs.readFileSync(outputFile).toString(),
+                                        path.dirname(outputFile).replace(outDir, rootDir))
             }
-        })
+        }
     }
 
     private async parseAuxFile(content: string, srcDir: string) {


### PR DESCRIPTION
We should await operations for each file with `for` loops. We cannot await them with `forEach`.