### PR TITLE
Strip .tex extension in \input completion

### DIFF
--- a/package.json
+++ b/package.json
@@ -1646,6 +1646,16 @@
           ],
           "markdownDescription": "Patterns to ignore in file completion"
         },
+        "latex-workshop.intellisense.file.stripExtension": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "tex"
+          ],
+          "markdownDescription": "Ignore these file extensions when inserting intellisense"
+        },
         "latex-workshop.intellisense.file.base": {
           "type": "string",
           "enum": [

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -95,7 +95,7 @@ export class Completer implements vscode.CompletionItemProvider {
                     const exts = configuration.get('intellisense.file.stripExtension') as Array<string>
                     if (exts.length > 0) {
                         // strip file extensions
-                        suggestions.map(item => {
+                        suggestions.forEach(item => {
                             const ext = item.label.split('.').slice(-1)[0]
                             if (exts.includes(ext)) {
                                 item.insertText = item.label.replace(new RegExp(`\\.${ext}$`), '')

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -90,6 +90,18 @@ export class Completer implements vscode.CompletionItemProvider {
                         setTimeout(() => this.citation.browser({document, position, token, context}), 10)
                         return
                     }
+                } else if(type === 'input'){
+                    const configuration = vscode.workspace.getConfiguration('latex-workshop')
+                    const exts = configuration.get('intellisense.file.stripExtension') as Array<string>
+                    if (exts.length > 0) {
+                        // strip file extensions
+                        suggestions.map(item => {
+                            const ext = item.label.split('.').slice(-1)[0]
+                            if (exts.includes(ext)) {
+                                item.insertText = item.label.replace(new RegExp(`\\.${ext}$`), '')
+                            }
+                        })
+                    }
                 }
                 return suggestions
             }


### PR DESCRIPTION
Currently the auto-completion for `\input` will insert the filename with extension. This pr provides option to strip certain extensions.
E.g., before: `\input{introduction}`, after: `\input{introduction}`