### PR TITLE
Match \, and \; as support.function

### DIFF
--- a/syntax/TeX.tmLanguage.json
+++ b/syntax/TeX.tmLanguage.json
@@ -117,7 +117,7 @@
           "name": "punctuation.definition.function.tex"
         }
       },
-      "match": "(\\\\)[A-Za-z@,;]+",
+      "match": "(\\\\)(?:[A-Za-z@]+|[,;])",
       "name": "support.function.general.tex"
     },
     {


### PR DESCRIPTION
This fixes 4760422407b7596c575e226bb3c452f577821fcd, which wrongly highlights commands like `\abc,abc` as a single token.

Some test cases:
```tex
\abc; text
\abc, text
\@bc, text
\,abc text
\;abc text
```
Before (see https://regex101.com/r/byAAUp/1):
![image](https://user-images.githubusercontent.com/6376638/127181490-f794dfe0-acbf-4634-a8f5-956cc2c0984a.png)

After:
![image](https://user-images.githubusercontent.com/6376638/127181525-66797457-a57d-44be-a558-65ea1daf872d.png)
