### PR TITLE
Set the host's UID and GID for the executed command within the docker container

### DIFF
--- a/scripts/latexindent
+++ b/scripts/latexindent
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker run -i --rm -w "$(pwd)" -v "$(pwd):$(pwd)" $LATEXWORKSHOP_DOCKER_LATEX latexindent "$@"
+docker run -i --rm -w "$(pwd)" -v "$(pwd):$(pwd)" --user "$(id -u):$(id -g)" $LATEXWORKSHOP_DOCKER_LATEX latexindent "$@"

--- a/scripts/latexmk
+++ b/scripts/latexmk
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker run -i --rm -w "$(pwd)" -v "$(pwd):$(pwd)" $LATEXWORKSHOP_DOCKER_LATEX latexmk "$@"
+docker run -i --rm -w "$(pwd)" -v "$(pwd):$(pwd)" --user "$(id -u):$(id -g)" $LATEXWORKSHOP_DOCKER_LATEX latexmk "$@"

--- a/scripts/synctex
+++ b/scripts/synctex
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker run -i --rm -w "$(pwd)" -v "$(pwd):$(pwd)" $LATEXWORKSHOP_DOCKER_LATEX synctex "$@"
+docker run -i --rm -w "$(pwd)" -v "$(pwd):$(pwd)" --user "$(id -u):$(id -g)" $LATEXWORKSHOP_DOCKER_LATEX synctex "$@"

--- a/scripts/texcount
+++ b/scripts/texcount
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker run -i --rm -w "$(pwd)" -v "$(pwd):$(pwd)" $LATEXWORKSHOP_DOCKER_LATEX texcount "$@"
+docker run -i --rm -w "$(pwd)" -v "$(pwd):$(pwd)" --user "$(id -u):$(id -g)" $LATEXWORKSHOP_DOCKER_LATEX texcount "$@"


### PR DESCRIPTION
The default user within a container is root (id=0). The written files in the mounted folder ($pwd) will end up with wrong/different file ownership. Starting the container with the host's UID and GID will result in files written with the "correct" ownership.