### PR TITLE
[Bugfix] Syntax highlighting for cite keys with -

### DIFF
--- a/syntax/LaTeX.tmLanguage.json
+++ b/syntax/LaTeX.tmLanguage.json
@@ -1334,7 +1334,7 @@
           "match": "((%).*)$"
         },
         {
-          "match": "[\\w:.]+",
+          "match": "[\\w\\-:.]+",
           "name": "constant.other.reference.citation.latex"
         }
       ]


### PR DESCRIPTION
closed #2855 

Should be fine, tested locally, but I had struggles with all those regex strings. Take a look at it please, to ensure I edited the right location. 