### PR TITLE
Use Custom Editor as a hook to start the internal PDF viewer.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "onLanguage:doctex",
     "onLanguage:jlweave",
     "onLanguage:rsweave",
-    "onLanguage:pdf",
     "onLanguage:bibtex",
     "onCommand:latex-workshop.build",
     "onCommand:latex-workshop.recipes",
@@ -48,6 +47,7 @@
     "onCommand:latex-workshop.bibsort",
     "onCommand:latex-workshop.bibalign",
     "onCommand:latex-workshop.bibalignsort",
+    "onCustomEditor:latex-workshop-pdf-hook",
     "onWebviewPanel:latex-workshop-pdf"
   ],
   "main": "./out/src/main.js",
@@ -122,16 +122,6 @@
           "LaTeX-Expl3"
         ],
         "configuration": "./syntax/syntax-expl3.json"
-      },
-      {
-        "id": "pdf",
-        "aliases": [
-          "PDF",
-          "pdf"
-        ],
-        "extensions": [
-          ".pdf"
-        ]
       },
       {
         "id": "jlweave",
@@ -2068,7 +2058,19 @@
           "name": "Snippet View"
         }
       ]
-    }
+    },
+    "customEditors": [
+      {
+        "viewType": "latex-workshop-pdf-hook",
+        "displayName": "LaTeX Workshop Internal PDF Viewer",
+        "selector": [
+          {
+            "filenamePattern": "*.pdf"
+          }
+        ],
+        "priority": "default"
+      }
+    ]
   },
   "scripts": {
     "clean": "rimraf out/ .eslintcache",

--- a/package.json
+++ b/package.json
@@ -2066,6 +2066,9 @@
         "selector": [
           {
             "filenamePattern": "*.pdf"
+          },
+          {
+            "filenamePattern": "*.PDF"
           }
         ],
         "priority": "default"

--- a/src/components/viewer.ts
+++ b/src/components/viewer.ts
@@ -14,6 +14,8 @@ import {openWebviewPanel} from '../utils/webview'
 import type {ClientRequest, ServerResponse, PanelRequest, PdfViewerState} from '../../viewer/components/protocol'
 import {getCurrentThemeLightness} from '../utils/theme'
 
+export {PdfViewerHookProvider} from './viewerlib/pdfviewerhook'
+
 class Client {
     readonly viewer: 'browser' | 'tab'
     readonly websocket: ws

--- a/src/components/viewerlib/pdfviewerhook.ts
+++ b/src/components/viewerlib/pdfviewerhook.ts
@@ -1,0 +1,28 @@
+import type * as vscode from 'vscode'
+
+import type {Extension} from '../../main'
+
+export class PdfViewerHookProvider implements vscode.CustomReadonlyEditorProvider {
+    private readonly extension: Extension
+
+    constructor(extension: Extension) {
+        this.extension = extension
+    }
+
+    openCustomDocument(uri: vscode.Uri) {
+        this.extension.manager.watchPdfFile(uri.fsPath)
+        return {
+            uri,
+            dispose: () => {}
+        }
+    }
+
+    resolveCustomEditor(document: vscode.CustomDocument, webviewPanel: vscode.WebviewPanel) {
+        webviewPanel.webview.html = 'LaTeX Workshop PDF Viewer is opening a PDF file...'
+        setTimeout(() => {
+            webviewPanel.dispose()
+            void this.extension.commander.pdf(document.uri)
+        }, 1000)
+    }
+
+}


### PR DESCRIPTION
Use Custom Editor as a hook to start the internal PDF viewer.

Since we cannot open muptiple cutom editors for the same PDF file in the same editor group,
we don't directly use Custom Editor for the viewer.

- https://code.visualstudio.com/api/extension-guides/custom-editors
- https://github.com/microsoft/vscode/issues/41289


https://user-images.githubusercontent.com/10665499/121760157-459cbc80-cb64-11eb-9a15-5e99ec343eb4.mp4




