### PR TITLE
Add language configuration for BibTeX style

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,8 @@
         ],
         "extensions": [
           ".bst"
-        ]
+        ],
+        "configuration": "./syntax/bibtex-style-language-configuration.json"
       },
       {
         "id": "latex-expl3",

--- a/syntax/BibTeX-style.tmLanguage.json
+++ b/syntax/BibTeX-style.tmLanguage.json
@@ -101,9 +101,14 @@
         }
       ]
     },
+    "string": {
+      "name": "string.quoted.double.bst",
+      "begin": "\"",
+      "end": "\""
+    },
     "number": {
       "name": "constant.numeric.bst",
-      "match": "\\#-?\\d+\\b"
+      "match": "#-?\\d+\\b"
     },
     "comments": {
       "name": "comment.line.percentage.bst",

--- a/syntax/bibtex-style-language-configuration.json
+++ b/syntax/bibtex-style-language-configuration.json
@@ -1,0 +1,21 @@
+{
+	"comments": {
+		"lineComment": "%"
+	},
+	"brackets": [
+		["{", "}"]
+	],
+	"autoClosingPairs": [
+		["{", "}"],
+		["\"", "\""]
+	],
+	"surroundingPairs": [
+		["{", "}"],
+		["\"", "\""]
+	],
+	"wordPattern": "(#-?\\d+|[A-Za-z_.][0-9A-Za-z_.]*\\$?)",
+	"indentationRules": {
+		"increaseIndentPattern": "^((?!%).)*(\\{[^}\"]*)$",
+		"decreaseIndentPattern": "^\\s*(\\}|if\\$|while\\$)"
+	}
+}


### PR DESCRIPTION
1. A language configuration file for BibTeX style (`.bst`) is added. It is more convenient to edit `.bst` files with it.
2. The syntax for BibTeX style is edited. In an earlier PR (#2679), the whole `string.quoted.double` pattern is removed by mistake. This causes strings are not correctly highlighted.
<img width="362" alt="Screen Shot 2021-12-09 at 18 49 43" src="https://user-images.githubusercontent.com/12290822/145382965-ca984520-8f9b-4d9d-8ebf-602a31f35165.png">

With this PR, the syntax highlighting is fixed and the
<img width="353" alt="Screen Shot 2021-12-09 at 18 53 22" src="https://user-images.githubusercontent.com/12290822/145383532-5f25986e-d542-4eb8-bdcf-f04f4f75d7f7.png">
 issue in #2679 is also addressed.

