### PR TITLE
Show some commands in outline/structure views

### DIFF
--- a/package.json
+++ b/package.json
@@ -1265,7 +1265,7 @@
           "default": [
             "label"
           ],
-          "markdownDescription": "The names of the commands to be shown in the outline/structure views. Reload VSCode after changing the value."
+          "markdownDescription": "The names of the commands to be shown in the outline/structure views. The commands must be called in the form `\\commandname{arg}`. Reload VSCode after changing the value."
         },
         "latex-workshop.view.outline.floats.enabled": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -1256,10 +1256,16 @@
           ],
           "markdownDescription": "The section names of LaTeX outline hierarchy. It is also used by the folding mechanism.\nThis property is an array of case-sensitive strings in the order of document structure hierarchy. For multiple tags in the same level, separate the tags with `|` as delimiters, e.g., `section|alternative`. Reload VSCode after changing the value."
         },
-        "latex-workshop.view.outline.labels.enabled": {
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Show the labels in the outline/structure views. Reload VSCode after changing the value."
+
+        "latex-workshop.view.outline.commands": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "label"
+          ],
+          "markdownDescription": "The names of the commands to be shown in the outline/structure views. Reload VSCode after changing the value."
         },
         "latex-workshop.view.outline.floats.enabled": {
           "type": "boolean",

--- a/src/providers/structure.ts
+++ b/src/providers/structure.ts
@@ -10,8 +10,8 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
 
     private readonly _onDidChangeTreeData: vscode.EventEmitter<Section | undefined> = new vscode.EventEmitter<Section | undefined>()
     readonly onDidChangeTreeData: vscode.Event<Section | undefined>
+    private readonly commandNames: string[]
     private readonly hierarchy: string[]
-    private readonly showLabels: boolean
     private readonly showFloats: boolean
     private readonly showNumbers: boolean
     public root: string = ''
@@ -23,10 +23,11 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
         this.onDidChangeTreeData = this._onDidChangeTreeData.event
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
 
+        this.commandNames = configuration.get('view.outline.commands') as string[]
         this.hierarchy = configuration.get('view.outline.sections') as string[]
-        this.showLabels = configuration.get('view.outline.labels.enabled') as boolean
         this.showFloats = configuration.get('view.outline.floats.enabled') as boolean
         this.showNumbers = configuration.get('view.outline.numbers.enabled') as boolean
+
     }
 
     refresh(): Section[] {
@@ -111,10 +112,8 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
             structureModel.buildHeadingModel(lines, lineNumber, this.showNumbers)
 
 
-            // Labels part
-            if (this.showLabels) {
-                structureModel.buildLabelModel(line, lineNumber, filePath)
-            }
+            // Commands part
+            structureModel.buildCommandModel(this.commandNames, line, lineNumber, filePath)
         }
         this.fixToLines(children)
         return children
@@ -299,18 +298,21 @@ class StructureModel {
         return inputFilePath
     }
 
-    buildLabelModel(line: string, lineNumber: number, filePath: string) {
-        const labelReg = /\\label{([^}]*)}/m
-        const result = labelReg.exec(line)
+    buildCommandModel(commandNames: string[], line: string, lineNumber: number, filePath: string) {
+        if (commandNames.length === 0) {
+            return
+        }
+        const commandReg = new RegExp('\\\\(' + commandNames.join('|') + '){([^}]*)}', 'm' )
+        const result = commandReg.exec(line)
         if (!result) {
             return
         }
         const depth = this.noRoot() ? 0 : this.currentRoot().depth + 1
-        const newLabel = new Section(SectionKind.Label, `#Label: ${result[1]}`, vscode.TreeItemCollapsibleState.None, depth, lineNumber, lineNumber, filePath)
+        const newCommand = new Section(SectionKind.Label, `#${result[1]}: ${result[2]}`, vscode.TreeItemCollapsibleState.None, depth, lineNumber, lineNumber, filePath)
         if (this.noRoot()) {
-            this.children.push(newLabel)
+            this.children.push(newCommand)
         } else {
-            this.currentRoot().children.push(newLabel)
+            this.currentRoot().children.push(newCommand)
         }
     }
 


### PR DESCRIPTION
This PR introduces the new setting `latex-workshop.view.outline.commands` with default value `["label"]`. It replaces `latex-workshop.view.outline.labels.enabled`, which was specific for labels.

This PR closes #2958.