### PR TITLE
Refactor the Input completer

### DIFF
--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -912,7 +912,7 @@ export class Manager {
             return
         }
         await this.updateCompleter(file, content)
-        this.extension.completer.input.getGraphicsPath(content)
+        this.extension.completer.input.setGraphicsPath(content)
     }
 
     /**

--- a/src/providers/completer/citation.ts
+++ b/src/providers/completer/citation.ts
@@ -50,7 +50,7 @@ export class Citation implements IProvider {
         this.extension = extension
     }
 
-    provideFrom(_type: string, _result: RegExpMatchArray, args: {document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken, context: vscode.CompletionContext}) {
+    provideFrom(_result: RegExpMatchArray, args: {document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken, context: vscode.CompletionContext}) {
         return this.provide(args)
     }
 

--- a/src/providers/completer/command.ts
+++ b/src/providers/completer/command.ts
@@ -71,7 +71,7 @@ export class Command implements IProvider {
         return this.commandFinder.definedCmds
     }
 
-    provideFrom(_type: string, result: RegExpMatchArray, args: {document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken, context: vscode.CompletionContext}) {
+    provideFrom(result: RegExpMatchArray, args: {document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken, context: vscode.CompletionContext}) {
         const suggestions = this.provide(args.document.languageId, args.document, args.position)
         // Commands ending with (, { or [ are not filtered properly by vscode intellisense. So we do it by hand.
         if (result[0].match(/[({[]$/)) {

--- a/src/providers/completer/environment.ts
+++ b/src/providers/completer/environment.ts
@@ -82,7 +82,6 @@ export class Environment implements IProvider {
     }
 
     provideFrom(
-        _type: string,
         _result: RegExpMatchArray,
         args: {document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken, context: vscode.CompletionContext}
     ) {

--- a/src/providers/completer/glossary.ts
+++ b/src/providers/completer/glossary.ts
@@ -28,7 +28,7 @@ export class Glossary implements IProvider {
         this.extension = extension
     }
 
-    provideFrom(_type: string, result: RegExpMatchArray) {
+    provideFrom(result: RegExpMatchArray) {
         return this.provide(result)
     }
 

--- a/src/providers/completer/input.ts
+++ b/src/providers/completer/input.ts
@@ -30,7 +30,7 @@ abstract class InputAbstract implements IProvider {
      *
      * @param content the content to be parsed for graphicspath
      */
