### PR TITLE
Add keyboard shortcuts for frac and partial

### DIFF
--- a/package.json
+++ b/package.json
@@ -683,6 +683,18 @@
         "command": "latex-workshop.shortcut.mathcal"
       },
       {
+        "key": "shift+alt+f",
+        "mac": "shift+alt+f",
+        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /latex|rsweave|jlweave/",
+        "command": "latex-workshop.shortcut.frac"
+      },
+      {
+        "key": "shift+alt+p",
+        "mac": "shift+alt+p",
+        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /latex|rsweave|jlweave/",
+        "command": "latex-workshop.shortcut.partial"
+      },
+      {
         "command": "expandLineSelection",
         "key": "ctrl+l ctrl+l",
         "mac": "cmd+l cmd+l",

--- a/src/main.ts
+++ b/src/main.ts
@@ -116,6 +116,8 @@ function registerLatexWorkshopCommands(extension: Extension) {
     vscode.commands.registerCommand('latex-workshop.shortcut.mathbb', () => extension.commander.toggleSelectedKeyword('mathbb'))
     vscode.commands.registerCommand('latex-workshop.shortcut.mathcal', () => extension.commander.toggleSelectedKeyword('mathcal'))
     vscode.commands.registerCommand('latex-workshop.surround', () => extension.completer.command.surround())
+    vscode.commands.registerCommand('latex-workshop.shortcut.frac', () => extension.commander.toggleSelectedKeyword('frac'))
+    vscode.commands.registerCommand('latex-workshop.shortcut.partial', () => extension.commander.toggleSelectedKeyword('partial'))
 
     vscode.commands.registerCommand('latex-workshop.promote-sectioning', () => extension.commander.shiftSectioningLevel('promote'))
     vscode.commands.registerCommand('latex-workshop.demote-sectioning', () => extension.commander.shiftSectioningLevel('demote'))


### PR DESCRIPTION
Two small changes, maybe you could change them to `ctrl+m ctrl+f` and `ctrl+m ctrl+p`