### PR TITLE
Fix code formatting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ In VS Code, simply press <kbd>F5</kbd> (or run `Debug: Start Debugging` from the
 
 ### Debugging PDF viewer
 
-To debug the internal PDF viewer, select `View LaTeX PDF > View in web browser,` and view a PDF file in Google Chrome. You can debug the viewer with [Chrome DevTools](https://developers.google.com/web/tools/chrome-devtools/) as a general web application.
+To debug the internal PDF viewer, select `View LaTeX PDF > View in web browser`, and view a PDF file in Google Chrome. You can debug the viewer with [Chrome DevTools](https://developers.google.com/web/tools/chrome-devtools/) as a general web application.
 
 ## Documents
 


### PR DESCRIPTION
It included a comma before that was not part of the section to be formatted.