### PR TITLE
cwl > json: Add fallback in case global env and package file doesn't exist

### DIFF
--- a/dev/pyintel/pkgcommand.py
+++ b/dev/pyintel/pkgcommand.py
@@ -108,10 +108,12 @@ class CwlIntel:
             self.commands = json.load(open(commands_file, encoding='utf8'))
         except:
             print('Cannot read JSON file {}'.format(commands_file))
+            self.commands = []
         try:
             self.envs = json.load(open(envs_file, encoding='utf8'))
         except:
             print('Cannot read JSON file {}'.format(envs_file))
+            self.envs = []
         self.compute_unimathsymbols()
 
 


### PR DESCRIPTION
If the global json files for environments or commands doesn't exist, then running `pkgcommand` doesn't work since `self.commands/envs` is not initialized. This is fixed.