### PR TITLE
Handle multiline section command in outline

### DIFF
--- a/src/providers/structure.ts
+++ b/src/providers/structure.ts
@@ -238,6 +238,8 @@ class StructureModel {
                 pattern += '|'
             }
         })
+        // To deal with multiline header, capture the whole line starting from the opening '{'
+        // The actual title will be determined later using getLongestBalancedString
         pattern += ')(\\*)?(?:\\[[^\\[\\]\\{\\}]*\\])?{(.*)$'
         this.headerPattern = pattern
     }

--- a/src/providers/structure.ts
+++ b/src/providers/structure.ts
@@ -238,7 +238,7 @@ class StructureModel {
                 pattern += '|'
             }
         })
-        pattern += ')(\\*)?(?:\\[[^\\[\\]\\{\\}]*\\])?{(.*)}'
+        pattern += ')(\\*)?(?:\\[[^\\[\\]\\{\\}]*\\])?{(.*)$'
         this.headerPattern = pattern
     }
 
@@ -326,7 +326,7 @@ class StructureModel {
         // is it a section, a subsection, etc?
         const heading = result[1]
         const depth = this.sectionDepths[heading]
-        const title = this.getSectionTitle(result[3])
+        const title = this.getSectionTitle(result[3] + lines.slice(lineNumber + 1).join('\n'))
         let sectionNumberStr: string = ''
         if (result[2] === undefined) {
             this.incrementSectionNumber(depth)

--- a/src/providers/structure.ts
+++ b/src/providers/structure.ts
@@ -251,7 +251,7 @@ class StructureModel {
     }
 
     buildEnvModel(envNames: string[], lines: string[], lineNumber: number) {
-        const envReg = RegExp(`(?:\\\\(begin|end)(?:\\[[^[\\]]*\\])?){(?:(${envNames.join('|')})\\*?)}`, 'm')
+        const envReg = RegExp(`(?:\\\\(begin|end)(?:\\[[^[\\]]*\\])?){(?:(${envNames.join('|')})\\*?)}`)
         const line = lines[lineNumber]
         const result = envReg.exec(line)
         if (result && result[1] === 'begin') {
@@ -302,7 +302,7 @@ class StructureModel {
         if (commandNames.length === 0) {
             return
         }
-        const commandReg = new RegExp('\\\\(' + commandNames.join('|') + '){([^}]*)}', 'm' )
+        const commandReg = new RegExp('\\\\(' + commandNames.join('|') + '){([^}]*)}')
         const result = commandReg.exec(line)
         if (!result) {
             return
@@ -318,7 +318,7 @@ class StructureModel {
 
     buildHeadingModel(lines: string[], lineNumber: number, showNumbers: boolean) {
         const line = lines[lineNumber]
-        const headerReg = RegExp(this.headerPattern, 'm')
+        const headerReg = RegExp(this.headerPattern)
         const result = headerReg.exec(line)
         if (!result) {
             return


### PR DESCRIPTION
This PR closes #3042. The price to pay is to look for the closing `}` of `\section{...}` in the whole rest of the document

https://github.com/James-Yu/LaTeX-Workshop/blob/1fb2e81b61131d13ff80803b3ddbede214ec0bcf/src/providers/structure.ts#L329

Is this worth it? @tamuratak Your opinion?