### PR TITLE
Disable commands and features on virtual workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -318,18 +318,21 @@
         "command": "latex-workshop.build",
         "title": "Build LaTeX project",
         "category": "LaTeX Workshop",
-        "icon": "$(debug-start)"
+        "icon": "$(debug-start)",
+        "enablement": "!virtualWorkspace"
       },
       {
         "command": "latex-workshop.recipes",
         "title": "Build with recipe",
-        "category": "LaTeX Workshop"
+        "category": "LaTeX Workshop",
+        "enablement": "!virtualWorkspace"
       },
       {
         "command": "latex-workshop.view",
         "title": "View LaTeX PDF file",
         "category": "LaTeX Workshop",
-        "icon": "$(open-preview)"
+        "icon": "$(open-preview)",
+        "enablement": "!virtualWorkspace"
       },
       {
         "command": "latex-workshop.tab",
@@ -339,12 +342,14 @@
       {
         "command": "latex-workshop.viewInBrowser",
         "title": "View LaTeX PDF file in web browser",
-        "category": "LaTeX Workshop"
+        "category": "LaTeX Workshop",
+        "enablement": "!virtualWorkspace"
       },
       {
         "command": "latex-workshop.viewExternal",
         "title": "View LaTeX PDF file in external viewer",
-        "category": "LaTeX Workshop"
+        "category": "LaTeX Workshop",
+        "enablement": "!virtualWorkspace"
       },
       {
         "command": "latex-workshop.setViewer",
@@ -359,22 +364,26 @@
       {
         "command": "latex-workshop.kill",
         "title": "Kill LaTeX compiler process",
-        "category": "LaTeX Workshop"
+        "category": "LaTeX Workshop",
+        "enablement": "!virtualWorkspace"
       },
       {
         "command": "latex-workshop.synctex",
         "title": "SyncTeX from cursor",
-        "category": "LaTeX Workshop"
+        "category": "LaTeX Workshop",
+        "enablement": "!virtualWorkspace"
       },
       {
         "command": "latex-workshop.clean",
         "title": "Clean up auxiliary files",
-        "category": "LaTeX Workshop"
+        "category": "LaTeX Workshop",
+        "enablement": "!virtualWorkspace"
       },
       {
         "command": "latex-workshop.citation",
         "title": "Open citation browser",
-        "category": "LaTeX Workshop"
+        "category": "LaTeX Workshop",
+        "enablement": "!virtualWorkspace"
       },
       {
         "command": "latex-workshop.addtexroot",
@@ -389,7 +398,8 @@
       {
         "command": "latex-workshop.compilerlog",
         "title": "View LaTeX compiler logs",
-        "category": "LaTeX Workshop"
+        "category": "LaTeX Workshop",
+        "enablement": "!virtualWorkspace"
       },
       {
         "command": "latex-workshop.log",
@@ -488,25 +498,25 @@
         "key": "ctrl+l alt+b",
         "mac": "cmd+l alt+b",
         "command": "latex-workshop.build",
-        "when": "editorLangId =~ /latex|rsweave|jlweave/ && config.latex-workshop.bind.altKeymap.enabled"
+        "when": "editorLangId =~ /latex|rsweave|jlweave/ && config.latex-workshop.bind.altKeymap.enabled && !virtualWorkspace"
       },
       {
         "key": "ctrl+l alt+c",
         "mac": "cmd+l alt+c",
         "command": "latex-workshop.clean",
-        "when": "editorLangId =~ /latex|rsweave|jlweave/ && config.latex-workshop.bind.altKeymap.enabled"
+        "when": "editorLangId =~ /latex|rsweave|jlweave/ && config.latex-workshop.bind.altKeymap.enabled && !virtualWorkspace"
       },
       {
         "key": "ctrl+l alt+v",
         "mac": "cmd+l alt+v",
         "command": "latex-workshop.view",
-        "when": "editorLangId =~ /latex|rsweave|jlweave/ && config.latex-workshop.bind.altKeymap.enabled"
+        "when": "editorLangId =~ /latex|rsweave|jlweave/ && config.latex-workshop.bind.altKeymap.enabled && !virtualWorkspace"
       },
       {
         "key": "ctrl+l alt+j",
         "mac": "cmd+l alt+j",
         "command": "latex-workshop.synctex",
-        "when": "editorTextFocus && editorLangId == 'latex' && config.latex-workshop.bind.altKeymap.enabled"
+        "when": "editorTextFocus && editorLangId == 'latex' && config.latex-workshop.bind.altKeymap.enabled && !virtualWorkspace"
       },
       {
         "key": "ctrl+l alt+x",
@@ -524,25 +534,25 @@
         "key": "ctrl+alt+b",
         "mac": "cmd+alt+b",
         "command": "latex-workshop.build",
-        "when": "editorLangId =~ /latex|rsweave|jlweave/ && !config.latex-workshop.bind.altKeymap.enabled"
+        "when": "editorLangId =~ /latex|rsweave|jlweave/ && !config.latex-workshop.bind.altKeymap.enabled && !virtualWorkspace"
       },
       {
         "key": "ctrl+alt+c",
         "mac": "cmd+alt+c",
         "command": "latex-workshop.clean",
-        "when": "editorLangId =~ /latex|rsweave|jlweave/ && !config.latex-workshop.bind.altKeymap.enabled"
+        "when": "editorLangId =~ /latex|rsweave|jlweave/ && !config.latex-workshop.bind.altKeymap.enabled && !virtualWorkspace"
       },
       {
         "key": "ctrl+alt+v",
         "mac": "cmd+alt+v",
         "command": "latex-workshop.view",
-        "when": "editorLangId =~ /latex|rsweave|jlweave/ && !config.latex-workshop.bind.altKeymap.enabled"
+        "when": "editorLangId =~ /latex|rsweave|jlweave/ && !config.latex-workshop.bind.altKeymap.enabled && !virtualWorkspace"
       },
       {
         "key": "ctrl+alt+j",
         "mac": "cmd+alt+j",
         "command": "latex-workshop.synctex",
-        "when": "editorTextFocus && editorLangId == 'latex' && !config.latex-workshop.bind.altKeymap.enabled"
+        "when": "editorTextFocus && editorLangId == 'latex' && !config.latex-workshop.bind.altKeymap.enabled && !virtualWorkspace"
       },
       {
         "key": "ctrl+alt+x",
@@ -2087,24 +2097,24 @@
     "menus": {
       "editor/context": [
         {
-          "when": "config.latex-workshop.showContextMenu && editorLangId == latex",
+          "when": "config.latex-workshop.showContextMenu && editorLangId == latex && !virtualWorkspace",
           "command": "latex-workshop.build",
           "group": "navigation@100"
         },
         {
-          "when": "config.latex-workshop.showContextMenu && editorLangId == latex",
+          "when": "config.latex-workshop.showContextMenu && editorLangId == latex && !virtualWorkspace",
           "command": "latex-workshop.synctex",
           "group": "navigation@101"
         }
       ],
       "editor/title": [
         {
-          "when": "editorLangId == latex",
+          "when": "editorLangId == latex && !virtualWorkspace",
           "command": "latex-workshop.view",
           "group": "navigation@2"
         },
         {
-          "when": "editorLangId == latex",
+          "when": "editorLangId == latex && !virtualWorkspace",
           "command": "latex-workshop.build",
           "group": "navigation@1"
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -170,6 +170,9 @@ export function activate(context: vscode.ExtensionContext): ReturnType<typeof ge
     registerLatexWorkshopCommands(extension)
 
     context.subscriptions.push(vscode.workspace.onDidSaveTextDocument( (e: vscode.TextDocument) => {
+        if (!extension.lwfs.isLocalUri(e.uri)){
+            return
+        }
         if (extension.manager.hasTexId(e.languageId)) {
             extension.logger.addLogMessage(`onDidSaveTextDocument triggered: ${e.uri.toString(true)}`)
             extension.manager.updateCachedContent(e)
@@ -189,6 +192,9 @@ export function activate(context: vscode.ExtensionContext): ReturnType<typeof ge
     }))
 
     context.subscriptions.push(vscode.workspace.onDidOpenTextDocument(async (e: vscode.TextDocument) => {
+        if (!extension.lwfs.isLocalUri(e.uri)){
+            return
+        }
         // This function will be called when a new text is opened, or an inactive editor is reactivated after vscode reload
         if (extension.manager.hasTexId(e.languageId)) {
             await extension.manager.findRoot()
@@ -197,6 +203,9 @@ export function activate(context: vscode.ExtensionContext): ReturnType<typeof ge
 
     let updateCompleter: NodeJS.Timeout
     context.subscriptions.push(vscode.workspace.onDidChangeTextDocument((e: vscode.TextDocumentChangeEvent) => {
+        if (!extension.lwfs.isLocalUri(e.document.uri)){
+            return
+        }
         if (!extension.manager.hasTexId(e.document.languageId)) {
             return
         }
@@ -233,7 +242,9 @@ export function activate(context: vscode.ExtensionContext): ReturnType<typeof ge
         } else if (vscode.window.activeTextEditor && vscode.window.activeTextEditor.document.languageId.toLowerCase() === 'log') {
             extension.logger.status.show()
         }
-
+        if (e && !extension.lwfs.isLocalUri(e.document.uri)){
+            return
+        }
         if (e && extension.manager.hasTexId(e.document.languageId)) {
             await extension.manager.findRoot()
             extension.linter.lintRootFileIfEnabled()

--- a/src/providers/definition.ts
+++ b/src/providers/definition.ts
@@ -48,6 +48,9 @@ export class DefinitionProvider implements vscode.DefinitionProvider {
     }
 
     provideDefinition(document: vscode.TextDocument, position: vscode.Position): vscode.Location | undefined {
+        if (!this.extension.lwfs.isLocalUri(document.uri)) {
+            return
+        }
         const token = tokenizer(document, position)
         if (token === undefined) {
             return

--- a/src/providers/docsymbol.ts
+++ b/src/providers/docsymbol.ts
@@ -17,6 +17,9 @@ export class DocSymbolProvider implements vscode.DocumentSymbolProvider {
     }
 
     provideDocumentSymbols(document: vscode.TextDocument): vscode.DocumentSymbol[] {
+        if (!this.extension.lwfs.isLocalUri(document.uri)) {
+            return []
+        }
         return this.sectionToSymbols(this.extension.structureProvider.buildModel(new Set<string>(), document.fileName, undefined, undefined, undefined, undefined, false))
     }
 

--- a/src/providers/projectsymbol.ts
+++ b/src/providers/projectsymbol.ts
@@ -15,6 +15,10 @@ export class ProjectSymbolProvider implements vscode.WorkspaceSymbolProvider {
         if (this.extension.manager.rootFile === undefined) {
             return symbols
         }
+        const rootFileUri = this.extension.manager.rootFileUri
+        if (rootFileUri && !this.extension.lwfs.isLocalUri(rootFileUri)) {
+            return symbols
+        }
         this.sectionToSymbols(symbols, this.extension.structureProvider.buildModel(new Set<string>(), this.extension.manager.rootFile))
         return symbols
     }


### PR DESCRIPTION
We had better disable commands and features on virtualworkspaces.  Extensions can be activated on virtualworkspaces even if `"virtualWorkspaces": false`.

See https://github.com/microsoft/vscode/issues/137152#issuecomment-974045485

> Extensions should always check and listen for workspace/folder changes and disable functionality when there's a workspace/folder they cannot work with.