-    getGraphicsPath(content: string) {
+    setGraphicsPath(content: string) {
         const regex = /\\graphicspath{[\s\n]*((?:{[^{}]*}[\s\n]*)*)}/g
         const noVerbContent = stripCommentsAndVerbatim(content)
         let result: string[] | null
@@ -59,6 +59,7 @@ abstract class InputAbstract implements IProvider {
 
     /**
      * Compute the base directory for file completion
+     *
      * @param currentFile current file path
      * @param importFromDir `From` argument of the import command
      * @param command The command which triggered the completion

--- a/src/providers/completer/input.ts
+++ b/src/providers/completer/input.ts
@@ -17,6 +17,23 @@ abstract class InputAbstract implements IProvider {
         this.extension = extension
     }
 
+    /**
+     * Compute the base directory for file completion
+     *
+     * @param currentFile current file path
+     * @param importFromDir `From` argument of the import command
+     * @param command The command which triggered the completion
+     */
+    abstract getBaseDir(currentFile: string, importFromDir: string, command: string): string[]
+
+    /**
+     * Do we only list directories?
+     *
+     * @param importFromDir `From` argument of the import command
+     */
+    abstract provideDirOnly(importFromDir: string): boolean
+
+
     private filterIgnoredFiles(files: string[], baseDir: string): string[] {
         const excludeGlob = (Object.keys(vscode.workspace.getConfiguration('files', null).get('exclude') || {})).concat(vscode.workspace.getConfiguration('latex-workshop').get('intellisense.file.exclude') || [] ).concat(ignoreFiles)
         return files.filter(file => {
@@ -56,22 +73,6 @@ abstract class InputAbstract implements IProvider {
         const payload = [...result.slice(2).reverse()]
         return this.provide(args.document, args.position, command, payload)
     }
-
-    /**
-     * Compute the base directory for file completion
-     *
-     * @param currentFile current file path
-     * @param importFromDir `From` argument of the import command
-     * @param command The command which triggered the completion
-     */
-    abstract getBaseDir(currentFile: string, importFromDir: string, command: string): string[]
-
-    /**
-     * Do we only list directories?
-     *
-     * @param importFromDir `From` argument of the import command
-     */
-    abstract provideDirOnly(importFromDir: string): boolean
 
     /**
      * Provide file name intellisense

--- a/src/providers/completer/input.ts
+++ b/src/providers/completer/input.ts
@@ -9,8 +9,8 @@ import {stripCommentsAndVerbatim} from '../../utils/utils'
 
 const ignoreFiles = ['**/.vscode', '**/.vscodeignore', '**/.gitignore']
 
-export class Input implements IProvider {
-    private readonly extension: Extension
+abstract class InputAbstract implements IProvider {
+    protected readonly extension: Extension
     graphicsPath: string[] = []
 
     constructor(extension: Extension) {
@@ -51,11 +51,26 @@ export class Input implements IProvider {
         this.graphicsPath = []
     }
 
-    provideFrom(type: string, result: RegExpMatchArray, args: {document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken, context: vscode.CompletionContext}) {
+    provideFrom(result: RegExpMatchArray, args: {document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken, context: vscode.CompletionContext}) {
         const command = result[1]
         const payload = [...result.slice(2).reverse()]
-        return this.provide(type, args.document, args.position, command, payload)
+        return this.provide(args.document, args.position, command, payload)
     }
+
+    /**
+     * Compute the base directory for file completion
+     * @param currentFile current file path
+     * @param importFromDir `From` argument of the import command
+     * @param command The command which triggered the completion
+     */
+    abstract getBaseDir(currentFile: string, importFromDir: string, command: string): string[]
+
+    /**
+     * Do we only list directories?
+     *
+     * @param importFromDir `From` argument of the import command
+     */
+    abstract provideDirOnly(importFromDir: string): boolean
 
     /**
      * Provide file name intellisense
@@ -66,66 +81,14 @@ export class Input implements IProvider {
      *      payload[2]: When defined, the path from which completion is triggered
      *      payload[3]: The already typed path
      */
-    private provide(mode: string, document: vscode.TextDocument, position: vscode.Position, command: string, payload: string[]): vscode.CompletionItem[] {
-        let provideDirOnly = false
-        let baseDir: string[] = []
+    private provide(document: vscode.TextDocument, position: vscode.Position, command: string, payload: string[]): vscode.CompletionItem[] {
         const currentFile = document.fileName
         const typedFolder = payload[0]
         const importFromDir = payload[1]
         const startPos = Math.max(document.lineAt(position).text.lastIndexOf('{', position.character), document.lineAt(position).text.lastIndexOf('/', position.character))
         const range: vscode.Range | undefined = startPos >= 0 ? new vscode.Range(position.line, startPos + 1, position.line, position.character) : undefined
-        switch (mode) {
-            case 'import':
-                if (importFromDir) {
-                    baseDir = [importFromDir]
-                } else {
-                    baseDir = ['/']
-                    provideDirOnly = true
-                }
-                break
-            case 'subimport':
-                if (importFromDir) {
-                    baseDir = [path.join(path.dirname(currentFile), importFromDir)]
-                } else {
-                    baseDir = [path.dirname(currentFile)]
-                    provideDirOnly = true
-                }
-                break
-            case 'includeonly':
-            case 'input': {
-                if (this.extension.manager.rootDir === undefined) {
-                    this.extension.logger.addLogMessage(`No root dir can be found. The current root file should be undefined, is ${this.extension.manager.rootFile}. How did you get here?`)
-                    break
-                }
-                // If there is no root, 'root relative' and 'both' should fall back to 'file relative'
-                const rootDir = this.extension.manager.rootDir
-                if (command === 'includegraphics' && this.graphicsPath.length > 0) {
-                    baseDir = this.graphicsPath.map(dir => path.join(rootDir, dir))
-                } else {
-                    const baseConfig = vscode.workspace.getConfiguration('latex-workshop').get('intellisense.file.base')
-                    const baseDirCurrentFile = path.dirname(currentFile)
-                    switch (baseConfig) {
-                        case 'root relative':
-                            baseDir = [rootDir]
-                            break
-                        case 'file relative':
-                            baseDir = [baseDirCurrentFile]
-                            break
-                        case 'both':
-                            if (baseDirCurrentFile !== rootDir) {
-                                baseDir = [baseDirCurrentFile, rootDir]
-                            } else {
-                                baseDir = [rootDir]
-                            }
-                            break
-                        default:
-                    }
-                }
-                break
-            }
-            default:
-                return []
-        }
+        const baseDir: string[] = this.getBaseDir(currentFile, importFromDir, command)
+        const provideDirOnly: boolean = this.provideDirOnly(importFromDir)
 
         const suggestions: vscode.CompletionItem[] = []
         baseDir.forEach(dir => {
@@ -167,5 +130,89 @@ export class Input implements IProvider {
             } catch (error) {}
         })
         return suggestions
+    }
+}
+
+export class Input extends InputAbstract {
+
+    constructor(extension: Extension) {
+        super(extension)
+    }
+
+    provideDirOnly(_importFromDir: string): boolean {
+        return false
+    }
+
+    getBaseDir(currentFile: string, _importFromDir: string, command: string): string[] {
+        let baseDir: string[] = []
+        if (this.extension.manager.rootDir === undefined) {
+            this.extension.logger.addLogMessage(`No root dir can be found. The current root file should be undefined, is ${this.extension.manager.rootFile}. How did you get here?`)
+            return []
+        }
+        // If there is no root, 'root relative' and 'both' should fall back to 'file relative'
+        const rootDir = this.extension.manager.rootDir
+        if (command === 'includegraphics' && this.graphicsPath.length > 0) {
+            baseDir = this.graphicsPath.map(dir => path.join(rootDir, dir))
+        } else {
+            const baseConfig = vscode.workspace.getConfiguration('latex-workshop').get('intellisense.file.base')
+            const baseDirCurrentFile = path.dirname(currentFile)
+            switch (baseConfig) {
+                case 'root relative':
+                    baseDir = [rootDir]
+                    break
+                case 'file relative':
+                    baseDir = [baseDirCurrentFile]
+                    break
+                case 'both':
+                    if (baseDirCurrentFile !== rootDir) {
+                        baseDir = [baseDirCurrentFile, rootDir]
+                    } else {
+                        baseDir = [rootDir]
+                    }
+                    break
+                default:
+            }
+        }
+        return baseDir
+    }
+}
+
+export class Import extends InputAbstract {
+
+    constructor(extension: Extension) {
+        super(extension)
+    }
+
+    provideDirOnly(importFromDir: string): boolean {
+        return (!importFromDir)
+    }
+
+    getBaseDir(_currentFile: string, importFromDir: string, _command: string): string[] {
+        if (importFromDir) {
+            return [importFromDir]
+        } else {
+            return ['/']
+        }
+    }
+}
+
+
+export class SubImport extends InputAbstract {
+
+    constructor(extension: Extension) {
+        super(extension)
+    }
+
+    provideDirOnly(importFromDir: string): boolean {
+        return (!importFromDir)
+    }
+
+
+    getBaseDir(currentFile: string, importFromDir: string, _command: string): string[] {
+        if (importFromDir) {
+            return [path.join(path.dirname(currentFile), importFromDir)]
+        } else {
+            return [path.dirname(currentFile)]
+        }
     }
 }

--- a/src/providers/completer/input.ts
+++ b/src/providers/completer/input.ts
@@ -76,10 +76,8 @@ abstract class InputAbstract implements IProvider {
      * Provide file name intellisense
      *
      * @param payload an array of string
-     *      payload[0]: the input command type  (input, import, subimport, includeonly)
-     *      payload[1]: the current file name
-     *      payload[2]: When defined, the path from which completion is triggered
-     *      payload[3]: The already typed path
+     *      payload[0]: The already typed path
+     *      payload[1]: The path from which completion is triggered, may be empty
      */
     private provide(document: vscode.TextDocument, position: vscode.Position, command: string, payload: string[]): vscode.CompletionItem[] {
         const currentFile = document.fileName

--- a/src/providers/completer/interface.ts
+++ b/src/providers/completer/interface.ts
@@ -6,7 +6,6 @@ export interface IProvider {
      * Returns the array of completion items. Should be called only from `Completer.completion`.
      */
     provideFrom(
-        type: string,
         result: RegExpMatchArray,
         args: {document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken, context: vscode.CompletionContext}
     ): vscode.CompletionItem[]

--- a/src/providers/completer/reference.ts
+++ b/src/providers/completer/reference.ts
@@ -42,7 +42,7 @@ export class Reference implements IProvider {
         this.extension = extension
     }
 
-    provideFrom(_type: string, _result: RegExpMatchArray, args: {document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken, context: vscode.CompletionContext}) {
+    provideFrom(_result: RegExpMatchArray, args: {document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken, context: vscode.CompletionContext}) {
         return this.provide(args)
     }
 

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -11,7 +11,7 @@ import {Environment} from './completer/environment'
 import type {EnvItemEntry} from './completer/environment'
 import {Reference} from './completer/reference'
 import {Package} from './completer/package'
-import {Input} from './completer/input'
+import {Input, Import, SubImport} from './completer/input'
 import {Glossary} from './completer/glossary'
 import type {ReferenceDocType} from './completer/reference'
 
@@ -28,6 +28,8 @@ export class Completer implements vscode.CompletionItemProvider {
     readonly reference: Reference
     readonly package: Package
     readonly input: Input
+    readonly import: Import
+    readonly subImport: SubImport
     readonly glossary: Glossary
 
     constructor(extension: Extension) {
@@ -39,6 +41,8 @@ export class Completer implements vscode.CompletionItemProvider {
         this.reference = new Reference(extension)
         this.package = new Package(extension)
         this.input = new Input(extension)
+        this.import = new Import(extension)
+        this.subImport = new SubImport(extension)
         this.glossary = new Glossary(extension)
         try {
             this.loadDefaultItems()
@@ -180,11 +184,11 @@ export class Completer implements vscode.CompletionItemProvider {
                 break
             case 'import':
                 reg = /\\(import|includefrom|inputfrom)\*?(?:{([^}]*)})?{([^}]*)$/
-                provider = this.input
+                provider = this.import
                 break
             case 'subimport':
                 reg = /\\(sub(?:import|includefrom|inputfrom))\*?(?:{([^}]*)})?{([^}]*)$/
-                provider = this.input
+                provider = this.subImport
                 break
             case 'glossary':
                 reg = /\\(gls(?:pl|text|first|plural|firstplural|name|symbol|desc|user(?:i|ii|iii|iv|v|vi))?|Acr(?:long|full|short)?(?:pl)?|ac[slf]?p?)(?:\[[^[\]]*\])?{([^}]*)$/i
@@ -198,7 +202,7 @@ export class Completer implements vscode.CompletionItemProvider {
         const result = line.match(reg)
         let suggestions: vscode.CompletionItem[] = []
         if (result) {
-            suggestions = provider.provideFrom(type, result, args)
+            suggestions = provider.provideFrom(result, args)
         }
         return suggestions
     }


### PR DESCRIPTION
This PR splits the `Input` completer into three subclasses corresponding to the different input completion modes.

It enables us to remove the `type` argument of `provideFrom` in the `Iprovider` interface. This argument had no meaning for all completers but the `Input` one.