### PR TITLE
Drop the supprot for VS Code prior to v1.61.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This project won't be successful without contributions from the community, espec
 
 Thank you so much!
 
-**Note that the latest version of LaTeX-Workshop requires at least VSCode `1.53.2`.**
+**Note that the latest version of LaTeX-Workshop requires at least VSCode `1.61.2`.**
 
 ## Manual
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -566,9 +566,9 @@
       "dev": true
     },
     "@types/vscode": {
-      "version": "1.53.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.53.0.tgz",
-      "integrity": "sha512-XjFWbSPOM0EKIT2XhhYm3D3cx3nn3lshMUcWNy1eqefk+oqRuBq8unVb6BYIZqXy9lQZyeUl7eaBCOZWv+LcXQ==",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.61.0.tgz",
+      "integrity": "sha512-9k5Nwq45hkRwdfCFY+eKXeQQSbPoA114mF7U/4uJXRBJeGIO7MuJdhF1PnaDN+lllL9iKGQtd6FFXShBXMNaFg==",
       "dev": true
     },
     "@types/workerpool": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/James-Yu/LaTeX-Workshop.git"
   },
   "engines": {
-    "vscode": "^1.53.2"
+    "vscode": "^1.61.2"
   },
   "categories": [
     "Programming Languages",
@@ -2173,7 +2173,7 @@
     "@types/mocha": "9.0.0",
     "@types/node": "14.14.45",
     "@types/tmp": "0.2.1",
-    "@types/vscode": "1.53.0",
+    "@types/vscode": "1.61.0",
     "@types/workerpool": "6.1.0",
     "@types/ws": "7.4.7",
     "@typescript-eslint/eslint-plugin": "5.1.0",

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -12,6 +12,7 @@ import type {Suggestion as CiteEntry} from '../providers/completer/citation'
 import type {Suggestion as CmdEntry} from '../providers/completer/command'
 import type {Suggestion as EnvEntry} from '../providers/completer/environment'
 import type {Suggestion as GlossEntry} from '../providers/completer/glossary'
+import type {ILwCompletionItem} from '../providers/completer/interface'
 
 import {PdfWatcher} from './managerlib/pdfwatcher'
 import {BibWatcher} from './managerlib/bibwatcher'
@@ -36,7 +37,7 @@ interface Content {
          * Completion item and other items for the LaTeX file.
          */
         element: {
-            reference?: vscode.CompletionItem[],
+            reference?: ILwCompletionItem[],
             glossary?: GlossEntry[],
             environment?: EnvEntry[],
             bibitem?: CiteEntry[],

--- a/src/providers/completer/citation.ts
+++ b/src/providers/completer/citation.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode'
 import * as fs from 'fs'
 import {bibtexParser} from 'latex-utensils'
 import {trimMultiLineString} from '../../utils/utils'
+import type {ILwCompletionItem} from './interface'
 
 import type {Extension} from '../../main'
 import type {IProvider} from './interface'
@@ -31,7 +32,7 @@ class Fields extends Map<string, string> {
 
 }
 
-export interface Suggestion extends vscode.CompletionItem {
+export interface Suggestion extends ILwCompletionItem {
     key: string,
     fields: Fields,
     file: string,
@@ -53,7 +54,7 @@ export class Citation implements IProvider {
         return this.provide(args)
     }
 
-    private provide(args?: {document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken, context: vscode.CompletionContext}): vscode.CompletionItem[] {
+    private provide(args?: {document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken, context: vscode.CompletionContext}): ILwCompletionItem[] {
         // Compile the suggestion array to vscode completion array
         const label = vscode.workspace.getConfiguration('latex-workshop').get('intellisense.citation.label') as string
         let range: vscode.Range | undefined = undefined

--- a/src/providers/completer/command.ts
+++ b/src/providers/completer/command.ts
@@ -4,7 +4,7 @@ import {latexParser} from 'latex-utensils'
 
 import type {Extension} from '../../main'
 import {Environment, EnvSnippetType} from './environment'
-import type {IProvider} from './interface'
+import type {IProvider, ILwCompletionItem} from './interface'
 import {CommandFinder, isTriggerSuggestNeeded, resolveCmdEnvFile} from './commandlib/commandfinder'
 import {SurroundCommand} from './commandlib/surround'
 
@@ -24,7 +24,7 @@ function isCmdItemEntry(obj: any): obj is CmdItemEntry {
     return (typeof obj.command === 'string') && (typeof obj.snippet === 'string')
 }
 
-export interface Suggestion extends vscode.CompletionItem {
+export interface Suggestion extends ILwCompletionItem {
     package: string
 }
 
@@ -83,7 +83,7 @@ export class Command implements IProvider {
         return suggestions
     }
 
-    private provide(languageId: string, document?: vscode.TextDocument, position?: vscode.Position): vscode.CompletionItem[] {
+    private provide(languageId: string, document?: vscode.TextDocument, position?: vscode.Position): ILwCompletionItem[] {
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         const useOptionalArgsEntries = configuration.get('intellisense.optionalArgsEntries.enabled')
         let range: vscode.Range | undefined = undefined

--- a/src/providers/completer/commandlib/commandfinder.ts
+++ b/src/providers/completer/commandlib/commandfinder.ts
@@ -4,6 +4,7 @@ import {latexParser} from 'latex-utensils'
 
 import type {Suggestion} from '../command'
 import type {Extension} from '../../../main'
+import type {ILwCompletionItem} from '../interface'
 
 
 export function isTriggerSuggestNeeded(name: string): boolean {
@@ -265,7 +266,7 @@ export class CommandFinder {
                     continue
                 }
                 for (const pkg of cachedPkgs) {
-                    const commands: vscode.CompletionItem[] = []
+                    const commands: ILwCompletionItem[] = []
                     this.extension.completer.command.provideCmdInPkg(pkg, commands, [])
                     for (const cmd of commands) {
                         const label = cmd.label.slice(1)

--- a/src/providers/completer/commandlib/surround.ts
+++ b/src/providers/completer/commandlib/surround.ts
@@ -1,8 +1,9 @@
+import type {ILwCompletionItem} from '../interface'
 import * as vscode from 'vscode'
 
 export class SurroundCommand {
 
-    surround(cmdItems: vscode.CompletionItem[]) {
+    surround(cmdItems: ILwCompletionItem[]) {
         if (!vscode.window.activeTextEditor) {
             return
         }

--- a/src/providers/completer/environment.ts
+++ b/src/providers/completer/environment.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs'
 import {latexParser} from 'latex-utensils'
 
 import type {Extension} from '../../main'
-import type {IProvider} from './interface'
+import type {IProvider, ILwCompletionItem} from './interface'
 import {resolveCmdEnvFile} from './commandlib/commandfinder'
 
 type DataEnvsJsonType = typeof import('../../../data/environments.json')
@@ -21,7 +21,7 @@ function isEnvItemEntry(obj: any): obj is EnvItemEntry {
 
 export enum EnvSnippetType { AsName, AsCommand, ForBegin, }
 
-export interface Suggestion extends vscode.CompletionItem {
+export interface Suggestion extends ILwCompletionItem {
     package: string
 }
 
@@ -81,7 +81,11 @@ export class Environment implements IProvider {
         }
     }
 
-    provideFrom(_type: string, _result: RegExpMatchArray, args: {document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken, context: vscode.CompletionContext}) {
+    provideFrom(
+        _type: string,
+        _result: RegExpMatchArray,
+        args: {document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken, context: vscode.CompletionContext}
+    ) {
         const payload = {document: args.document, position: args.position}
         return this.provide(payload)
     }

--- a/src/providers/completer/glossary.ts
+++ b/src/providers/completer/glossary.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode'
 import {latexParser} from 'latex-utensils'
 
 import type {Extension} from '../../main'
-import type {IProvider} from './interface'
+import type {IProvider, ILwCompletionItem} from './interface'
 
 enum GlossaryType {
     glossary,
@@ -14,7 +14,7 @@ interface GlossaryEntry {
     description: string | undefined
 }
 
-export interface Suggestion extends vscode.CompletionItem {
+export interface Suggestion extends ILwCompletionItem {
     type: GlossaryType
 }
 

--- a/src/providers/completer/interface.ts
+++ b/src/providers/completer/interface.ts
@@ -11,3 +11,7 @@ export interface IProvider {
         args: {document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken, context: vscode.CompletionContext}
     ): vscode.CompletionItem[]
 }
+
+export interface ILwCompletionItem extends vscode.CompletionItem {
+    label: string
+}

--- a/src/providers/completer/reference.ts
+++ b/src/providers/completer/reference.ts
@@ -5,9 +5,9 @@ import {latexParser} from 'latex-utensils'
 import {stripEnvironments, isNewCommand} from '../../utils/utils'
 
 import type {Extension} from '../../main'
-import type {IProvider} from './interface'
+import type {IProvider, ILwCompletionItem} from './interface'
 
-export interface ReferenceEntry extends vscode.CompletionItem {
+export interface ReferenceEntry extends ILwCompletionItem {
     /**
      *  The file that defines the ref.
      */
@@ -139,8 +139,8 @@ export class Reference implements IProvider {
     }
 
     // This function will return all references in a node array, including sub-nodes
-    private getRefFromNodeArray(nodes: latexParser.Node[], lines: string[]): vscode.CompletionItem[] {
-        let refs: vscode.CompletionItem[] = []
+    private getRefFromNodeArray(nodes: latexParser.Node[], lines: string[]): ILwCompletionItem[] {
+        let refs: ILwCompletionItem[] = []
         for (let index = 0; index < nodes.length; ++index) {
             if (index < nodes.length - 1) {
                 // Also pass the next node to handle cases like `label={some-text}`
@@ -153,10 +153,10 @@ export class Reference implements IProvider {
     }
 
     // This function will return the reference defined by the node, or all references in `content`
-    private getRefFromNode(node: latexParser.Node, lines: string[], nextNode?: latexParser.Node): vscode.CompletionItem[] {
+    private getRefFromNode(node: latexParser.Node, lines: string[], nextNode?: latexParser.Node): ILwCompletionItem[] {
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         const useLabelKeyVal = configuration.get('intellisense.label.keyval')
-        const refs: vscode.CompletionItem[] = []
+        const refs: ILwCompletionItem[] = []
         let label = ''
         if (isNewCommand(node) || latexParser.isDefCommand(node)) {
             // Do not scan labels inside \newcommand & co
@@ -193,9 +193,9 @@ export class Reference implements IProvider {
         return refs
     }
 
-    private getRefFromContent(content: string): vscode.CompletionItem[] {
+    private getRefFromContent(content: string): ILwCompletionItem[] {
         const refReg = /(?:\\label(?:\[[^[\]{}]*\])?|(?:^|[,\s])label=){([^#\\}]*)}/gm
-        const refs: vscode.CompletionItem[] = []
+        const refs: ILwCompletionItem[] = []
         const refList: string[] = []
         content = stripEnvironments(content, this.envsToSkip)
         while (true) {

--- a/test/runTest.ts
+++ b/test/runTest.ts
@@ -45,7 +45,7 @@ async function runTestsOnEachFixture(targetName: 'build' | 'rootfile' | 'viewer'
     for (const testWorkspace of testBuildWorkspaces) {
         const nodejsTimeout = setTimeout(() => process.exit(1), firstTime ? 3*60000 : 60000)
         await runTests({
-            version: '1.60.2',
+            version: '1.61.2',
             extensionDevelopmentPath,
             extensionTestsPath,
             launchArgs: [


### PR DESCRIPTION
To make references on hovers up-to-date, update `@types/vscode` to `v1.61.0`

- Drop the supprot for VS Code prior to v1.61.2
- Add LwCompletionItem.

@jlelong  How do you think?