### PR TITLE
Add configuration latex.toolsEnv to allow environment customization without having to alter all tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -957,6 +957,10 @@
           ],
           "markdownDescription": "Define LaTeX compiling tools to be used in recipes.\nEach tool is labeled by its `name`. When invoked, `command` is spawned with arguments defined in `args` and environment variables defined in `env`. Typically no spaces should appear in each argument unless in paths.\nPlaceholders `%DOC%`, `%DOC_W32%, %DOC_EXT%`, `%DOC_EXT_W32%`, `%DOCFILE%`, `%DOCFILE_EXT%`, `%DIR%`, `%DIR_W32%`, `%TMPDIR%` and `%OUTDIR%`, `%OUTDIR_W32%` are available. For more details, please visit https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#placeholders."
         },
+        "latex-workshop.latex.toolsEnv": {
+          "type": "object",
+          "markdownDescription": "Define the default environment variables for `#latex-workshop.latex.tools#`.\nPlaceholders and `${env:variable}` for environment variables are available as in the `env` property of each tool."
+        },
         "latex-workshop.latex.magic.args": {
           "type": "array",
           "items": {


### PR DESCRIPTION
Currently, if you wanted to modify, for example, the `PATH` variable for your tools, you have to copy paste the default list of tools, and then edit the `env` property of each tool.

Instead, you will be able to just set
```js
"latex-workshop.latex.toolsEnv": { "PATH": "..." },
```

This PR also:
- fixes #3039
- Allows access to environment variables in the `env` property value using the vscode style variables `${env:variable}`.