### PR TITLE
Add more placeholders

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -144,7 +144,7 @@ export function replaceArgumentPlaceholders(rootFile: string, tmpDir: string): (
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         const docker = configuration.get('docker.enabled')
 
-        const workspaceDir = vscode.workspace.workspaceFolders ? vscode.workspace.workspaceFolders[0].uri.fsPath : ''
+        const workspaceDir = vscode.workspace.workspaceFolders ? vscode.workspace.workspaceFolders[0].uri.fsPath.split(path.sep).join('/') : ''
         const rootFileParsed = path.parse(rootFile)
         const docfile = rootFileParsed.name
         const docfileExt = rootFileParsed.base


### PR DESCRIPTION
This PR adds three new placeholders

- `WORKSPACE_FOLDER`: current workspace path
- `RELATIVE_DIR`: file directory relative to the workspace folder
- `RELATIVE_DOC`: file path relative to the workspace folder

Close #2884