### PR TITLE
Set a scope to \text in maths

### DIFF
--- a/syntax/TeX.tmLanguage.json
+++ b/syntax/TeX.tmLanguage.json
@@ -134,6 +134,35 @@
     "math": {
       "patterns": [
         {
+          "begin": "((\\\\)(?:text|mbox))(\\{)",
+          "beginCaptures": {
+            "1": {
+              "name": "constant.other.math.tex"
+            },
+            "2": {
+              "name": "punctuation.definition.function.tex"
+            },
+            "3": {
+              "name": "punctuation.definition.arguments.begin.tex"
+            }
+          },
+          "contentName": "meta.text.normal.tex",
+          "end": "\\}",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.arguments.end.tex"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#math"
+            },
+            {
+              "include": "$base"
+            }
+          ]
+        },
+        {
           "captures": {
             "1": {
               "name": "punctuation.definition.constant.math.tex"

--- a/syntax/TeX.tmLanguage.json
+++ b/syntax/TeX.tmLanguage.json
@@ -143,14 +143,14 @@
               "name": "punctuation.definition.function.tex"
             },
             "3": {
-              "name": "punctuation.definition.arguments.begin.tex"
+              "name": "punctuation.definition.arguments.begin.tex meta.text.normal.tex"
             }
           },
           "contentName": "meta.text.normal.tex",
           "end": "\\}",
           "endCaptures": {
             "0": {
-              "name": "punctuation.definition.arguments.end.tex"
+              "name": "punctuation.definition.arguments.end.tex meta.text.normal.tex"
             }
           },
           "patterns": [


### PR DESCRIPTION
Close #2708.

The new scope is `meta.text.normal.tex`.