### PR TITLE
Clean *.vrb files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1187,7 +1187,8 @@
             "*.snm",
             "*.synctex(busy)",
             "*.synctex.gz(busy)",
-            "*.nav"
+            "*.nav",
+            "*.vrb"
           ],
           "markdownDescription": "Files to clean.\nThis property must be an array of strings. File globs such as *.removeme, something?.aux can be used."
         },


### PR DESCRIPTION
The .vrb files produced by Beamer (for slides) can be cleaned