### PR TITLE
Set showCollapseAll: true for Structure View.

### DIFF
--- a/src/providers/structure.ts
+++ b/src/providers/structure.ts
@@ -361,7 +361,7 @@ export class StructureTreeView {
 
     constructor(private readonly extension: Extension) {
         this._treeDataProvider = this.extension.structureProvider
-        this._viewer = vscode.window.createTreeView('latex-workshop-structure', { treeDataProvider: this._treeDataProvider })
+        this._viewer = vscode.window.createTreeView('latex-workshop-structure', { treeDataProvider: this._treeDataProvider, showCollapseAll: true })
         vscode.commands.registerCommand('latex-workshop.structure-toggle-follow-cursor', () => {
            this._followCursor = ! this._followCursor
         })


### PR DESCRIPTION
Set `showCollapseAll: true` for Structure View. 

Notice that the button works only on VS Code Insiders now. See microsoft/vscode/issues/134762