### PR TITLE
Use the prefix `latex-workshop`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -431,7 +431,7 @@
         "category": "LaTeX Workshop"
       },
       {
-        "command": "latex-structure.toggle-follow-cursor",
+        "command": "latex-workshop.structure-toggle-follow-cursor",
         "title": "Toggle follow cursor",
         "category": "LaTeX Workshop"
       },
@@ -2025,8 +2025,8 @@
       ],
       "view/title": [
         {
-          "when": "view == latex-structure",
-          "command": "latex-structure.toggle-follow-cursor"
+          "when": "view == latex-workshop-structure",
+          "command": "latex-workshop.structure-toggle-follow-cursor"
         }
       ]
     },
@@ -2047,7 +2047,7 @@
           "when": "latex-workshop:enabled"
         },
         {
-          "id": "latex-structure",
+          "id": "latex-workshop-structure",
           "name": "Structure",
           "when": "latex-workshop:enabled"
         },

--- a/src/providers/structure.ts
+++ b/src/providers/structure.ts
@@ -337,8 +337,8 @@ export class StructureTreeView {
 
     constructor(private readonly extension: Extension) {
         this._treeDataProvider = this.extension.structureProvider
-        this._viewer = vscode.window.createTreeView('latex-structure', { treeDataProvider: this._treeDataProvider })
-        vscode.commands.registerCommand('latex-structure.toggle-follow-cursor', () => {
+        this._viewer = vscode.window.createTreeView('latex-workshop-structure', { treeDataProvider: this._treeDataProvider })
+        vscode.commands.registerCommand('latex-workshop.structure-toggle-follow-cursor', () => {
            this._followCursor = ! this._followCursor
         })
     }


### PR DESCRIPTION
Use the prefix `latex-workshop` to avoid conflicts with other extensions.