### PR TITLE
Enable debugWebviews.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -31,6 +31,7 @@
             "outFiles": [
                 "${workspaceFolder}/out/src/**/*.js"
             ],
+            "debugWebviews": true,
             "preLaunchTask": "npm: watch"
         },
         {


### PR DESCRIPTION
Set `"debugWebviews": true`. This enable us to debug WebView. microsoft/vscode-js-debug/pull/540

@jlelong  @James-Yu  if something goes wrong with debugging, please set false to the option.