### PR TITLE
Change the menu title of structure-toggle-follow-cursor based on enablement

### DIFF
--- a/package.json
+++ b/package.json
@@ -443,8 +443,15 @@
       },
       {
         "command": "latex-workshop.structure-toggle-follow-cursor",
-        "title": "Toggle follow cursor",
-        "category": "LaTeX Workshop"
+        "title": "Toggle follow cursor: On",
+        "category": "LaTeX Workshop",
+        "enablement": "latex-workshop.structure-toggle-follow-cursor:enabled"
+      },
+      {
+        "command": "latex-workshop.structure-toggle-follow-cursor-alias",
+        "title": "Toggle follow cursor: Off",
+        "category": "LaTeX Workshop",
+        "enablement": "!latex-workshop.structure-toggle-follow-cursor:enabled"
       },
       {
         "command": "latex-workshop.showSnippetPanel",
@@ -2083,8 +2090,11 @@
       ],
       "view/title": [
         {
-          "when": "view == latex-workshop-structure",
+          "when": "view == latex-workshop-structure && latex-workshop.structure-toggle-follow-cursor:enabled",
           "command": "latex-workshop.structure-toggle-follow-cursor"
+        },{
+          "when": "view == latex-workshop-structure && !latex-workshop.structure-toggle-follow-cursor:enabled",
+          "command": "latex-workshop.structure-toggle-follow-cursor-alias"
         }
       ]
     },

--- a/src/providers/structure.ts
+++ b/src/providers/structure.ts
@@ -362,8 +362,14 @@ export class StructureTreeView {
     constructor(private readonly extension: Extension) {
         this._treeDataProvider = this.extension.structureProvider
         this._viewer = vscode.window.createTreeView('latex-workshop-structure', { treeDataProvider: this._treeDataProvider, showCollapseAll: true })
+        void vscode.commands.executeCommand('setContext', 'latex-workshop.structure-toggle-follow-cursor:enabled', this._followCursor)
         vscode.commands.registerCommand('latex-workshop.structure-toggle-follow-cursor', () => {
-           this._followCursor = ! this._followCursor
+            this._followCursor = ! this._followCursor
+            void vscode.commands.executeCommand('setContext', 'latex-workshop.structure-toggle-follow-cursor:enabled', this._followCursor)
+        })
+        vscode.commands.registerCommand('latex-workshop.structure-toggle-follow-cursor-alias', () => {
+            this._followCursor = ! this._followCursor
+            void vscode.commands.executeCommand('setContext', 'latex-workshop.structure-toggle-follow-cursor:enabled', this._followCursor)
         })
     }
 


### PR DESCRIPTION
Change the menu title of structure-toggle-follow-cursor based on enablement.

![スクリーンショット 2021-11-08 13 01 46](https://user-images.githubusercontent.com/10665499/140682526-49812a14-fe33-434c-8687-445ae8c5ad49.png)


