### PR TITLE
Update PDF.js to v2.11.338

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2500,9 +2500,9 @@
       "dev": true
     },
     "pdfjs-dist": {
-      "version": "2.10.377",
-      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-2.10.377.tgz",
-      "integrity": "sha512-i0jRShtvgfsVQUNCoFYH4SVhPO3U0yhtiFLfZ0RR0B+68N+Vnwq+8B3cjWjLEwWGh8wg1XQ/sYMYKUlHn/Qpsw=="
+      "version": "2.11.338",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-2.11.338.tgz",
+      "integrity": "sha512-Ti5VTB0VvSdtTtc7TG71ghMx0SEuNcEs4ghVuZxW0p6OqLjMc0xekZV1B+MmlxEG2Du2e5jgazucWIG/SXTcdA=="
     },
     "pegjs-backtrace": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -2200,7 +2200,7 @@
     "latex-utensils": "4.1.0",
     "mathjax-full": "3.2.0",
     "micromatch": "4.0.4",
-    "pdfjs-dist": "2.10.377",
+    "pdfjs-dist": "2.11.338",
     "tmp": "0.2.1",
     "workerpool": "6.1.5",
     "ws": "8.2.3"

--- a/viewer/latexworkshop.css
+++ b/viewer/latexworkshop.css
@@ -102,6 +102,14 @@
 }
 
 #secondaryDownload {
+    display: inherit !important;
+}
+
+#secondaryToolbarButtonContainer .horizontalToolbarSeparator {
+    display: inherit !important;
+}
+
+#toolbarViewerRight .verticalToolbarSeparator {
     display: none  !important;
 }
 

--- a/viewer/latexworkshop.ts
+++ b/viewer/latexworkshop.ts
@@ -394,13 +394,13 @@ class LateXWorkshopPdfViewer implements ILatexWorkshopPdfViewer {
         const smallViewMaxWidth = 580 + numPagesWidth + scaleWidth + printerButtonWidth
         const smallViewRule = `@media all and (max-width: ${smallViewMaxWidth}px) { .hiddenSmallView, .hiddenSmallView * { display: none; } }`
         styleSheet.insertRule(smallViewRule)
-        const buttonSpacerMaxWidth = 520 + numPagesWidth + scaleWidth + printerButtonWidth
+        const buttonSpacerMaxWidth = 540 + numPagesWidth + scaleWidth + printerButtonWidth
         const buttonSpacerRule = `@media all and (max-width: ${buttonSpacerMaxWidth}px) { .toolbarButtonSpacer { width: 0; } }`
         styleSheet.insertRule(buttonSpacerRule)
-        const scaleMaxWidth = 480 + numPagesWidth + scaleWidth + printerButtonWidth
+        const scaleMaxWidth = 500 + numPagesWidth + scaleWidth + printerButtonWidth
         const scaleRule = `@media all and (max-width: ${scaleMaxWidth}px) { #scaleSelectContainer { display: none; } }`
         styleSheet.insertRule(scaleRule)
-        const trimMaxWidth = 480 + numPagesWidth + printerButtonWidth
+        const trimMaxWidth = 500 + numPagesWidth + printerButtonWidth
         const trimRule = `@media all and (max-width: ${trimMaxWidth}px) { #trimSelectContainer { display: none; } }`
         styleSheet.insertRule(trimRule)
     }

--- a/viewer/locale/ach/viewer.properties
+++ b/viewer/locale/ach/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Neno ma kombedi
 tools.title=Gintic
 tools_label=Gintic
 first_page.title=Cit i pot buk mukwongo
-first_page.label=Cit i pot buk mukwongo
 first_page_label=Cit i pot buk mukwongo
 last_page.title=Cit i pot buk magiko
-last_page.label=Cit i pot buk magiko
 last_page_label=Cit i pot buk magiko
 page_rotate_cw.title=Wire i tung lacuc
-page_rotate_cw.label=Wire i tung lacuc
 page_rotate_cw_label=Wire i tung lacuc
 page_rotate_ccw.title=Wire i tung lacam
-page_rotate_ccw.label=Wire i tung lacam
 page_rotate_ccw_label=Wire i tung lacam
 
 cursor_text_select_tool.title=Cak gitic me yero coc
@@ -124,7 +120,6 @@ print_progress_close=Juki
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Lok gintic ma inget
-toggle_sidebar_notification.title=Lok lanyut me nget (wiyewiye tye i gin acoya/attachments)
 toggle_sidebar_label=Lok gintic ma inget
 document_outline.title=Nyut Wiyewiye me Gin acoya (dii-kiryo me yaro/kano jami weng)
 document_outline_label=Pek pa gin acoya
@@ -183,9 +178,6 @@ page_scale_actual=Dite kikome
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Bal
 
 loading_error=Bal otime kun cano PDF.
 invalid_file_error=Pwail me PDF ma pe atir onyo obale woko.

--- a/viewer/locale/af/viewer.properties
+++ b/viewer/locale/af/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Huidige aansig
 tools.title=Nutsgoed
 tools_label=Nutsgoed
 first_page.title=Gaan na eerste bladsy
-first_page.label=Gaan na eerste bladsy
 first_page_label=Gaan na eerste bladsy
 last_page.title=Gaan na laaste bladsy
-last_page.label=Gaan na laaste bladsy
 last_page_label=Gaan na laaste bladsy
 page_rotate_cw.title=Roteer kloksgewys
-page_rotate_cw.label=Roteer kloksgewys
 page_rotate_cw_label=Roteer kloksgewys
 page_rotate_ccw.title=Roteer anti-kloksgewys
-page_rotate_ccw.label=Roteer anti-kloksgewys
 page_rotate_ccw_label=Roteer anti-kloksgewys
 
 cursor_text_select_tool.title=Aktiveer gereedskap om teks te merk
@@ -101,7 +97,6 @@ print_progress_close=Kanselleer
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Sypaneel aan/af
-toggle_sidebar_notification.title=Sypaneel aan/af (dokument bevat skema/aanhegsels)
 toggle_sidebar_label=Sypaneel aan/af
 document_outline.title=Wys dokumentskema (dubbelklik om alle items oop/toe te vou)
 document_outline_label=Dokumentoorsig
@@ -160,9 +155,6 @@ page_scale_actual=Werklike grootte
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Fout
 
 loading_error='n Fout het voorgekom met die laai van die PDF.
 invalid_file_error=Ongeldige of korrupte PDF-lêer.

--- a/viewer/locale/an/viewer.properties
+++ b/viewer/locale/an/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Vista actual
 tools.title=Ferramientas
 tools_label=Ferramientas
 first_page.title=Ir ta la primer pachina
-first_page.label=Ir ta la primer pachina
 first_page_label=Ir ta la primer pachina
 last_page.title=Ir ta la zaguer pachina
-last_page.label=Ir ta la zaguera pachina
 last_page_label=Ir ta la zaguer pachina
 page_rotate_cw.title=Chirar enta la dreita
-page_rotate_cw.label=Chirar enta la dreita
 page_rotate_cw_label=Chira enta la dreita
 page_rotate_ccw.title=Chirar enta la zurda
-page_rotate_ccw.label=Chirar en sentiu antihorario
 page_rotate_ccw_label=Chirar enta la zurda
 
 cursor_text_select_tool.title=Activar la ferramienta de selección de texto
@@ -137,7 +133,6 @@ print_progress_close=Cancelar
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Amostrar u amagar a barra lateral
-toggle_sidebar_notification.title=Cambiar barra lateral (lo documento contiene esquema/adchuntos)
 toggle_sidebar_notification2.title=Cambiar barra lateral (lo documento contiene esquema/adchuntos/capas)
 toggle_sidebar_label=Amostrar a barra lateral
 document_outline.title=Amostrar esquema d'o documento (fer doble clic pa expandir/compactar totz los items)
@@ -150,9 +145,6 @@ thumbs.title=Amostrar as miniaturas
 thumbs_label=Miniaturas
 findbar.title=Trobar en o documento
 findbar_label=Trobar
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=Pachina {{page}}
 
 additional_layers=Capas adicionals
 # Thumbnails panel item (tooltip and alt text for images)
@@ -225,9 +217,6 @@ page_scale_actual=Grandaria actual
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Error
 
 loading_error=S'ha produciu una error en cargar o PDF.
 invalid_file_error=O PDF no ye valido u ye estorbau.

--- a/viewer/locale/ar/viewer.properties
+++ b/viewer/locale/ar/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=المنظور الحالي
 tools.title=الأدوات
 tools_label=الأدوات
 first_page.title=انتقل إلى الصفحة الأولى
-first_page.label=انتقل إلى الصفحة الأولى
 first_page_label=انتقل إلى الصفحة الأولى
 last_page.title=انتقل إلى الصفحة الأخيرة
-last_page.label=انتقل إلى الصفحة الأخيرة
 last_page_label=انتقل إلى الصفحة الأخيرة
 page_rotate_cw.title=أدر باتجاه عقارب الساعة
-page_rotate_cw.label=أدر باتجاه عقارب الساعة
 page_rotate_cw_label=أدر باتجاه عقارب الساعة
 page_rotate_ccw.title=أدر بعكس اتجاه عقارب الساعة
-page_rotate_ccw.label=أدر بعكس اتجاه عقارب الساعة
 page_rotate_ccw_label=أدر بعكس اتجاه عقارب الساعة
 
 cursor_text_select_tool.title=فعّل أداة اختيار النص
@@ -137,7 +133,6 @@ print_progress_close=ألغِ
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=بدّل ظهور الشريط الجانبي
-toggle_sidebar_notification.title=بدّل ظهور الشريط الجانبي (يحتوي المستند على مخطط أو مرفقات)
 toggle_sidebar_notification2.title=بدّل ظهور الشريط الجانبي (يحتوي المستند على مخطط أو مرفقات أو طبقات)
 toggle_sidebar_label=بدّل ظهور الشريط الجانبي
 document_outline.title=اعرض فهرس المستند (نقر مزدوج لتمديد أو تقليص كل العناصر)
@@ -150,9 +145,6 @@ thumbs.title=اعرض مُصغرات
 thumbs_label=مُصغّرات
 findbar.title=ابحث في المستند
 findbar_label=ابحث
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=صفحة {{page}}
 
 additional_layers=الطبقات الإضافية
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -227,9 +219,6 @@ page_scale_actual=الحجم الفعلي
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}٪
-
-# Loading indicator messages
-loading_error_indicator=عطل
 
 # Loading indicator messages
 loading=يحمّل…

--- a/viewer/locale/ast/viewer.properties
+++ b/viewer/locale/ast/viewer.properties
@@ -127,9 +127,6 @@ thumbs.title=Amosar les miniatures
 thumbs_label=Miniatures
 findbar_label=Atopar
 
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=Páxina {{page}}
-
 additional_layers=Capes adicionales
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
 page_landmark=Páxina {{page}}
@@ -189,9 +186,6 @@ page_scale_actual=Tamañu real
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Fallu
 
 # Loading indicator messages
 loading=Cargando…

--- a/viewer/locale/az/viewer.properties
+++ b/viewer/locale/az/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Hazırkı görünüş
 tools.title=Alətlər
 tools_label=Alətlər
 first_page.title=İlk Səhifəyə get
-first_page.label=İlk Səhifəyə get
 first_page_label=İlk Səhifəyə get
 last_page.title=Son Səhifəyə get
-last_page.label=Son Səhifəyə get
 last_page_label=Son Səhifəyə get
 page_rotate_cw.title=Saat İstiqamətində Fırlat
-page_rotate_cw.label=Saat İstiqamətində Fırlat
 page_rotate_cw_label=Saat İstiqamətində Fırlat
 page_rotate_ccw.title=Saat İstiqamətinin Əksinə Fırlat
-page_rotate_ccw.label=Saat İstiqamətinin Əksinə Fırlat
 page_rotate_ccw_label=Saat İstiqamətinin Əksinə Fırlat
 
 cursor_text_select_tool.title=Yazı seçmə alətini aktivləşdir
@@ -137,7 +133,6 @@ print_progress_close=Ləğv et
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Yan Paneli Aç/Bağla
-toggle_sidebar_notification.title=Yan paneli çevir (sənəddə icmal/bağlama var)
 toggle_sidebar_notification2.title=Yan paneli çevir (sənəddə icmal/bağlamalar/laylar mövcuddur)
 toggle_sidebar_label=Yan Paneli Aç/Bağla
 document_outline.title=Sənədin eskizini göstər (bütün bəndləri açmaq/yığmaq üçün iki dəfə klikləyin)
@@ -150,9 +145,6 @@ thumbs.title=Kiçik şəkilləri göstər
 thumbs_label=Kiçik şəkillər
 findbar.title=Sənəddə Tap
 findbar_label=Tap
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=Səhifə {{page}}
 
 additional_layers=Əlavə laylar
 # Thumbnails panel item (tooltip and alt text for images)
@@ -225,9 +217,6 @@ page_scale_actual=Hazırkı Həcm
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Səhv
 
 loading_error=PDF yüklenərkən bir səhv yarandı.
 invalid_file_error=Səhv və ya zədələnmiş olmuş PDF fayl.

--- a/viewer/locale/be/viewer.properties
+++ b/viewer/locale/be/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Цяперашняя праява
 tools.title=Прылады
 tools_label=Прылады
 first_page.title=Перайсці на першую старонку
-first_page.label=Перайсці на першую старонку
 first_page_label=Перайсці на першую старонку
 last_page.title=Перайсці на апошнюю старонку
-last_page.label=Перайсці на апошнюю старонку
 last_page_label=Перайсці на апошнюю старонку
 page_rotate_cw.title=Павярнуць па сонцу
-page_rotate_cw.label=Павярнуць па сонцу
 page_rotate_cw_label=Павярнуць па сонцу
 page_rotate_ccw.title=Павярнуць супраць сонца
-page_rotate_ccw.label=Павярнуць супраць сонца
 page_rotate_ccw_label=Павярнуць супраць сонца
 
 cursor_text_select_tool.title=Уключыць прыладу выбару тэксту
@@ -137,7 +133,6 @@ print_progress_close=Скасаваць
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Паказаць/схаваць бакавую панэль
-toggle_sidebar_notification.title=Паказаць/схаваць бакавую панэль (дакумент мае змест/укладанні)
 toggle_sidebar_notification2.title=Паказаць/схаваць бакавую панэль (дакумент мае змест/укладанні/пласты)
 toggle_sidebar_label=Паказаць/схаваць бакавую панэль
 document_outline.title=Паказаць структуру дакумента (двайная пстрычка, каб разгарнуць /згарнуць усе элементы)
@@ -152,9 +147,6 @@ current_outline_item.title=Знайсці бягучы элемент струк
 current_outline_item_label=Бягучы элемент структуры
 findbar.title=Пошук у дакуменце
 findbar_label=Знайсці
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=Старонка {{page}}
 
 additional_layers=Дадатковыя пласты
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -229,9 +221,6 @@ page_scale_actual=Сапраўдны памер
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Памылка
 
 # Loading indicator messages
 loading=Чытаецца…

--- a/viewer/locale/bg/viewer.properties
+++ b/viewer/locale/bg/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Текущ изглед
 tools.title=Инструменти
 tools_label=Инструменти
 first_page.title=Към първата страница
-first_page.label=Към първата страница
 first_page_label=Към първата страница
 last_page.title=Към последната страница
-last_page.label=Към последната страница
 last_page_label=Към последната страница
 page_rotate_cw.title=Завъртане по час. стрелка
-page_rotate_cw.label=Завъртане по часовниковата стрелка
 page_rotate_cw_label=Завъртане по часовниковата стрелка
 page_rotate_ccw.title=Завъртане обратно на час. стрелка
-page_rotate_ccw.label=Завъртане обратно на часовниковата стрелка
 page_rotate_ccw_label=Завъртане обратно на часовниковата стрелка
 
 cursor_text_select_tool.title=Включване на инструмента за избор на текст
@@ -137,7 +133,6 @@ print_progress_close=Отказ
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Превключване на страничната лента
-toggle_sidebar_notification.title=Превключване на страничната лента (документи със структура/прикачени файлове)
 toggle_sidebar_label=Превключване на страничната лента
 document_outline.title=Показване на структурата на документа (двукратно щракване за свиване/разгъване на всичко)
 document_outline_label=Структура на документа
@@ -218,9 +213,6 @@ page_scale_actual=Действителен размер
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Грешка
 
 loading_error=Получи се грешка при зареждане на PDF-а.
 invalid_file_error=Невалиден или повреден PDF файл.

--- a/viewer/locale/bn/viewer.properties
+++ b/viewer/locale/bn/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=বর্তমান অবস্থা
 tools.title=টুল
 tools_label=টুল
 first_page.title=প্রথম পাতায় যাও
-first_page.label=প্রথম পাতায় যাও
 first_page_label=প্রথম পাতায় যাও
 last_page.title=শেষ পাতায় যাও
-last_page.label=শেষ পাতায় যাও
 last_page_label=শেষ পাতায় যাও
 page_rotate_cw.title=ঘড়ির কাঁটার দিকে ঘোরাও
-page_rotate_cw.label=ঘড়ির কাঁটার দিকে ঘোরাও
 page_rotate_cw_label=ঘড়ির কাঁটার দিকে ঘোরাও
 page_rotate_ccw.title=ঘড়ির কাঁটার বিপরীতে ঘোরাও
-page_rotate_ccw.label=ঘড়ির কাঁটার বিপরীতে ঘোরাও
 page_rotate_ccw_label=ঘড়ির কাঁটার বিপরীতে ঘোরাও
 
 cursor_text_select_tool.title=লেখা নির্বাচক টুল সক্রিয় করুন
@@ -135,7 +131,6 @@ print_progress_close=বাতিল
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=সাইডবার টগল করুন
-toggle_sidebar_notification.title=সাইডবার টগল (নথিতে আউটলাইন/এটাচমেন্ট রয়েছে)
 toggle_sidebar_label=সাইডবার টগল করুন
 document_outline.title=নথির আউটলাইন দেখাও (সব আইটেম প্রসারিত/সঙ্কুচিত করতে ডবল ক্লিক করুন)
 document_outline_label=নথির রূপরেখা
@@ -145,9 +140,6 @@ thumbs.title=থাম্বনেইল সমূহ প্রদর্শন �
 thumbs_label=থাম্বনেইল সমূহ
 findbar.title=নথির মধ্যে খুঁজুন
 findbar_label=খুঁজুন
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=পাতা {{page}}
 
 # Thumbnails panel item (tooltip and alt text for images)
 # LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
@@ -219,9 +211,6 @@ page_scale_actual=প্রকৃত আকার
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=ত্রুটি
 
 loading_error=পিডিএফ লোড করার সময় ত্রুটি দেখা দিয়েছে।
 invalid_file_error=অকার্যকর অথবা ক্ষতিগ্রস্ত পিডিএফ ফাইল।

--- a/viewer/locale/bo/viewer.properties
+++ b/viewer/locale/bo/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Current View
 tools.title=Tools
 tools_label=Tools
 first_page.title=Go to First Page
-first_page.label=Go to First Page
 first_page_label=Go to First Page
 last_page.title=Go to Last Page
-last_page.label=Go to Last Page
 last_page_label=Go to Last Page
 page_rotate_cw.title=Rotate Clockwise
-page_rotate_cw.label=Rotate Clockwise
 page_rotate_cw_label=Rotate Clockwise
 page_rotate_ccw.title=Rotate Counterclockwise
-page_rotate_ccw.label=Rotate Counterclockwise
 page_rotate_ccw_label=Rotate Counterclockwise
 
 cursor_text_select_tool.title=Enable Text Selection Tool
@@ -137,7 +133,6 @@ print_progress_close=Cancel
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Toggle Sidebar
-toggle_sidebar_notification.title=Toggle Sidebar (document contains outline/attachments)
 toggle_sidebar_label=Toggle Sidebar
 document_outline.title=Show Document Outline (double-click to expand/collapse all items)
 document_outline_label=Document Outline
@@ -218,9 +213,6 @@ page_scale_actual=Actual Size
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Error
 
 loading_error=An error occurred while loading the PDF.
 invalid_file_error=Invalid or corrupted PDF file.

--- a/viewer/locale/br/viewer.properties
+++ b/viewer/locale/br/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Gwel bremanel
 tools.title=Ostilhoù
 tools_label=Ostilhoù
 first_page.title=Mont d'ar bajenn gentañ
-first_page.label=Mont d'ar bajenn gentañ
 first_page_label=Mont d'ar bajenn gentañ
 last_page.title=Mont d'ar bajenn diwezhañ
-last_page.label=Mont d'ar bajenn diwezhañ
 last_page_label=Mont d'ar bajenn diwezhañ
 page_rotate_cw.title=C'hwelañ gant roud ar bizied
-page_rotate_cw.label=C'hwelañ gant roud ar bizied
 page_rotate_cw_label=C'hwelañ gant roud ar bizied
 page_rotate_ccw.title=C'hwelañ gant roud gin ar bizied
-page_rotate_ccw.label=C'hwelañ gant roud gin ar bizied
 page_rotate_ccw_label=C'hwelañ gant roud gin ar bizied
 
 cursor_text_select_tool.title=Gweredekaat an ostilh diuzañ testenn
@@ -137,7 +133,6 @@ print_progress_close=Nullañ
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Diskouez/kuzhat ar varrenn gostez
-toggle_sidebar_notification.title=Trec'haoliñ ar verrenn-gostez (ur steuñv pe stagadennoù a zo en teul)
 toggle_sidebar_notification2.title=Trec'haoliñ ar varrenn-gostez (ur steuñv pe stagadennoù a zo en teul)
 toggle_sidebar_label=Diskouez/kuzhat ar varrenn gostez
 document_outline.title=Diskouez steuñv an teul (daouglikit evit brasaat/bihanaat an holl elfennoù)
@@ -150,9 +145,6 @@ thumbs.title=Diskouez ar melvennoù
 thumbs_label=Melvennoù
 findbar.title=Klask e-barzh an teuliad
 findbar_label=Klask
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=Pajenn {{page}}
 
 additional_layers=Gwiskadoù ouzhpenn
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -227,9 +219,6 @@ page_scale_actual=Ment wir
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Fazi
 
 # Loading indicator messages
 loading=O kargañ…

--- a/viewer/locale/brx/viewer.properties
+++ b/viewer/locale/brx/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=दानि नुथाय
 tools.title=टुल
 tools_label=टुल
 first_page.title=गिबि बिलाइआव थां
-first_page.label=गिबि बिलाइआव थां
 first_page_label=गिबि बिलाइआव थां
 last_page.title=जोबथा बिलाइआव थां
-last_page.label=जोबथा बिलाइआव थां
 last_page_label=जोबथा बिलाइआव थां
 page_rotate_cw.title=घरि गिदिंनाय फार्से फिदिं
-page_rotate_cw.label=घरि गिदिंनाय फार्से फिदिं
 page_rotate_cw_label=घरि गिदिंनाय फार्से फिदिं
 page_rotate_ccw.title=घरि गिदिंनाय उल्था फार्से फिदिं
-page_rotate_ccw.label=घरि गिदिंनाय उल्था फार्से फिदिं
 page_rotate_ccw_label=घरि गिदिंनाय उल्था फार्से फिदिं
 
 
@@ -183,9 +179,6 @@ page_scale_actual=थार महर
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=गोरोन्थि
 
 loading_error=PDF ल'ड खालामनाय समाव मोनसे गोरोन्थि जाबाय।
 invalid_file_error=बाहायजायै एबा गाज्रि जानाय PDF फाइल

--- a/viewer/locale/bs/viewer.properties
+++ b/viewer/locale/bs/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Trenutni prikaz
 tools.title=Alati
 tools_label=Alati
 first_page.title=Idi na prvu stranu
-first_page.label=Idi na prvu stranu
 first_page_label=Idi na prvu stranu
 last_page.title=Idi na zadnju stranu
-last_page.label=Idi na zadnju stranu
 last_page_label=Idi na zadnju stranu
 page_rotate_cw.title=Rotiraj u smjeru kazaljke na satu
-page_rotate_cw.label=Rotiraj u smjeru kazaljke na satu
 page_rotate_cw_label=Rotiraj u smjeru kazaljke na satu
 page_rotate_ccw.title=Rotiraj suprotno smjeru kazaljke na satu
-page_rotate_ccw.label=Rotiraj suprotno smjeru kazaljke na satu
 page_rotate_ccw_label=Rotiraj suprotno smjeru kazaljke na satu
 
 cursor_text_select_tool.title=Omogući alat za označavanje teksta
@@ -118,7 +114,6 @@ print_progress_close=Otkaži
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Uključi/isključi bočnu traku
-toggle_sidebar_notification.title=Uključi/isključi sidebar (dokument sadrži outline/priloge)
 toggle_sidebar_label=Uključi/isključi bočnu traku
 document_outline.title=Prikaži outline dokumenta (dvoklik za skupljanje/širenje svih stavki)
 document_outline_label=Konture dokumenta
@@ -177,9 +172,6 @@ page_scale_actual=Stvarna veličina
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Greška
 
 loading_error=Došlo je do greške prilikom učitavanja PDF-a.
 invalid_file_error=Neispravan ili oštećen PDF fajl.

--- a/viewer/locale/ca/viewer.properties
+++ b/viewer/locale/ca/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Vista actual
 tools.title=Eines
 tools_label=Eines
 first_page.title=Vés a la primera pàgina
-first_page.label=Vés a la primera pàgina
 first_page_label=Vés a la primera pàgina
 last_page.title=Vés a l'última pàgina
-last_page.label=Vés a l'última pàgina
 last_page_label=Vés a l'última pàgina
 page_rotate_cw.title=Gira cap a la dreta
-page_rotate_cw.label=Gira cap a la dreta
 page_rotate_cw_label=Gira cap a la dreta
 page_rotate_ccw.title=Gira cap a l'esquerra
-page_rotate_ccw.label=Gira cap a l'esquerra
 page_rotate_ccw_label=Gira cap a l'esquerra
 
 cursor_text_select_tool.title=Habilita l'eina de selecció de text
@@ -137,7 +133,6 @@ print_progress_close=Cancel·la
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Mostra/amaga la barra lateral
-toggle_sidebar_notification.title=Mostra/amaga la barra lateral (el document conté un esquema o adjuncions)
 toggle_sidebar_notification2.title=Mostra/amaga la barra lateral (el document conté un esquema, adjuncions o capes)
 toggle_sidebar_label=Mostra/amaga la barra lateral
 document_outline.title=Mostra l'esquema del document (doble clic per ampliar/reduir tots els elements)
@@ -152,9 +147,6 @@ current_outline_item.title=Cerca l'element d'esquema actual
 current_outline_item_label=Element d'esquema actual
 findbar.title=Cerca al document
 findbar_label=Cerca
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=Pàgina {{page}}
 
 additional_layers=Capes addicionals
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -229,9 +221,6 @@ page_scale_actual=Mida real
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Error
 
 # Loading indicator messages
 loading=S'està carregant…

--- a/viewer/locale/cak/viewer.properties
+++ b/viewer/locale/cak/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Rutzub'al wakami
 tools.title=Samajib'äl
 tools_label=Samajib'äl
 first_page.title=Tib'e pa nab'ey ruxaq
-first_page.label=Tib'e pa nab'ey ruxaq
 first_page_label=Tib'e pa nab'ey ruxaq
 last_page.title=Tib'e pa ruk'isib'äl ruxaq
-last_page.label=Tib'e pa ruk'isib'äl ruxaq
 last_page_label=Tib'e pa ruk'isib'äl ruxaq
 page_rotate_cw.title=Tisutïx pan ajkiq'a'
-page_rotate_cw.label=Tisutïx pan ajkiq'a'
 page_rotate_cw_label=Tisutïx pan ajkiq'a'
 page_rotate_ccw.title=Tisutïx pan ajxokon
-page_rotate_ccw.label=Tisutïx pan ajxokon
 page_rotate_ccw_label=Tisutïx pan ajxokon
 
 cursor_text_select_tool.title=Titzij ri rusamajib'al Rucha'ik Rucholajem Tzij
@@ -137,7 +133,6 @@ print_progress_close=Tiq'at
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Tijal ri ajxikin kajtz'ik
-toggle_sidebar_notification.title=Tik'ex ri ajxikin yuqkajtz'ik (ri wuj eruk'wan taq ruchi'/taqoj taq yakb'äl)
 toggle_sidebar_notification2.title=Tik'ex ri ajxikin yuqkajtz'ik (ri wuj eruk'wan taq ruchi'/taqo/kuchuj)
 toggle_sidebar_label=Tijal ri ajxikin kajtz'ik
 document_outline.title=Tik'ut pe ruch'akulal wuj (kamul-pitz'oj richin nirik'/nich'utinirisäx ronojel ruch'akulal)
@@ -152,9 +147,6 @@ current_outline_item.title=Kekanöx  Taq Ch'akulal Kik'wan Chib'äl
 current_outline_item_label=Taq Ch'akulal Kik'wan Chib'äl
 findbar.title=Tikanöx chupam ri wuj
 findbar_label=Tikanöx
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=Ruxaq {{page}}
 
 additional_layers=Tz'aqat ta Kuchuj
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -229,9 +221,6 @@ page_scale_actual=Runimilem Wakami
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Sachoj
 
 # Loading indicator messages
 loading=Nisamäj…

--- a/viewer/locale/ckb/viewer.properties
+++ b/viewer/locale/ckb/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=پیشبینینی ئێستا
 tools.title=ئامرازەکان
 tools_label=ئامرازەکان
 first_page.title=برۆ بۆ یەکەم پەڕە
-first_page.label=بڕۆ بۆ یەکەم پەڕە
 first_page_label=بڕۆ بۆ یەکەم پەڕە
 last_page.title=بڕۆ بۆ کۆتا پەڕە
-last_page.label=بڕۆ بۆ کۆتا پەڕە
 last_page_label=بڕۆ بۆ کۆتا پەڕە
 page_rotate_cw.title=ئاڕاستەی میلی کاتژمێر
-page_rotate_cw.label=ئاڕاستەی میلی کاتژمێر
 page_rotate_cw_label=ئاڕاستەی میلی کاتژمێر
 page_rotate_ccw.title=پێچەوانەی میلی کاتژمێر
-page_rotate_ccw.label=پێچەوانەی میلی کاتژمێر
 page_rotate_ccw_label=پێچەوانەی میلی کاتژمێر
 
 cursor_text_select_tool.title=توڵامرازی نیشانکەری دەق چالاک بکە
@@ -141,9 +137,6 @@ thumbs_label=وێنۆچکە
 findbar.title=لە بەڵگەنامە بگەرێ
 findbar_label=دۆزینەوە
 
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=پەڕەی {{page}}
-
 additional_layers=چینی زیاتر
 # Thumbnails panel item (tooltip and alt text for images)
 # LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
@@ -215,9 +208,6 @@ page_scale_actual=قەبارەی ڕاستی
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=هەڵە
 
 loading_error=هەڵەیەک ڕوویدا لە کاتی بارکردنی  PDF.
 invalid_file_error=پەڕگەی pdf تێکچووە یان نەگونجاوە.

--- a/viewer/locale/cs/viewer.properties
+++ b/viewer/locale/cs/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Současný pohled
 tools.title=Nástroje
 tools_label=Nástroje
 first_page.title=Přejde na první stránku
-first_page.label=Přejít na první stránku
 first_page_label=Přejít na první stránku
 last_page.title=Přejde na poslední stránku
-last_page.label=Přejít na poslední stránku
 last_page_label=Přejít na poslední stránku
 page_rotate_cw.title=Otočí po směru hodin
-page_rotate_cw.label=Otočit po směru hodin
 page_rotate_cw_label=Otočit po směru hodin
 page_rotate_ccw.title=Otočí proti směru hodin
-page_rotate_ccw.label=Otočit proti směru hodin
 page_rotate_ccw_label=Otočit proti směru hodin
 
 cursor_text_select_tool.title=Povolí výběr textu
@@ -137,7 +133,6 @@ print_progress_close=Zrušit
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Postranní lišta
-toggle_sidebar_notification.title=Přepne postranní lištu (dokument obsahuje osnovu/přílohy)
 toggle_sidebar_notification2.title=Přepnout postranní lištu (dokument obsahuje osnovu/přílohy/vrstvy)
 toggle_sidebar_label=Postranní lišta
 document_outline.title=Zobrazí osnovu dokumentu (dvojité klepnutí rozbalí/sbalí všechny položky)
@@ -152,9 +147,6 @@ current_outline_item.title=Najít aktuální položku v osnově
 current_outline_item_label=Aktuální položka v osnově
 findbar.title=Najde v dokumentu
 findbar_label=Najít
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=Strana {{page}}
 
 additional_layers=Další vrstvy
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -229,9 +221,6 @@ page_scale_actual=Skutečná velikost
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}} %
-
-# Loading indicator messages
-loading_error_indicator=Chyba
 
 # Loading indicator messages
 loading=Načítání…

--- a/viewer/locale/cy/viewer.properties
+++ b/viewer/locale/cy/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Golwg Gyfredol
 tools.title=Offer
 tools_label=Offer
 first_page.title=Mynd i'r Dudalen Gyntaf
-first_page.label=Mynd i'r Dudalen Gyntaf
 first_page_label=Mynd i'r Dudalen Gyntaf
 last_page.title=Mynd i'r Dudalen Olaf
-last_page.label=Mynd i'r Dudalen Olaf
 last_page_label=Mynd i'r Dudalen Olaf
 page_rotate_cw.title=Cylchdroi Clocwedd
-page_rotate_cw.label=Cylchdroi Clocwedd
 page_rotate_cw_label=Cylchdroi Clocwedd
 page_rotate_ccw.title=Cylchdroi Gwrthglocwedd
-page_rotate_ccw.label=Cylchdroi Gwrthglocwedd
 page_rotate_ccw_label=Cylchdroi Gwrthglocwedd
 
 cursor_text_select_tool.title=Galluogi Dewis Offeryn Testun
@@ -137,7 +133,6 @@ print_progress_close=Diddymu
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Toglo'r Bar Ochr
-toggle_sidebar_notification.title=Toglo'r Bar Ochr (mae'r ddogfen yn cynnwys outline/attachments)
 toggle_sidebar_notification2.title=Toglo'r Bar Ochr (mae'r ddogfen yn cynnwys amlinelliadau/atodiadau/haenau)
 toggle_sidebar_label=Toglo'r Bar Ochr
 document_outline.title=Dangos Amlinell Dogfen (clic dwbl i ymestyn/cau pob eitem)
@@ -152,9 +147,6 @@ current_outline_item.title=Canfod yr Eitem Amlinellol Gyfredol
 current_outline_item_label=Yr Eitem Amlinellol Gyfredol
 findbar.title=Canfod yn y Ddogfen
 findbar_label=Canfod
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=Tudalen {{page}}
 
 additional_layers=Haenau Ychwanegol
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -229,9 +221,6 @@ page_scale_actual=Maint Gwirioneddol
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Gwall
 
 # Loading indicator messages
 loading=Yn llwytho…

--- a/viewer/locale/da/viewer.properties
+++ b/viewer/locale/da/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Aktuel visning
 tools.title=Funktioner
 tools_label=Funktioner
 first_page.title=Gå til første side
-first_page.label=Gå til første side
 first_page_label=Gå til første side
 last_page.title=Gå til sidste side
-last_page.label=Gå til sidste side
 last_page_label=Gå til sidste side
 page_rotate_cw.title=Roter med uret
-page_rotate_cw.label=Roter med uret
 page_rotate_cw_label=Roter med uret
 page_rotate_ccw.title=Roter mod uret
-page_rotate_ccw.label=Roter mod uret
 page_rotate_ccw_label=Roter mod uret
 
 cursor_text_select_tool.title=Aktiver markeringsværktøj
@@ -137,7 +133,6 @@ print_progress_close=Annuller
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Slå sidepanel til eller fra
-toggle_sidebar_notification.title=Slå sidepanel til eller fra (dokumentet indeholder disposition/vedhæftede filer)
 toggle_sidebar_notification2.title=Slå sidepanel til eller fra (dokumentet indeholder disposition/vedhæftede filer/lag)
 toggle_sidebar_label=Slå sidepanel til eller fra
 document_outline.title=Vis dokumentets disposition (dobbeltklik for at vise/skjule alle elementer)
@@ -152,9 +147,6 @@ current_outline_item.title=Find det aktuelle dispositions-element
 current_outline_item_label=Aktuelt dispositions-element
 findbar.title=Find i dokument
 findbar_label=Find
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=Side {{page}}
 
 additional_layers=Yderligere lag
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -229,9 +221,6 @@ page_scale_actual=Faktisk størrelse
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Fejl
 
 # Loading indicator messages
 loading=Indlæser…

--- a/viewer/locale/de/viewer.properties
+++ b/viewer/locale/de/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Aktuelle Ansicht
 tools.title=Werkzeuge
 tools_label=Werkzeuge
 first_page.title=Erste Seite anzeigen
-first_page.label=Erste Seite anzeigen
 first_page_label=Erste Seite anzeigen
 last_page.title=Letzte Seite anzeigen
-last_page.label=Letzte Seite anzeigen
 last_page_label=Letzte Seite anzeigen
 page_rotate_cw.title=Im Uhrzeigersinn drehen
-page_rotate_cw.label=Im Uhrzeigersinn drehen
 page_rotate_cw_label=Im Uhrzeigersinn drehen
 page_rotate_ccw.title=Gegen Uhrzeigersinn drehen
-page_rotate_ccw.label=Gegen Uhrzeigersinn drehen
 page_rotate_ccw_label=Gegen Uhrzeigersinn drehen
 
 cursor_text_select_tool.title=Textauswahl-Werkzeug aktivieren
@@ -137,7 +133,6 @@ print_progress_close=Abbrechen
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Sidebar umschalten
-toggle_sidebar_notification.title=Sidebar umschalten (Dokument enthält Dokumentstruktur/Anhänge)
 toggle_sidebar_notification2.title=Sidebar umschalten (Dokument enthält Dokumentstruktur/Anhänge/Ebenen)
 toggle_sidebar_label=Sidebar umschalten
 document_outline.title=Dokumentstruktur anzeigen (Doppelklicken, um alle Einträge aus- bzw. einzuklappen)
@@ -152,9 +147,6 @@ current_outline_item.title=Aktuelles Struktur-Element finden
 current_outline_item_label=Aktuelles Struktur-Element
 findbar.title=Dokument durchsuchen
 findbar_label=Suchen
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=Seite {{page}}
 
 additional_layers=Zusätzliche Ebenen
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -229,9 +221,6 @@ page_scale_actual=Originalgröße
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}} %
-
-# Loading indicator messages
-loading_error_indicator=Fehler
 
 # Loading indicator messages
 loading=Wird geladen…

--- a/viewer/locale/dsb/viewer.properties
+++ b/viewer/locale/dsb/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Aktualny naglěd
 tools.title=Rědy
 tools_label=Rědy
 first_page.title=K prědnemu bokoju
-first_page.label=K prědnemu bokoju
 first_page_label=K prědnemu bokoju
 last_page.title=K slědnemu bokoju
-last_page.label=K slědnemu bokoju
 last_page_label=K slědnemu bokoju
 page_rotate_cw.title=Wobwjertnuś ako špěra źo
-page_rotate_cw.label=Wobwjertnuś ako špěra źo
 page_rotate_cw_label=Wobwjertnuś ako špěra źo
 page_rotate_ccw.title=Wobwjertnuś nawopaki ako špěra źo
-page_rotate_ccw.label=Wobwjertnuś nawopaki ako špěra źo
 page_rotate_ccw_label=Wobwjertnuś nawopaki ako špěra źo
 
 cursor_text_select_tool.title=Rěd za wuběranje teksta zmóžniś
@@ -137,7 +133,6 @@ print_progress_close=Pśetergnuś
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Bócnicu pokazaś/schowaś
-toggle_sidebar_notification.title=Bocnicu pśešaltowaś (dokument wopśimujo pśeglěd/pśipiski)
 toggle_sidebar_notification2.title=Bocnicu pśešaltowaś (dokument rozrědowanje/pśipiski/warstwy wopśimujo)
 toggle_sidebar_label=Bócnicu pokazaś/schowaś
 document_outline.title=Dokumentowe naraźenje pokazaś (dwójne kliknjenje, aby se wšykne zapiski pokazali/schowali)
@@ -152,9 +147,6 @@ current_outline_item.title=Aktualny rozrědowański zapisk pytaś
 current_outline_item_label=Aktualny rozrědowański zapisk
 findbar.title=W dokumenśe pytaś
 findbar_label=Pytaś
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=Bok {{page}}
 
 additional_layers=Dalšne warstwy
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -229,9 +221,6 @@ page_scale_actual=Aktualna wjelikosć
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Zmólka
 
 # Loading indicator messages
 loading=Zacytujo se…

--- a/viewer/locale/el/viewer.properties
+++ b/viewer/locale/el/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Τρέχουσα προβολή
 tools.title=Εργαλεία
 tools_label=Εργαλεία
 first_page.title=Μετάβαση στην πρώτη σελίδα
-first_page.label=Μετάβαση στην πρώτη σελίδα
 first_page_label=Μετάβαση στην πρώτη σελίδα
 last_page.title=Μετάβαση στην τελευταία σελίδα
-last_page.label=Μετάβαση στην τελευταία σελίδα
 last_page_label=Μετάβαση στην τελευταία σελίδα
 page_rotate_cw.title=Δεξιόστροφη περιστροφή
-page_rotate_cw.label=Δεξιόστροφη περιστροφή
 page_rotate_cw_label=Δεξιόστροφη περιστροφή
 page_rotate_ccw.title=Αριστερόστροφη περιστροφή
-page_rotate_ccw.label=Αριστερόστροφη περιστροφή
 page_rotate_ccw_label=Αριστερόστροφη περιστροφή
 
 cursor_text_select_tool.title=Ενεργοποίηση εργαλείου επιλογής κειμένου
@@ -93,7 +89,7 @@ document_properties_mb={{size_mb}} MB ({{size_b}} bytes)
 document_properties_title=Τίτλος:
 document_properties_author=Συγγραφέας:
 document_properties_subject=Θέμα:
-document_properties_keywords=Λέξεις κλειδιά:
+document_properties_keywords=Λέξεις-κλειδιά:
 document_properties_creation_date=Ημερομηνία δημιουργίας:
 document_properties_modification_date=Ημερομηνία τροποποίησης:
 # LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
@@ -136,25 +132,21 @@ print_progress_close=Ακύρωση
 # Tooltips and alt text for side panel toolbar buttons
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
-toggle_sidebar.title=(Απ)ενεργοποίηση πλευρικής στήλης
-toggle_sidebar_notification.title=(Απ)ενεργοποίηση πλευρικής στήλης (το έγγραφο περιέχει περίγραμμα/συνημμένα)
-toggle_sidebar_notification2.title=(Απ)ενεργοποίηση πλευρικής στήλης (το έγγραφο περιέχει περίγραμμα/συνημμένα/επίπεδα)
-toggle_sidebar_label=(Απ)ενεργοποίηση πλευρικής στήλης
+toggle_sidebar.title=(Απ)ενεργοποίηση πλαϊνής γραμμής
+toggle_sidebar_notification2.title=(Απ)ενεργοποίηση πλαϊνής γραμμής (το έγγραφο περιέχει περίγραμμα/συνημμένα/επίπεδα)
+toggle_sidebar_label=(Απ)ενεργοποίηση πλαϊνής γραμμής
 document_outline.title=Εμφάνιση διάρθρωσης εγγράφου (διπλό κλικ για ανάπτυξη/σύμπτυξη όλων των στοιχείων)
 document_outline_label=Διάρθρωση εγγράφου
-attachments.title=Προβολή συνημμένων
+attachments.title=Εμφάνιση συνημμένων
 attachments_label=Συνημμένα
 layers.title=Εμφάνιση επιπέδων (διπλό κλικ για επαναφορά όλων των επιπέδων στην προεπιλεγμένη κατάσταση)
 layers_label=Επίπεδα
-thumbs.title=Προβολή μικρογραφιών
+thumbs.title=Εμφάνιση μικρογραφιών
 thumbs_label=Μικρογραφίες
 current_outline_item.title=Εύρεση τρέχοντος στοιχείου διάρθρωσης
 current_outline_item_label=Τρέχον στοιχείο διάρθρωσης
 findbar.title=Εύρεση στο έγγραφο
 findbar_label=Εύρεση
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=Σελίδα {{page}}
 
 additional_layers=Επιπρόσθετα επίπεδα
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -165,7 +157,7 @@ page_landmark=Σελίδα {{page}}
 thumb_page_title=Σελίδα {{page}}
 # LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
 # number.
-thumb_page_canvas=Μικρογραφία της σελίδας {{page}}
+thumb_page_canvas=Μικρογραφία σελίδας {{page}}
 
 # Find panel button title and messages
 find_input.title=Εύρεση
@@ -177,8 +169,8 @@ find_next_label=Επόμενο
 find_highlight=Επισήμανση όλων
 find_match_case_label=Συμφωνία πεζών/κεφαλαίων
 find_entire_word_label=Ολόκληρες λέξεις
-find_reached_top=Έλευση στην αρχή του εγγράφου, συνέχεια από το τέλος
-find_reached_bottom=Έλευση στο τέλος του εγγράφου, συνέχεια από την αρχή
+find_reached_top=Φτάσατε στην αρχή του εγγράφου, συνέχεια από το τέλος
+find_reached_bottom=Φτάσατε στο τέλος του εγγράφου, συνέχεια από την αρχή
 # LOCALIZATION NOTE (find_match_count): The supported plural forms are
 # [one|two|few|many|other], with [other] as the default value.
 # "{{current}}" and "{{total}}" will be replaced by a number representing the
@@ -219,7 +211,7 @@ error_stack=Στοίβα: {{stack}}
 error_file=Αρχείο: {{file}}
 # LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
 error_line=Γραμμή: {{line}}
-rendering_error=Προέκυψε σφάλμα κατά την ανάλυση της σελίδας.
+rendering_error=Προέκυψε σφάλμα κατά την εμφάνιση της σελίδας.
 
 # Predefined zoom values
 page_scale_width=Πλάτος σελίδας
@@ -231,11 +223,8 @@ page_scale_actual=Πραγματικό μέγεθος
 page_scale_percent={{scale}}%
 
 # Loading indicator messages
-loading_error_indicator=Σφάλμα
-
-# Loading indicator messages
 loading=Φόρτωση…
-loading_error=Προέκυψε ένα σφάλμα κατά τη φόρτωση του PDF.
+loading_error=Προέκυψε σφάλμα κατά τη φόρτωση του PDF.
 invalid_file_error=Μη έγκυρο ή κατεστραμμένο αρχείο PDF.
 missing_file_error=Λείπει αρχείο PDF.
 unexpected_response_error=Μη αναμενόμενη απόκριση από το διακομιστή.
@@ -248,12 +237,12 @@ annotation_date_string={{date}}, {{time}}
 # "{{type}}" will be replaced with an annotation type from a list defined in
 # the PDF spec (32000-1:2008 Table 169 – Annotation types).
 # Some common types are e.g.: "Check", "Text", "Comment", "Note"
-text_annotation_type.alt=[{{type}} Σχόλιο]
-password_label=Εισαγωγή κωδικού για το άνοιγμα του PDF αρχείου.
-password_invalid=Μη έγκυρος κωδικός. Προσπαθείστε ξανά.
+text_annotation_type.alt=[Σχόλιο «{{type}}»]
+password_label=Εισαγάγετε τον κωδικό πρόσβασης για να ανοίξετε αυτό το αρχείο PDF.
+password_invalid=Μη έγκυρος κωδικός πρόσβασης. Παρακαλώ δοκιμάστε ξανά.
 password_ok=OK
 password_cancel=Ακύρωση
 
 printing_not_supported=Προειδοποίηση: Η εκτύπωση δεν υποστηρίζεται πλήρως από το πρόγραμμα περιήγησης.
 printing_not_ready=Προειδοποίηση: Το PDF δεν φορτώθηκε πλήρως για εκτύπωση.
-web_fonts_disabled=Οι γραμματοσειρές Web απενεργοποιημένες: αδυναμία χρήσης των ενσωματωμένων γραμματοσειρών PDF.
+web_fonts_disabled=Οι γραμματοσειρές ιστού είναι ανενεργές: δεν είναι δυνατή η χρήση των ενσωματωμένων γραμματοσειρών PDF.

--- a/viewer/locale/en-CA/viewer.properties
+++ b/viewer/locale/en-CA/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Current View
 tools.title=Tools
 tools_label=Tools
 first_page.title=Go to First Page
-first_page.label=Go to First Page
 first_page_label=Go to First Page
 last_page.title=Go to Last Page
-last_page.label=Go to Last Page
 last_page_label=Go to Last Page
 page_rotate_cw.title=Rotate Clockwise
-page_rotate_cw.label=Rotate Clockwise
 page_rotate_cw_label=Rotate Clockwise
 page_rotate_ccw.title=Rotate Counterclockwise
-page_rotate_ccw.label=Rotate Counterclockwise
 page_rotate_ccw_label=Rotate Counterclockwise
 
 cursor_text_select_tool.title=Enable Text Selection Tool
@@ -137,7 +133,6 @@ print_progress_close=Cancel
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Toggle Sidebar
-toggle_sidebar_notification.title=Toggle Sidebar (document contains outline/attachments)
 toggle_sidebar_notification2.title=Toggle Sidebar (document contains outline/attachments/layers)
 toggle_sidebar_label=Toggle Sidebar
 document_outline.title=Show Document Outline (double-click to expand/collapse all items)
@@ -152,9 +147,6 @@ current_outline_item.title=Find Current Outline Item
 current_outline_item_label=Current Outline Item
 findbar.title=Find in Document
 findbar_label=Find
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=Page {{page}}
 
 additional_layers=Additional Layers
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -229,9 +221,6 @@ page_scale_actual=Actual Size
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Error
 
 # Loading indicator messages
 loading=Loading…

--- a/viewer/locale/en-GB/viewer.properties
+++ b/viewer/locale/en-GB/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Current View
 tools.title=Tools
 tools_label=Tools
 first_page.title=Go to First Page
-first_page.label=Go to First Page
 first_page_label=Go to First Page
 last_page.title=Go to Last Page
-last_page.label=Go to Last Page
 last_page_label=Go to Last Page
 page_rotate_cw.title=Rotate Clockwise
-page_rotate_cw.label=Rotate Clockwise
 page_rotate_cw_label=Rotate Clockwise
 page_rotate_ccw.title=Rotate Anti-Clockwise
-page_rotate_ccw.label=Rotate Anti-Clockwise
 page_rotate_ccw_label=Rotate Anti-Clockwise
 
 cursor_text_select_tool.title=Enable Text Selection Tool
@@ -137,7 +133,6 @@ print_progress_close=Cancel
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Toggle Sidebar
-toggle_sidebar_notification.title=Toggle Sidebar (document contains outline/attachments)
 toggle_sidebar_notification2.title=Toggle Sidebar (document contains outline/attachments/layers)
 toggle_sidebar_label=Toggle Sidebar
 document_outline.title=Show Document Outline (double-click to expand/collapse all items)
@@ -152,9 +147,6 @@ current_outline_item.title=Find Current Outline Item
 current_outline_item_label=Current Outline Item
 findbar.title=Find in Document
 findbar_label=Find
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=Page {{page}}
 
 additional_layers=Additional Layers
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -229,9 +221,6 @@ page_scale_actual=Actual Size
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Error
 
 # Loading indicator messages
 loading=Loading…

--- a/viewer/locale/eo/viewer.properties
+++ b/viewer/locale/eo/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Nuna vido
 tools.title=Iloj
 tools_label=Iloj
 first_page.title=Iri al la unua paĝo
-first_page.label=Iri al la unua paĝo
 first_page_label=Iri al la unua paĝo
 last_page.title=Iri al la lasta paĝo
-last_page.label=Iri al la lasta paĝo
 last_page_label=Iri al la lasta paĝo
 page_rotate_cw.title=Rotaciigi dekstrume
-page_rotate_cw.label=Rotaciigi dekstrume
 page_rotate_cw_label=Rotaciigi dekstrume
 page_rotate_ccw.title=Rotaciigi maldekstrume
-page_rotate_ccw.label=Rotaciigi maldekstrume
 page_rotate_ccw_label=Rotaciigi maldekstrume
 
 cursor_text_select_tool.title=Aktivigi tekstan elektilon
@@ -137,7 +133,6 @@ print_progress_close=Nuligi
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Montri/kaŝi flankan strion
-toggle_sidebar_notification.title=Montri/kaŝi flankan strion (la dokumento enhavas konturon/aneksaĵojn)
 toggle_sidebar_notification2.title=Montri/kaŝi flankan strion (la dokumento enhavas konturon/kunsendaĵojn/tavolojn)
 toggle_sidebar_label=Montri/kaŝi flankan strion
 document_outline.title=Montri la konturon de dokumento (alklaku duoble por faldi/malfaldi ĉiujn elementojn)
@@ -152,9 +147,6 @@ current_outline_item.title=Trovi nunan konturan elementon
 current_outline_item_label=Nuna kontura elemento
 findbar.title=Serĉi en dokumento
 findbar_label=Serĉi
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=Paĝo {{page}}
 
 additional_layers=Aldonaj tavoloj
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -229,9 +221,6 @@ page_scale_actual=Reala grando
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Eraro
 
 # Loading indicator messages
 loading=Ŝargado…

--- a/viewer/locale/es-AR/viewer.properties
+++ b/viewer/locale/es-AR/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Vista actual
 tools.title=Herramientas
 tools_label=Herramientas
 first_page.title=Ir a primera página
-first_page.label=Ir a primera página
 first_page_label=Ir a primera página
 last_page.title=Ir a última página
-last_page.label=Ir a última página
 last_page_label=Ir a última página
 page_rotate_cw.title=Rotar horario
-page_rotate_cw.label=Rotar horario
 page_rotate_cw_label=Rotar horario
 page_rotate_ccw.title=Rotar antihorario
-page_rotate_ccw.label=Rotar antihorario
 page_rotate_ccw_label=Rotar antihorario
 
 cursor_text_select_tool.title=Habilitar herramienta de selección de texto
@@ -137,7 +133,6 @@ print_progress_close=Cancelar
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Alternar barra lateral
-toggle_sidebar_notification.title=Intercambiar barra lateral (el documento contiene esquema/adjuntos)
 toggle_sidebar_notification2.title=Alternar barra lateral (el documento contiene esquemas/adjuntos/capas)
 toggle_sidebar_label=Alternar barra lateral
 document_outline.title=Mostrar esquema del documento (doble clic para expandir/colapsar todos los ítems)
@@ -152,9 +147,6 @@ current_outline_item.title=Buscar elemento de esquema actual
 current_outline_item_label=Elemento de esquema actual
 findbar.title=Buscar en documento
 findbar_label=Buscar
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=Página {{page}}
 
 additional_layers=Capas adicionales
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -229,9 +221,6 @@ page_scale_actual=Tamaño real
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Error
 
 # Loading indicator messages
 loading=Cargando…

--- a/viewer/locale/es-CL/viewer.properties
+++ b/viewer/locale/es-CL/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Vista actual
 tools.title=Herramientas
 tools_label=Herramientas
 first_page.title=Ir a la primera página
-first_page.label=Ir a la primera página
 first_page_label=Ir a la primera página
 last_page.title=Ir a la última página
-last_page.label=Ir a la última página
 last_page_label=Ir a la última página
 page_rotate_cw.title=Girar a la derecha
-page_rotate_cw.label=Girar a la derecha
 page_rotate_cw_label=Girar a la derecha
 page_rotate_ccw.title=Girar a la izquierda
-page_rotate_ccw.label=Girar a la izquierda
 page_rotate_ccw_label=Girar a la izquierda
 
 cursor_text_select_tool.title=Activar la herramienta de selección de texto
@@ -137,7 +133,6 @@ print_progress_close=Cancelar
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Barra lateral
-toggle_sidebar_notification.title=Cambiar barra lateral (índice de contenidos del documento/adjuntos)
 toggle_sidebar_notification2.title=Cambiar barra lateral (índice de contenidos del documento/adjuntos/capas)
 toggle_sidebar_label=Mostrar u ocultar la barra lateral
 document_outline.title=Mostrar esquema del documento (doble clic para expandir/contraer todos los elementos)
@@ -152,9 +147,6 @@ current_outline_item.title=Buscar elemento de esquema actual
 current_outline_item_label=Elemento de esquema actual
 findbar.title=Buscar en el documento
 findbar_label=Buscar
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=Página {{page}}
 
 additional_layers=Capas adicionales
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -229,9 +221,6 @@ page_scale_actual=Tamaño actual
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Error
 
 # Loading indicator messages
 loading=Cargando…

--- a/viewer/locale/es-ES/viewer.properties
+++ b/viewer/locale/es-ES/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Vista actual
 tools.title=Herramientas
 tools_label=Herramientas
 first_page.title=Ir a la primera página
-first_page.label=Ir a la primera página
 first_page_label=Ir a la primera página
 last_page.title=Ir a la última página
-last_page.label=Ir a la última página
 last_page_label=Ir a la última página
 page_rotate_cw.title=Rotar en sentido horario
-page_rotate_cw.label=Rotar en sentido horario
 page_rotate_cw_label=Rotar en sentido horario
 page_rotate_ccw.title=Rotar en sentido antihorario
-page_rotate_ccw.label=Rotar en sentido antihorario
 page_rotate_ccw_label=Rotar en sentido antihorario
 
 cursor_text_select_tool.title=Activar herramienta de selección de texto
@@ -137,7 +133,6 @@ print_progress_close=Cancelar
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Cambiar barra lateral
-toggle_sidebar_notification.title=Alternar panel lateral (el documento contiene un esquema o adjuntos)
 toggle_sidebar_notification2.title=Alternar barra lateral (el documento contiene esquemas/adjuntos/capas)
 toggle_sidebar_label=Cambiar barra lateral
 document_outline.title=Mostrar resumen del documento (doble clic para expandir/contraer todos los elementos)
@@ -152,9 +147,6 @@ current_outline_item.title=Encontrar elemento de esquema actual
 current_outline_item_label=Elemento de esquema actual
 findbar.title=Buscar en el documento
 findbar_label=Buscar
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=Página {{page}}
 
 additional_layers=Capas adicionales
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -229,9 +221,6 @@ page_scale_actual=Tamaño real
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Error
 
 # Loading indicator messages
 loading=Cargando…

--- a/viewer/locale/es-MX/viewer.properties
+++ b/viewer/locale/es-MX/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Vista actual
 tools.title=Herramientas
 tools_label=Herramientas
 first_page.title=Ir a la primera página
-first_page.label=Ir a la primera página
 first_page_label=Ir a la primera página
 last_page.title=Ir a la última página
-last_page.label=Ir a la última página
 last_page_label=Ir a la última página
 page_rotate_cw.title=Girar a la derecha
-page_rotate_cw.label=Girar a la derecha
 page_rotate_cw_label=Girar a la derecha
 page_rotate_ccw.title=Girar a la izquierda
-page_rotate_ccw.label=Girar a la izquierda
 page_rotate_ccw_label=Girar a la izquierda
 
 cursor_text_select_tool.title=Activar la herramienta de selección de texto
@@ -137,7 +133,6 @@ print_progress_close=Cancelar
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Cambiar barra lateral
-toggle_sidebar_notification.title=Cambiar barra lateral (índice de contenidos del documento/adjuntos)
 toggle_sidebar_notification2.title=Alternar barra lateral (el documento contiene esquemas/adjuntos/capas)
 toggle_sidebar_label=Cambiar barra lateral
 document_outline.title=Mostrar esquema del documento (doble clic para expandir/contraer todos los elementos)
@@ -152,9 +147,6 @@ current_outline_item.title=Buscar elemento de esquema actual
 current_outline_item_label=Elemento de esquema actual
 findbar.title=Buscar en el documento
 findbar_label=Buscar
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=Página {{page}}
 
 additional_layers=Capas adicionales
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -229,9 +221,6 @@ page_scale_actual=Tamaño real
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Error
 
 # Loading indicator messages
 loading=Cargando…

--- a/viewer/locale/et/viewer.properties
+++ b/viewer/locale/et/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Praegune vaade
 tools.title=Tööriistad
 tools_label=Tööriistad
 first_page.title=Mine esimesele leheküljele
-first_page.label=Mine esimesele leheküljele
 first_page_label=Mine esimesele leheküljele
 last_page.title=Mine viimasele leheküljele
-last_page.label=Mine viimasele leheküljele
 last_page_label=Mine viimasele leheküljele
 page_rotate_cw.title=Pööra päripäeva
-page_rotate_cw.label=Pööra päripäeva
 page_rotate_cw_label=Pööra päripäeva
 page_rotate_ccw.title=Pööra vastupäeva
-page_rotate_ccw.label=Pööra vastupäeva
 page_rotate_ccw_label=Pööra vastupäeva
 
 cursor_text_select_tool.title=Luba teksti valimise tööriist
@@ -137,7 +133,6 @@ print_progress_close=Loobu
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Näita külgriba
-toggle_sidebar_notification.title=Näita külgriba (dokument sisaldab sisukorda/manuseid)
 toggle_sidebar_label=Näita külgriba
 document_outline.title=Näita sisukorda (kõigi punktide laiendamiseks/ahendamiseks topeltklõpsa)
 document_outline_label=Näita sisukorda
@@ -218,9 +213,6 @@ page_scale_actual=Tegelik suurus
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Viga
 
 loading_error=PDFi laadimisel esines viga.
 invalid_file_error=Vigane või rikutud PDF-fail.

--- a/viewer/locale/eu/viewer.properties
+++ b/viewer/locale/eu/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Uneko ikuspegia
 tools.title=Tresnak
 tools_label=Tresnak
 first_page.title=Joan lehen orrira
-first_page.label=Joan lehen orrira
 first_page_label=Joan lehen orrira
 last_page.title=Joan azken orrira
-last_page.label=Joan azken orrira
 last_page_label=Joan azken orrira
 page_rotate_cw.title=Biratu erlojuaren norantzan
-page_rotate_cw.label=Biratu erlojuaren norantzan
 page_rotate_cw_label=Biratu erlojuaren norantzan
 page_rotate_ccw.title=Biratu erlojuaren aurkako norantzan
-page_rotate_ccw.label=Biratu erlojuaren aurkako norantzan
 page_rotate_ccw_label=Biratu erlojuaren aurkako norantzan
 
 cursor_text_select_tool.title=Gaitu testuaren hautapen tresna
@@ -137,7 +133,6 @@ print_progress_close=Utzi
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Txandakatu alboko barra
-toggle_sidebar_notification.title=Txandakatu alboko barra (dokumentuak eskema/eranskinak ditu)
 toggle_sidebar_notification2.title=Txandakatu alboko barra (dokumentuak eskema/eranskinak/geruzak ditu)
 toggle_sidebar_label=Txandakatu alboko barra
 document_outline.title=Erakutsi dokumentuaren eskema (klik bikoitza elementu guztiak zabaltzeko/tolesteko)
@@ -152,9 +147,6 @@ current_outline_item.title=Bilatu uneko eskemaren elementua
 current_outline_item_label=Uneko eskemaren elementua
 findbar.title=Bilatu dokumentuan
 findbar_label=Bilatu
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas={{page}}. orria
 
 additional_layers=Geruza gehigarriak
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -229,9 +221,6 @@ page_scale_actual=Benetako tamaina
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent=%{{scale}}
-
-# Loading indicator messages
-loading_error_indicator=Errorea
 
 # Loading indicator messages
 loading=Kargatzen…

--- a/viewer/locale/fa/viewer.properties
+++ b/viewer/locale/fa/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=نمای فعلی
 tools.title=ابزارها
 tools_label=ابزارها
 first_page.title=برو به اولین صفحه
-first_page.label=برو یه اولین صفحه
 first_page_label=برو به اولین صفحه
 last_page.title=برو به آخرین صفحه
-last_page.label=برو به آخرین صفحه
 last_page_label=برو به آخرین صفحه
 page_rotate_cw.title=چرخش ساعتگرد
-page_rotate_cw.label=چرخش ساعتگرد
 page_rotate_cw_label=چرخش ساعتگرد
 page_rotate_ccw.title=چرخش پاد ساعتگرد
-page_rotate_ccw.label=چرخش پاد ساعتگرد
 page_rotate_ccw_label=چرخش پاد ساعتگرد
 
 cursor_text_select_tool.title=فعال کردن ابزارِ انتخابِ متن
@@ -126,7 +122,6 @@ print_progress_close=لغو
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=باز و بسته کردن نوار کناری
-toggle_sidebar_notification.title=تغییر وضعیت نوار کناری (سند حاوی طرح/پیوست است)
 toggle_sidebar_label=تغییرحالت نوارکناری
 document_outline.title=نمایش رئوس مطالب مدارک(برای بازشدن/جمع شدن همه موارد دوبار کلیک کنید)
 document_outline_label=طرح نوشتار
@@ -199,9 +194,6 @@ page_scale_actual=اندازه واقعی‌
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=خطا
 
 loading_error=هنگام بارگیری پرونده PDF خطایی رخ داد.
 invalid_file_error=پرونده PDF نامعتبر یامعیوب می‌باشد.

--- a/viewer/locale/ff/viewer.properties
+++ b/viewer/locale/ff/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Jiytol Gonangol
 tools.title=Kuutorɗe
 tools_label=Kuutorɗe
 first_page.title=Yah to hello adanngo
-first_page.label=Yah to hello adanngo
 first_page_label=Yah to hello adanngo
 last_page.title=Yah to hello wattindiingo
-last_page.label=Yah to hello wattindiingo
 last_page_label=Yah to hello wattindiingo
 page_rotate_cw.title=Yiiltu Faya Ñaamo
-page_rotate_cw.label=Yiiltu Faya Ñaamo
 page_rotate_cw_label=Yiiltu Faya Ñaamo
 page_rotate_ccw.title=Yiiltu Faya Nano
-page_rotate_ccw.label=Yiiltu Faya Nano
 page_rotate_ccw_label=Yiiltu Faya Nano
 
 cursor_text_select_tool.title=Gollin kaɓirgel cuɓirgel binndi
@@ -137,7 +133,6 @@ print_progress_close=Haaytu
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Toggilo Palal Sawndo
-toggle_sidebar_notification.title=Palal sawndo (dokimaa oo ina waɗi taarngo/cinnde)
 toggle_sidebar_label=Toggilo Palal Sawndo
 document_outline.title=Hollu Ƴiyal Fiilannde (dobdobo ngam wertude/taggude teme fof)
 document_outline_label=Toɓɓe Fiilannde
@@ -218,9 +213,6 @@ page_scale_actual=Ɓetol Jaati
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Juumre
 
 loading_error=Juumre waɗii tuma nde loowata PDF oo.
 invalid_file_error=Fiilde PDF moƴƴaani walla jiibii.

--- a/viewer/locale/fi/viewer.properties
+++ b/viewer/locale/fi/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Avoin ikkuna
 tools.title=Tools
 tools_label=Tools
 first_page.title=Siirry ensimmäiselle sivulle
-first_page.label=Siirry ensimmäiselle sivulle
 first_page_label=Siirry ensimmäiselle sivulle
 last_page.title=Siirry viimeiselle sivulle
-last_page.label=Siirry viimeiselle sivulle
 last_page_label=Siirry viimeiselle sivulle
 page_rotate_cw.title=Kierrä oikealle
-page_rotate_cw.label=Kierrä oikealle
 page_rotate_cw_label=Kierrä oikealle
 page_rotate_ccw.title=Kierrä vasemmalle
-page_rotate_ccw.label=Kierrä vasemmalle
 page_rotate_ccw_label=Kierrä vasemmalle
 
 cursor_text_select_tool.title=Käytä tekstinvalintatyökalua
@@ -137,7 +133,6 @@ print_progress_close=Peruuta
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Näytä/piilota sivupaneeli
-toggle_sidebar_notification.title=Näytä/piilota sivupaneeli (dokumentissa on sisällys tai liitteitä)
 toggle_sidebar_notification2.title=Näytä/piilota sivupaneeli (dokumentissa on sisällys/liitteitä/tasoja)
 toggle_sidebar_label=Näytä/piilota sivupaneeli
 document_outline.title=Näytä dokumentin sisällys (laajenna tai kutista kohdat kaksoisnapsauttamalla)
@@ -152,9 +147,6 @@ current_outline_item.title=Etsi nykyinen sisällyksen kohta
 current_outline_item_label=Nykyinen sisällyksen kohta
 findbar.title=Etsi dokumentista
 findbar_label=Etsi
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=Sivu {{page}}
 
 additional_layers=Lisätasot
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -229,9 +221,6 @@ page_scale_actual=Todellinen koko
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}} %
-
-# Loading indicator messages
-loading_error_indicator=Virhe
 
 # Loading indicator messages
 loading=Ladataan…

--- a/viewer/locale/fr/viewer.properties
+++ b/viewer/locale/fr/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Affichage actuel
 tools.title=Outils
 tools_label=Outils
 first_page.title=Aller à la première page
-first_page.label=Aller à la première page
 first_page_label=Aller à la première page
 last_page.title=Aller à la dernière page
-last_page.label=Aller à la dernière page
 last_page_label=Aller à la dernière page
 page_rotate_cw.title=Rotation horaire
-page_rotate_cw.label=Rotation horaire
 page_rotate_cw_label=Rotation horaire
 page_rotate_ccw.title=Rotation antihoraire
-page_rotate_ccw.label=Rotation antihoraire
 page_rotate_ccw_label=Rotation antihoraire
 
 cursor_text_select_tool.title=Activer l’outil de sélection de texte
@@ -137,7 +133,6 @@ print_progress_close=Annuler
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Afficher/Masquer le panneau latéral
-toggle_sidebar_notification.title=Afficher/Masquer le panneau latéral (le document contient des signets/pièces jointes)
 toggle_sidebar_notification2.title=Afficher/Masquer le panneau latéral (le document contient des signets/pièces jointes/calques)
 toggle_sidebar_label=Afficher/Masquer le panneau latéral
 document_outline.title=Afficher les signets du document (double-cliquer pour développer/réduire tous les éléments)
@@ -152,9 +147,6 @@ current_outline_item.title=Trouver l’élément de plan actuel
 current_outline_item_label=Élément de plan actuel
 findbar.title=Rechercher dans le document
 findbar_label=Rechercher
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=Page {{page}}
 
 additional_layers=Calques additionnels
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -229,9 +221,6 @@ page_scale_actual=Taille réelle
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}} %
-
-# Loading indicator messages
-loading_error_indicator=Erreur
 
 # Loading indicator messages
 loading=Chargement…

--- a/viewer/locale/fy-NL/viewer.properties
+++ b/viewer/locale/fy-NL/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Aktuele finster
 tools.title=Ark
 tools_label=Ark
 first_page.title=Gean nei earste side
-first_page.label=Nei earste side gean
 first_page_label=Gean nei earste side
 last_page.title=Gean nei lêste side
-last_page.label=Nei lêste side gean
 last_page_label=Gean nei lêste side
 page_rotate_cw.title=Rjochtsom draaie
-page_rotate_cw.label=Rjochtsom draaie
 page_rotate_cw_label=Rjochtsom draaie
 page_rotate_ccw.title=Loftsom draaie
-page_rotate_ccw.label=Loftsom draaie
 page_rotate_ccw_label=Loftsom draaie
 
 cursor_text_select_tool.title=Tekstseleksjehelpmiddel ynskeakelje
@@ -137,7 +133,6 @@ print_progress_close=Annulearje
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Sidebalke yn-/útskeakelje
-toggle_sidebar_notification.title=Sidebalke yn-/útskeakelje (dokumint befettet outline/bylagen)
 toggle_sidebar_notification2.title=Sidebalke yn-/útskeakelje (dokumint befettet oersjoch/bylagen/lagen)
 toggle_sidebar_label=Sidebalke yn-/útskeakelje
 document_outline.title=Dokumintoersjoch toane (dûbelklik om alle items út/yn te klappen)
@@ -152,9 +147,6 @@ current_outline_item.title=Aktueel item yn ynhâldsopjefte sykje
 current_outline_item_label=Aktueel item yn ynhâldsopjefte
 findbar.title=Sykje yn dokumint
 findbar_label=Sykje
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=Side {{page}}
 
 additional_layers=Oanfoljende lagen
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -229,9 +221,6 @@ page_scale_actual=Werklike grutte
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Flater
 
 # Loading indicator messages
 loading=Lade…

--- a/viewer/locale/ga-IE/viewer.properties
+++ b/viewer/locale/ga-IE/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=An tAmharc Reatha
 tools.title=Uirlisí
 tools_label=Uirlisí
 first_page.title=Go dtí an chéad leathanach
-first_page.label=Go dtí an chéad leathanach
 first_page_label=Go dtí an chéad leathanach
 last_page.title=Go dtí an leathanach deiridh
-last_page.label=Go dtí an leathanach deiridh
 last_page_label=Go dtí an leathanach deiridh
 page_rotate_cw.title=Rothlaigh ar deiseal
-page_rotate_cw.label=Rothlaigh ar deiseal
 page_rotate_cw_label=Rothlaigh ar deiseal
 page_rotate_ccw.title=Rothlaigh ar tuathal
-page_rotate_ccw.label=Rothlaigh ar tuathal
 page_rotate_ccw_label=Rothlaigh ar tuathal
 
 cursor_text_select_tool.title=Cumasaigh an Uirlis Roghnaithe Téacs
@@ -101,7 +97,6 @@ print_progress_close=Cealaigh
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Scoránaigh an Barra Taoibh
-toggle_sidebar_notification.title=Scoránaigh an Barra Taoibh (achoimre/iatáin sa cháipéis)
 toggle_sidebar_label=Scoránaigh an Barra Taoibh
 document_outline.title=Taispeáin Imlíne na Cáipéise (déchliceáil chun chuile rud a leathnú nó a laghdú)
 document_outline_label=Creatlach na Cáipéise
@@ -160,9 +155,6 @@ page_scale_actual=Fíormhéid
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Earráid
 
 loading_error=Tharla earráid agus an cháipéis PDF á lódáil.
 invalid_file_error=Comhad neamhbhailí nó truaillithe PDF.

--- a/viewer/locale/gd/viewer.properties
+++ b/viewer/locale/gd/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=An sealladh làithreach
 tools.title=Innealan
 tools_label=Innealan
 first_page.title=Rach gun chiad duilleag
-first_page.label=Rach gun chiad duilleag
 first_page_label=Rach gun chiad duilleag
 last_page.title=Rach gun duilleag mu dheireadh
-last_page.label=Rach gun duilleag mu dheireadh
 last_page_label=Rach gun duilleag mu dheireadh
 page_rotate_cw.title=Cuairtich gu deiseil
-page_rotate_cw.label=Cuairtich gu deiseil
 page_rotate_cw_label=Cuairtich gu deiseil
 page_rotate_ccw.title=Cuairtich gu tuathail
-page_rotate_ccw.label=Cuairtich gu tuathail
 page_rotate_ccw_label=Cuairtich gu tuathail
 
 cursor_text_select_tool.title=Cuir an comas inneal taghadh an teacsa
@@ -137,14 +133,13 @@ print_progress_close=Sguir dheth
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Toglaich am bàr-taoibh
-toggle_sidebar_notification.title=Toglaich am bàr-taoibh (tha oir-loidhne/ceanglachain aig an sgrìobhainn)
 toggle_sidebar_notification2.title=Toglaich am bàr-taoibh (tha oir-loidhne/ceanglachain/breathan aig an sgrìobhainn)
 toggle_sidebar_label=Toglaich am bàr-taoibh
 document_outline.title=Seall oir-loidhne na sgrìobhainn (dèan briogadh dùbailte airson a h-uile nì a leudachadh/a cho-theannadh)
 document_outline_label=Oir-loidhne na sgrìobhainne
 attachments.title=Seall na ceanglachain
 attachments_label=Ceanglachain
-layers.title=Seall na breathan (dèan briogadh dùbailte airson a h-uile breath ath-shuidheachadh dhan staid thùsail)
+layers.title=Seall na breathan (dèan briogadh dùbailte airson a h-uile breath ath-shuidheachadh dhan staid bhunaiteach)
 layers_label=Breathan
 thumbs.title=Seall na dealbhagan
 thumbs_label=Dealbhagan
@@ -152,9 +147,6 @@ current_outline_item.title=Lorg nì làithreach na h-oir-loidhne
 current_outline_item_label=Nì làithreach na h-oir-loidhne
 findbar.title=Lorg san sgrìobhainn
 findbar_label=Lorg
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=Duilleag {{page}}
 
 additional_layers=Barrachd breathan
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -229,9 +221,6 @@ page_scale_actual=Am fìor-mheud
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Mearachd
 
 # Loading indicator messages
 loading=’Ga luchdadh…

--- a/viewer/locale/gl/viewer.properties
+++ b/viewer/locale/gl/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Vista actual
 tools.title=Ferramentas
 tools_label=Ferramentas
 first_page.title=Ir á primeira páxina
-first_page.label=Ir á primeira páxina
 first_page_label=Ir á primeira páxina
 last_page.title=Ir á última páxina
-last_page.label=Ir á última páxina
 last_page_label=Ir á última páxina
 page_rotate_cw.title=Rotar no sentido das agullas do reloxo
-page_rotate_cw.label=Rotar no sentido das agullas do reloxo
 page_rotate_cw_label=Rotar no sentido das agullas do reloxo
 page_rotate_ccw.title=Rotar no sentido contrario ás agullas do reloxo
-page_rotate_ccw.label=Rotar no sentido contrario ás agullas do reloxo
 page_rotate_ccw_label=Rotar no sentido contrario ás agullas do reloxo
 
 cursor_text_select_tool.title=Activar a ferramenta de selección de texto
@@ -137,7 +133,6 @@ print_progress_close=Cancelar
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Amosar/agochar a barra lateral
-toggle_sidebar_notification.title=Amosar/agochar a barra lateral (o documento contén un esquema ou anexos)
 toggle_sidebar_notification2.title=Alternar barra lateral (o documento contén esquema/anexos/capas)
 toggle_sidebar_label=Amosar/agochar a barra lateral
 document_outline.title=Amosar o esquema do documento (prema dúas veces para expandir/contraer todos os elementos)
@@ -152,9 +147,6 @@ current_outline_item.title=Atopar o elemento delimitado actualmente
 current_outline_item_label=Elemento delimitado actualmente
 findbar.title=Atopar no documento
 findbar_label=Atopar
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=Páxina {{page}}
 
 additional_layers=Capas adicionais
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -229,9 +221,6 @@ page_scale_actual=Tamaño actual
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Erro
 
 # Loading indicator messages
 loading=A cargar…

--- a/viewer/locale/gn/viewer.properties
+++ b/viewer/locale/gn/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Ag̃agua jehecha
 tools.title=Tembipuru
 tools_label=Tembipuru
 first_page.title=Kuatiarogue ñepyrũme jeho
-first_page.label=Kuatiarogue ñepyrũme jeho
 first_page_label=Kuatiarogue ñepyrũme jeho
 last_page.title=Kuatiarogue pahápe jeho
-last_page.label=Kuatiarogue pahápe jeho
 last_page_label=Kuatiarogue pahápe jeho
 page_rotate_cw.title=Aravóicha mbojere
-page_rotate_cw.label=Aravóicha mbojere
 page_rotate_cw_label=Aravóicha mbojere
 page_rotate_ccw.title=Aravo rapykue gotyo mbojere
-page_rotate_ccw.label=Aravo rapykue gotyo mbojere
 page_rotate_ccw_label=Aravo rapykue gotyo mbojere
 
 cursor_text_select_tool.title=Emyandy moñe’ẽrã jeporavo rembipuru
@@ -137,7 +133,6 @@ print_progress_close=Heja
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Tenda yke moambue
-toggle_sidebar_notification.title=Embojopyru tenda ykegua (kuatia oguereko kora/marandurenda moirũha)
 toggle_sidebar_notification2.title=Embojopyru tenda ykegua (kuatia oguereko kuaakaha/moirũha/ñuãha)
 toggle_sidebar_label=Tenda yke moambue
 document_outline.title=Ehechauka kuatia rape (eikutu mokõi jey embotuicha/emomichĩ hag̃ua opavavete mba’epuru)
@@ -152,9 +147,6 @@ current_outline_item.title=Eheka mba’epuru ag̃aguaitéva
 current_outline_item_label=Mba’epuru ag̃aguaitéva
 findbar.title=Kuatiápe jeheka
 findbar_label=Juhu
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=Kuatiarogue {{page}}
 
 additional_layers=Ñuãha moirũguáva
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -229,9 +221,6 @@ page_scale_actual=Tuichakue ag̃agua
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Oĩvaíva
 
 # Loading indicator messages
 loading=Henyhẽhína…

--- a/viewer/locale/gu-IN/viewer.properties
+++ b/viewer/locale/gu-IN/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=વર્તમાન દૃશ્ય
 tools.title=સાધનો
 tools_label=સાધનો
 first_page.title=પહેલાં પાનામાં જાવ
-first_page.label=પહેલાં પાનામાં જાવ
 first_page_label=પ્રથમ પાનાં પર જાવ
 last_page.title=છેલ્લા પાનાં પર જાવ
-last_page.label=છેલ્લા પાનામાં જાવ
 last_page_label=છેલ્લા પાનાં પર જાવ
 page_rotate_cw.title=ઘડિયાળનાં કાંટા તરફ ફેરવો
-page_rotate_cw.label=ઘડિયાળનાં કાંટાની જેમ ફેરવો
 page_rotate_cw_label=ઘડિયાળનાં કાંટા તરફ ફેરવો
 page_rotate_ccw.title=ઘડિયાળનાં કાંટાની ઉલટી દિશામાં ફેરવો
-page_rotate_ccw.label=ઘડિયાળનાં કાંટાની ઉલટી દિશામાં ફેરવો
 page_rotate_ccw_label=ઘડિયાળનાં કાંટાની વિરુદ્દ ફેરવો
 
 cursor_text_select_tool.title=ટેક્સ્ટ પસંદગી ટૂલ સક્ષમ કરો
@@ -137,7 +133,6 @@ print_progress_close=રદ કરો
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=ટૉગલ બાજુપટ્ટી
-toggle_sidebar_notification.title=સાઇડબારને ટૉગલ કરો(દસ્તાવેજની રૂપરેખા/જોડાણો શામેલ છે)
 toggle_sidebar_label=ટૉગલ બાજુપટ્ટી
 document_outline.title=દસ્તાવેજની રૂપરેખા બતાવો(બધી આઇટમ્સને વિસ્તૃત/સંકુચિત કરવા માટે ડબલ-ક્લિક કરો)
 document_outline_label=દસ્તાવેજ રૂપરેખા
@@ -218,9 +213,6 @@ page_scale_actual=ચોક્કસ માપ
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=ભૂલ
 
 loading_error=ભૂલ ઉદ્ભવી જ્યારે PDF ને લાવી રહ્યા હોય.
 invalid_file_error=અયોગ્ય અથવા ભાંગેલ PDF ફાઇલ.

--- a/viewer/locale/he/viewer.properties
+++ b/viewer/locale/he/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=תצוגה נוכחית
 tools.title=כלים
 tools_label=כלים
 first_page.title=מעבר לעמוד הראשון
-first_page.label=מעבר לעמוד הראשון
 first_page_label=מעבר לעמוד הראשון
 last_page.title=מעבר לעמוד האחרון
-last_page.label=מעבר לעמוד האחרון
 last_page_label=מעבר לעמוד האחרון
 page_rotate_cw.title=הטיה עם כיוון השעון
-page_rotate_cw.label=הטיה עם כיוון השעון
 page_rotate_cw_label=הטיה עם כיוון השעון
 page_rotate_ccw.title=הטיה כנגד כיוון השעון
-page_rotate_ccw.label=הטיה כנגד כיוון השעון
 page_rotate_ccw_label=הטיה כנגד כיוון השעון
 
 cursor_text_select_tool.title=הפעלת כלי בחירת טקסט
@@ -137,7 +133,6 @@ print_progress_close=ביטול
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=הצגה/הסתרה של סרגל הצד
-toggle_sidebar_notification.title=החלפת תצוגת סרגל צד (מסמך שמכיל תוכן עניינים/קבצים מצורפים)
 toggle_sidebar_notification2.title=החלפת תצוגת סרגל צד (מסמך שמכיל תוכן עניינים/קבצים מצורפים/שכבות)
 toggle_sidebar_label=הצגה/הסתרה של סרגל הצד
 document_outline.title=הצגת תוכן העניינים של המסמך (לחיצה כפולה כדי להרחיב או לצמצם את כל הפריטים)
@@ -152,9 +147,6 @@ current_outline_item.title=מציאת פריט תוכן העניינים הנו�
 current_outline_item_label=פריט תוכן העניינים הנוכחי
 findbar.title=חיפוש במסמך
 findbar_label=חיפוש
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=עמוד {{page}}
 
 additional_layers=שכבות נוספות
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -229,9 +221,6 @@ page_scale_actual=גודל אמיתי
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=שגיאה
 
 # Loading indicator messages
 loading=בטעינה…

--- a/viewer/locale/hi-IN/viewer.properties
+++ b/viewer/locale/hi-IN/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=\u0020मौजूदा दृश्य
 tools.title=औज़ार
 tools_label=औज़ार
 first_page.title=प्रथम पृष्ठ पर जाएँ
-first_page.label=\u0020प्रथम पृष्ठ पर जाएँ
 first_page_label=प्रथम पृष्ठ पर जाएँ
 last_page.title=अंतिम पृष्ठ पर जाएँ
-last_page.label=\u0020अंतिम पृष्ठ पर जाएँ
 last_page_label=\u0020अंतिम पृष्ठ पर जाएँ
 page_rotate_cw.title=घड़ी की दिशा में घुमाएँ
-page_rotate_cw.label=घड़ी की दिशा में घुमाएँ
 page_rotate_cw_label=घड़ी की दिशा में घुमाएँ
 page_rotate_ccw.title=घड़ी की दिशा से उल्टा घुमाएँ
-page_rotate_ccw.label=घड़ी की दिशा से उल्टा घुमाएँ
 page_rotate_ccw_label=\u0020घड़ी की दिशा से उल्टा घुमाएँ
 
 cursor_text_select_tool.title=पाठ चयन उपकरण सक्षम करें
@@ -133,7 +129,6 @@ print_progress_close=रद्द करें
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=\u0020स्लाइडर टॉगल करें
-toggle_sidebar_notification.title=साइडबार टॉगल करें (दस्तावेज़ में रूपरेखा शामिल है/attachments)
 toggle_sidebar_label=स्लाइडर टॉगल करें
 document_outline.title=दस्तावेज़ की रूपरेखा दिखाइए (सारी वस्तुओं को फलने अथवा समेटने के लिए दो बार क्लिक करें)
 document_outline_label=दस्तावेज़ आउटलाइन
@@ -143,9 +138,6 @@ thumbs.title=लघुछवियाँ दिखाएँ
 thumbs_label=लघु छवि
 findbar.title=\u0020दस्तावेज़ में ढूँढ़ें
 findbar_label=ढूँढें
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=पृष्ठ {{page}}
 
 # Thumbnails panel item (tooltip and alt text for images)
 # LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
@@ -217,9 +209,6 @@ page_scale_actual=वास्तविक आकार
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=त्रुटि
 
 loading_error=PDF लोड करते समय एक त्रुटि हुई.
 invalid_file_error=अमान्य या भ्रष्ट PDF फ़ाइल.

--- a/viewer/locale/hr/viewer.properties
+++ b/viewer/locale/hr/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Trenutačni prikaz
 tools.title=Alati
 tools_label=Alati
 first_page.title=Idi na prvu stranicu
-first_page.label=Idi na prvu stranicu
 first_page_label=Idi na prvu stranicu
 last_page.title=Idi na posljednju stranicu
-last_page.label=Idi na posljednju stranicu
 last_page_label=Idi na posljednju stranicu
 page_rotate_cw.title=Rotiraj u smjeru kazaljke na satu
-page_rotate_cw.label=Rotiraj u smjeru kazaljke na satu
 page_rotate_cw_label=Rotiraj u smjeru kazaljke na satu
 page_rotate_ccw.title=Rotiraj obrnutno od smjera kazaljke na satu
-page_rotate_ccw.label=Rotiraj obrnutno od smjera kazaljke na satu
 page_rotate_ccw_label=Rotiraj obrnutno od smjera kazaljke na satu
 
 cursor_text_select_tool.title=Omogući alat za označavanje teksta
@@ -137,7 +133,6 @@ print_progress_close=Odustani
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Prikaži/sakrij bočnu traku
-toggle_sidebar_notification.title=Prikazivanje i sklanjanje bočne trake (dokument sadrži strukturu/privitke)
 toggle_sidebar_notification2.title=Prikazivanje i sklanjanje bočne trake (dokument sadrži strukturu/privitke/slojeve)
 toggle_sidebar_label=Prikaži/sakrij bočnu traku
 document_outline.title=Prikaži strukturu dokumenta (dvostruki klik za rasklapanje/sklapanje svih stavki)
@@ -152,9 +147,6 @@ current_outline_item.title=Pronađi trenutačni element strukture
 current_outline_item_label=Trenutačni element strukture
 findbar.title=Pronađi u dokumentu
 findbar_label=Pronađi
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=Stranica br. {{page}}
 
 additional_layers=Dodatni slojevi
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -229,9 +221,6 @@ page_scale_actual=Stvarna veličina
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}} %
-
-# Loading indicator messages
-loading_error_indicator=Greška
 
 # Loading indicator messages
 loading=Učitavanje…

--- a/viewer/locale/hsb/viewer.properties
+++ b/viewer/locale/hsb/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Aktualny napohlad
 tools.title=Nastroje
 tools_label=Nastroje
 first_page.title=K prěnjej stronje
-first_page.label=K prěnjej stronje
 first_page_label=K prěnjej stronje
 last_page.title=K poslednjej stronje
-last_page.label=K poslednjej stronje
 last_page_label=K poslednjej stronje
 page_rotate_cw.title=K směrej časnika wjerćeć
-page_rotate_cw.label=K směrej časnika wjerćeć
 page_rotate_cw_label=K směrej časnika wjerćeć
 page_rotate_ccw.title=Přećiwo směrej časnika wjerćeć
-page_rotate_ccw.label=Přećiwo směrej časnika wjerćeć
 page_rotate_ccw_label=Přećiwo směrej časnika wjerćeć
 
 cursor_text_select_tool.title=Nastroj za wuběranje teksta zmóžnić
@@ -137,7 +133,6 @@ print_progress_close=Přetorhnyć
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Bóčnicu pokazać/schować
-toggle_sidebar_notification.title=Bóčnicu přepinać (dokument wobsahuje wobrys/přiwěški)
 toggle_sidebar_notification2.title=Bóčnicu přepinać (dokument rozrjad/přiwěški/woršty wobsahuje)
 toggle_sidebar_label=Bóčnicu pokazać/schować
 document_outline.title=Dokumentowy naćisk pokazać (dwójne kliknjenje, zo bychu so wšě zapiski pokazali/schowali)
@@ -152,9 +147,6 @@ current_outline_item.title=Aktualny rozrjadowy zapisk pytać
 current_outline_item_label=Aktualny rozrjadowy zapisk
 findbar.title=W dokumenće pytać
 findbar_label=Pytać
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=Strona {{page}}
 
 additional_layers=Dalše woršty
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -229,9 +221,6 @@ page_scale_actual=Aktualna wulkosć
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Zmylk
 
 # Loading indicator messages
 loading=Začituje so…

--- a/viewer/locale/hu/viewer.properties
+++ b/viewer/locale/hu/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Aktuális nézet
 tools.title=Eszközök
 tools_label=Eszközök
 first_page.title=Ugrás az első oldalra
-first_page.label=Ugrás az első oldalra
 first_page_label=Ugrás az első oldalra
 last_page.title=Ugrás az utolsó oldalra
-last_page.label=Ugrás az utolsó oldalra
 last_page_label=Ugrás az utolsó oldalra
 page_rotate_cw.title=Forgatás az óramutató járásával egyezően
-page_rotate_cw.label=Forgatás az óramutató járásával egyezően
 page_rotate_cw_label=Forgatás az óramutató járásával egyezően
 page_rotate_ccw.title=Forgatás az óramutató járásával ellentétesen
-page_rotate_ccw.label=Forgatás az óramutató járásával ellentétesen
 page_rotate_ccw_label=Forgatás az óramutató járásával ellentétesen
 
 cursor_text_select_tool.title=Szövegkijelölő eszköz bekapcsolása
@@ -137,7 +133,6 @@ print_progress_close=Mégse
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Oldalsáv be/ki
-toggle_sidebar_notification.title=Oldalsáv be/ki (a dokumentum vázlatot/mellékleteket tartalmaz)
 toggle_sidebar_notification2.title=Oldalsáv be/ki (a dokumentum vázlatot/mellékleteket/rétegeket tartalmaz)
 toggle_sidebar_label=Oldalsáv be/ki
 document_outline.title=Dokumentum megjelenítése online (dupla kattintás minden elem kinyitásához/összecsukásához)
@@ -152,9 +147,6 @@ current_outline_item.title=Jelenlegi vázlatelem megkeresése
 current_outline_item_label=Jelenlegi vázlatelem
 findbar.title=Keresés a dokumentumban
 findbar_label=Keresés
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas={{page}}. oldal
 
 additional_layers=További rétegek
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -229,9 +221,6 @@ page_scale_actual=Valódi méret
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Hiba
 
 # Loading indicator messages
 loading=Betöltés…

--- a/viewer/locale/hy-AM/viewer.properties
+++ b/viewer/locale/hy-AM/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Ընթացիկ տեսքը
 tools.title=Գործիքներ
 tools_label=Գործիքներ
 first_page.title=Անցնել առաջին էջին
-first_page.label=Անցնել առաջին էջին
 first_page_label=Անցնել առաջին էջին
 last_page.title=Անցնել վերջին էջին
-last_page.label=Անցնել վերջին էջին
 last_page_label=Անցնել վերջին էջին
 page_rotate_cw.title=Պտտել ըստ ժամացույցի սլաքի
-page_rotate_cw.label=Պտտել ըստ ժամացույցի սլաքի
 page_rotate_cw_label=Պտտել ըստ ժամացույցի սլաքի
 page_rotate_ccw.title=Պտտել հակառակ ժամացույցի սլաքի
-page_rotate_ccw.label=Պտտել հակառակ ժամացույցի սլաքի
 page_rotate_ccw_label=Պտտել հակառակ ժամացույցի սլաքի
 
 cursor_text_select_tool.title=Միացնել գրույթ ընտրելու գործիքը
@@ -137,7 +133,6 @@ print_progress_close=Չեղարկել
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Բացել/Փակել Կողային վահանակը
-toggle_sidebar_notification.title=Փոխարկել Կողային փեղկը (փաստաթուղթը պարունակում է ուրվագիծ/կցորդներ)
 toggle_sidebar_label=Բացել/Փակել Կողային վահանակը
 document_outline.title=Ցուցադրել փաստաթղթի ուրվագիծը (կրկնակի սեղմեք՝ միավորները ընդարձակելու/կոծկելու համար)
 document_outline_label=Փաստաթղթի բովանդակությունը
@@ -147,9 +142,6 @@ thumbs.title=Ցուցադրել Մանրապատկերը
 thumbs_label=Մանրապատկերը
 findbar.title=Գտնել փաստաթղթում
 findbar_label=Որոնում
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=Էջ {{page}}
 
 # Thumbnails panel item (tooltip and alt text for images)
 # LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
@@ -221,9 +213,6 @@ page_scale_actual=Իրական չափը
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Սխալ
 
 loading_error=Սխալ՝ PDF ֆայլը բացելիս։
 invalid_file_error=Սխալ կամ վնասված PDF ֆայլ:

--- a/viewer/locale/hye/viewer.properties
+++ b/viewer/locale/hye/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Ընթացիկ տեսք
 tools.title=Գործիքներ
 tools_label=Գործիքներ
 first_page.title=Գնալ դէպի առաջին էջ
-first_page.label=Գնալ դէպի առաջին էջ
 first_page_label=Գնալ դէպի առաջին էջ
 last_page.title=Գնալ դէպի վերջին էջ
-last_page.label=Գնալ դէպի վերջին էջ
 last_page_label=Գնալ դէպի վերջին էջ
 page_rotate_cw.title=Պտտել ժամացոյցի սլաքի ուղղութեամբ
-page_rotate_cw.label=Պտտել ժամացոյցի սլաքի ուղղութեամբ
 page_rotate_cw_label=Պտտել ժամացոյցի սլաքի ուղղութեամբ
 page_rotate_ccw.title=Պտտել ժամացոյցի սլաքի հակառակ ուղղութեամբ
-page_rotate_ccw.label=Պտտել ժամացոյցի սլաքի հակառակ ուղղութեամբ
 page_rotate_ccw_label=Պտտել ժամացոյցի սլաքի հակառակ ուղղութեամբ
 
 cursor_text_select_tool.title=Միացնել գրոյթ ընտրելու գործիքը
@@ -137,7 +133,6 @@ print_progress_close=Չեղարկել
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Փոխարկել կողային վահանակը
-toggle_sidebar_notification.title=Փոխարկել կողային վահանակը (փաստաթուղթը պարունակում է ուրուագիծ/կցորդ)
 toggle_sidebar_notification2.title=Փոխանջատել կողմնասիւնը (փաստաթուղթը պարունակում է ուրուագիծ/կցորդներ/շերտեր)
 toggle_sidebar_label=Փոխարկել կողային վահանակը
 document_outline.title=Ցուցադրել փաստաթղթի ուրուագիծը (կրկնակի սեղմէք՝ միաւորները ընդարձակելու/կոծկելու համար)
@@ -152,9 +147,6 @@ current_outline_item.title=Գտէք ընթացիկ գծագրման տարրը
 current_outline_item_label=Ընթացիկ գծագրման տարր
 findbar.title=Գտնել փաստաթղթում
 findbar_label=Որոնում
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=Էջ {{page}}
 
 additional_layers=Լրացուցիչ շերտեր
 # Thumbnails panel item (tooltip and alt text for images)
@@ -227,9 +219,6 @@ page_scale_actual=Իրական չափը
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Սխալ
 
 loading_error=PDF նիշքը բացելիս սխալ է տեղի ունեցել։
 invalid_file_error=Սխալ կամ վնասուած PDF նիշք։

--- a/viewer/locale/ia/viewer.properties
+++ b/viewer/locale/ia/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Vista actual
 tools.title=Instrumentos
 tools_label=Instrumentos
 first_page.title=Ir al prime pagina
-first_page.label=Ir al prime pagina
 first_page_label=Ir al prime pagina
 last_page.title=Ir al prime pagina
-last_page.label=Ir al prime pagina
 last_page_label=Ir al prime pagina
 page_rotate_cw.title=Rotar in senso horari
-page_rotate_cw.label=Rotar in senso horari
 page_rotate_cw_label=Rotar in senso horari
 page_rotate_ccw.title=Rotar in senso antihorari
-page_rotate_ccw.label=Rotar in senso antihorari
 page_rotate_ccw_label=Rotar in senso antihorari
 
 cursor_text_select_tool.title=Activar le instrumento de selection de texto
@@ -137,7 +133,6 @@ print_progress_close=Cancellar
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Monstrar/celar le barra lateral
-toggle_sidebar_notification.title=Monstrar/celar le barra lateral (le documento contine structura/attachamentos)
 toggle_sidebar_notification2.title=Monstrar/celar le barra lateral (le documento contine structura/attachamentos/stratos)
 toggle_sidebar_label=Monstrar/celar le barra lateral
 document_outline.title=Monstrar le schema del documento (clic duple pro expander/contraher tote le elementos)
@@ -152,9 +147,6 @@ current_outline_item.title=Trovar le elemento de structura actual
 current_outline_item_label=Elemento de structura actual
 findbar.title=Cercar in le documento
 findbar_label=Cercar
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=Pagina {{page}}
 
 additional_layers=Altere stratos
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -229,9 +221,6 @@ page_scale_actual=Dimension actual
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Error
 
 # Loading indicator messages
 loading=Cargante…

--- a/viewer/locale/id/viewer.properties
+++ b/viewer/locale/id/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Tampilan Sekarang
 tools.title=Alat
 tools_label=Alat
 first_page.title=Buka Halaman Pertama
-first_page.label=Ke Halaman Pertama
 first_page_label=Buka Halaman Pertama
 last_page.title=Buka Halaman Terakhir
-last_page.label=Ke Halaman Terakhir
 last_page_label=Buka Halaman Terakhir
 page_rotate_cw.title=Putar Searah Jarum Jam
-page_rotate_cw.label=Putar Searah Jarum Jam
 page_rotate_cw_label=Putar Searah Jarum Jam
 page_rotate_ccw.title=Putar Berlawanan Arah Jarum Jam
-page_rotate_ccw.label=Putar Berlawanan Arah Jarum Jam
 page_rotate_ccw_label=Putar Berlawanan Arah Jarum Jam
 
 cursor_text_select_tool.title=Aktifkan Alat Seleksi Teks
@@ -137,7 +133,6 @@ print_progress_close=Batalkan
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Aktif/Nonaktifkan Bilah Samping
-toggle_sidebar_notification.title=Aktif/Nonaktifkan Bilah Samping (dokumen berisi kerangka/lampiran)
 toggle_sidebar_notification2.title=Aktif/Nonaktifkan Bilah Samping (dokumen berisi kerangka/lampiran/lapisan)
 toggle_sidebar_label=Aktif/Nonaktifkan Bilah Samping
 document_outline.title=Tampilkan Kerangka Dokumen (klik ganda untuk membentangkan/menciutkan semua item)
@@ -152,9 +147,6 @@ current_outline_item.title=Cari Butir Ikhtisar Saat Ini
 current_outline_item_label=Butir Ikhtisar Saat Ini
 findbar.title=Temukan di Dokumen
 findbar_label=Temukan
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=Laman {{page}}
 
 additional_layers=Lapisan Tambahan
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -229,9 +221,6 @@ page_scale_actual=Ukuran Asli
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Galat
 
 # Loading indicator messages
 loading=Memuat…

--- a/viewer/locale/is/viewer.properties
+++ b/viewer/locale/is/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Núverandi sýn
 tools.title=Verkfæri
 tools_label=Verkfæri
 first_page.title=Fara á fyrstu síðu
-first_page.label=Fara á fyrstu síðu
 first_page_label=Fara á fyrstu síðu
 last_page.title=Fara á síðustu síðu
-last_page.label=Fara á síðustu síðu
 last_page_label=Fara á síðustu síðu
 page_rotate_cw.title=Snúa réttsælis
-page_rotate_cw.label=Snúa réttsælis
 page_rotate_cw_label=Snúa réttsælis
 page_rotate_ccw.title=Snúa rangsælis
-page_rotate_ccw.label=Snúa rangsælis
 page_rotate_ccw_label=Snúa rangsælis
 
 cursor_text_select_tool.title=Virkja textavalsáhald
@@ -134,7 +130,6 @@ print_progress_close=Hætta við
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Víxla hliðslá
-toggle_sidebar_notification.title=Víxla hliðarslá (skjal inniheldur yfirlit/viðhengi)
 toggle_sidebar_label=Víxla hliðslá
 document_outline.title=Sýna yfirlit skjals (tvísmelltu til að opna/loka öllum hlutum)
 document_outline_label=Efnisskipan skjals
@@ -215,9 +210,6 @@ page_scale_actual=Raunstærð
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Villa
 
 loading_error=Villa kom upp við að hlaða inn PDF.
 invalid_file_error=Ógild eða skemmd PDF skrá.

--- a/viewer/locale/it/viewer.properties
+++ b/viewer/locale/it/viewer.properties
@@ -44,16 +44,12 @@ bookmark_label = Visualizzazione corrente
 tools.title = Strumenti
 tools_label = Strumenti
 first_page.title = Vai alla prima pagina
-first_page.label = Vai alla prima pagina
 first_page_label = Vai alla prima pagina
 last_page.title = Vai all’ultima pagina
-last_page.label = Vai all’ultima pagina
 last_page_label = Vai all’ultima pagina
 page_rotate_cw.title = Ruota in senso orario
-page_rotate_cw.label = Ruota in senso orario
 page_rotate_cw_label = Ruota in senso orario
 page_rotate_ccw.title = Ruota in senso antiorario
-page_rotate_ccw.label = Ruota in senso antiorario
 page_rotate_ccw_label = Ruota in senso antiorario
 
 cursor_text_select_tool.title = Attiva strumento di selezione testo
@@ -113,7 +109,6 @@ print_progress_percent = {{progress}}%
 print_progress_close = Annulla
 
 toggle_sidebar.title = Attiva/disattiva barra laterale
-toggle_sidebar_notification.title = Attiva/disattiva barra laterale (il documento contiene struttura/allegati)
 toggle_sidebar_notification2.title = Attiva/disattiva barra laterale (il documento contiene struttura/allegati/livelli)
 toggle_sidebar_label = Attiva/disattiva barra laterale
 document_outline.title = Visualizza la struttura del documento (doppio clic per visualizzare/comprimere tutti gli elementi)
@@ -128,8 +123,6 @@ current_outline_item.title = Trova elemento struttura corrente
 current_outline_item_label = Elemento struttura corrente
 findbar.title = Trova nel documento
 findbar_label = Trova
-
-page_canvas = Pagina {{page}}
 
 additional_layers = Livelli aggiuntivi
 page_landmark = Pagina {{page}}
@@ -177,8 +170,6 @@ page_scale_fit = Adatta a una pagina
 page_scale_auto = Zoom automatico
 page_scale_actual = Dimensioni effettive
 page_scale_percent = {{scale}}%
-
-loading_error_indicator = Errore
 
 loading = Caricamento in corso…
 loading_error = Si è verificato un errore durante il caricamento del PDF.

--- a/viewer/locale/ja/viewer.properties
+++ b/viewer/locale/ja/viewer.properties
@@ -257,6 +257,3 @@ password_cancel=キャンセル
 printing_not_supported=警告: このブラウザーでは印刷が完全にサポートされていません。
 printing_not_ready=警告: PDF を印刷するための読み込みが終了していません。
 web_fonts_disabled=ウェブフォントが無効になっています: 埋め込まれた PDF のフォントを使用できません。
-# LOCALIZATION NOTE (unsupported_feature_signatures): Should contain the same
-# exact string as in the `chrome.properties` file.
-unsupported_feature_signatures=この PDF ドキュメントは、デジタル署名が含まれています。署名の検証はサポートされていません。

--- a/viewer/locale/ka/viewer.properties
+++ b/viewer/locale/ka/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=მიმდინარე ხედი
 tools.title=ხელსაწყოები
 tools_label=ხელსაწყოები
 first_page.title=პირველ გვერდზე გადასვლა
-first_page.label=პირველ გვერდზე გადასვლა
 first_page_label=პირველ გვერდზე გადასვლა
 last_page.title=ბოლო გვერდზე გადასვლა
-last_page.label=ბოლო გვერდზე გადასვლა
 last_page_label=ბოლო გვერდზე გადასვლა
 page_rotate_cw.title=საათის ისრის მიმართულებით შებრუნება
-page_rotate_cw.label=მარჯვნივ გადაბრუნება
 page_rotate_cw_label=მარჯვნივ გადაბრუნება
 page_rotate_ccw.title=საათის ისრის საპირისპიროდ შებრუნება
-page_rotate_ccw.label=მარცხნივ გადაბრუნება
 page_rotate_ccw_label=მარცხნივ გადაბრუნება
 
 cursor_text_select_tool.title=მოსანიშნი მაჩვენებლის გამოყენება
@@ -137,7 +133,6 @@ print_progress_close=გაუქმება
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=გვერდითა ზოლის გამოჩენა/დამალვა
-toggle_sidebar_notification.title=გვერდითა ზოლის გამოჩენა (შეიცავს სარჩევს/დანართს)
 toggle_sidebar_notification2.title=გვერდითი ზოლის გამოჩენა (შეიცავს სარჩევს/დანართს/ფენებს)
 toggle_sidebar_label=გვერდითა ზოლის გამოჩენა/დამალვა
 document_outline.title=დოკუმენტის სარჩევის ჩვენება (ორმაგი წკაპით თითოეულის ჩამოშლა/აკეცვა)
@@ -152,9 +147,6 @@ current_outline_item.title=მიმდინარე გვერდის მ
 current_outline_item_label=მიმდინარე გვერდი სარჩევში
 findbar.title=პოვნა დოკუმენტში
 findbar_label=ძიება
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=გვერდი {{page}}
 
 additional_layers=დამატებითი ფენები
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -229,9 +221,6 @@ page_scale_actual=საწყისი ზომა
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=შეცდომა
 
 # Loading indicator messages
 loading=ჩატვირთვა…

--- a/viewer/locale/kab/viewer.properties
+++ b/viewer/locale/kab/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Askan amiran
 tools.title=Ifecka
 tools_label=Ifecka
 first_page.title=Ddu ɣer usebter amezwaru
-first_page.label=Ddu ɣer usebter amezwaru
 first_page_label=Ddu ɣer usebter amezwaru
 last_page.title=Ddu ɣer usebter aneggaru
-last_page.label=Ddu ɣer usebter aneggaru
 last_page_label=Ddu ɣer usebter aneggaru
 page_rotate_cw.title=Tuzzya tusrigt
-page_rotate_cw.label=Tuzzya tusrigt
 page_rotate_cw_label=Tuzzya tusrigt
 page_rotate_ccw.title=Tuzzya amgal-usrig
-page_rotate_ccw.label=Tuzzya amgal-usrig
 page_rotate_ccw_label=Tuzzya amgal-usrig
 
 cursor_text_select_tool.title=Rmed afecku n tefrant n uḍris
@@ -137,7 +133,6 @@ print_progress_close=Sefsex
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Sken/Fer agalis adisan
-toggle_sidebar_notification.title=Ffer/Sken agalis adisan (isemli yegber aɣawas/imeddayen)
 toggle_sidebar_notification2.title=Ffer/Sekn agalis adisan (isemli yegber aɣawas/ticeqqufin yeddan/tissiwin)
 toggle_sidebar_label=Sken/Fer agalis adisan
 document_outline.title=Sken isemli (Senned snat tikal i wesemɣer/Afneẓ n iferdisen meṛṛa)
@@ -152,9 +147,6 @@ current_outline_item.title=Af-d aferdis n uɣawas amiran
 current_outline_item_label=Aferdis n uɣawas amiran
 findbar.title=Nadi deg isemli
 findbar_label=Nadi
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=Asebter {{page}}
 
 additional_layers=Tissiwin-nniḍen
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -229,9 +221,6 @@ page_scale_actual=Teɣzi tilawt
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Error
 
 # Loading indicator messages
 loading=Asali…

--- a/viewer/locale/kk/viewer.properties
+++ b/viewer/locale/kk/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Ағымдағы көрініс
 tools.title=Құралдар
 tools_label=Құралдар
 first_page.title=Алғашқы параққа өту
-first_page.label=Алғашқы параққа өту
 first_page_label=Алғашқы параққа өту
 last_page.title=Соңғы параққа өту
-last_page.label=Соңғы параққа өту
 last_page_label=Соңғы параққа өту
 page_rotate_cw.title=Сағат тілі бағытымен айналдыру
-page_rotate_cw.label=Сағат тілі бағытымен бұру
 page_rotate_cw_label=Сағат тілі бағытымен бұру
 page_rotate_ccw.title=Сағат тілі бағытына қарсы бұру
-page_rotate_ccw.label=Сағат тілі бағытына қарсы бұру
 page_rotate_ccw_label=Сағат тілі бағытына қарсы бұру
 
 cursor_text_select_tool.title=Мәтінді таңдау құралын іске қосу
@@ -137,7 +133,6 @@ print_progress_close=Бас тарту
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Бүйір панелін көрсету/жасыру
-toggle_sidebar_notification.title=Бүйір панелін көрсету/жасыру (құжатта құрылымы/салынымдар бар)
 toggle_sidebar_notification2.title=Бүйір панелін көрсету/жасыру (құжатта құрылымы/салынымдар/қабаттар бар)
 toggle_sidebar_label=Бүйір панелін көрсету/жасыру
 document_outline.title=Құжат құрылымын көрсету (барлық нәрселерді жазық қылу/жинау үшін қос шерту керек)
@@ -152,9 +147,6 @@ current_outline_item.title=Құрылымның ағымдағы элемент�
 current_outline_item_label=Құрылымның ағымдағы элементі
 findbar.title=Құжаттан табу
 findbar_label=Табу
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=Бет {{page}}
 
 additional_layers=Қосымша қабаттар
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -229,9 +221,6 @@ page_scale_actual=Нақты өлшемі
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Қате
 
 # Loading indicator messages
 loading=Жүктелуде…

--- a/viewer/locale/km/viewer.properties
+++ b/viewer/locale/km/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=ទិដ្ឋភាព​បច្ចុប្បន្ន
 tools.title=ឧបករណ៍
 tools_label=ឧបករណ៍
 first_page.title=ទៅកាន់​ទំព័រ​ដំបូង​
-first_page.label=ទៅកាន់​ទំព័រ​ដំបូង​
 first_page_label=ទៅកាន់​ទំព័រ​ដំបូង​
 last_page.title=ទៅកាន់​ទំព័រ​ចុងក្រោយ​
-last_page.label=ទៅកាន់​ទំព័រ​ចុងក្រោយ​
 last_page_label=ទៅកាន់​ទំព័រ​ចុងក្រោយ
 page_rotate_cw.title=បង្វិល​ស្រប​ទ្រនិច​នាឡិកា
-page_rotate_cw.label=បង្វិល​ស្រប​ទ្រនិច​នាឡិកា
 page_rotate_cw_label=បង្វិល​ស្រប​ទ្រនិច​នាឡិកា
 page_rotate_ccw.title=បង្វិល​ច្រាស​ទ្រនិច​នាឡិកា​​
-page_rotate_ccw.label=បង្វិល​ច្រាស​ទ្រនិច​នាឡិកា​​
 page_rotate_ccw_label=បង្វិល​ច្រាស​ទ្រនិច​នាឡិកា​​
 
 cursor_text_select_tool.title=បើក​ឧបករណ៍​ជ្រើស​អត្ថបទ
@@ -122,7 +118,6 @@ print_progress_close=បោះបង់
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=បិទ/បើក​គ្រាប់​រំកិល
-toggle_sidebar_notification.title=បិទ/បើក​របារ​ចំហៀង (ឯកសារ​មាន​មាតិកា​នៅ​ក្រៅ/attachments)
 toggle_sidebar_label=បិទ/បើក​គ្រាប់​រំកិល
 document_outline.title=បង្ហាញ​គ្រោង​ឯកសារ (ចុច​ទ្វេ​ដង​ដើម្បី​ពង្រីក/បង្រួម​ធាតុ​ទាំងអស់)
 document_outline_label=គ្រោង​ឯកសារ
@@ -190,9 +185,6 @@ page_scale_actual=ទំហំ​ជាក់ស្ដែង
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=កំហុស
 
 loading_error=មាន​កំហុស​បាន​កើតឡើង​ពេល​កំពុង​ផ្ទុក PDF ។
 invalid_file_error=ឯកសារ PDF ខូច ឬ​មិន​ត្រឹមត្រូវ ។

--- a/viewer/locale/kn/viewer.properties
+++ b/viewer/locale/kn/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=ಪ್ರಸಕ್ತ ನೋಟ
 tools.title=ಉಪಕರಣಗಳು
 tools_label=ಉಪಕರಣಗಳು
 first_page.title=ಮೊದಲ ಪುಟಕ್ಕೆ ತೆರಳು
-first_page.label=ಮೊದಲ ಪುಟಕ್ಕೆ ತೆರಳು
 first_page_label=ಮೊದಲ ಪುಟಕ್ಕೆ ತೆರಳು
 last_page.title=ಕೊನೆಯ ಪುಟಕ್ಕೆ ತೆರಳು
-last_page.label=ಕೊನೆಯ ಪುಟಕ್ಕೆ ತೆರಳು
 last_page_label=ಕೊನೆಯ ಪುಟಕ್ಕೆ ತೆರಳು
 page_rotate_cw.title=ಪ್ರದಕ್ಷಿಣೆಯಲ್ಲಿ ತಿರುಗಿಸು
-page_rotate_cw.label=ಪ್ರದಕ್ಷಿಣೆಯಲ್ಲಿ ತಿರುಗಿಸು
 page_rotate_cw_label=ಪ್ರದಕ್ಷಿಣೆಯಲ್ಲಿ ತಿರುಗಿಸು
 page_rotate_ccw.title=ಅಪ್ರದಕ್ಷಿಣೆಯಲ್ಲಿ ತಿರುಗಿಸು
-page_rotate_ccw.label=ಅಪ್ರದಕ್ಷಿಣೆಯಲ್ಲಿ ತಿರುಗಿಸು
 page_rotate_ccw_label=ಅಪ್ರದಕ್ಷಿಣೆಯಲ್ಲಿ ತಿರುಗಿಸು
 
 cursor_text_select_tool.title=ಪಠ್ಯ ಆಯ್ಕೆ ಉಪಕರಣವನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಿ
@@ -169,9 +165,6 @@ page_scale_actual=ನಿಜವಾದ ಗಾತ್ರ
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=ದೋಷ
 
 loading_error=PDF ಅನ್ನು ಲೋಡ್ ಮಾಡುವಾಗ ಒಂದು ದೋಷ ಎದುರಾಗಿದೆ.
 invalid_file_error=ಅಮಾನ್ಯವಾದ ಅಥವ ಹಾಳಾದ PDF ಕಡತ.

--- a/viewer/locale/ko/viewer.properties
+++ b/viewer/locale/ko/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=현재 보기
 tools.title=도구
 tools_label=도구
 first_page.title=첫 페이지로 이동
-first_page.label=첫 페이지로 이동
 first_page_label=첫 페이지로 이동
 last_page.title=마지막 페이지로 이동
-last_page.label=마지막 페이지로 이동
 last_page_label=마지막 페이지로 이동
 page_rotate_cw.title=시계방향으로 회전
-page_rotate_cw.label=시계방향으로 회전
 page_rotate_cw_label=시계방향으로 회전
 page_rotate_ccw.title=시계 반대방향으로 회전
-page_rotate_ccw.label=시계 반대방향으로 회전
 page_rotate_ccw_label=시계 반대방향으로 회전
 
 cursor_text_select_tool.title=텍스트 선택 도구 활성화
@@ -137,7 +133,6 @@ print_progress_close=취소
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=탐색창 표시/숨기기
-toggle_sidebar_notification.title=탐색창 표시/숨기기 (문서에 아웃라인/첨부파일 포함됨)
 toggle_sidebar_notification2.title=탐색창 표시/숨기기 (문서에 아웃라인/첨부파일/레이어 포함됨)
 toggle_sidebar_label=탐색창 표시/숨기기
 document_outline.title=문서 아웃라인 보기 (더블 클릭해서 모든 항목 펼치기/접기)
@@ -152,9 +147,6 @@ current_outline_item.title=현재 아웃라인 항목 찾기
 current_outline_item_label=현재 아웃라인 항목
 findbar.title=검색
 findbar_label=검색
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas={{page}} 페이지
 
 additional_layers=추가 레이어
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -203,7 +195,7 @@ find_match_count_limit[other]={{limit}} 이상 일치
 find_not_found=검색 결과 없음
 
 # Error panel labels
-error_more_info=정보 더 보기
+error_more_info=자세한 정보
 error_less_info=정보 간단히 보기
 error_close=닫기
 # LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
@@ -229,9 +221,6 @@ page_scale_actual=실제 크기
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=오류
 
 # Loading indicator messages
 loading=로드 중…

--- a/viewer/locale/lij/viewer.properties
+++ b/viewer/locale/lij/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Vixon corente
 tools.title=Atressi
 tools_label=Atressi
 first_page.title=Vanni a-a primma pagina
-first_page.label=Vanni a-a primma pagina
 first_page_label=Vanni a-a primma pagina
 last_page.title=Vanni a l'urtima pagina
-last_page.label=Vanni a l'urtima pagina
 last_page_label=Vanni a l'urtima pagina
 page_rotate_cw.title=Gia into verso oraio
-page_rotate_cw.label=Gia in senso do releuio
 page_rotate_cw_label=Gia into verso oraio
 page_rotate_ccw.title=Gia into verso antioraio
-page_rotate_ccw.label=Gia in senso do releuio a-a reversa
 page_rotate_ccw_label=Gia into verso antioraio
 
 cursor_text_select_tool.title=Abilita strumento de seleçion do testo
@@ -137,7 +133,6 @@ print_progress_close=Anulla
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Ativa/dizativa bara de scianco
-toggle_sidebar_notification.title=Cangia bara de löo (o documento o contegne di alegæ)
 toggle_sidebar_label=Ativa/dizativa bara de scianco
 document_outline.title=Fanni vedde o contorno do documento (scicca doggio pe espande/ridue tutti i elementi)
 document_outline_label=Contorno do documento
@@ -218,9 +213,6 @@ page_scale_actual=Dimenscioin efetive
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Erô
 
 loading_error=S'é verificou 'n'erô itno caregamento do PDF.
 invalid_file_error=O schedaio PDF o l'é no valido ò aroinou.

--- a/viewer/locale/lo/viewer.properties
+++ b/viewer/locale/lo/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=ມຸມມອງປະຈຸບັນ
 tools.title=ເຄື່ອງມື
 tools_label=ເຄື່ອງມື
 first_page.title=ໄປທີ່ຫນ້າທຳອິດ
-first_page.label=ໄປທີ່ຫນ້າທຳອິດ
 first_page_label=ໄປທີ່ຫນ້າທຳອິດ
 last_page.title=ໄປທີ່ຫນ້າສຸດທ້າຍ
-last_page.label=ໄປທີ່ຫນ້າສຸດທ້າຍ
 last_page_label=ໄປທີ່ຫນ້າສຸດທ້າຍ
 page_rotate_cw.title=ຫມູນຕາມເຂັມໂມງ
-page_rotate_cw.label=ຫມູນຕາມເຂັມໂມງ
 page_rotate_cw_label=ຫມູນຕາມເຂັມໂມງ
 page_rotate_ccw.title=ຫມູນທວນເຂັມໂມງ
-page_rotate_ccw.label=ຫມູນທວນເຂັມໂມງ
 page_rotate_ccw_label=ຫມູນທວນເຂັມໂມງ
 
 
@@ -98,7 +94,6 @@ print_progress_close=ຍົກເລີກ
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=ເປີດ/ປິດແຖບຂ້າງ
-toggle_sidebar_notification.title=ເປີດ/ປິດແຖບຂ້າງ (ເອກະສານມີເຄົ້າຮ່າງ/ໄຟລ໌ແນບ)
 toggle_sidebar_label=ເປີດ/ປິດແຖບຂ້າງ
 document_outline_label=ເຄົ້າຮ່າງເອກະສານ
 findbar_label=ຄົ້ນຫາ
@@ -137,9 +132,6 @@ rendering_error=ມີຂໍ້ຜິດພາດເກີດຂື້ນຂະ�
 # Predefined zoom values
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
-
-# Loading indicator messages
-loading_error_indicator=ຂໍ້ຜິດພາດ
 
 loading_error=ມີຂໍ້ຜິດພາດເກີດຂື້ນຂະນະທີ່ກຳລັງໂຫລດ PDF.
 invalid_file_error=ໄຟລ໌ PDF ບໍ່ຖືກຕ້ອງຫລືເສຍຫາຍ.

--- a/viewer/locale/lt/viewer.properties
+++ b/viewer/locale/lt/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Esamasis rodinys
 tools.title=Priemonės
 tools_label=Priemonės
 first_page.title=Eiti į pirmą puslapį
-first_page.label=Eiti į pirmą puslapį
 first_page_label=Eiti į pirmą puslapį
 last_page.title=Eiti į paskutinį puslapį
-last_page.label=Eiti į paskutinį puslapį
 last_page_label=Eiti į paskutinį puslapį
 page_rotate_cw.title=Pasukti pagal laikrodžio rodyklę
-page_rotate_cw.label=Pasukti pagal laikrodžio rodyklę
 page_rotate_cw_label=Pasukti pagal laikrodžio rodyklę
 page_rotate_ccw.title=Pasukti prieš laikrodžio rodyklę
-page_rotate_ccw.label=Pasukti prieš laikrodžio rodyklę
 page_rotate_ccw_label=Pasukti prieš laikrodžio rodyklę
 
 cursor_text_select_tool.title=Įjungti teksto žymėjimo įrankį
@@ -137,7 +133,6 @@ print_progress_close=Atsisakyti
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Rodyti / slėpti šoninį polangį
-toggle_sidebar_notification.title=Parankinė (dokumentas turi struktūrą / priedų)
 toggle_sidebar_notification2.title=Parankinė (dokumentas turi struktūrą / priedų / sluoksnių)
 toggle_sidebar_label=Šoninis polangis
 document_outline.title=Rodyti dokumento struktūrą (spustelėkite dukart norėdami išplėsti/suskleisti visus elementus)
@@ -152,9 +147,6 @@ current_outline_item.title=Rasti dabartinį struktūros elementą
 current_outline_item_label=Dabartinis struktūros elementas
 findbar.title=Ieškoti dokumente
 findbar_label=Rasti
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas={{page}} puslapis
 
 additional_layers=Papildomi sluoksniai
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -229,9 +221,6 @@ page_scale_actual=Tikras dydis
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Klaida
 
 # Loading indicator messages
 loading=Įkeliama…

--- a/viewer/locale/ltg/viewer.properties
+++ b/viewer/locale/ltg/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Pošreizejais skots
 tools.title=Reiki
 tools_label=Reiki
 first_page.title=Īt iz pyrmū lopu
-first_page.label=Īt iz pyrmū lopu
 first_page_label=Īt iz pyrmū lopu
 last_page.title=Īt iz piedejū lopu
-last_page.label=Īt iz piedejū lopu
 last_page_label=Īt iz piedejū lopu
 page_rotate_cw.title=Pagrīzt pa pulksteni
-page_rotate_cw.label=Pagrīzt pa pulksteni
 page_rotate_cw_label=Pagrīzt pa pulksteni
 page_rotate_ccw.title=Pagrīzt pret pulksteni
-page_rotate_ccw.label=Pagrīzt pret pulksteni
 page_rotate_ccw_label=Pagrīzt pret pulksteni
 
 cursor_text_select_tool.title=Aktivizēt teksta izvieles reiku
@@ -137,7 +133,6 @@ print_progress_close=Atceļt
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Puorslēgt suonu jūslu
-toggle_sidebar_notification.title=Toggle Sidebar (document contains outline/attachments)
 toggle_sidebar_label=Puorslēgt suonu jūslu
 document_outline.title=Show Document Outline (double-click to expand/collapse all items)
 document_outline_label=Dokumenta saturs
@@ -196,9 +191,6 @@ page_scale_actual=Patīsais izmārs
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Klaida
 
 loading_error=Īluodejūt PDF nūtyka klaida.
 invalid_file_error=Nadereigs voi būjuots PDF fails.

--- a/viewer/locale/lv/viewer.properties
+++ b/viewer/locale/lv/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Pašreizējais skats
 tools.title=Rīki
 tools_label=Rīki
 first_page.title=Iet uz pirmo lapu
-first_page.label=Iet uz pirmo lapu
 first_page_label=Iet uz pirmo lapu
 last_page.title=Iet uz pēdējo lapu
-last_page.label=Iet uz pēdējo lapu
 last_page_label=Iet uz pēdējo lapu
 page_rotate_cw.title=Pagriezt pa pulksteni
-page_rotate_cw.label=Pagriezt pa pulksteni
 page_rotate_cw_label=Pagriezt pa pulksteni
 page_rotate_ccw.title=Pagriezt pret pulksteni
-page_rotate_ccw.label=Pagriezt pret pulksteni
 page_rotate_ccw_label=Pagriezt pret pulksteni
 
 cursor_text_select_tool.title=Aktivizēt teksta izvēles rīku
@@ -137,7 +133,6 @@ print_progress_close=Atcelt
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Pārslēgt sānu joslu
-toggle_sidebar_notification.title=Pārslēgt sānu joslu (dokumenta saturu un pielikumus)
 toggle_sidebar_label=Pārslēgt sānu joslu
 document_outline.title=Rādīt dokumenta struktūru (veiciet dubultklikšķi lai izvērstu/sakļautu visus vienumus)
 document_outline_label=Dokumenta saturs
@@ -218,9 +213,6 @@ page_scale_actual=Patiesais izmērs
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Kļūda
 
 loading_error=Ielādējot PDF notika kļūda.
 invalid_file_error=Nederīgs vai bojāts PDF fails.

--- a/viewer/locale/mk/viewer.properties
+++ b/viewer/locale/mk/viewer.properties
@@ -43,10 +43,6 @@ bookmark_label=Овој преглед
 
 # Secondary toolbar and context menu
 tools.title=Алатки
-first_page.label=Оди до првата страница
-last_page.label=Оди до последната страница
-page_rotate_cw.label=Ротирај по стрелките на часовникот
-page_rotate_ccw.label=Ротирај спротивно од стрелките на часовникот
 
 
 
@@ -126,9 +122,6 @@ page_scale_auto=Автоматска големина
 page_scale_actual=Вистинска големина
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
-
-# Loading indicator messages
-loading_error_indicator=Грешка
 
 loading_error=Настана грешка при вчитувањето на PDF-от.
 invalid_file_error=Невалидна или корумпирана PDF датотека.

--- a/viewer/locale/mr/viewer.properties
+++ b/viewer/locale/mr/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=सध्याचे अवलोकन
 tools.title=साधने
 tools_label=साधने
 first_page.title=पहिल्या पृष्ठावर जा
-first_page.label=पहिल्या पृष्ठावर जा
 first_page_label=पहिल्या पृष्ठावर जा
 last_page.title=शेवटच्या पृष्ठावर जा
-last_page.label=शेवटच्या पृष्ठावर जा
 last_page_label=शेवटच्या पृष्ठावर जा
 page_rotate_cw.title=घड्याळाच्या काट्याच्या दिशेने फिरवा
-page_rotate_cw.label=घड्याळाच्या काट्याच्या दिशेने फिरवा
 page_rotate_cw_label=घड्याळाच्या काट्याच्या दिशेने फिरवा
 page_rotate_ccw.title=घड्याळाच्या काट्याच्या उलट दिशेने फिरवा
-page_rotate_ccw.label=घड्याळाच्या काट्याच्या उलट दिशेने फिरवा
 page_rotate_ccw_label=घड्याळाच्या काट्याच्या उलट दिशेने फिरवा
 
 cursor_text_select_tool.title=मजकूर निवड साधन कार्यान्वयीत करा
@@ -129,7 +125,6 @@ print_progress_close=रद्द करा
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=बाजूचीपट्टी टॉगल करा
-toggle_sidebar_notification.title=बाजूची पट्टी टॉगल करा (दस्तऐवजामध्ये रुपरेषा/जोडण्या आहेत)
 toggle_sidebar_label=बाजूचीपट्टी टॉगल करा
 document_outline.title=दस्तऐवज बाह्यरेखा दर्शवा (विस्तृत करण्यासाठी दोनवेळा क्लिक करा /सर्व घटक दाखवा)
 document_outline_label=दस्तऐवज रूपरेषा
@@ -210,9 +205,6 @@ page_scale_actual=प्रत्यक्ष आकार
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=त्रुटी
 
 loading_error=PDF लोड करतेवेळी त्रुटी आढळली.
 invalid_file_error=अवैध किंवा दोषीत PDF फाइल.

--- a/viewer/locale/ms/viewer.properties
+++ b/viewer/locale/ms/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Paparan Semasa
 tools.title=Alatan
 tools_label=Alatan
 first_page.title=Pergi ke Halaman Pertama
-first_page.label=Pergi ke Halaman Pertama
 first_page_label=Pergi ke Halaman Pertama
 last_page.title=Pergi ke Halaman Terakhir
-last_page.label=Pergi ke Halaman Terakhir
 last_page_label=Pergi ke Halaman Terakhir
 page_rotate_cw.title=Berputar ikut arah Jam
-page_rotate_cw.label=Berputar ikut arah Jam
 page_rotate_cw_label=Berputar ikut arah Jam
 page_rotate_ccw.title=Pusing berlawan arah jam
-page_rotate_ccw.label=Pusing berlawan arah jam
 page_rotate_ccw_label=Pusing berlawan arah jam
 
 cursor_text_select_tool.title=Dayakan Alatan Pilihan Teks
@@ -137,7 +133,6 @@ print_progress_close=Batal
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Togol Bar Sisi
-toggle_sidebar_notification.title=Togol Sidebar (dokumen mengandungi rangka/attachments)
 toggle_sidebar_label=Togol Bar Sisi
 document_outline.title=Papar Rangka Dokumen (klik-dua-kali untuk kembangkan/kolaps semua item)
 document_outline_label=Rangka Dokumen
@@ -218,9 +213,6 @@ page_scale_actual=Saiz Sebenar
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Ralat
 
 loading_error=Masalah berlaku semasa menuatkan sebuah PDF.
 invalid_file_error=Tidak sah atau fail PDF rosak.

--- a/viewer/locale/my/viewer.properties
+++ b/viewer/locale/my/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=လက်ရှိ မြင်ကွင်း
 tools.title=ကိရိယာများ
 tools_label=ကိရိယာများ
 first_page.title=ပထမ စာမျက်နှာသို့
-first_page.label=ပထမ စာမျက်နှာသို့
 first_page_label=ပထမ စာမျက်နှာသို့
 last_page.title=နောက်ဆုံး စာမျက်နှာသို့
-last_page.label=နောက်ဆုံး စာမျက်နှာသို့
 last_page_label=နောက်ဆုံး စာမျက်နှာသို့
 page_rotate_cw.title=နာရီလက်တံ အတိုင်း
-page_rotate_cw.label=နာရီလက်တံ အတိုင်း
 page_rotate_cw_label=နာရီလက်တံ အတိုင်း
 page_rotate_ccw.title=နာရီလက်တံ ပြောင်းပြန်
-page_rotate_ccw.label=နာရီလက်တံ ပြောင်းပြန်
 page_rotate_ccw_label=နာရီလက်တံ ပြောင်းပြန်
 
 
@@ -107,7 +103,6 @@ print_progress_close=ပယ်​ဖျက်ပါ
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=ဘေးတန်းဖွင့်ပိတ်
-toggle_sidebar_notification.title=ဘေးဘားတန်းကို အဖွင့်/အပိတ် လုပ်ရန် (စာတမ်းတွင် outline/attachments ပါဝင်နိုင်သည်)
 toggle_sidebar_label=ဖွင့်ပိတ် ဆလိုက်ဒါ
 document_outline.title=စာတမ်းအကျဉ်းချုပ်ကို ပြပါ (စာရင်းအားလုံးကို ချုံ့/ချဲ့ရန် ကလစ်နှစ်ချက်နှိပ်ပါ)
 document_outline_label=စာတမ်းအကျဉ်းချုပ်
@@ -174,9 +169,6 @@ page_scale_actual=အမှန်တကယ်ရှိတဲ့ အရွယ်
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=အမှား
 
 loading_error=PDF ဖိုင် ကိုဆွဲတင်နေချိန်မှာ အမှားတစ်ခုတွေ့ရပါတယ်။
 invalid_file_error=မရသော သို့ ပျက်နေသော PDF ဖိုင်

--- a/viewer/locale/nb-NO/viewer.properties
+++ b/viewer/locale/nb-NO/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Nåværende visning
 tools.title=Verktøy
 tools_label=Verktøy
 first_page.title=Gå til første side
-first_page.label=Gå til første side
 first_page_label=Gå til første side
 last_page.title=Gå til siste side
-last_page.label=Gå til siste side
 last_page_label=Gå til siste side
 page_rotate_cw.title=Roter med klokken
-page_rotate_cw.label=Roter med klokken
 page_rotate_cw_label=Roter med klokken
 page_rotate_ccw.title=Roter mot klokken
-page_rotate_ccw.label=Roter mot klokken
 page_rotate_ccw_label=Roter mot klokken
 
 cursor_text_select_tool.title=Aktiver tekstmarkeringsverktøy
@@ -137,7 +133,6 @@ print_progress_close=Avbryt
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Slå av/på sidestolpe
-toggle_sidebar_notification.title=Vis/gjem sidestolpe (dokumentet inneholder oversikt/vedlegg)
 toggle_sidebar_notification2.title=Vis/gjem sidestolpe (dokumentet inneholder oversikt/vedlegg/lag)
 toggle_sidebar_label=Slå av/på sidestolpe
 document_outline.title=Vis dokumentdisposisjonen (dobbeltklikk for å utvide/skjule alle elementer)
@@ -152,9 +147,6 @@ current_outline_item.title=Finn gjeldende disposisjonselement
 current_outline_item_label=Gjeldende disposisjonselement
 findbar.title=Finn i dokumentet
 findbar_label=Finn
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=Side {{page}}
 
 additional_layers=Ytterligere lag
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -229,9 +221,6 @@ page_scale_actual=Virkelig størrelse
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}} %
-
-# Loading indicator messages
-loading_error_indicator=Feil
 
 # Loading indicator messages
 loading=Laster…

--- a/viewer/locale/ne-NP/viewer.properties
+++ b/viewer/locale/ne-NP/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=हालको दृश्य
 tools.title=औजारहरू
 tools_label=औजारहरू
 first_page.title=पहिलो पृष्ठमा जानुहोस्
-first_page.label=पहिलो पृष्ठमा जानुहोस्
 first_page_label=पहिलो पृष्ठमा जानुहोस्
 last_page.title=पछिल्लो पृष्ठमा जानुहोस्
-last_page.label=पछिल्लो पृष्ठमा जानुहोस्
 last_page_label=पछिल्लो पृष्ठमा जानुहोस्
 page_rotate_cw.title=घडीको दिशामा घुमाउनुहोस्
-page_rotate_cw.label=घडीको दिशामा घुमाउनुहोस्
 page_rotate_cw_label=घडीको दिशामा घुमाउनुहोस्
 page_rotate_ccw.title=घडीको विपरित दिशामा घुमाउनुहोस्
-page_rotate_ccw.label=घडीको विपरित दिशामा घुमाउनुहोस्
 page_rotate_ccw_label=घडीको विपरित दिशामा घुमाउनुहोस्
 
 cursor_text_select_tool.title=पाठ चयन उपकरण सक्षम गर्नुहोस्
@@ -101,7 +97,6 @@ print_progress_close=रद्द गर्नुहोस्
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=टगल साइडबार
-toggle_sidebar_notification.title=साइडबार टगल गर्नुहोस् (कागजातमा समावेश भएको कुराहरू रूपरेखा/attachments)
 toggle_sidebar_label=टगल साइडबार
 document_outline.title=कागजातको रूपरेखा देखाउनुहोस् (सबै वस्तुहरू विस्तार/पतन गर्न डबल-क्लिक गर्नुहोस्)
 document_outline_label=दस्तावेजको रूपरेखा
@@ -160,9 +155,6 @@ page_scale_actual=वास्तविक आकार
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=त्रुटि
 
 loading_error=यो PDF लोड गर्दा एउटा त्रुटि देखापर्‍यो।
 invalid_file_error=अवैध वा दुषित PDF फाइल।

--- a/viewer/locale/nl/viewer.properties
+++ b/viewer/locale/nl/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Huidige weergave
 tools.title=Hulpmiddelen
 tools_label=Hulpmiddelen
 first_page.title=Naar eerste pagina gaan
-first_page.label=Naar eerste pagina gaan
 first_page_label=Naar eerste pagina gaan
 last_page.title=Naar laatste pagina gaan
-last_page.label=Naar laatste pagina gaan
 last_page_label=Naar laatste pagina gaan
 page_rotate_cw.title=Rechtsom draaien
-page_rotate_cw.label=Rechtsom draaien
 page_rotate_cw_label=Rechtsom draaien
 page_rotate_ccw.title=Linksom draaien
-page_rotate_ccw.label=Linksom draaien
 page_rotate_ccw_label=Linksom draaien
 
 cursor_text_select_tool.title=Tekstselectiehulpmiddel inschakelen
@@ -137,7 +133,6 @@ print_progress_close=Annuleren
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Zijbalk in-/uitschakelen
-toggle_sidebar_notification.title=Zijbalk in-/uitschakelen (document bevat overzicht/bijlagen)
 toggle_sidebar_notification2.title=Zijbalk in-/uitschakelen (document bevat overzicht/bijlagen/lagen)
 toggle_sidebar_label=Zijbalk in-/uitschakelen
 document_outline.title=Documentoverzicht tonen (dubbelklik om alle items uit/samen te vouwen)
@@ -152,9 +147,6 @@ current_outline_item.title=Huidig item in inhoudsopgave zoeken
 current_outline_item_label=Huidig item in inhoudsopgave
 findbar.title=Zoeken in document
 findbar_label=Zoeken
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=Pagina {{page}}
 
 additional_layers=Aanvullende lagen
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -229,9 +221,6 @@ page_scale_actual=Werkelijke grootte
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Fout
 
 # Loading indicator messages
 loading=Laden…

--- a/viewer/locale/nn-NO/viewer.properties
+++ b/viewer/locale/nn-NO/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Gjeldande vising
 tools.title=Verktøy
 tools_label=Verktøy
 first_page.title=Gå til første side
-first_page.label=Gå til første side
 first_page_label=Gå til første side
 last_page.title=Gå til siste side
-last_page.label=Gå til siste side
 last_page_label=Gå til siste side
 page_rotate_cw.title=Roter med klokka
-page_rotate_cw.label=Roter med klokka
 page_rotate_cw_label=Roter med klokka
 page_rotate_ccw.title=Roter mot klokka
-page_rotate_ccw.label=Roter mot klokka
 page_rotate_ccw_label=Roter mot klokka
 
 cursor_text_select_tool.title=Aktiver tekstmarkeringsverktøy
@@ -137,7 +133,6 @@ print_progress_close=Avbryt
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Slå av/på sidestolpe
-toggle_sidebar_notification.title=Vis/gøym sidestolpen (dokumentet inneheld oversikt/vedlegg)
 toggle_sidebar_notification2.title=Vis/gøym sidestolpe (dokumentet inneheld oversikt/vedlegg/lag)
 toggle_sidebar_label=Slå av/på sidestolpe
 document_outline.title=Vis dokumentdisposisjonen (dobbelklikk for å utvide/gøyme alle elementa)
@@ -152,9 +147,6 @@ current_outline_item.title=Finn gjeldande disposisjonselement
 current_outline_item_label=Gjeldande disposisjonselement
 findbar.title=Finn i dokumentet
 findbar_label=Finn
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=Side {{page}}
 
 additional_layers=Ytterlegare lag
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -229,9 +221,6 @@ page_scale_actual=Verkeleg storleik
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Feil
 
 # Loading indicator messages
 loading=Lastar…

--- a/viewer/locale/oc/viewer.properties
+++ b/viewer/locale/oc/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Afichatge actual
 tools.title=Aisinas
 tools_label=Aisinas
 first_page.title=Anar a la primièra pagina
-first_page.label=Anar a la primièra pagina
 first_page_label=Anar a la primièra pagina
 last_page.title=Anar a la darrièra pagina
-last_page.label=Anar a la darrièra pagina
 last_page_label=Anar a la darrièra pagina
 page_rotate_cw.title=Rotacion orària
-page_rotate_cw.label=Rotacion orària
 page_rotate_cw_label=Rotacion orària
 page_rotate_ccw.title=Rotacion antiorària
-page_rotate_ccw.label=Rotacion antiorària
 page_rotate_ccw_label=Rotacion antiorària
 
 cursor_text_select_tool.title=Activar l'aisina de seleccion de tèxte
@@ -137,7 +133,6 @@ print_progress_close=Anullar
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Afichar/amagar lo panèl lateral
-toggle_sidebar_notification.title=Afichar/amagar lo panèl lateral (lo document conten esquèmas/pèças juntas)
 toggle_sidebar_notification2.title=Afichar/amagar lo panèl lateral (lo document conten esquèmas/pèças juntas/calques)
 toggle_sidebar_label=Afichar/amagar lo panèl lateral
 document_outline.title=Mostrar los esquèmas del document (dobleclicar per espandre/reduire totes los elements)
@@ -152,9 +147,6 @@ current_outline_item.title=Trobar l’element de plan actual
 current_outline_item_label=Element de plan actual
 findbar.title=Cercar dins lo document
 findbar_label=Recercar
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=Pagina {{page}}
 
 additional_layers=Calques suplementaris
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -229,9 +221,6 @@ page_scale_actual=Talha vertadièra
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Error
 
 # Loading indicator messages
 loading=Cargament…

--- a/viewer/locale/pa-IN/viewer.properties
+++ b/viewer/locale/pa-IN/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=ਮੌਜੂਦਾ ਝਲਕ
 tools.title=ਟੂਲ
 tools_label=ਟੂਲ
 first_page.title=ਪਹਿਲੇ ਸਫ਼ੇ ਉੱਤੇ ਜਾਓ
-first_page.label=ਪਹਿਲੇ ਸਫ਼ੇ ਉੱਤੇ ਜਾਓ
 first_page_label=ਪਹਿਲੇ ਸਫ਼ੇ ਉੱਤੇ ਜਾਓ
 last_page.title=ਆਖਰੀ ਸਫ਼ੇ ਉੱਤੇ ਜਾਓ
-last_page.label=ਆਖਰੀ ਸਫ਼ੇ ਉੱਤੇ ਜਾਓ
 last_page_label=ਆਖਰੀ ਸਫ਼ੇ ਉੱਤੇ ਜਾਓ
 page_rotate_cw.title=ਸੱਜੇ ਦਾਅ ਘੁੰਮਾਓ
-page_rotate_cw.label=ਸੱਜੇ ਦਾਅ ਘੁੰਮਾਉ
 page_rotate_cw_label=ਸੱਜੇ ਦਾਅ ਘੁੰਮਾਓ
 page_rotate_ccw.title=ਖੱਬੇ ਦਾਅ ਘੁੰਮਾਓ
-page_rotate_ccw.label=ਖੱਬੇ ਦਾਅ ਘੁੰਮਾਉ
 page_rotate_ccw_label=ਖੱਬੇ ਦਾਅ ਘੁੰਮਾਓ
 
 cursor_text_select_tool.title=ਲਿਖਤ ਚੋਣ ਟੂਲ ਸਮਰੱਥ ਕਰੋ
@@ -137,7 +133,6 @@ print_progress_close=ਰੱਦ ਕਰੋ
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=ਬਾਹੀ ਬਦਲੋ
-toggle_sidebar_notification.title=ਬਾਹੀ ਨੂੰ ਬਦਲੋ (ਦਸਤਾਵੇਜ਼ ਖਾਕਾ/ਅਟੈਚਮੈਂਟਾਂ ਰੱਖਦਾ ਹੈ)
 toggle_sidebar_notification2.title=ਬਾਹੀ ਨੂੰ ਬਦਲੋ (ਦਸਤਾਵੇਜ਼ ਖਾਕਾ/ਅਟੈਚਮੈਂਟ/ਪਰਤਾਂ ਰੱਖਦਾ ਹੈ)
 toggle_sidebar_label=ਬਾਹੀ ਬਦਲੋ
 document_outline.title=ਦਸਤਾਵੇਜ਼ ਖਾਕਾ ਦਿਖਾਓ (ਸਾਰੀਆਂ ਆਈਟਮਾਂ ਨੂੰ ਫੈਲਾਉਣ/ਸਮੇਟਣ ਲਈ ਦੋ ਵਾਰ ਕਲਿੱਕ ਕਰੋ)
@@ -152,9 +147,6 @@ current_outline_item.title=ਮੌੌਜੂਦਾ ਖਾਕਾ ਚੀਜ਼ ਲੱ�
 current_outline_item_label=ਮੌਜੂਦਾ ਖਾਕਾ ਚੀਜ਼
 findbar.title=ਦਸਤਾਵੇਜ਼ ਵਿੱਚ ਲੱਭੋ
 findbar_label=ਲੱਭੋ
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=ਸਫ਼ਾ {{page}}
 
 additional_layers=ਵਾਧੂ ਪਰਤਾਂ
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -229,9 +221,6 @@ page_scale_actual=ਆਟੋਮੈਟਿਕ ਆਕਾਰ
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=ਗਲਤੀ
 
 # Loading indicator messages
 loading=…ਲੋਡ ਹੋ ਰਿਹਾ ਹੈ

--- a/viewer/locale/pl/viewer.properties
+++ b/viewer/locale/pl/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Bieżąca pozycja
 tools.title=Narzędzia
 tools_label=Narzędzia
 first_page.title=Przejdź do pierwszej strony
-first_page.label=Przejdź do pierwszej strony
 first_page_label=Przejdź do pierwszej strony
 last_page.title=Przejdź do ostatniej strony
-last_page.label=Przejdź do ostatniej strony
 last_page_label=Przejdź do ostatniej strony
 page_rotate_cw.title=Obróć zgodnie z ruchem wskazówek zegara
-page_rotate_cw.label=Obróć zgodnie z ruchem wskazówek zegara
 page_rotate_cw_label=Obróć zgodnie z ruchem wskazówek zegara
 page_rotate_ccw.title=Obróć przeciwnie do ruchu wskazówek zegara
-page_rotate_ccw.label=Obróć przeciwnie do ruchu wskazówek zegara
 page_rotate_ccw_label=Obróć przeciwnie do ruchu wskazówek zegara
 
 cursor_text_select_tool.title=Włącz narzędzie zaznaczania tekstu
@@ -137,7 +133,6 @@ print_progress_close=Anuluj
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Przełącz panel boczny
-toggle_sidebar_notification.title=Przełącz panel boczny (dokument zawiera konspekt/załączniki)
 toggle_sidebar_notification2.title=Przełącz panel boczny (dokument zawiera konspekt/załączniki/warstwy)
 toggle_sidebar_label=Przełącz panel boczny
 document_outline.title=Konspekt dokumentu (podwójne kliknięcie rozwija lub zwija wszystkie pozycje)
@@ -152,9 +147,6 @@ current_outline_item.title=Znajdź bieżący element konspektu
 current_outline_item_label=Bieżący element konspektu
 findbar.title=Znajdź w dokumencie
 findbar_label=Znajdź
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas={{page}}. strona
 
 additional_layers=Dodatkowe warstwy
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -229,9 +221,6 @@ page_scale_actual=Rozmiar oryginalny
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Błąd
 
 # Loading indicator messages
 loading=Wczytywanie…

--- a/viewer/locale/pt-BR/viewer.properties
+++ b/viewer/locale/pt-BR/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Visualização atual
 tools.title=Ferramentas
 tools_label=Ferramentas
 first_page.title=Ir para a primeira página
-first_page.label=Ir para a primeira página
 first_page_label=Ir para a primeira página
 last_page.title=Ir para a última página
-last_page.label=Ir para a última página
 last_page_label=Ir para a última página
 page_rotate_cw.title=Girar no sentido horário
-page_rotate_cw.label=Girar no sentido horário
 page_rotate_cw_label=Girar no sentido horário
 page_rotate_ccw.title=Girar no sentido anti-horário
-page_rotate_ccw.label=Girar no sentido anti-horário
 page_rotate_ccw_label=Girar no sentido anti-horário
 
 cursor_text_select_tool.title=Ativar a ferramenta de seleção de texto
@@ -137,7 +133,6 @@ print_progress_close=Cancelar
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Exibir/ocultar painel lateral
-toggle_sidebar_notification.title=Exibir/ocultar painel lateral (documento contém estrutura/anexos)
 toggle_sidebar_notification2.title=Exibir/ocultar painel (documento contém estrutura/anexos/camadas)
 toggle_sidebar_label=Exibir/ocultar painel
 document_outline.title=Mostrar a estrutura do documento (dê um duplo-clique para expandir/recolher todos os itens)
@@ -152,9 +147,6 @@ current_outline_item.title=Encontrar item atual da estrutura
 current_outline_item_label=Item atual da estrutura
 findbar.title=Procurar no documento
 findbar_label=Procurar
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=Página {{page}}
 
 additional_layers=Camadas adicionais
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -229,9 +221,6 @@ page_scale_actual=Tamanho real
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Erro
 
 # Loading indicator messages
 loading=Carregando…

--- a/viewer/locale/pt-PT/viewer.properties
+++ b/viewer/locale/pt-PT/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Visão atual
 tools.title=Ferramentas
 tools_label=Ferramentas
 first_page.title=Ir para a primeira página
-first_page.label=Ir para a primeira página
 first_page_label=Ir para a primeira página
 last_page.title=Ir para a última página
-last_page.label=Ir para a última página
 last_page_label=Ir para a última página
 page_rotate_cw.title=Rodar à direita
-page_rotate_cw.label=Rodar à direita
 page_rotate_cw_label=Rodar à direita
 page_rotate_ccw.title=Rodar à esquerda
-page_rotate_ccw.label=Rodar à esquerda
 page_rotate_ccw_label=Rodar à esquerda
 
 cursor_text_select_tool.title=Ativar ferramenta de seleção de texto
@@ -137,7 +133,6 @@ print_progress_close=Cancelar
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Alternar barra lateral
-toggle_sidebar_notification.title=Alternar barra lateral (documento contém contorno/anexos)
 toggle_sidebar_notification2.title=Alternar barra lateral (o documento contém contornos/anexos/camadas)
 toggle_sidebar_label=Alternar barra lateral
 document_outline.title=Mostrar esquema do documento (duplo clique para expandir/colapsar todos os itens)
@@ -152,9 +147,6 @@ current_outline_item.title=Encontrar o item atualmente destacado
 current_outline_item_label=Item atualmente destacado
 findbar.title=Localizar em documento
 findbar_label=Localizar
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=Página {{page}}
 
 additional_layers=Camadas adicionais
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -229,9 +221,6 @@ page_scale_actual=Tamanho real
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Erro
 
 # Loading indicator messages
 loading=A carregar…

--- a/viewer/locale/rm/viewer.properties
+++ b/viewer/locale/rm/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Vista actuala
 tools.title=Utensils
 tools_label=Utensils
 first_page.title=Siglir a l'emprima pagina
-first_page.label=Siglir a l'emprima pagina
 first_page_label=Siglir a l'emprima pagina
 last_page.title=Siglir a la davosa pagina
-last_page.label=Siglir a la davosa pagina
 last_page_label=Siglir a la davosa pagina
 page_rotate_cw.title=Rotar en direcziun da l'ura
-page_rotate_cw.label=Rotar en direcziun da l'ura
 page_rotate_cw_label=Rotar en direcziun da l'ura
 page_rotate_ccw.title=Rotar en direcziun cuntraria a l'ura
-page_rotate_ccw.label=Rotar en direcziun cuntraria a l'ura
 page_rotate_ccw_label=Rotar en direcziun cuntraria a l'ura
 
 cursor_text_select_tool.title=Activar l'utensil per selecziunar text
@@ -137,7 +133,6 @@ print_progress_close=Interrumper
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Activar/deactivar la trav laterala
-toggle_sidebar_notification.title=Activar/deactivar la trav laterala (structura dal document/agiuntas)
 toggle_sidebar_notification2.title=Activar/deactivar la trav laterala (il document cuntegna structura dal document/agiuntas/nivels)
 toggle_sidebar_label=Activar/deactivar la trav laterala
 document_outline.title=Mussar la structura dal document (cliccar duas giadas per extender/cumprimer tut ils elements)
@@ -152,9 +147,6 @@ current_outline_item.title=Tschertgar l'element da structura actual
 current_outline_item_label=Element da structura actual
 findbar.title=Tschertgar en il document
 findbar_label=Tschertgar
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=Pagina {{page}}
 
 additional_layers=Nivels supplementars
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -229,9 +221,6 @@ page_scale_actual=Grondezza actuala
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Errur
 
 # Loading indicator messages
 loading=Chargiar…

--- a/viewer/locale/ro/viewer.properties
+++ b/viewer/locale/ro/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Vizualizare actuală
 tools.title=Instrumente
 tools_label=Instrumente
 first_page.title=Mergi la prima pagină
-first_page.label=Mergi la prima pagină
 first_page_label=Mergi la prima pagină
 last_page.title=Mergi la ultima pagină
-last_page.label=Mergi la ultima pagină
 last_page_label=Mergi la ultima pagină
 page_rotate_cw.title=Rotește în sensul acelor de ceas
-page_rotate_cw.label=Rotește în sensul acelor de ceas
 page_rotate_cw_label=Rotește în sensul acelor de ceas
 page_rotate_ccw.title=Rotește în sens invers al acelor de ceas
-page_rotate_ccw.label=Rotește în sens invers al acelor de ceas
 page_rotate_ccw_label=Rotește în sens invers al acelor de ceas
 
 cursor_text_select_tool.title=Activează instrumentul de selecție a textului
@@ -137,7 +133,6 @@ print_progress_close=Renunță
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Comută bara laterală
-toggle_sidebar_notification.title=Comută bara laterală (documentul conține schițe/atașamente)
 toggle_sidebar_label=Comută bara laterală
 document_outline.title=Afișează schița documentului (dublu-clic pentru a extinde/restrânge toate elementele)
 document_outline_label=Schița documentului
@@ -148,9 +143,7 @@ thumbs_label=Miniaturi
 findbar.title=Caută în document
 findbar_label=Caută
 
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=Pagina {{page}}
-
+# LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
 # Thumbnails panel item (tooltip and alt text for images)
 # LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
 # number.
@@ -223,8 +216,6 @@ page_scale_actual=Mărime reală
 page_scale_percent={{scale}}%
 
 # Loading indicator messages
-loading_error_indicator=Eroare
-
 loading_error=A intervenit o eroare la încărcarea PDF-ului.
 invalid_file_error=Fișier PDF nevalid sau corupt.
 missing_file_error=Fișier PDF lipsă.
@@ -241,7 +232,7 @@ annotation_date_string={{date}}, {{time}}
 text_annotation_type.alt=[Adnotare {{type}}]
 password_label=Introdu parola pentru a deschide acest fișier PDF.
 password_invalid=Parolă nevalidă. Te rugăm să încerci din nou.
-password_ok=Ok
+password_ok=OK
 password_cancel=Renunță
 
 printing_not_supported=Avertisment: Tipărirea nu este suportată în totalitate de acest browser.

--- a/viewer/locale/ru/viewer.properties
+++ b/viewer/locale/ru/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Текущий вид
 tools.title=Инструменты
 tools_label=Инструменты
 first_page.title=Перейти на первую страницу
-first_page.label=Перейти на первую страницу
 first_page_label=Перейти на первую страницу
 last_page.title=Перейти на последнюю страницу
-last_page.label=Перейти на последнюю страницу
 last_page_label=Перейти на последнюю страницу
 page_rotate_cw.title=Повернуть по часовой стрелке
-page_rotate_cw.label=Повернуть по часовой стрелке
 page_rotate_cw_label=Повернуть по часовой стрелке
 page_rotate_ccw.title=Повернуть против часовой стрелки
-page_rotate_ccw.label=Повернуть против часовой стрелки
 page_rotate_ccw_label=Повернуть против часовой стрелки
 
 cursor_text_select_tool.title=Включить Инструмент «Выделение текста»
@@ -137,7 +133,6 @@ print_progress_close=Отмена
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Показать/скрыть боковую панель
-toggle_sidebar_notification.title=Показать/скрыть боковую панель (документ имеет содержание/вложения)
 toggle_sidebar_notification2.title=Показать/скрыть боковую панель (документ имеет содержание/вложения/слои)
 toggle_sidebar_label=Показать/скрыть боковую панель
 document_outline.title=Показать содержание документа (двойной щелчок, чтобы развернуть/свернуть все элементы)
@@ -152,9 +147,6 @@ current_outline_item.title=Найти текущий элемент структ
 current_outline_item_label=Текущий элемент структуры
 findbar.title=Найти в документе
 findbar_label=Найти
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=Страница {{page}}
 
 additional_layers=Дополнительные слои
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -229,9 +221,6 @@ page_scale_actual=Реальный размер
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Ошибка
 
 # Loading indicator messages
 loading=Загрузка…

--- a/viewer/locale/sco/viewer.properties
+++ b/viewer/locale/sco/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=View The Noo
 tools.title=Tools
 tools_label=Tools
 first_page.title=Gang tae First Page
-first_page.label=Gang tae First Page
 first_page_label=Gang tae First Page
 last_page.title=Gang tae Lest Page
-last_page.label=Gang tae Lest Page
 last_page_label=Gang tae Lest Page
 page_rotate_cw.title=Rotate Clockwise
-page_rotate_cw.label=Rotate Clockwise
 page_rotate_cw_label=Rotate Clockwise
 page_rotate_ccw.title=Rotate Coonterclockwise
-page_rotate_ccw.label=Rotate Coonterclockwise
 page_rotate_ccw_label=Rotate Coonterclockwise
 
 cursor_text_select_tool.title=Enable Text Walin Tool
@@ -137,7 +133,6 @@ print_progress_close=Stap
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Toggle Sidebaur
-toggle_sidebar_notification.title=Toggle Sidebaur (document conteens ootline/attachments)
 toggle_sidebar_notification2.title=Toggle Sidebaur (document conteens ootline/attachments/layers)
 toggle_sidebar_label=Toggle Sidebaur
 document_outline.title=Kythe Document Ootline (double-click fur tae oot-fauld/in-fauld aw items)
@@ -152,9 +147,6 @@ current_outline_item.title=Find Current Ootline Item
 current_outline_item_label=Current Ootline Item
 findbar.title=Find in Document
 findbar_label=Find
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=Page {{page}}
 
 additional_layers=Mair Layers
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -229,9 +221,6 @@ page_scale_actual=Actual Size
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Mishanter
 
 # Loading indicator messages
 loading=Loadin…

--- a/viewer/locale/si/viewer.properties
+++ b/viewer/locale/si/viewer.properties
@@ -46,16 +46,12 @@ bookmark_label=දැනට ඇති දසුන
 tools.title=මෙවලම්
 tools_label=මෙවලම්
 first_page.title=මුල් පිටුවට යන්න
-first_page.label=මුල් පිටුවට යන්න
 first_page_label=මුල් පිටුවට යන්න
 last_page.title=අවසන් පිටුවට යන්න
-last_page.label=අවසන් පිටුවට යන්න
 last_page_label=අවසන් පිටුවට යන්න
 page_rotate_cw.title=දක්ශිණාවර්තව භ්‍රමණය
-page_rotate_cw.label=දක්ශිණාවර්තව භ්‍රමණය
 page_rotate_cw_label=දක්ශිණාවර්තව භ්‍රමණය
 page_rotate_ccw.title=වාමාවර්තව භ්‍රමණය
-page_rotate_ccw.label=වාමාවර්තව භ්‍රමණය
 page_rotate_ccw_label=වාමාවර්තව භ්‍රමණය
 
 cursor_hand_tool_label=අත් මෙවලම
@@ -184,9 +180,6 @@ page_scale_actual=නියමිත ප්‍රමාණය
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=දෝෂය
 
 loading_error=PDF පූරණය විමේදි දෝෂයක් හට ගැනුණි.
 invalid_file_error=දූශිත හෝ සාවද්‍ය PDF ගොනුව.

--- a/viewer/locale/sk/viewer.properties
+++ b/viewer/locale/sk/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Aktuálne zobrazenie
 tools.title=Nástroje
 tools_label=Nástroje
 first_page.title=Prejsť na prvú stranu
-first_page.label=Prejsť na prvú stranu
 first_page_label=Prejsť na prvú stranu
 last_page.title=Prejsť na poslednú stranu
-last_page.label=Prejsť na poslednú stranu
 last_page_label=Prejsť na poslednú stranu
 page_rotate_cw.title=Otočiť v smere hodinových ručičiek
-page_rotate_cw.label=Otočiť v smere hodinových ručičiek
 page_rotate_cw_label=Otočiť v smere hodinových ručičiek
 page_rotate_ccw.title=Otočiť proti smeru hodinových ručičiek
-page_rotate_ccw.label=Otočiť proti smeru hodinových ručičiek
 page_rotate_ccw_label=Otočiť proti smeru hodinových ručičiek
 
 cursor_text_select_tool.title=Povoliť výber textu
@@ -137,7 +133,6 @@ print_progress_close=Zrušiť
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Prepnúť bočný panel
-toggle_sidebar_notification.title=Prepnúť bočný panel (dokument obsahuje osnovu/prílohy)
 toggle_sidebar_notification2.title=Prepnúť bočný panel (dokument obsahuje osnovu/prílohy/vrstvy)
 toggle_sidebar_label=Prepnúť bočný panel
 document_outline.title=Zobraziť osnovu dokumentu (dvojitým kliknutím rozbalíte/zbalíte všetky položky)
@@ -152,9 +147,6 @@ current_outline_item.title=Nájsť aktuálnu položku v osnove
 current_outline_item_label=Aktuálna položka v osnove
 findbar.title=Hľadať v dokumente
 findbar_label=Hľadať
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=Strana {{page}}
 
 additional_layers=Ďalšie vrstvy
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -229,9 +221,6 @@ page_scale_actual=Skutočná veľkosť
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}} %
-
-# Loading indicator messages
-loading_error_indicator=Chyba
 
 # Loading indicator messages
 loading=Načítava sa…

--- a/viewer/locale/sl/viewer.properties
+++ b/viewer/locale/sl/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Trenutni pogled
 tools.title=Orodja
 tools_label=Orodja
 first_page.title=Pojdi na prvo stran
-first_page.label=Pojdi na prvo stran
 first_page_label=Pojdi na prvo stran
 last_page.title=Pojdi na zadnjo stran
-last_page.label=Pojdi na zadnjo stran
 last_page_label=Pojdi na zadnjo stran
 page_rotate_cw.title=Zavrti v smeri urnega kazalca
-page_rotate_cw.label=Zavrti v smeri urnega kazalca
 page_rotate_cw_label=Zavrti v smeri urnega kazalca
 page_rotate_ccw.title=Zavrti v nasprotni smeri urnega kazalca
-page_rotate_ccw.label=Zavrti v nasprotni smeri urnega kazalca
 page_rotate_ccw_label=Zavrti v nasprotni smeri urnega kazalca
 
 cursor_text_select_tool.title=Omogoči orodje za izbor besedila
@@ -137,7 +133,6 @@ print_progress_close=Prekliči
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Preklopi stransko vrstico
-toggle_sidebar_notification.title=Preklopi stransko vrstico (dokument vsebuje oris/priponke)
 toggle_sidebar_notification2.title=Preklopi stransko vrstico (dokument vsebuje oris/priponke/plasti)
 toggle_sidebar_label=Preklopi stransko vrstico
 document_outline.title=Prikaži oris dokumenta (dvokliknite za razširitev/strnitev vseh predmetov)
@@ -152,9 +147,6 @@ current_outline_item.title=Najdi trenutni predmet orisa
 current_outline_item_label=Trenutni predmet orisa
 findbar.title=Iskanje po dokumentu
 findbar_label=Najdi
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=Stran {{page}}
 
 additional_layers=Dodatne plasti
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -229,9 +221,6 @@ page_scale_actual=Dejanska velikost
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}} %
-
-# Loading indicator messages
-loading_error_indicator=Napaka
 
 # Loading indicator messages
 loading=Nalaganje …

--- a/viewer/locale/son/viewer.properties
+++ b/viewer/locale/son/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Sohõ gunaroo
 tools.title=Goyjinawey
 tools_label=Goyjinawey
 first_page.title=Koy moo jinaa ga
-first_page.label=Koy moo jinaa ga
 first_page_label=Koy moo jinaa ga
 last_page.title=Koy moo koraa ga
-last_page.label=Koy moo koraa ga
 last_page_label=Koy moo koraa ga
 page_rotate_cw.title=Kuubi kanbe guma here
-page_rotate_cw.label=Kuubi kanbe guma here
 page_rotate_cw_label=Kuubi kanbe guma here
 page_rotate_ccw.title=Kuubi kanbe wowa here
-page_rotate_ccw.label=Kuubi kanbe wowa here
 page_rotate_ccw_label=Kuubi kanbe wowa here
 
 
@@ -97,7 +93,6 @@ print_progress_close=Naŋ
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Kanjari ceraw zuu
-toggle_sidebar_notification.title=Kanjari ceraw-zuu (takaddaa goo nda filla-boŋ/hangandiyaŋ)
 toggle_sidebar_label=Kanjari ceraw zuu
 document_outline.title=Takaddaa korfur alhaaloo cebe (naagu cee hinka ka haya-izey kul hayandi/kankamandi)
 document_outline_label=Takadda filla-boŋ
@@ -156,9 +151,6 @@ page_scale_actual=Adadu cimi
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Firka
 
 loading_error=Firka bangay kaŋ PDF goo ma zumandi.
 invalid_file_error=PDF tuku laala wala laybante.

--- a/viewer/locale/sq/viewer.properties
+++ b/viewer/locale/sq/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Pamja e Tanishme
 tools.title=Mjete
 tools_label=Mjete
 first_page.title=Kaloni te Faqja e Parë
-first_page.label=Kaloni te Faqja e Parë
 first_page_label=Kaloni te Faqja e Parë
 last_page.title=Kaloni te Faqja e Fundit
-last_page.label=Kaloni te Faqja e Fundit
 last_page_label=Kaloni te Faqja e Fundit
 page_rotate_cw.title=Rrotullojeni Në Kahun Orar
-page_rotate_cw.label=Rrotulloje Në Kahun Orar
 page_rotate_cw_label=Rrotulloje Në Kahun Orar
 page_rotate_ccw.title=Rrotullojeni Në Kahun Kundërorar
-page_rotate_ccw.label=Rrotulloje Në Kahun Kundërorar
 page_rotate_ccw_label=Rrotulloje Në Kahun Kundërorar
 
 cursor_text_select_tool.title=Aktivizo Mjet Përzgjedhjeje Teksti
@@ -130,7 +126,6 @@ print_progress_close=Anuloje
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Shfaqni/Fshihni Anështyllën
-toggle_sidebar_notification.title=Shfaqni Anështyllën (dokumenti përmban përvijim/bashkëngjitje)
 toggle_sidebar_notification2.title=Hap/Mbyll Anështylë (dokumenti përmban përvijim/nashkëngjitje/shtresa)
 toggle_sidebar_label=Shfaq/Fshih Anështyllën
 document_outline.title=Shfaqni Përvijim Dokumenti (dyklikoni që të shfaqen/fshihen krejt elementët)
@@ -143,9 +138,6 @@ thumbs.title=Shfaqni Miniatura
 thumbs_label=Miniatura
 findbar.title=Gjeni në Dokument
 findbar_label=Gjej
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=Faqja {{page}}
 
 additional_layers=Shtresa Shtesë
 # Thumbnails panel item (tooltip and alt text for images)
@@ -218,9 +210,6 @@ page_scale_actual=Madhësia Faktike
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Gabim
 
 loading_error=Ndodhi një gabim gjatë ngarkimit të PDF-së.
 invalid_file_error=Kartelë PDF e pavlefshme ose e dëmtuar.

--- a/viewer/locale/sr/viewer.properties
+++ b/viewer/locale/sr/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Тренутни приказ
 tools.title=Алатке
 tools_label=Алатке
 first_page.title=Иди на прву страницу
-first_page.label=Иди на прву страницу
 first_page_label=Иди на прву страницу
 last_page.title=Иди на последњу страницу
-last_page.label=Иди на последњу страницу
 last_page_label=Иди на последњу страницу
 page_rotate_cw.title=Ротирај у смеру казаљке на сату
-page_rotate_cw.label=Ротирај у смеру казаљке на сату
 page_rotate_cw_label=Ротирај у смеру казаљке на сату
 page_rotate_ccw.title=Ротирај у смеру супротном од казаљке на сату
-page_rotate_ccw.label=Ротирај у смеру супротном од казаљке на сату
 page_rotate_ccw_label=Ротирај у смеру супротном од казаљке на сату
 
 cursor_text_select_tool.title=Омогући алат за селектовање текста
@@ -137,7 +133,6 @@ print_progress_close=Откажи
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Прикажи додатну палету
-toggle_sidebar_notification.title=Прикажи додатну траку (докуменат садржи оквире/прилоге)
 toggle_sidebar_notification2.title=Прикажи/сакриј бочну траку (документ садржи контуру/прилоге/слојеве)
 toggle_sidebar_label=Прикажи додатну палету
 document_outline.title=Прикажи структуру документа (двоструким кликом проширујете/скупљате све ставке)
@@ -152,9 +147,6 @@ current_outline_item.title=Пронађите тренутни елемент с
 current_outline_item_label=Тренутна контура
 findbar.title=Пронађи у документу
 findbar_label=Пронађи
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=Страница {{page}}
 
 additional_layers=Додатни слојеви
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -229,9 +221,6 @@ page_scale_actual=Стварна величина
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Грешка
 
 # Loading indicator messages
 loading=Учитавање…

--- a/viewer/locale/sv-SE/viewer.properties
+++ b/viewer/locale/sv-SE/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Aktuell vy
 tools.title=Verktyg
 tools_label=Verktyg
 first_page.title=Gå till första sidan
-first_page.label=Gå till första sidan
 first_page_label=Gå till första sidan
 last_page.title=Gå till sista sidan
-last_page.label=Gå till sista sidan
 last_page_label=Gå till sista sidan
 page_rotate_cw.title=Rotera medurs
-page_rotate_cw.label=Rotera medurs
 page_rotate_cw_label=Rotera medurs
 page_rotate_ccw.title=Rotera moturs
-page_rotate_ccw.label=Rotera moturs
 page_rotate_ccw_label=Rotera moturs
 
 cursor_text_select_tool.title=Aktivera textmarkeringsverktyg
@@ -137,7 +133,6 @@ print_progress_close=Avbryt
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Visa/dölj sidofält
-toggle_sidebar_notification.title=Visa/dölj sidofält (dokument innehåller översikt/bilagor)
 toggle_sidebar_notification2.title=Växla sidofält (dokumentet innehåller dokumentstruktur/bilagor/lager)
 toggle_sidebar_label=Visa/dölj sidofält
 document_outline.title=Visa dokumentdisposition (dubbelklicka för att expandera/komprimera alla objekt)
@@ -152,9 +147,6 @@ current_outline_item.title=Hitta aktuellt dispositionsobjekt
 current_outline_item_label=Aktuellt dispositionsobjekt
 findbar.title=Sök i dokument
 findbar_label=Sök
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=Sida {{page}}
 
 additional_layers=Ytterligare lager
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -229,9 +221,6 @@ page_scale_actual=Verklig storlek
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Fel
 
 # Loading indicator messages
 loading=Laddar…

--- a/viewer/locale/szl/viewer.properties
+++ b/viewer/locale/szl/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Aktualny widok
 tools.title=Noczynia
 tools_label=Noczynia
 first_page.title=Idź ku piyrszyj strōnie
-first_page.label=Idź ku piyrszyj strōnie
 first_page_label=Idź ku piyrszyj strōnie
 last_page.title=Idź ku ôstatnij strōnie
-last_page.label=Idź ku ôstatnij strōnie
 last_page_label=Idź ku ôstatnij strōnie
 page_rotate_cw.title=Zwyrtnij w prawo
-page_rotate_cw.label=Zwyrtnij w prawo
 page_rotate_cw_label=Zwyrtnij w prawo
 page_rotate_ccw.title=Zwyrtnij w lewo
-page_rotate_ccw.label=Zwyrtnij w lewo
 page_rotate_ccw_label=Zwyrtnij w lewo
 
 cursor_text_select_tool.title=Załōncz noczynie ôbiyranio tekstu
@@ -137,7 +133,6 @@ print_progress_close=Pociep
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Przełōncz posek na rancie
-toggle_sidebar_notification.title=Przełōncz posek na rancie (dokumynt mo struktura/przidowki)
 toggle_sidebar_notification2.title=Przełōncz posek na rancie (dokumynt mo struktura/przidowki/warstwy)
 toggle_sidebar_label=Przełōncz posek na rancie
 document_outline.title=Pokoż struktura dokumyntu (tuplowane klikniyncie rozszyrzo/swijo wszyskie elymynta)
@@ -150,9 +145,6 @@ thumbs.title=Pokoż miniatury
 thumbs_label=Miniatury
 findbar.title=Znojdź w dokumyncie
 findbar_label=Znojdź
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=Strōna {{page}}
 
 additional_layers=Nadbytnie warstwy
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -226,9 +218,6 @@ page_scale_actual=Aktualno srogość
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Feler
 
 # Loading indicator messages
 loading_error=Przi ladowaniu PDFa pokozoł sie feler.

--- a/viewer/locale/ta/viewer.properties
+++ b/viewer/locale/ta/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=தற்போதைய காட்சி
 tools.title=கருவிகள்
 tools_label=கருவிகள்
 first_page.title=முதல் பக்கத்திற்கு செல்லவும்
-first_page.label=முதல் பக்கத்திற்கு செல்லவும்
 first_page_label=முதல் பக்கத்திற்கு செல்லவும்
 last_page.title=கடைசி பக்கத்திற்கு செல்லவும்
-last_page.label=கடைசி பக்கத்திற்கு செல்லவும்
 last_page_label=கடைசி பக்கத்திற்கு செல்லவும்
 page_rotate_cw.title=வலஞ்சுழியாக சுழற்று
-page_rotate_cw.label=வலஞ்சுழியாக சுழற்று
 page_rotate_cw_label=வலஞ்சுழியாக சுழற்று
 page_rotate_ccw.title=இடஞ்சுழியாக சுழற்று
-page_rotate_ccw.label=இடஞ்சுழியாக சுழற்று
 page_rotate_ccw_label=இடஞ்சுழியாக சுழற்று
 
 cursor_text_select_tool.title=உரைத் தெரிவு கருவியைச் செயல்படுத்து
@@ -118,7 +114,6 @@ print_progress_close=ரத்து
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=பக்கப் பட்டியை நிலைமாற்று
-toggle_sidebar_notification.title=பக்கப்பட்டையை நிலைமாற்று (வெளிக்கோடு/இணைப்புகளை ஆவணம் கொண்டுள்ளது)
 toggle_sidebar_label=பக்கப் பட்டியை நிலைமாற்று
 document_outline.title=ஆவண அடக்கத்தைக் காட்டு (இருமுறைச் சொடுக்கி அனைத்து உறுப்பிடிகளையும் விரி/சேர்)
 document_outline_label=ஆவண வெளிவரை
@@ -177,9 +172,6 @@ page_scale_actual=உண்மையான அளவு
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=பிழை
 
 loading_error=PDF ஐ ஏற்றும் போது ஒரு பிழை ஏற்பட்டது.
 invalid_file_error=செல்லுபடியாகாத அல்லது சிதைந்த PDF கோப்பு.

--- a/viewer/locale/te/viewer.properties
+++ b/viewer/locale/te/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=ప్రస్తుత దర్శనం
 tools.title=పనిముట్లు
 tools_label=పనిముట్లు
 first_page.title=మొదటి పేజీకి వెళ్ళు
-first_page.label=మొదటి పేజీకి వెళ్ళు
 first_page_label=మొదటి పేజీకి వెళ్ళు
 last_page.title=చివరి పేజీకి వెళ్ళు
-last_page.label=చివరి పేజీకి వెళ్ళు
 last_page_label=చివరి పేజీకి వెళ్ళు
 page_rotate_cw.title=సవ్యదిశలో తిప్పు
-page_rotate_cw.label=సవ్యదిశలో తిప్పు
 page_rotate_cw_label=సవ్యదిశలో తిప్పు
 page_rotate_ccw.title=అపసవ్యదిశలో తిప్పు
-page_rotate_ccw.label=అపసవ్యదిశలో తిప్పు
 page_rotate_ccw_label=అపసవ్యదిశలో తిప్పు
 
 cursor_text_select_tool.title=టెక్స్ట్ ఎంపిక సాధనాన్ని ప్రారంభించండి
@@ -136,9 +132,6 @@ thumbs_label=థంబ్‌నైల్స్
 findbar.title=పత్రములో కనుగొనుము
 findbar_label=కనుగొను
 
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=పేజి {{page}}
-
 additional_layers=అదనపు పొరలు
 # Thumbnails panel item (tooltip and alt text for images)
 # LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
@@ -199,9 +192,6 @@ page_scale_actual=యథార్ధ పరిమాణం
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=దోషం
 
 loading_error=PDF లోడవుచున్నప్పుడు ఒక దోషం ఎదురైంది.
 invalid_file_error=చెల్లని లేదా పాడైన PDF ఫైలు.

--- a/viewer/locale/th/viewer.properties
+++ b/viewer/locale/th/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=มุมมองปัจจุบัน
 tools.title=เครื่องมือ
 tools_label=เครื่องมือ
 first_page.title=ไปยังหน้าแรก
-first_page.label=ไปยังหน้าแรก
 first_page_label=ไปยังหน้าแรก
 last_page.title=ไปยังหน้าสุดท้าย
-last_page.label=ไปยังหน้าสุดท้าย
 last_page_label=ไปยังหน้าสุดท้าย
 page_rotate_cw.title=หมุนตามเข็มนาฬิกา
-page_rotate_cw.label=หมุนตามเข็มนาฬิกา
 page_rotate_cw_label=หมุนตามเข็มนาฬิกา
 page_rotate_ccw.title=หมุนทวนเข็มนาฬิกา
-page_rotate_ccw.label=หมุนทวนเข็มนาฬิกา
 page_rotate_ccw_label=หมุนทวนเข็มนาฬิกา
 
 cursor_text_select_tool.title=เปิดใช้งานเครื่องมือการเลือกข้อความ
@@ -137,7 +133,6 @@ print_progress_close=ยกเลิก
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=เปิด/ปิดแถบข้าง
-toggle_sidebar_notification.title=เปิด/ปิดแถบข้าง (เอกสารมีเค้าร่าง/ไฟล์แนบ)
 toggle_sidebar_notification2.title=เปิด/ปิดแถบข้าง (เอกสารมีเค้าร่าง/ไฟล์แนบ/เลเยอร์)
 toggle_sidebar_label=เปิด/ปิดแถบข้าง
 document_outline.title=แสดงเค้าร่างเอกสาร (คลิกสองครั้งเพื่อขยาย/ยุบรายการทั้งหมด)
@@ -152,9 +147,6 @@ current_outline_item.title=ค้นหารายการเค้าร่�
 current_outline_item_label=รายการเค้าร่างปัจจุบัน
 findbar.title=ค้นหาในเอกสาร
 findbar_label=ค้นหา
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=หน้า {{page}}
 
 additional_layers=เลเยอร์เพิ่มเติม
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -229,9 +221,6 @@ page_scale_actual=ขนาดจริง
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=ข้อผิดพลาด
 
 # Loading indicator messages
 loading=กำลังโหลด…

--- a/viewer/locale/tl/viewer.properties
+++ b/viewer/locale/tl/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Kasalukuyang tingin
 tools.title=Mga Kagamitan
 tools_label=Mga Kagamitan
 first_page.title=Pumunta sa Unang Pahina
-first_page.label=Pumunta sa Unang Pahina
 first_page_label=Pumunta sa Unang Pahina
 last_page.title=Pumunta sa Huling Pahina
-last_page.label=Pumunta sa Huling Pahina
 last_page_label=Pumunta sa Huling Pahina
 page_rotate_cw.title=Paikutin Pakanan
-page_rotate_cw.label=Paikutin Pakanan
 page_rotate_cw_label=Paikutin Pakanan
 page_rotate_ccw.title=Paikutin Pakaliwa
-page_rotate_ccw.label=Paikutin Pakaliwa
 page_rotate_ccw_label=Paikutin Pakaliwa
 
 cursor_text_select_tool.title=I-enable ang Text Selection Tool
@@ -137,7 +133,6 @@ print_progress_close=Kanselahin
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Ipakita/Itago ang Sidebar
-toggle_sidebar_notification.title=Ipakita/Itago ang Sidebar (nagtataglay ang dokumento ng balangkas/mga attachment)
 toggle_sidebar_notification2.title=Ipakita/Itago ang Sidebar (nagtataglay ang dokumento ng balangkas/mga attachment/mga layer)
 toggle_sidebar_label=Ipakita/Itago ang Sidebar
 document_outline.title=Ipakita ang Document Outline (mag-double-click para i-expand/collapse ang laman)
@@ -150,9 +145,6 @@ thumbs.title=Ipakita ang mga Thumbnail
 thumbs_label=Mga thumbnail
 findbar.title=Hanapin sa Dokumento
 findbar_label=Hanapin
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=Pahina {{page}}
 
 additional_layers=Mga Karagdagang Layer
 # Thumbnails panel item (tooltip and alt text for images)
@@ -225,9 +217,6 @@ page_scale_actual=Totoong sukat
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Error
 
 loading_error=Nagkaproblema habang niloload ang PDF.
 invalid_file_error=Di-wasto o sira ang PDF file.

--- a/viewer/locale/tr/viewer.properties
+++ b/viewer/locale/tr/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Geçerli görünüm
 tools.title=Araçlar
 tools_label=Araçlar
 first_page.title=İlk sayfaya git
-first_page.label=İlk sayfaya git
 first_page_label=İlk sayfaya git
 last_page.title=Son sayfaya git
-last_page.label=Son sayfaya git
 last_page_label=Son sayfaya git
 page_rotate_cw.title=Saat yönünde döndür
-page_rotate_cw.label=Saat yönünde döndür
 page_rotate_cw_label=Saat yönünde döndür
 page_rotate_ccw.title=Saat yönünün tersine döndür
-page_rotate_ccw.label=Saat yönünün tersine döndür
 page_rotate_ccw_label=Saat yönünün tersine döndür
 
 cursor_text_select_tool.title=Metin seçme aracını etkinleştir
@@ -137,7 +133,6 @@ print_progress_close=İptal
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Kenar çubuğunu aç/kapat
-toggle_sidebar_notification.title=Kenar çubuğunu aç/kapat (Belge ana hat/ekler içeriyor)
 toggle_sidebar_notification2.title=Kenar çubuğunu aç/kapat (Belge ana hat/ekler/katmanlar içeriyor)
 toggle_sidebar_label=Kenar çubuğunu aç/kapat
 document_outline.title=Belge ana hatlarını göster (Tüm öğeleri genişletmek/daraltmak için çift tıklayın)
@@ -152,9 +147,6 @@ current_outline_item.title=Mevcut ana hat öğesini bul
 current_outline_item_label=Mevcut ana hat öğesi
 findbar.title=Belgede bul
 findbar_label=Bul
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=Sayfa {{page}}
 
 additional_layers=Ek katmanlar
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -229,9 +221,6 @@ page_scale_actual=Gerçek boyut
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent=%{{scale}}
-
-# Loading indicator messages
-loading_error_indicator=Hata
 
 # Loading indicator messages
 loading=Yükleniyor…

--- a/viewer/locale/trs/viewer.properties
+++ b/viewer/locale/trs/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Daj hua ma
 tools.title=Rasun
 tools_label=Nej rasùun
 first_page.title=gun' riña pajina asiniin
-first_page.label=Gun' riña pajina asiniin
 first_page_label=Gun' riña pajina asiniin
 last_page.title=Gun' riña pajina rukù ni'in
-last_page.label=Gun' riña pajina rukù ni'inj
 last_page_label=Gun' riña pajina rukù ni'inj
 page_rotate_cw.title=Tanikaj ne' huat
-page_rotate_cw.label=Tanikaj ne' huat
 page_rotate_cw_label=Tanikaj ne' huat
 page_rotate_ccw.title=Tanikaj ne' chînt'
-page_rotate_ccw.label=Tanikaj ne' chint
 page_rotate_ccw_label=Tanikaj ne' chint
 
 cursor_text_select_tool.title=Dugi'iaj sun' sa ganahui texto
@@ -197,9 +193,6 @@ page_scale_actual=Dàj yàchi akuan' nín
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Nitaj si hua hue'ej
 
 # LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
 # replaced by the modification date, and time, of the annotation.

--- a/viewer/locale/uk/viewer.properties
+++ b/viewer/locale/uk/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Поточний вигляд
 tools.title=Інструменти
 tools_label=Інструменти
 first_page.title=На першу сторінку
-first_page.label=На першу сторінку
 first_page_label=На першу сторінку
 last_page.title=На останню сторінку
-last_page.label=На останню сторінку
 last_page_label=На останню сторінку
 page_rotate_cw.title=Повернути за годинниковою стрілкою
-page_rotate_cw.label=Повернути за годинниковою стрілкою
 page_rotate_cw_label=Повернути за годинниковою стрілкою
 page_rotate_ccw.title=Повернути проти годинникової стрілки
-page_rotate_ccw.label=Повернути проти годинникової стрілки
 page_rotate_ccw_label=Повернути проти годинникової стрілки
 
 cursor_text_select_tool.title=Увімкнути інструмент вибору тексту
@@ -137,7 +133,6 @@ print_progress_close=Скасувати
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Бічна панель
-toggle_sidebar_notification.title=Перемкнути бічну панель (документ має вміст/вкладення)
 toggle_sidebar_notification2.title=Перемкнути бічну панель (документ містить ескіз/вкладення/шари)
 toggle_sidebar_label=Перемкнути бічну панель
 document_outline.title=Показати схему документу (подвійний клік для розгортання/згортання елементів)
@@ -152,9 +147,6 @@ current_outline_item.title=Знайти поточний елемент зміс
 current_outline_item_label=Поточний елемент змісту
 findbar.title=Знайти в документі
 findbar_label=Знайти
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=Сторінка {{page}}
 
 additional_layers=Додаткові шари
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -229,9 +221,6 @@ page_scale_actual=Дійсний розмір
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Помилка
 
 # Loading indicator messages
 loading=Завантаження…

--- a/viewer/locale/ur/viewer.properties
+++ b/viewer/locale/ur/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=حالیہ نظارہ
 tools.title=آلات
 tools_label=آلات
 first_page.title=پہلے صفحہ پر جائیں
-first_page.label=پہلے صفحہ پر جائیں
 first_page_label=پہلے صفحہ پر جائیں
 last_page.title=آخری صفحہ پر جائیں
-last_page.label=آخری صفحہ پر جائیں
 last_page_label=آخری صفحہ پر جائیں
 page_rotate_cw.title=گھڑی وار گھمائیں
-page_rotate_cw.label=گھڑی وار گھمائیں
 page_rotate_cw_label=گھڑی وار گھمائیں
 page_rotate_ccw.title=ضد گھڑی وار گھمائیں
-page_rotate_ccw.label=ضد گھڑی وار گھمائیں
 page_rotate_ccw_label=ضد گھڑی وار گھمائیں
 
 cursor_text_select_tool.title=متن کے انتخاب کے ٹول کو فعال بناے
@@ -143,9 +139,6 @@ thumbs_label=مجمل
 findbar.title=دستاویز میں ڈھونڈیں
 findbar_label=ڈھونڈیں
 
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=صفحہ {{page}}
-
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
 page_landmark=صفحہ {{page}}
 # Thumbnails panel item (tooltip and alt text for images)
@@ -217,9 +210,6 @@ page_scale_actual=اصل سائز
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=نقص
 
 # Loading indicator messages
 loading_error=PDF لوڈ کرتے وقت نقص آ گیا۔

--- a/viewer/locale/uz/viewer.properties
+++ b/viewer/locale/uz/viewer.properties
@@ -46,16 +46,12 @@ bookmark_label=Joriy koʻrinish
 tools.title=Vositalar
 tools_label=Vositalar
 first_page.title=Birinchi sahifaga oʻtish
-first_page.label=Birinchi sahifaga oʻtish
 first_page_label=Birinchi sahifaga oʻtish
 last_page.title=Soʻnggi sahifaga oʻtish
-last_page.label=Soʻnggi sahifaga oʻtish
 last_page_label=Soʻnggi sahifaga oʻtish
 page_rotate_cw.title=Soat yoʻnalishi boʻyicha burish
-page_rotate_cw.label=Soat yoʻnalishi boʻyicha burish
 page_rotate_cw_label=Soat yoʻnalishi boʻyicha burish
 page_rotate_ccw.title=Soat yoʻnalishiga qarshi burish
-page_rotate_ccw.label=Soat yoʻnalishiga qarshi burish
 page_rotate_ccw_label=Soat yoʻnalishiga qarshi burish
 
 
@@ -146,9 +142,6 @@ page_scale_actual=Haqiqiy hajmi
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Xato
 
 loading_error=PDF yuklanayotganda xato yuz berdi.
 invalid_file_error=Xato yoki buzuq PDF fayli.

--- a/viewer/locale/vi/viewer.properties
+++ b/viewer/locale/vi/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Chế độ xem hiện tại
 tools.title=Công cụ
 tools_label=Công cụ
 first_page.title=Về trang đầu
-first_page.label=Về trang đầu
 first_page_label=Về trang đầu
 last_page.title=Đến trang cuối
-last_page.label=Đến trang cuối
 last_page_label=Đến trang cuối
 page_rotate_cw.title=Xoay theo chiều kim đồng hồ
-page_rotate_cw.label=Xoay theo chiều kim đồng hồ
 page_rotate_cw_label=Xoay theo chiều kim đồng hồ
 page_rotate_ccw.title=Xoay ngược chiều kim đồng hồ
-page_rotate_ccw.label=Xoay ngược chiều kim đồng hồ
 page_rotate_ccw_label=Xoay ngược chiều kim đồng hồ
 
 cursor_text_select_tool.title=Kích hoạt công cụ chọn vùng văn bản
@@ -137,7 +133,6 @@ print_progress_close=Hủy bỏ
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Bật/Tắt thanh lề
-toggle_sidebar_notification.title=Bật tắt thanh lề (tài liệu bao gồm bản phác thảo/tập tin đính kèm)
 toggle_sidebar_notification2.title=Bật tắt thanh lề (tài liệu bao gồm bản phác thảo/tập tin đính kèm/lớp)
 toggle_sidebar_label=Bật/Tắt thanh lề
 document_outline.title=Hiện tài liệu phác thảo (nhấp đúp vào để mở rộng/thu gọn tất cả các mục)
@@ -152,9 +147,6 @@ current_outline_item.title=Tìm mục phác thảo hiện tại
 current_outline_item_label=Mục phác thảo hiện tại
 findbar.title=Tìm trong tài liệu
 findbar_label=Tìm
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=Trang {{page}}
 
 additional_layers=Các lớp bổ sung
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -229,9 +221,6 @@ page_scale_actual=Kích thước thực
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Lỗi
 
 # Loading indicator messages
 loading=Đang tải…

--- a/viewer/locale/wo/viewer.properties
+++ b/viewer/locale/wo/viewer.properties
@@ -108,9 +108,6 @@ page_scale_actual=Dayo bi am
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 
-# Loading indicator messages
-loading_error_indicator=Njumte
-
 loading_error=Am na njumte ci yebum dencukaay PDF bi.
 invalid_file_error=Dencukaay PDF bi baaxul walla mu sankar.
 

--- a/viewer/locale/xh/viewer.properties
+++ b/viewer/locale/xh/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Imbonakalo ekhoyo
 tools.title=Izixhobo zemiyalelo
 tools_label=Izixhobo zemiyalelo
 first_page.title=Yiya kwiphepha lokuqala
-first_page.label=Yiya kwiphepha lokuqala
 first_page_label=Yiya kwiphepha lokuqala
 last_page.title=Yiya kwiphepha lokugqibela
-last_page.label=Yiya kwiphepha lokugqibela
 last_page_label=Yiya kwiphepha lokugqibela
 page_rotate_cw.title=Jikelisa ngasekunene
-page_rotate_cw.label=Jikelisa ngasekunene
 page_rotate_cw_label=Jikelisa ngasekunene
 page_rotate_ccw.title=Jikelisa ngasekhohlo
-page_rotate_ccw.label=Jikelisa ngasekhohlo
 page_rotate_ccw_label=Jikelisa ngasekhohlo
 
 cursor_text_select_tool.title=Vumela iSixhobo sokuKhetha iTeksti
@@ -101,7 +97,6 @@ print_progress_close=Rhoxisa
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Togola ngebha eseCaleni
-toggle_sidebar_notification.title=ISidebar yeQhosha (uxwebhu lunolwandlalo/iziqhotyoshelwa)
 toggle_sidebar_label=Togola ngebha eseCaleni
 document_outline.title=Bonisa uLwandlalo loXwebhu (cofa kabini ukuze wandise/diliza zonke izinto)
 document_outline_label=Isishwankathelo soxwebhu
@@ -160,9 +155,6 @@ page_scale_actual=Ubungakanani bokwenene
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=Imposiso
 
 loading_error=Imposiso yenzekile xa kulayishwa i-PDF.
 invalid_file_error=Ifayile ye-PDF engeyiyo okanye eyonakalisiweyo.

--- a/viewer/locale/zh-CN/viewer.properties
+++ b/viewer/locale/zh-CN/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=当前在看
 tools.title=工具
 tools_label=工具
 first_page.title=转到第一页
-first_page.label=转到第一页
 first_page_label=转到第一页
 last_page.title=转到最后一页
-last_page.label=转到最后一页
 last_page_label=转到最后一页
 page_rotate_cw.title=顺时针旋转
-page_rotate_cw.label=顺时针旋转
 page_rotate_cw_label=顺时针旋转
 page_rotate_ccw.title=逆时针旋转
-page_rotate_ccw.label=逆时针旋转
 page_rotate_ccw_label=逆时针旋转
 
 cursor_text_select_tool.title=启用文本选择工具
@@ -137,7 +133,6 @@ print_progress_close=取消
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=切换侧栏
-toggle_sidebar_notification.title=切换侧栏（文档所含的大纲/附件）
 toggle_sidebar_notification2.title=切换侧栏（文档所含的大纲/附件/图层）
 toggle_sidebar_label=切换侧栏
 document_outline.title=显示文档大纲（双击展开/折叠所有项）
@@ -152,9 +147,6 @@ current_outline_item.title=查找当前大纲项目
 current_outline_item_label=当前大纲项目
 findbar.title=在文档中查找
 findbar_label=查找
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=第 {{page}} 页
 
 additional_layers=其他图层
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -229,9 +221,6 @@ page_scale_actual=实际大小
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=错误
 
 # Loading indicator messages
 loading=正在载入…

--- a/viewer/locale/zh-TW/viewer.properties
+++ b/viewer/locale/zh-TW/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=目前檢視
 tools.title=工具
 tools_label=工具
 first_page.title=跳到第一頁
-first_page.label=跳到第一頁
 first_page_label=跳到第一頁
 last_page.title=跳到最後一頁
-last_page.label=跳到最後一頁
 last_page_label=跳到最後一頁
 page_rotate_cw.title=順時針旋轉
-page_rotate_cw.label=順時針旋轉
 page_rotate_cw_label=順時針旋轉
 page_rotate_ccw.title=逆時針旋轉
-page_rotate_ccw.label=逆時針旋轉
 page_rotate_ccw_label=逆時針旋轉
 
 cursor_text_select_tool.title=開啟文字選擇工具
@@ -137,7 +133,6 @@ print_progress_close=取消
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=切換側邊欄
-toggle_sidebar_notification.title=切換側邊攔（文件包含大綱或附件）
 toggle_sidebar_notification2.title=切換側邊欄（包含大綱、附件、圖層的文件）
 toggle_sidebar_label=切換側邊欄
 document_outline.title=顯示文件大綱（雙擊展開/摺疊所有項目）
@@ -152,9 +147,6 @@ current_outline_item.title=尋找目前的大綱項目
 current_outline_item_label=目前的大綱項目
 findbar.title=在文件中尋找
 findbar_label=尋找
-
-# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
-page_canvas=第 {{page}} 頁
 
 additional_layers=其他圖層
 # LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
@@ -229,9 +221,6 @@ page_scale_actual=實際大小
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading_error_indicator=錯誤
 
 # Loading indicator messages
 loading=載入中…

--- a/viewer/viewer.css
+++ b/viewer/viewer.css
@@ -69,6 +69,14 @@
   background: rgba(0, 0, 255, 1);
 }
 
+/* Avoids https://github.com/mozilla/pdf.js/issues/13840 in Chrome */
+.textLayer br::-moz-selection {
+  background: transparent;
+}
+.textLayer br::selection {
+  background: transparent;
+}
+
 .textLayer .endOfContent {
   display: block;
   position: absolute;
@@ -87,6 +95,10 @@
   top: 0;
 }
 
+
+:root {
+  --annotation-unfocused-field-background: url("data:image/svg+xml;charset=UTF-8,<svg width='1px' height='1px' xmlns='http://www.w3.org/2000/svg'><rect width='100%' height='100%' style='fill:rgba(0, 54, 255, 0.13);'/></svg>");
+}
 
 .annotationLayer section {
   position: absolute;
@@ -120,7 +132,7 @@
 .annotationLayer .choiceWidgetAnnotation select,
 .annotationLayer .buttonWidgetAnnotation.checkBox input,
 .annotationLayer .buttonWidgetAnnotation.radioButton input {
-  background-color: rgba(0, 54, 255, 0.13);
+  background-image: var(--annotation-unfocused-field-background);
   border: 1px solid transparent;
   box-sizing: border-box;
   font-size: 9px;
@@ -170,6 +182,16 @@
   border: 1px solid transparent;
 }
 
+.annotationLayer .textWidgetAnnotation input :focus,
+.annotationLayer .textWidgetAnnotation textarea :focus,
+.annotationLayer .choiceWidgetAnnotation select :focus,
+.annotationLayer .buttonWidgetAnnotation.checkBox :focus,
+.annotationLayer .buttonWidgetAnnotation.radioButton :focus {
+  background-image: none;
+  background-color: transparent;
+  outline: auto;
+}
+
 .annotationLayer .buttonWidgetAnnotation.checkBox input:checked:before,
 .annotationLayer .buttonWidgetAnnotation.checkBox input:checked:after,
 .annotationLayer .buttonWidgetAnnotation.radioButton input:checked:before {
@@ -206,16 +228,6 @@
   font-family: monospace;
   padding-left: 2px;
   padding-right: 0;
-}
-
-.annotationLayer .textWidgetAnnotation input.comb:focus {
-  /*
-   * Letter spacing is placed on the right side of each character. Hence, the
-   * letter spacing of the last character may be placed outside the visible
-   * area, causing horizontal scrolling. We avoid this by extending the width
-   * when the element has focus and revert this when it loses focus.
-   */
-  width: 103%;
 }
 
 .annotationLayer .buttonWidgetAnnotation.checkBox input,
@@ -284,6 +296,45 @@
 }
 
 
+:root {
+  --xfa-unfocused-field-background: url("data:image/svg+xml;charset=UTF-8,<svg width='1px' height='1px' xmlns='http://www.w3.org/2000/svg'><rect width='100%' height='100%' style='fill:rgba(0, 54, 255, 0.13);'/></svg>");
+}
+
+.xfaLayer .highlight {
+  margin: -1px;
+  padding: 1px;
+  background-color: rgba(239, 203, 237, 1);
+  border-radius: 4px;
+}
+
+.xfaLayer .highlight.appended {
+  position: initial;
+}
+
+.xfaLayer .highlight.begin {
+  border-radius: 4px 0 0 4px;
+}
+
+.xfaLayer .highlight.end {
+  border-radius: 0 4px 4px 0;
+}
+
+.xfaLayer .highlight.middle {
+  border-radius: 0;
+}
+
+.xfaLayer .highlight.selected {
+  background-color: rgba(203, 223, 203, 1);
+}
+
+.xfaLayer ::-moz-selection {
+  background: rgba(0, 0, 255, 1);
+}
+
+.xfaLayer ::selection {
+  background: rgba(0, 0, 255, 1);
+}
+
 .xfaPage {
   overflow: hidden;
   position: relative;
@@ -316,10 +367,11 @@
   text-align: inherit;
   text-decoration: inherit;
   box-sizing: border-box;
-  background: transparent;
+  background-color: transparent;
   padding: 0;
   margin: 0;
   pointer-events: auto;
+  line-height: inherit;
 }
 
 .xfaLayer div {
@@ -355,7 +407,7 @@
 
 .xfaCaption {
   overflow: hidden;
-  flex: 0 1 auto;
+  flex: 0 0 auto;
 }
 
 .xfaCaptionForCheckButton {
@@ -374,8 +426,16 @@
   align-items: center;
 }
 
+.xfaRight {
+  display: flex;
+  flex-direction: row-reverse;
+  align-items: center;
+}
+
 .xfaLeft > .xfaCaption,
-.xfaLeft > .xfaCaptionForCheckButton {
+.xfaLeft > .xfaCaptionForCheckButton,
+.xfaRight > .xfaCaption,
+.xfaRight > .xfaCaptionForCheckButton {
   max-height: 100%;
 }
 
@@ -385,13 +445,21 @@
   align-items: flex-start;
 }
 
+.xfaBottom {
+  display: flex;
+  flex-direction: column-reverse;
+  align-items: flex-start;
+}
+
 .xfaTop > .xfaCaption,
-.xfaTop > .xfaCaptionForCheckButton {
+.xfaTop > .xfaCaptionForCheckButton,
+.xfaBottom > .xfaCaption,
+.xfaBottom > .xfaCaptionForCheckButton {
   width: 100%;
 }
 
 .xfaBorder {
-  background: transparent;
+  background-color: transparent;
   position: absolute;
   pointer-events: none;
 }
@@ -401,24 +469,34 @@
   height: 100%;
 }
 
-.xfaTextfield,
-.xfaSelect {
-  background-color: rgba(0, 54, 255, 0.13);
-}
-
 .xfaTextfield:focus,
 .xfaSelect:focus {
+  background-image: none;
   background-color: transparent;
-  outline: none;
+  outline: auto;
+  outline-offset: -1px;
+}
+
+.xfaCheckbox:focus,
+.xfaRadio:focus {
+  outline: auto;
 }
 
 .xfaTextfield,
 .xfaSelect {
-  width: 100%;
   height: 100%;
-  flex: 1 1 0;
+  width: 100%;
+  flex: 1 1 auto;
   border: none;
   resize: none;
+  background-image: var(--xfa-unfocused-field-background);
+}
+
+.xfaTop > .xfaTextfield,
+.xfaTop > .xfaSelect,
+.xfaBottom > .xfaTextfield,
+.xfaBottom > .xfaSelect {
+  flex: 0 1 auto;
 }
 
 .xfaButton {
@@ -429,8 +507,9 @@
   text-align: center;
 }
 
-.xfaButton:hover {
-  background: Highlight;
+.xfaLink {
+  width: 100%;
+  height: 100%;
 }
 
 .xfaCheckbox,
@@ -528,7 +607,7 @@
 @media print {
   .xfaTextfield,
   .xfaSelect {
-    background-color: transparent;
+    background: transparent;
   }
 
   .xfaSelect {
@@ -545,6 +624,7 @@
   --page-margin: 1px auto -8px;
   --page-border: 9px solid transparent;
   --spreadHorizontalWrapped-margin-LR: -3.5px;
+  --zoom-factor: 1;
 }
 
 @media screen and (forced-colors: active) {
@@ -684,6 +764,8 @@
   --sidebar-width: 200px;
   --sidebar-transition-duration: 200ms;
   --sidebar-transition-timing-function: ease;
+  --scale-select-container-width: 140px;
+  --scale-select-overflow: 22px;
   --loadingBar-end-offset: 0;
 
   --toolbar-icon-opacity: 0.7;
@@ -815,7 +897,6 @@
 
 @media screen and (forced-colors: active) {
   :root {
-    --main-color: ButtonText;
     --button-hover-color: Highlight;
     --doorhanger-hover-bg-color: Highlight;
     --toolbar-icon-opacity: 1;
@@ -1592,7 +1673,7 @@ html[dir="rtl"] #toolbarViewerLeft > .toolbarButton:first-child {
 }
 
 .dropdownToolbarButton {
-  width: 140px;
+  width: var(--scale-select-container-width);
   padding: 0;
   overflow: hidden;
   background-color: var(--dropdown-btn-bg-color);
@@ -1613,7 +1694,7 @@ html[dir="rtl"] .dropdownToolbarButton::after {
 }
 
 .dropdownToolbarButton > select {
-  width: 162px;
+  width: calc(var(--scale-select-container-width) + var(--scale-select-overflow));
   height: 28px;
   font-size: 12px;
   color: var(--main-color);
@@ -2561,7 +2642,7 @@ html[dir="rtl"] #documentPropertiesOverlay .row > * {
   }
 
   #printContainer > .xfaPrintedPage .xfaPage {
-    position: initial;
+    position: absolute;
   }
 
   #printContainer > .xfaPrintedPage {

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -315,17 +315,6 @@ See https://github.com/adobe-type-tools/cmap-resources
           </div>
         </div>
 
-        <menu type="context" id="viewerContextMenu">
-          <menuitem id="contextFirstPage" label="First Page"
-                    data-l10n-id="first_page"></menuitem>
-          <menuitem id="contextLastPage" label="Last Page"
-                    data-l10n-id="last_page"></menuitem>
-          <menuitem id="contextPageRotateCw" label="Rotate Clockwise"
-                    data-l10n-id="page_rotate_cw"></menuitem>
-          <menuitem id="contextPageRotateCcw" label="Rotate Counter-Clockwise"
-                    data-l10n-id="page_rotate_ccw"></menuitem>
-        </menu>
-
         <div id="viewerContainer" tabindex="0">
           <div id="viewer" class="pdfViewer"></div>
           <div id="synctex-indicator"></div>

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -25,7 +25,6 @@ See https://github.com/adobe-type-tools/cmap-resources
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <meta name="google" content="notranslate">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'none'; connect-src 'self' ws://127.0.0.1:*; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:;">
     <title>PDF.js viewer</title>
 

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -25,17 +25,36 @@
 /******/ 	var __webpack_modules__ = ([
 /* 0 */,
 /* 1 */
-/***/ ((__unused_webpack_module, exports, __webpack_require__) => {
+/***/ ((__unused_webpack_module, exports) => {
 
 
 
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.OptionKind = exports.AppOptions = void 0;
+exports.OptionKind = exports.compatibilityParams = exports.AppOptions = void 0;
+const compatibilityParams = Object.create(null);
+exports.compatibilityParams = compatibilityParams;
+{
+  const userAgent = typeof navigator !== "undefined" && navigator.userAgent || "";
+  const platform = typeof navigator !== "undefined" && navigator.platform || "";
+  const maxTouchPoints = typeof navigator !== "undefined" && navigator.maxTouchPoints || 1;
+  const isAndroid = /Android/.test(userAgent);
+  const isIOS = /\b(iPad|iPhone|iPod)(?=;)/.test(userAgent) || platform === "MacIntel" && maxTouchPoints > 1;
+  const isIOSChrome = /CriOS/.test(userAgent);
 
-var _viewer_compatibility = __webpack_require__(2);
+  (function checkOnBlobSupport() {
+    if (isIOSChrome) {
+      compatibilityParams.disableCreateObjectURL = true;
+    }
+  })();
 
+  (function checkCanvasSizeLimitation() {
+    if (isIOS || isAndroid) {
+      compatibilityParams.maxCanvasPixels = 5242880;
+    }
+  })();
+}
 const OptionKind = {
   VIEWER: 0x02,
   API: 0x04,
@@ -44,6 +63,10 @@ const OptionKind = {
 };
 exports.OptionKind = OptionKind;
 const defaultOptions = {
+  annotationMode: {
+    value: 2,
+    kind: OptionKind.VIEWER + OptionKind.PREFERENCE
+  },
   cursorToolOnLoad: {
     value: 0,
     kind: OptionKind.VIEWER + OptionKind.PREFERENCE
@@ -73,7 +96,7 @@ const defaultOptions = {
     kind: OptionKind.VIEWER + OptionKind.PREFERENCE
   },
   enableScripting: {
-    value: false,
+    value: true,
     kind: OptionKind.VIEWER + OptionKind.PREFERENCE
   },
   externalLinkRel: {
@@ -98,7 +121,7 @@ const defaultOptions = {
   },
   maxCanvasPixels: {
     value: 16777216,
-    compatibility: _viewer_compatibility.viewerCompatibilityParams.maxCanvasPixels,
+    compatibility: compatibilityParams.maxCanvasPixels,
     kind: OptionKind.VIEWER
   },
   pdfBugEnabled: {
@@ -112,10 +135,6 @@ const defaultOptions = {
   renderer: {
     value: "canvas",
     kind: OptionKind.VIEWER
-  },
-  renderInteractiveForms: {
-    value: true,
-    kind: OptionKind.VIEWER + OptionKind.PREFERENCE
   },
   sidebarViewOnLoad: {
     value: -1,
@@ -150,7 +169,7 @@ const defaultOptions = {
     kind: OptionKind.API
   },
   cMapUrl: {
-    value: "/cmaps/",
+    value: "../web/cmaps/",
     kind: OptionKind.API
   },
   disableAutoFetch: {
@@ -174,7 +193,7 @@ const defaultOptions = {
     kind: OptionKind.API
   },
   enableXfa: {
-    value: false,
+    value: true,
     kind: OptionKind.API + OptionKind.PREFERENCE
   },
   fontExtraProperties: {
@@ -194,7 +213,7 @@ const defaultOptions = {
     kind: OptionKind.API
   },
   standardFontDataUrl: {
-    value: "/standard_fonts/",
+    value: "../web/standard_fonts/",
     kind: OptionKind.API
   },
   verbosity: {
@@ -202,11 +221,11 @@ const defaultOptions = {
     kind: OptionKind.API
   },
   workerPort: {
-    value: new Worker('/build/pdf.worker.js'),
+    value: null,
     kind: OptionKind.WORKER
   },
   workerSrc: {
-    value: "/build/pdf.worker.js",
+    value: "../build/pdf.worker.js",
     kind: OptionKind.WORKER
   }
 };
@@ -220,7 +239,7 @@ const defaultOptions = {
     kind: OptionKind.VIEWER
   };
   defaultOptions.sandboxBundleSrc = {
-    value: "/build/pdf.sandbox.js",
+    value: "../build/pdf.sandbox.js",
     kind: OptionKind.VIEWER
   };
   defaultOptions.renderer.kind += OptionKind.PREFERENCE;
@@ -293,46 +312,16 @@ class AppOptions {
     delete userOptions[name];
   }
 
+  static _hasUserOptions() {
+    return Object.keys(userOptions).length > 0;
+  }
+
 }
 
 exports.AppOptions = AppOptions;
 
 /***/ }),
 /* 2 */
-/***/ ((__unused_webpack_module, exports) => {
-
-
-
-Object.defineProperty(exports, "__esModule", ({
-  value: true
-}));
-exports.viewerCompatibilityParams = void 0;
-const compatibilityParams = Object.create(null);
-{
-  const userAgent = typeof navigator !== "undefined" && navigator.userAgent || "";
-  const platform = typeof navigator !== "undefined" && navigator.platform || "";
-  const maxTouchPoints = typeof navigator !== "undefined" && navigator.maxTouchPoints || 1;
-  const isAndroid = /Android/.test(userAgent);
-  const isIOS = /\b(iPad|iPhone|iPod)(?=;)/.test(userAgent) || platform === "MacIntel" && maxTouchPoints > 1;
-  const isIOSChrome = /CriOS/.test(userAgent);
-
-  (function checkOnBlobSupport() {
-    if (isIOSChrome) {
-      compatibilityParams.disableCreateObjectURL = true;
-    }
-  })();
-
-  (function checkCanvasSizeLimitation() {
-    if (isIOS || isAndroid) {
-      compatibilityParams.maxCanvasPixels = 5242880;
-    }
-  })();
-}
-const viewerCompatibilityParams = Object.freeze(compatibilityParams);
-exports.viewerCompatibilityParams = viewerCompatibilityParams;
-
-/***/ }),
-/* 3 */
 /***/ ((__unused_webpack_module, exports, __webpack_require__) => {
 
 
@@ -342,57 +331,54 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports.PDFViewerApplication = exports.PDFPrintServiceFactory = exports.DefaultExternalServices = void 0;
 
-var _ui_utils = __webpack_require__(4);
+var _ui_utils = __webpack_require__(3);
 
 var _app_options = __webpack_require__(1);
 
-var _pdfjsLib = __webpack_require__(5);
+var _pdfjsLib = __webpack_require__(4);
 
-var _pdf_cursor_tools = __webpack_require__(6);
+var _pdf_cursor_tools = __webpack_require__(5);
 
-var _pdf_rendering_queue = __webpack_require__(8);
+var _pdf_rendering_queue = __webpack_require__(7);
 
-var _overlay_manager = __webpack_require__(9);
+var _overlay_manager = __webpack_require__(8);
 
-var _password_prompt = __webpack_require__(10);
+var _password_prompt = __webpack_require__(9);
 
-var _pdf_attachment_viewer = __webpack_require__(11);
+var _pdf_attachment_viewer = __webpack_require__(10);
 
-var _pdf_document_properties = __webpack_require__(13);
+var _pdf_document_properties = __webpack_require__(12);
 
-var _pdf_find_bar = __webpack_require__(14);
+var _pdf_find_bar = __webpack_require__(13);
 
-var _pdf_find_controller = __webpack_require__(15);
+var _pdf_find_controller = __webpack_require__(14);
 
-var _pdf_history = __webpack_require__(17);
+var _pdf_history = __webpack_require__(16);
 
-var _pdf_layer_viewer = __webpack_require__(18);
+var _pdf_layer_viewer = __webpack_require__(17);
 
-var _pdf_link_service = __webpack_require__(19);
+var _pdf_link_service = __webpack_require__(18);
 
-var _pdf_outline_viewer = __webpack_require__(20);
+var _pdf_outline_viewer = __webpack_require__(19);
 
-var _pdf_presentation_mode = __webpack_require__(21);
+var _pdf_presentation_mode = __webpack_require__(20);
 
-var _pdf_scripting_manager = __webpack_require__(22);
+var _pdf_scripting_manager = __webpack_require__(21);
 
-var _pdf_sidebar = __webpack_require__(23);
+var _pdf_sidebar = __webpack_require__(22);
 
-var _pdf_sidebar_resizer = __webpack_require__(24);
+var _pdf_sidebar_resizer = __webpack_require__(23);
 
-var _pdf_thumbnail_viewer = __webpack_require__(25);
+var _pdf_thumbnail_viewer = __webpack_require__(24);
 
-var _pdf_viewer = __webpack_require__(27);
+var _pdf_viewer = __webpack_require__(26);
 
 var _secondary_toolbar = __webpack_require__(35);
 
 var _toolbar = __webpack_require__(37);
 
-var _viewer_compatibility = __webpack_require__(2);
-
 var _view_history = __webpack_require__(38);
 
-const DEFAULT_SCALE_DELTA = 1.1;
 const DISABLE_AUTO_FETCH_LOADING_BAR_TIMEOUT = 5000;
 const FORCE_PAGES_LOADED_TIMEOUT = 10000;
 const WHEEL_ZOOM_DISABLED_TIMEOUT = 1000;
@@ -498,6 +484,7 @@ const PDFViewerApplication = {
   isViewerEmbedded: window.parent !== window,
   url: "",
   baseUrl: "",
+  _downloadUrl: "",
   externalServices: DefaultExternalServices,
   _boundEvents: Object.create(null),
   documentInfo: null,
@@ -540,6 +527,10 @@ const PDFViewerApplication = {
       return;
     }
 
+    if (_app_options.AppOptions._hasUserOptions()) {
+      console.warn("_readPreferences: The Preferences may override manually set AppOptions; " + 'please use the "disablePreferences"-option in order to prevent that.');
+    }
+
     try {
       _app_options.AppOptions.setAll(await this.preferences.getAll());
     } catch (reason) {
@@ -549,48 +540,48 @@ const PDFViewerApplication = {
 
   async _parseHashParameters() {
     if (!_app_options.AppOptions.get("pdfBugEnabled")) {
-      return undefined;
+      return;
     }
 
     const hash = document.location.hash.substring(1);
 
     if (!hash) {
-      return undefined;
+      return;
     }
 
-    const hashParams = (0, _ui_utils.parseQueryString)(hash),
+    const params = (0, _ui_utils.parseQueryString)(hash),
           waitOn = [];
 
-    if ("disableworker" in hashParams && hashParams.disableworker === "true") {
+    if (params.get("disableworker") === "true") {
       waitOn.push(loadFakeWorker());
     }
 
-    if ("disablerange" in hashParams) {
-      _app_options.AppOptions.set("disableRange", hashParams.disablerange === "true");
+    if (params.has("disablerange")) {
+      _app_options.AppOptions.set("disableRange", params.get("disablerange") === "true");
     }
 
-    if ("disablestream" in hashParams) {
-      _app_options.AppOptions.set("disableStream", hashParams.disablestream === "true");
+    if (params.has("disablestream")) {
+      _app_options.AppOptions.set("disableStream", params.get("disablestream") === "true");
     }
 
-    if ("disableautofetch" in hashParams) {
-      _app_options.AppOptions.set("disableAutoFetch", hashParams.disableautofetch === "true");
+    if (params.has("disableautofetch")) {
+      _app_options.AppOptions.set("disableAutoFetch", params.get("disableautofetch") === "true");
     }
 
-    if ("disablefontface" in hashParams) {
-      _app_options.AppOptions.set("disableFontFace", hashParams.disablefontface === "true");
+    if (params.has("disablefontface")) {
+      _app_options.AppOptions.set("disableFontFace", params.get("disablefontface") === "true");
     }
 
-    if ("disablehistory" in hashParams) {
-      _app_options.AppOptions.set("disableHistory", hashParams.disablehistory === "true");
+    if (params.has("disablehistory")) {
+      _app_options.AppOptions.set("disableHistory", params.get("disablehistory") === "true");
     }
 
-    if ("verbosity" in hashParams) {
-      _app_options.AppOptions.set("verbosity", hashParams.verbosity | 0);
+    if (params.has("verbosity")) {
+      _app_options.AppOptions.set("verbosity", params.get("verbosity") | 0);
     }
 
-    if ("textlayer" in hashParams) {
-      switch (hashParams.textlayer) {
+    if (params.has("textlayer")) {
+      switch (params.get("textlayer")) {
         case "off":
           _app_options.AppOptions.set("textLayerMode", _ui_utils.TextLayerMode.DISABLE);
 
@@ -600,31 +591,33 @@ const PDFViewerApplication = {
         case "shadow":
         case "hover":
           const viewer = this.appConfig.viewerContainer;
-          viewer.classList.add("textLayer-" + hashParams.textlayer);
+          viewer.classList.add(`textLayer-${params.get("textlayer")}`);
           break;
       }
     }
 
-    if ("pdfbug" in hashParams) {
+    if (params.has("pdfbug")) {
       _app_options.AppOptions.set("pdfBug", true);
 
       _app_options.AppOptions.set("fontExtraProperties", true);
 
-      const enabled = hashParams.pdfbug.split(",");
-      waitOn.push(loadAndEnablePDFBug(enabled));
+      const enabled = params.get("pdfbug").split(",");
+      waitOn.push(initPDFBug(enabled));
     }
 
-    if ("locale" in hashParams) {
-      _app_options.AppOptions.set("locale", hashParams.locale);
+    if (params.has("locale")) {
+      _app_options.AppOptions.set("locale", params.get("locale"));
     }
 
     if (waitOn.length === 0) {
-      return undefined;
+      return;
     }
 
-    return Promise.all(waitOn).catch(reason => {
+    try {
+      await Promise.all(waitOn);
+    } catch (reason) {
       console.error(`_parseHashParameters: "${reason.message}".`);
-    });
+    }
   },
 
   async _initializeL10n() {
@@ -674,10 +667,20 @@ const PDFViewerApplication = {
   },
 
   async _initializeViewerComponents() {
-    const appConfig = this.appConfig;
-    const eventBus = appConfig.eventBus || new _ui_utils.EventBus({
-      isInAutomation: this.externalServices.isInAutomation
-    });
+    const {
+      appConfig,
+      externalServices
+    } = this;
+    let eventBus;
+
+    if (appConfig.eventBus) {
+      eventBus = appConfig.eventBus;
+    } else if (externalServices.isInAutomation) {
+      eventBus = new _ui_utils.AutomationEventBus();
+    } else {
+      eventBus = new _ui_utils.EventBus();
+    }
+
     this.eventBus = eventBus;
     this.overlayManager = new _overlay_manager.OverlayManager();
     const pdfRenderingQueue = new _pdf_rendering_queue.PDFRenderingQueue();
@@ -690,7 +693,7 @@ const PDFViewerApplication = {
       ignoreDestinationZoom: _app_options.AppOptions.get("ignoreDestinationZoom")
     });
     this.pdfLinkService = pdfLinkService;
-    const downloadManager = this.externalServices.createDownloadManager();
+    const downloadManager = externalServices.createDownloadManager();
     this.downloadManager = downloadManager;
     const findController = new _pdf_find_controller.PDFFindController({
       linkService: pdfLinkService,
@@ -700,7 +703,7 @@ const PDFViewerApplication = {
     const pdfScriptingManager = new _pdf_scripting_manager.PDFScriptingManager({
       eventBus,
       sandboxBundleSrc: _app_options.AppOptions.get("sandboxBundleSrc"),
-      scriptingFactory: this.externalServices,
+      scriptingFactory: externalServices,
       docPropertiesLookup: this._scriptingDocProperties.bind(this)
     });
     this.pdfScriptingManager = pdfScriptingManager;
@@ -714,16 +717,15 @@ const PDFViewerApplication = {
       linkService: pdfLinkService,
       downloadManager,
       findController,
-      scriptingManager: pdfScriptingManager,
+      scriptingManager: _app_options.AppOptions.get("enableScripting") && pdfScriptingManager,
       renderer: _app_options.AppOptions.get("renderer"),
       l10n: this.l10n,
       textLayerMode: _app_options.AppOptions.get("textLayerMode"),
+      annotationMode: _app_options.AppOptions.get("annotationMode"),
       imageResourcesPath: _app_options.AppOptions.get("imageResourcesPath"),
-      renderInteractiveForms: _app_options.AppOptions.get("renderInteractiveForms"),
       enablePrintAutoRotate: _app_options.AppOptions.get("enablePrintAutoRotate"),
       useOnlyCssZoom: _app_options.AppOptions.get("useOnlyCssZoom"),
-      maxCanvasPixels: _app_options.AppOptions.get("maxCanvasPixels"),
-      enableScripting: _app_options.AppOptions.get("enableScripting")
+      maxCanvasPixels: _app_options.AppOptions.get("maxCanvasPixels")
     });
     pdfRenderingQueue.setViewer(this.pdfViewer);
     pdfLinkService.setViewer(this.pdfViewer);
@@ -736,11 +738,14 @@ const PDFViewerApplication = {
       l10n: this.l10n
     });
     pdfRenderingQueue.setThumbnailViewer(this.pdfThumbnailViewer);
-    this.pdfHistory = new _pdf_history.PDFHistory({
-      linkService: pdfLinkService,
-      eventBus
-    });
-    pdfLinkService.setHistory(this.pdfHistory);
+
+    if (!this.isViewerEmbedded && !_app_options.AppOptions.get("disableHistory")) {
+      this.pdfHistory = new _pdf_history.PDFHistory({
+        linkService: pdfLinkService,
+        eventBus
+      });
+      pdfLinkService.setHistory(this.pdfHistory);
+    }
 
     if (!this.supportsIntegratedFind) {
       this.findBar = new _pdf_find_bar.PDFFindBar(appConfig.findBar, eventBus, this.l10n);
@@ -802,36 +807,20 @@ const PDFViewerApplication = {
     return this._initializedCapability.promise;
   },
 
-  zoomIn(ticks) {
+  zoomIn(steps) {
     if (this.pdfViewer.isInPresentationMode) {
       return;
     }
 
-    let newScale = this.pdfViewer.currentScale;
-
-    do {
-      newScale = (newScale * DEFAULT_SCALE_DELTA).toFixed(2);
-      newScale = Math.ceil(newScale * 10) / 10;
-      newScale = Math.min(_ui_utils.MAX_SCALE, newScale);
-    } while (--ticks > 0 && newScale < _ui_utils.MAX_SCALE);
-
-    this.pdfViewer.currentScaleValue = newScale;
+    this.pdfViewer.increaseScale(steps);
   },
 
-  zoomOut(ticks) {
+  zoomOut(steps) {
     if (this.pdfViewer.isInPresentationMode) {
       return;
     }
 
-    let newScale = this.pdfViewer.currentScale;
-
-    do {
-      newScale = (newScale / DEFAULT_SCALE_DELTA).toFixed(2);
-      newScale = Math.floor(newScale * 10) / 10;
-      newScale = Math.max(_ui_utils.MIN_SCALE, newScale);
-    } while (--ticks > 0 && newScale > _ui_utils.MIN_SCALE);
-
-    this.pdfViewer.currentScaleValue = newScale;
+    this.pdfViewer.decreaseScale(steps);
   },
 
   zoomReset() {
@@ -859,14 +848,7 @@ const PDFViewerApplication = {
   },
 
   get supportsFullscreen() {
-    const doc = document.documentElement;
-    let support = !!(doc.requestFullscreen || doc.mozRequestFullScreen || doc.webkitRequestFullScreen);
-
-    if (document.fullscreenEnabled === false || document.mozFullScreenEnabled === false || document.webkitFullscreenEnabled === false) {
-      support = false;
-    }
-
-    return (0, _pdfjsLib.shadow)(this, "supportsFullscreen", support);
+    return (0, _pdfjsLib.shadow)(this, "supportsFullscreen", document.fullscreenEnabled || document.mozFullScreenEnabled || document.webkitFullscreenEnabled);
   },
 
   get supportsIntegratedFind() {
@@ -890,9 +872,14 @@ const PDFViewerApplication = {
     throw new Error("Not implemented: initPassiveLoading");
   },
 
-  setTitleUsingUrl(url = "") {
+  setTitleUsingUrl(url = "", downloadUrl = null) {
     this.url = url;
     this.baseUrl = url.split("#")[0];
+
+    if (downloadUrl) {
+      this._downloadUrl = downloadUrl === url ? this.baseUrl : downloadUrl.split("#")[0];
+    }
+
     let title = (0, _pdfjsLib.getPdfFilenameFromUrl)(url, "");
 
     if (!title) {
@@ -903,7 +890,7 @@ const PDFViewerApplication = {
       }
     }
 
-    // this.setTitle(title);
+    this.setTitle(title);
   },
 
   setTitle(title) {
@@ -916,6 +903,15 @@ const PDFViewerApplication = {
 
   get _docFilename() {
     return this._contentDispositionFilename || (0, _pdfjsLib.getPdfFilenameFromUrl)(this.url);
+  },
+
+  _hideViewBookmark() {
+    const {
+      toolbar,
+      secondaryToolbar
+    } = this.appConfig;
+    toolbar.viewBookmark.hidden = true;
+    secondaryToolbar.viewBookmarkButton.hidden = true;
   },
 
   _cancelIdleCallbacks() {
@@ -932,6 +928,8 @@ const PDFViewerApplication = {
 
   async close() {
     this._unblockDocumentLoadEvent();
+
+    this._hideViewBookmark();
 
     const {
       container
@@ -970,6 +968,7 @@ const PDFViewerApplication = {
     this.downloadComplete = false;
     this.url = "";
     this.baseUrl = "";
+    this._downloadUrl = "";
     this.documentInfo = null;
     this.metadata = null;
     this._contentDispositionFilename = null;
@@ -983,15 +982,8 @@ const PDFViewerApplication = {
     this.pdfOutlineViewer.reset();
     this.pdfAttachmentViewer.reset();
     this.pdfLayerViewer.reset();
-
-    if (this.pdfHistory) {
-      this.pdfHistory.reset();
-    }
-
-    if (this.findBar) {
-      this.findBar.reset();
-    }
-
+    this.pdfHistory?.reset();
+    this.findBar?.reset();
     this.toolbar.reset();
     this.secondaryToolbar.reset();
 
@@ -1016,12 +1008,12 @@ const PDFViewerApplication = {
     const parameters = Object.create(null);
 
     if (typeof file === "string") {
-      this.setTitleUsingUrl(file);
+      this.setTitleUsingUrl(file, file);
       parameters.url = file;
     } else if (file && "byteLength" in file) {
       parameters.data = file;
     } else if (file.url && file.originalUrl) {
-      this.setTitleUsingUrl(file.originalUrl);
+      this.setTitleUsingUrl(file.originalUrl, file.url);
       parameters.url = file.url;
     }
 
@@ -1096,7 +1088,7 @@ const PDFViewerApplication = {
   async download({
     sourceEventType = "download"
   } = {}) {
-    const url = this.baseUrl,
+    const url = this._downloadUrl,
           filename = this._docFilename;
 
     try {
@@ -1121,7 +1113,7 @@ const PDFViewerApplication = {
 
     this._saveInProgress = true;
     await this.pdfScriptingManager.dispatchWillSave();
-    const url = this.baseUrl,
+    const url = this._downloadUrl,
           filename = this._docFilename;
 
     try {
@@ -1133,6 +1125,7 @@ const PDFViewerApplication = {
       });
       await this.downloadManager.download(blob, url, filename, sourceEventType);
     } catch (reason) {
+      console.error(`Error when saving the document: ${reason.message}`);
       await this.download({
         sourceEventType
       });
@@ -1565,8 +1558,8 @@ const PDFViewerApplication = {
 
     this.documentInfo = info;
     this.metadata = metadata;
-    this._contentDispositionFilename ?? (this._contentDispositionFilename = contentDispositionFilename);
-    this._contentLength ?? (this._contentLength = contentLength);
+    this._contentDispositionFilename ??= contentDispositionFilename;
+    this._contentLength ??= contentLength;
     console.log(`PDF ${pdfDocument.fingerprints[0]} [${info.PDFFormatVersion} ` + `${(info.Producer || "-").trim()} / ${(info.Creator || "-").trim()}] ` + `(PDF.js: ${_pdfjsLib.version || "-"})`);
     let pdfTitle = info?.Title;
     const metadataTitle = metadata?.get("dc:title");
@@ -1584,9 +1577,14 @@ const PDFViewerApplication = {
     }
 
     if (info.IsXFAPresent && !info.IsAcroFormPresent && !pdfDocument.isPureXfa) {
-      console.warn("Warning: XFA support is not enabled");
+      if (pdfDocument.loadingParams.enableXfa) {
+        console.warn("Warning: XFA Foreground documents are not supported");
+      } else {
+        console.warn("Warning: XFA support is not enabled");
+      }
+
       this.fallback(_pdfjsLib.UNSUPPORTED_FEATURES.forms);
-    } else if ((info.IsAcroFormPresent || info.IsXFAPresent) && !this.pdfViewer.renderInteractiveForms) {
+    } else if ((info.IsAcroFormPresent || info.IsXFAPresent) && !this.pdfViewer.renderForms) {
       console.warn("Warning: Interactive form support is not enabled");
       this.fallback(_pdfjsLib.UNSUPPORTED_FEATURES.forms);
     }
@@ -1679,7 +1677,7 @@ const PDFViewerApplication = {
     viewOnLoad,
     initialDest = null
   }) {
-    if (this.isViewerEmbedded || _app_options.AppOptions.get("disableHistory")) {
+    if (!this.pdfHistory) {
       return;
     }
 
@@ -1841,10 +1839,7 @@ const PDFViewerApplication = {
     if (this.printService) {
       this.printService.destroy();
       this.printService = null;
-
-      if (this.pdfDocument) {
-        this.pdfDocument.annotationStorage.resetModified();
-      }
+      this.pdfDocument?.annotationStorage.resetModified();
     }
 
     this.forceRendering();
@@ -1855,11 +1850,7 @@ const PDFViewerApplication = {
   },
 
   requestPresentationMode() {
-    if (!this.pdfPresentationMode) {
-      return;
-    }
-
-    this.pdfPresentationMode.request();
+    this.pdfPresentationMode?.request();
   },
 
   triggerPrinting() {
@@ -2209,17 +2200,18 @@ async function loadFakeWorker() {
     _pdfjsLib.GlobalWorkerOptions.workerSrc = _app_options.AppOptions.get("workerSrc");
   }
 
-  return (0, _pdfjsLib.loadScript)(_pdfjsLib.PDFWorker.getWorkerSrc());
+  await (0, _pdfjsLib.loadScript)(_pdfjsLib.PDFWorker.workerSrc);
 }
 
-function loadAndEnablePDFBug(enabledTabs) {
-  const appConfig = PDFViewerApplication.appConfig;
-  return (0, _pdfjsLib.loadScript)(appConfig.debuggerScriptPath).then(function () {
-    PDFBug.enable(enabledTabs);
-    PDFBug.init({
-      OPS: _pdfjsLib.OPS
-    }, appConfig.mainContainer);
-  });
+async function initPDFBug(enabledTabs) {
+  const {
+    debuggerScriptPath,
+    mainContainer
+  } = PDFViewerApplication.appConfig;
+  await (0, _pdfjsLib.loadScript)(debuggerScriptPath);
+  PDFBug.init({
+    OPS: _pdfjsLib.OPS
+  }, mainContainer, enabledTabs);
 }
 
 function reportPageStatsPDFBug({
@@ -2244,7 +2236,7 @@ function webViewerInitialized() {
   let file;
   const queryString = document.location.search.substring(1);
   const params = (0, _ui_utils.parseQueryString)(queryString);
-  file = "file" in params ? params.file : _app_options.AppOptions.get("defaultUrl");
+  file = params.get("file") ?? _app_options.AppOptions.get("defaultUrl");
   validateFileURL(file);
   const fileInput = document.createElement("input");
   fileInput.id = appConfig.openFileInputName;
@@ -2332,6 +2324,8 @@ function webViewerInitialized() {
 function webViewerOpenFileViaURL(file) {
   if (file) {
     PDFViewerApplication.open(file);
+  } else {
+    PDFViewerApplication._hideViewBookmark();
   }
 }
 
@@ -2520,7 +2514,7 @@ function webViewerHashchange(evt) {
 
   if (!PDFViewerApplication.isInitialViewSet) {
     PDFViewerApplication.initialBookmark = hash;
-  } else if (!PDFViewerApplication.pdfHistory.popStateInProgress) {
+  } else if (!PDFViewerApplication.pdfHistory?.popStateInProgress) {
     PDFViewerApplication.pdfLinkService.setHash(hash);
   }
 }
@@ -2534,7 +2528,7 @@ let webViewerFileInputChange, webViewerOpenFile;
 
     const file = evt.fileInput.files[0];
 
-    if (!_viewer_compatibility.viewerCompatibilityParams.disableCreateObjectURL) {
+    if (!_app_options.compatibilityParams.disableCreateObjectURL) {
       let url = URL.createObjectURL(file);
 
       if (file.name) {
@@ -2556,12 +2550,6 @@ let webViewerFileInputChange, webViewerOpenFile;
 
       fileReader.readAsArrayBuffer(file);
     }
-
-    const appConfig = PDFViewerApplication.appConfig;
-    appConfig.toolbar.viewBookmark.hidden = true;
-    appConfig.secondaryToolbar.viewBookmarkButton.hidden = true;
-    appConfig.toolbar.download.hidden = true;
-    appConfig.secondaryToolbar.downloadButton.hidden = true;
   };
 
   webViewerOpenFile = function (evt) {
@@ -3147,7 +3135,7 @@ const PDFPrintServiceFactory = {
 exports.PDFPrintServiceFactory = PDFPrintServiceFactory;
 
 /***/ }),
-/* 4 */
+/* 3 */
 /***/ ((__unused_webpack_module, exports) => {
 
 
@@ -3177,13 +3165,13 @@ exports.roundToDivide = roundToDivide;
 exports.scrollIntoView = scrollIntoView;
 exports.waitOnEventOrTimeout = waitOnEventOrTimeout;
 exports.watchScroll = watchScroll;
-exports.WaitOnType = exports.VERTICAL_PADDING = exports.UNKNOWN_SCALE = exports.TextLayerMode = exports.SpreadMode = exports.SidebarView = exports.ScrollMode = exports.SCROLLBAR_PADDING = exports.RendererType = exports.ProgressBar = exports.PresentationModeState = exports.MIN_SCALE = exports.MAX_SCALE = exports.MAX_AUTO_SCALE = exports.EventBus = exports.DEFAULT_SCALE_VALUE = exports.DEFAULT_SCALE = exports.CSS_UNITS = exports.AutoPrintRegExp = exports.animationStarted = void 0;
-const CSS_UNITS = 96.0 / 72.0;
-exports.CSS_UNITS = CSS_UNITS;
+exports.WaitOnType = exports.VERTICAL_PADDING = exports.UNKNOWN_SCALE = exports.TextLayerMode = exports.SpreadMode = exports.SidebarView = exports.ScrollMode = exports.SCROLLBAR_PADDING = exports.RendererType = exports.ProgressBar = exports.PresentationModeState = exports.MIN_SCALE = exports.MAX_SCALE = exports.MAX_AUTO_SCALE = exports.EventBus = exports.DEFAULT_SCALE_VALUE = exports.DEFAULT_SCALE_DELTA = exports.DEFAULT_SCALE = exports.AutoPrintRegExp = exports.AutomationEventBus = exports.animationStarted = void 0;
 const DEFAULT_SCALE_VALUE = "auto";
 exports.DEFAULT_SCALE_VALUE = DEFAULT_SCALE_VALUE;
 const DEFAULT_SCALE = 1.0;
 exports.DEFAULT_SCALE = DEFAULT_SCALE;
+const DEFAULT_SCALE_DELTA = 1.1;
+exports.DEFAULT_SCALE_DELTA = DEFAULT_SCALE_DELTA;
 const MIN_SCALE = 0.1;
 exports.MIN_SCALE = MIN_SCALE;
 const MAX_SCALE = 10.0;
@@ -3328,14 +3316,13 @@ function watchScroll(viewAreaElement, callback) {
 }
 
 function parseQueryString(query) {
-  const parts = query.split("&");
-  const params = Object.create(null);
+  const params = new Map();
 
-  for (let i = 0, ii = parts.length; i < ii; ++i) {
-    const param = parts[i].split("=");
-    const key = param[0].toLowerCase();
-    const value = param.length > 1 ? param[1] : null;
-    params[decodeURIComponent(key)] = decodeURIComponent(value);
+  for (const part of query.split("&")) {
+    const param = part.split("="),
+          key = param[0].toLowerCase(),
+          value = param.length > 1 ? param[1] : "";
+    params.set(decodeURIComponent(key), decodeURIComponent(value));
   }
 
   return params;
@@ -3650,12 +3637,8 @@ const animationStarted = new Promise(function (resolve) {
 });
 exports.animationStarted = animationStarted;
 
-function dispatchDOMEvent(eventName, args = null) {
-  throw new Error("Not implemented: dispatchDOMEvent");
-}
-
 class EventBus {
-  constructor(options) {
+  constructor() {
     this._listeners = Object.create(null);
   }
 
@@ -3673,14 +3656,13 @@ class EventBus {
     });
   }
 
-  dispatch(eventName) {
+  dispatch(eventName, data) {
     const eventListeners = this._listeners[eventName];
 
     if (!eventListeners || eventListeners.length === 0) {
       return;
     }
 
-    const args = Array.prototype.slice.call(arguments, 1);
     let externalListeners;
 
     for (const {
@@ -3693,16 +3675,16 @@ class EventBus {
       }
 
       if (external) {
-        (externalListeners || (externalListeners = [])).push(listener);
+        (externalListeners ||= []).push(listener);
         continue;
       }
 
-      listener.apply(null, args);
+      listener(data);
     }
 
     if (externalListeners) {
       for (const listener of externalListeners) {
-        listener.apply(null, args);
+        listener(data);
       }
 
       externalListeners = null;
@@ -3710,9 +3692,7 @@ class EventBus {
   }
 
   _on(eventName, listener, options = null) {
-    var _this$_listeners;
-
-    const eventListeners = (_this$_listeners = this._listeners)[eventName] || (_this$_listeners[eventName] = []);
+    const eventListeners = this._listeners[eventName] ||= [];
     eventListeners.push({
       listener,
       external: options?.external === true,
@@ -3738,6 +3718,15 @@ class EventBus {
 }
 
 exports.EventBus = EventBus;
+
+class AutomationEventBus extends EventBus {
+  dispatch(eventName, data) {
+    throw new Error("Not implemented: AutomationEventBus.dispatch");
+  }
+
+}
+
+exports.AutomationEventBus = AutomationEventBus;
 
 function clamp(v, min, max) {
   return Math.min(Math.max(v, min), max);
@@ -3889,7 +3878,7 @@ function apiPageModeToSidebarView(mode) {
 }
 
 /***/ }),
-/* 5 */
+/* 4 */
 /***/ ((module) => {
 
 
@@ -3905,7 +3894,7 @@ if (typeof window !== "undefined" && window["pdfjs-dist/build/pdf"]) {
 module.exports = pdfjsLib;
 
 /***/ }),
-/* 6 */
+/* 5 */
 /***/ ((__unused_webpack_module, exports, __webpack_require__) => {
 
 
@@ -3915,9 +3904,9 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports.PDFCursorTools = exports.CursorTool = void 0;
 
-var _grab_to_pan = __webpack_require__(7);
+var _grab_to_pan = __webpack_require__(6);
 
-var _ui_utils = __webpack_require__(4);
+var _ui_utils = __webpack_require__(3);
 
 const CursorTool = {
   SELECT: 0,
@@ -4032,7 +4021,7 @@ class PDFCursorTools {
 exports.PDFCursorTools = PDFCursorTools;
 
 /***/ }),
-/* 7 */
+/* 6 */
 /***/ ((__unused_webpack_module, exports) => {
 
 
@@ -4180,7 +4169,7 @@ function isLeftMouseReleased(event) {
 }
 
 /***/ }),
-/* 8 */
+/* 7 */
 /***/ ((__unused_webpack_module, exports, __webpack_require__) => {
 
 
@@ -4190,7 +4179,7 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports.RenderingStates = exports.PDFRenderingQueue = void 0;
 
-var _pdfjsLib = __webpack_require__(5);
+var _pdfjsLib = __webpack_require__(4);
 
 const CLEANUP_TIMEOUT = 30000;
 const RenderingStates = {
@@ -4224,6 +4213,10 @@ class PDFRenderingQueue {
     return this.highestPriorityPage === view.renderingId;
   }
 
+  hasViewer() {
+    return !!this.pdfViewer;
+  }
+
   renderHighestPriority(currentlyVisiblePages) {
     if (this.idleTimeout) {
       clearTimeout(this.idleTimeout);
@@ -4249,7 +4242,7 @@ class PDFRenderingQueue {
     }
   }
 
-  getHighestPriority(visible, views, scrolledDown) {
+  getHighestPriority(visible, views, scrolledDown, preRenderExtra = false) {
     const visibleViews = visible.views;
     const numVisible = visibleViews.length;
 
@@ -4265,17 +4258,19 @@ class PDFRenderingQueue {
       }
     }
 
-    if (scrolledDown) {
-      const nextPageIndex = visible.last.id;
+    let preRenderIndex = scrolledDown ? visible.last.id : visible.first.id - 2;
+    let preRenderView = views[preRenderIndex];
 
-      if (views[nextPageIndex] && !this.isViewFinished(views[nextPageIndex])) {
-        return views[nextPageIndex];
-      }
-    } else {
-      const previousPageIndex = visible.first.id - 2;
+    if (preRenderView && !this.isViewFinished(preRenderView)) {
+      return preRenderView;
+    }
 
-      if (views[previousPageIndex] && !this.isViewFinished(views[previousPageIndex])) {
-        return views[previousPageIndex];
+    if (preRenderExtra) {
+      preRenderIndex += scrolledDown ? 1 : -1;
+      preRenderView = views[preRenderIndex];
+
+      if (preRenderView && !this.isViewFinished(preRenderView)) {
+        return preRenderView;
       }
     }
 
@@ -4322,7 +4317,7 @@ class PDFRenderingQueue {
 exports.PDFRenderingQueue = PDFRenderingQueue;
 
 /***/ }),
-/* 9 */
+/* 8 */
 /***/ ((__unused_webpack_module, exports) => {
 
 
@@ -4432,7 +4427,7 @@ class OverlayManager {
 exports.OverlayManager = OverlayManager;
 
 /***/ }),
-/* 10 */
+/* 9 */
 /***/ ((__unused_webpack_module, exports, __webpack_require__) => {
 
 
@@ -4442,7 +4437,7 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports.PasswordPrompt = void 0;
 
-var _pdfjsLib = __webpack_require__(5);
+var _pdfjsLib = __webpack_require__(4);
 
 class PasswordPrompt {
   constructor(options, overlayManager, l10n, isViewerEmbedded = false) {
@@ -4503,7 +4498,7 @@ class PasswordPrompt {
 exports.PasswordPrompt = PasswordPrompt;
 
 /***/ }),
-/* 11 */
+/* 10 */
 /***/ ((__unused_webpack_module, exports, __webpack_require__) => {
 
 
@@ -4513,9 +4508,9 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports.PDFAttachmentViewer = void 0;
 
-var _pdfjsLib = __webpack_require__(5);
+var _pdfjsLib = __webpack_require__(4);
 
-var _base_tree_viewer = __webpack_require__(12);
+var _base_tree_viewer = __webpack_require__(11);
 
 class PDFAttachmentViewer extends _base_tree_viewer.BaseTreeViewer {
   constructor(options) {
@@ -4658,7 +4653,7 @@ class PDFAttachmentViewer extends _base_tree_viewer.BaseTreeViewer {
 exports.PDFAttachmentViewer = PDFAttachmentViewer;
 
 /***/ }),
-/* 12 */
+/* 11 */
 /***/ ((__unused_webpack_module, exports, __webpack_require__) => {
 
 
@@ -4668,7 +4663,7 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports.BaseTreeViewer = void 0;
 
-var _pdfjsLib = __webpack_require__(5);
+var _pdfjsLib = __webpack_require__(4);
 
 const TREEITEM_OFFSET_TOP = -100;
 const TREEITEM_SELECTED_CLASS = "selected";
@@ -4792,7 +4787,7 @@ class BaseTreeViewer {
 exports.BaseTreeViewer = BaseTreeViewer;
 
 /***/ }),
-/* 13 */
+/* 12 */
 /***/ ((__unused_webpack_module, exports, __webpack_require__) => {
 
 
@@ -4802,9 +4797,9 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports.PDFDocumentProperties = void 0;
 
-var _pdfjsLib = __webpack_require__(5);
+var _pdfjsLib = __webpack_require__(4);
 
-var _ui_utils = __webpack_require__(4);
+var _ui_utils = __webpack_require__(3);
 
 const DEFAULT_FIELD_CONTENT = "-";
 const NON_METRIC_LOCALES = ["en-us", "en-lr", "my"];
@@ -5064,7 +5059,7 @@ class PDFDocumentProperties {
 exports.PDFDocumentProperties = PDFDocumentProperties;
 
 /***/ }),
-/* 14 */
+/* 13 */
 /***/ ((__unused_webpack_module, exports, __webpack_require__) => {
 
 
@@ -5074,7 +5069,7 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports.PDFFindBar = void 0;
 
-var _pdf_find_controller = __webpack_require__(15);
+var _pdf_find_controller = __webpack_require__(14);
 
 const MATCHES_COUNT_LIMIT = 1000;
 
@@ -5265,7 +5260,7 @@ class PDFFindBar {
 exports.PDFFindBar = PDFFindBar;
 
 /***/ }),
-/* 15 */
+/* 14 */
 /***/ ((__unused_webpack_module, exports, __webpack_require__) => {
 
 
@@ -5275,11 +5270,11 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports.PDFFindController = exports.FindState = void 0;
 
-var _pdfjsLib = __webpack_require__(5);
+var _pdfjsLib = __webpack_require__(4);
 
-var _pdf_find_utils = __webpack_require__(16);
+var _pdf_find_utils = __webpack_require__(15);
 
-var _ui_utils = __webpack_require__(4);
+var _ui_utils = __webpack_require__(3);
 
 const FindState = {
   FOUND: 0,
@@ -5289,7 +5284,7 @@ const FindState = {
 };
 exports.FindState = FindState;
 const FIND_TIMEOUT = 250;
-const MATCH_SCROLL_OFFSET_TOP = -100;
+const MATCH_SCROLL_OFFSET_TOP = -50;
 const MATCH_SCROLL_OFFSET_LEFT = -400;
 const CHARACTERS_TO_NORMALIZE = {
   "\u2010": "-",
@@ -5319,7 +5314,7 @@ function normalize(text) {
           diff = normalizedCh.length - ch.length;
 
     if (diff !== 0) {
-      (diffs || (diffs = [])).push([index, diff]);
+      (diffs ||= []).push([index, diff]);
     }
 
     return normalizedCh;
@@ -5994,7 +5989,7 @@ class PDFFindController {
 exports.PDFFindController = PDFFindController;
 
 /***/ }),
-/* 16 */
+/* 15 */
 /***/ ((__unused_webpack_module, exports) => {
 
 
@@ -6089,7 +6084,7 @@ function getCharacterType(charCode) {
 }
 
 /***/ }),
-/* 17 */
+/* 16 */
 /***/ ((__unused_webpack_module, exports, __webpack_require__) => {
 
 
@@ -6101,7 +6096,7 @@ exports.isDestArraysEqual = isDestArraysEqual;
 exports.isDestHashesEqual = isDestHashesEqual;
 exports.PDFHistory = void 0;
 
-var _ui_utils = __webpack_require__(4);
+var _ui_utils = __webpack_require__(3);
 
 const HASH_CHANGE_TIMEOUT = 1000;
 const POSITION_UPDATED_THRESHOLD = 50;
@@ -6488,8 +6483,8 @@ class PDFHistory {
   _parseCurrentHash(checkNameddest = false) {
     const hash = unescape(getCurrentHash()).substring(1);
     const params = (0, _ui_utils.parseQueryString)(hash);
-    const nameddest = params.nameddest || "";
-    let page = params.page | 0;
+    const nameddest = params.get("nameddest") || "";
+    let page = params.get("page") | 0;
 
     if (!this._isValidPage(page) || checkNameddest && nameddest.length > 0) {
       page = null;
@@ -6647,9 +6642,7 @@ function isDestHashesEqual(destHash, pushHash) {
     return true;
   }
 
-  const {
-    nameddest
-  } = (0, _ui_utils.parseQueryString)(destHash);
+  const nameddest = (0, _ui_utils.parseQueryString)(destHash).get("nameddest");
 
   if (nameddest === pushHash) {
     return true;
@@ -6703,7 +6696,7 @@ function isDestArraysEqual(firstDest, secondDest) {
 }
 
 /***/ }),
-/* 18 */
+/* 17 */
 /***/ ((__unused_webpack_module, exports, __webpack_require__) => {
 
 
@@ -6713,7 +6706,7 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports.PDFLayerViewer = void 0;
 
-var _base_tree_viewer = __webpack_require__(12);
+var _base_tree_viewer = __webpack_require__(11);
 
 class PDFLayerViewer extends _base_tree_viewer.BaseTreeViewer {
   constructor(options) {
@@ -6887,7 +6880,7 @@ class PDFLayerViewer extends _base_tree_viewer.BaseTreeViewer {
 exports.PDFLayerViewer = PDFLayerViewer;
 
 /***/ }),
-/* 19 */
+/* 18 */
 /***/ ((__unused_webpack_module, exports, __webpack_require__) => {
 
 
@@ -6897,7 +6890,9 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports.SimpleLinkService = exports.PDFLinkService = void 0;
 
-var _ui_utils = __webpack_require__(4);
+var _pdfjsLib = __webpack_require__(4);
+
+var _ui_utils = __webpack_require__(3);
 
 class PDFLinkService {
   constructor({
@@ -7042,6 +7037,15 @@ class PDFLinkService {
     });
   }
 
+  addLinkAttributes(link, url, newWindow = false) {
+    (0, _pdfjsLib.addLinkAttributes)(link, {
+      url,
+      target: newWindow ? _pdfjsLib.LinkTarget.BLANK : this.externalLinkTarget,
+      rel: this.externalLinkRel,
+      enabled: this.externalLinkEnabled
+    });
+  }
+
   getDestinationHash(dest) {
     if (typeof dest === "string") {
       if (dest.length > 0) {
@@ -7072,20 +7076,20 @@ class PDFLinkService {
     if (hash.includes("=")) {
       const params = (0, _ui_utils.parseQueryString)(hash);
 
-      if ("search" in params) {
+      if (params.has("search")) {
         this.eventBus.dispatch("findfromurlhash", {
           source: this,
-          query: params.search.replace(/"/g, ""),
-          phraseSearch: params.phrase === "true"
+          query: params.get("search").replace(/"/g, ""),
+          phraseSearch: params.get("phrase") === "true"
         });
       }
 
-      if ("page" in params) {
-        pageNumber = params.page | 0 || 1;
+      if (params.has("page")) {
+        pageNumber = params.get("page") | 0 || 1;
       }
 
-      if ("zoom" in params) {
-        const zoomArgs = params.zoom.split(",");
+      if (params.has("zoom")) {
+        const zoomArgs = params.get("zoom").split(",");
         const zoomArg = zoomArgs[0];
         const zoomArgNumber = parseFloat(zoomArg);
 
@@ -7126,15 +7130,15 @@ class PDFLinkService {
         this.page = pageNumber;
       }
 
-      if ("pagemode" in params) {
+      if (params.has("pagemode")) {
         this.eventBus.dispatch("pagemode", {
           source: this,
-          mode: params.pagemode
+          mode: params.get("pagemode")
         });
       }
 
-      if ("nameddest" in params) {
-        this.goToDestination(params.nameddest);
+      if (params.has("nameddest")) {
+        this.goToDestination(params.get("nameddest"));
       }
     } else {
       dest = unescape(hash);
@@ -7159,17 +7163,11 @@ class PDFLinkService {
   executeNamedAction(action) {
     switch (action) {
       case "GoBack":
-        if (this.pdfHistory) {
-          this.pdfHistory.back();
-        }
-
+        this.pdfHistory?.back();
         break;
 
       case "GoForward":
-        if (this.pdfHistory) {
-          this.pdfHistory.forward();
-        }
-
+        this.pdfHistory?.forward();
         break;
 
       case "NextPage":
@@ -7296,10 +7294,7 @@ function isValidExplicitDestination(dest) {
 
 class SimpleLinkService {
   constructor() {
-    this.externalLinkTarget = null;
-    this.externalLinkRel = null;
     this.externalLinkEnabled = true;
-    this._ignoreDestinationZoom = false;
   }
 
   get pagesCount() {
@@ -7321,6 +7316,13 @@ class SimpleLinkService {
   async goToDestination(dest) {}
 
   goToPage(val) {}
+
+  addLinkAttributes(link, url, newWindow = false) {
+    (0, _pdfjsLib.addLinkAttributes)(link, {
+      url,
+      enabled: this.externalLinkEnabled
+    });
+  }
 
   getDestinationHash(dest) {
     return "#";
@@ -7349,7 +7351,7 @@ class SimpleLinkService {
 exports.SimpleLinkService = SimpleLinkService;
 
 /***/ }),
-/* 20 */
+/* 19 */
 /***/ ((__unused_webpack_module, exports, __webpack_require__) => {
 
 
@@ -7359,11 +7361,11 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports.PDFOutlineViewer = void 0;
 
-var _pdfjsLib = __webpack_require__(5);
+var _base_tree_viewer = __webpack_require__(11);
 
-var _base_tree_viewer = __webpack_require__(12);
+var _pdfjsLib = __webpack_require__(4);
 
-var _ui_utils = __webpack_require__(4);
+var _ui_utils = __webpack_require__(3);
 
 class PDFOutlineViewer extends _base_tree_viewer.BaseTreeViewer {
   constructor(options) {
@@ -7431,12 +7433,7 @@ class PDFOutlineViewer extends _base_tree_viewer.BaseTreeViewer {
     } = this;
 
     if (url) {
-      (0, _pdfjsLib.addLinkAttributes)(element, {
-        url,
-        target: newWindow ? _pdfjsLib.LinkTarget.BLANK : linkService.externalLinkTarget,
-        rel: linkService.externalLinkRel,
-        enabled: linkService.externalLinkEnabled
-      });
+      linkService.addLinkAttributes(element, url, newWindow);
       return;
     }
 
@@ -7689,7 +7686,7 @@ class PDFOutlineViewer extends _base_tree_viewer.BaseTreeViewer {
 exports.PDFOutlineViewer = PDFOutlineViewer;
 
 /***/ }),
-/* 21 */
+/* 20 */
 /***/ ((__unused_webpack_module, exports, __webpack_require__) => {
 
 
@@ -7699,7 +7696,7 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports.PDFPresentationMode = void 0;
 
-var _ui_utils = __webpack_require__(4);
+var _ui_utils = __webpack_require__(3);
 
 const DELAY_BEFORE_RESETTING_SWITCH_IN_PROGRESS = 1500;
 const DELAY_BEFORE_HIDING_CONTROLS = 3000;
@@ -8048,7 +8045,7 @@ class PDFPresentationMode {
 exports.PDFPresentationMode = PDFPresentationMode;
 
 /***/ }),
-/* 22 */
+/* 21 */
 /***/ ((__unused_webpack_module, exports, __webpack_require__) => {
 
 
@@ -8058,11 +8055,11 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports.PDFScriptingManager = void 0;
 
-var _pdfjsLib = __webpack_require__(5);
+var _pdfjsLib = __webpack_require__(4);
 
-var _ui_utils = __webpack_require__(4);
+var _ui_utils = __webpack_require__(3);
 
-var _pdf_rendering_queue = __webpack_require__(8);
+var _pdf_rendering_queue = __webpack_require__(7);
 
 class PDFScriptingManager {
   constructor({
@@ -8325,6 +8322,49 @@ class PDFScriptingManager {
 
           this._pdfViewer.currentScaleValue = value;
           break;
+
+        case "SaveAs":
+          this._eventBus.dispatch("save", {
+            source: this
+          });
+
+          break;
+
+        case "FirstPage":
+          this._pdfViewer.currentPageNumber = 1;
+          break;
+
+        case "LastPage":
+          this._pdfViewer.currentPageNumber = this._pdfViewer.pagesCount;
+          break;
+
+        case "NextPage":
+          this._pdfViewer.nextPage();
+
+          break;
+
+        case "PrevPage":
+          this._pdfViewer.previousPage();
+
+          break;
+
+        case "ZoomViewIn":
+          if (isInPresentationMode) {
+            return;
+          }
+
+          this._pdfViewer.increaseScale();
+
+          break;
+
+        case "ZoomViewOut":
+          if (isInPresentationMode) {
+            return;
+          }
+
+          this._pdfViewer.decreaseScale();
+
+          break;
       }
 
       return;
@@ -8496,7 +8536,7 @@ class PDFScriptingManager {
 exports.PDFScriptingManager = PDFScriptingManager;
 
 /***/ }),
-/* 23 */
+/* 22 */
 /***/ ((__unused_webpack_module, exports, __webpack_require__) => {
 
 
@@ -8506,9 +8546,9 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports.PDFSidebar = void 0;
 
-var _ui_utils = __webpack_require__(4);
+var _ui_utils = __webpack_require__(3);
 
-var _pdf_rendering_queue = __webpack_require__(8);
+var _pdf_rendering_queue = __webpack_require__(7);
 
 const UI_NOTIFICATION_CLASS = "pdfSidebarNotification";
 
@@ -8590,7 +8630,7 @@ class PDFSidebar {
       return;
     }
 
-    if (!this._switchView(view, false)) {
+    if (!this._switchView(view, true)) {
       this._dispatchEvent();
     }
   }
@@ -8856,7 +8896,7 @@ class PDFSidebar {
 exports.PDFSidebar = PDFSidebar;
 
 /***/ }),
-/* 24 */
+/* 23 */
 /***/ ((__unused_webpack_module, exports) => {
 
 
@@ -8888,7 +8928,7 @@ class PDFSidebarResizer {
   }
 
   get outerContainerWidth() {
-    return this._outerContainerWidth || (this._outerContainerWidth = this.outerContainer.clientWidth);
+    return this._outerContainerWidth ||= this.outerContainer.clientWidth;
   }
 
   _updateWidth(width = 0) {
@@ -8987,7 +9027,7 @@ class PDFSidebarResizer {
 exports.PDFSidebarResizer = PDFSidebarResizer;
 
 /***/ }),
-/* 25 */
+/* 24 */
 /***/ ((__unused_webpack_module, exports, __webpack_require__) => {
 
 
@@ -8997,11 +9037,11 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports.PDFThumbnailViewer = void 0;
 
-var _ui_utils = __webpack_require__(4);
+var _ui_utils = __webpack_require__(3);
 
-var _pdf_thumbnail_view = __webpack_require__(26);
+var _pdf_thumbnail_view = __webpack_require__(25);
 
-var _pdf_rendering_queue = __webpack_require__(8);
+var _pdf_rendering_queue = __webpack_require__(7);
 
 const THUMBNAIL_SCROLL_MARGIN = -19;
 const THUMBNAIL_SELECTED_CLASS = "selected";
@@ -9110,9 +9150,12 @@ class PDFThumbnailViewer {
     }
 
     this._pagesRotation = rotation;
+    const updateArgs = {
+      rotation
+    };
 
-    for (let i = 0, ii = this._thumbnails.length; i < ii; i++) {
-      this._thumbnails[i].update(rotation);
+    for (const thumbnail of this._thumbnails) {
+      thumbnail.update(updateArgs);
     }
   }
 
@@ -9267,7 +9310,7 @@ class PDFThumbnailViewer {
 exports.PDFThumbnailViewer = PDFThumbnailViewer;
 
 /***/ }),
-/* 26 */
+/* 25 */
 /***/ ((__unused_webpack_module, exports, __webpack_require__) => {
 
 
@@ -9277,11 +9320,11 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports.TempImageFactory = exports.PDFThumbnailView = void 0;
 
-var _ui_utils = __webpack_require__(4);
+var _ui_utils = __webpack_require__(3);
 
-var _pdfjsLib = __webpack_require__(5);
+var _pdfjsLib = __webpack_require__(4);
 
-var _pdf_rendering_queue = __webpack_require__(8);
+var _pdf_rendering_queue = __webpack_require__(7);
 
 const DRAW_UPSCALE_FACTOR = 2;
 const MAX_NUM_SCALING_STEPS = 3;
@@ -9430,8 +9473,10 @@ class PDFThumbnailView {
     }
   }
 
-  update(rotation) {
-    if (typeof rotation !== "undefined") {
+  update({
+    rotation = null
+  }) {
+    if (typeof rotation === "number") {
       this.rotation = rotation;
     }
 
@@ -9670,7 +9715,7 @@ class PDFThumbnailView {
 exports.PDFThumbnailView = PDFThumbnailView;
 
 /***/ }),
-/* 27 */
+/* 26 */
 /***/ ((__unused_webpack_module, exports, __webpack_require__) => {
 
 
@@ -9680,11 +9725,11 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports.PDFViewer = void 0;
 
-var _ui_utils = __webpack_require__(4);
+var _ui_utils = __webpack_require__(3);
 
-var _base_viewer = __webpack_require__(28);
+var _base_viewer = __webpack_require__(27);
 
-var _pdfjsLib = __webpack_require__(5);
+var _pdfjsLib = __webpack_require__(4);
 
 class PDFViewer extends _base_viewer.BaseViewer {
   get _viewerElement() {
@@ -9758,7 +9803,7 @@ class PDFViewer extends _base_viewer.BaseViewer {
 exports.PDFViewer = PDFViewer;
 
 /***/ }),
-/* 28 */
+/* 27 */
 /***/ ((__unused_webpack_module, exports, __webpack_require__) => {
 
 
@@ -9768,21 +9813,23 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports.BaseViewer = void 0;
 
-var _pdfjsLib = __webpack_require__(5);
+var _pdfjsLib = __webpack_require__(4);
 
-var _ui_utils = __webpack_require__(4);
+var _ui_utils = __webpack_require__(3);
 
-var _pdf_rendering_queue = __webpack_require__(8);
+var _pdf_rendering_queue = __webpack_require__(7);
 
-var _annotation_layer_builder = __webpack_require__(29);
+var _annotation_layer_builder = __webpack_require__(28);
 
-var _l10n_utils = __webpack_require__(30);
+var _l10n_utils = __webpack_require__(29);
 
-var _pdf_page_view = __webpack_require__(31);
+var _pdf_page_view = __webpack_require__(30);
 
-var _pdf_link_service = __webpack_require__(19);
+var _pdf_link_service = __webpack_require__(18);
 
-var _struct_tree_layer_builder = __webpack_require__(32);
+var _struct_tree_layer_builder = __webpack_require__(31);
+
+var _text_highlighter = __webpack_require__(32);
 
 var _text_layer_builder = __webpack_require__(33);
 
@@ -9850,13 +9897,12 @@ class BaseViewer {
       throw new Error("Cannot initialize BaseViewer.");
     }
 
-    const viewerVersion = '2.10.377';
+    const viewerVersion = '2.11.338';
 
     if (_pdfjsLib.version !== viewerVersion) {
       throw new Error(`The API version "${_pdfjsLib.version}" does not match the Viewer version "${viewerVersion}".`);
     }
 
-    this._name = this.constructor.name;
     this.container = options.container;
     this.viewer = options.viewer || options.container.firstElementChild;
 
@@ -9873,16 +9919,15 @@ class BaseViewer {
     this.downloadManager = options.downloadManager || null;
     this.findController = options.findController || null;
     this._scriptingManager = options.scriptingManager || null;
-    this.removePageBorders = options.removePageBorders || true;
-    this.textLayerMode = Number.isInteger(options.textLayerMode) ? options.textLayerMode : _ui_utils.TextLayerMode.ENABLE;
+    this.removePageBorders = options.removePageBorders || false;
+    this.textLayerMode = options.textLayerMode ?? _ui_utils.TextLayerMode.ENABLE;
+    this._annotationMode = options.annotationMode ?? _pdfjsLib.AnnotationMode.ENABLE_FORMS;
     this.imageResourcesPath = options.imageResourcesPath || "";
-    this.renderInteractiveForms = options.renderInteractiveForms !== false;
     this.enablePrintAutoRotate = options.enablePrintAutoRotate || false;
     this.renderer = options.renderer || _ui_utils.RendererType.CANVAS;
     this.useOnlyCssZoom = options.useOnlyCssZoom || false;
     this.maxCanvasPixels = options.maxCanvasPixels;
     this.l10n = options.l10n || _l10n_utils.NullL10n;
-    this.enableScripting = options.enableScripting === true && !!this._scriptingManager;
     this.defaultRenderingQueue = !options.renderingQueue;
 
     if (this.defaultRenderingQueue) {
@@ -9892,6 +9937,7 @@ class BaseViewer {
       this.renderingQueue = options.renderingQueue;
     }
 
+    this._doc = document.documentElement;
     this.scroll = (0, _ui_utils.watchScroll)(this.container, this._scrollUpdate.bind(this));
     this.presentationModeState = _ui_utils.PresentationModeState.UNKNOWN;
     this._onBeforeDraw = this._onAfterDraw = null;
@@ -9927,6 +9973,14 @@ class BaseViewer {
     });
   }
 
+  get renderForms() {
+    return this._annotationMode === _pdfjsLib.AnnotationMode.ENABLE_FORMS;
+  }
+
+  get enableScripting() {
+    return !!this._scriptingManager;
+  }
+
   get currentPageNumber() {
     return this._currentPageNumber;
   }
@@ -9941,7 +9995,7 @@ class BaseViewer {
     }
 
     if (!this._setCurrentPageNumber(val, true)) {
-      console.error(`${this._name}.currentPageNumber: "${val}" is not a valid page.`);
+      console.error(`currentPageNumber: "${val}" is not a valid page.`);
     }
   }
 
@@ -9994,7 +10048,7 @@ class BaseViewer {
     }
 
     if (!this._setCurrentPageNumber(page, true)) {
-      console.error(`${this._name}.currentPageLabel: "${val}" is not a valid page.`);
+      console.error(`currentPageLabel: "${val}" is not a valid page.`);
     }
   }
 
@@ -10051,10 +10105,12 @@ class BaseViewer {
 
     this._pagesRotation = rotation;
     const pageNumber = this._currentPageNumber;
+    const updateArgs = {
+      rotation
+    };
 
-    for (let i = 0, ii = this._pages.length; i < ii; i++) {
-      const pageView = this._pages[i];
-      pageView.update(pageView.scale, rotation);
+    for (const pageView of this._pages) {
+      pageView.update(updateArgs);
     }
 
     if (this._currentScaleValue) {
@@ -10165,9 +10221,10 @@ class BaseViewer {
       this._optionalContentConfigPromise = optionalContentConfigPromise;
       const scale = this.currentScale;
       const viewport = firstPdfPage.getViewport({
-        scale: scale * _ui_utils.CSS_UNITS
+        scale: scale * _pdfjsLib.PixelsPerInch.PDF_TO_CSS_UNITS
       });
-      const textLayerFactory = this.textLayerMode !== _ui_utils.TextLayerMode.DISABLE ? this : null;
+      const textLayerFactory = this.textLayerMode !== _ui_utils.TextLayerMode.DISABLE && !isPureXfa ? this : null;
+      const annotationLayerFactory = this._annotationMode !== _pdfjsLib.AnnotationMode.DISABLE ? this : null;
       const xfaLayerFactory = isPureXfa ? this : null;
 
       for (let pageNum = 1; pageNum <= pagesCount; ++pageNum) {
@@ -10181,11 +10238,12 @@ class BaseViewer {
           renderingQueue: this.renderingQueue,
           textLayerFactory,
           textLayerMode: this.textLayerMode,
-          annotationLayerFactory: this,
+          annotationLayerFactory,
+          annotationMode: this._annotationMode,
           xfaLayerFactory,
+          textHighlighterFactory: this,
           structTreeLayerFactory: this,
           imageResourcesPath: this.imageResourcesPath,
-          renderInteractiveForms: this.renderInteractiveForms,
           renderer: this.renderer,
           useOnlyCssZoom: this.useOnlyCssZoom,
           maxCanvasPixels: this.maxCanvasPixels,
@@ -10211,7 +10269,7 @@ class BaseViewer {
           this.findController.setDocument(pdfDocument);
         }
 
-        if (this.enableScripting) {
+        if (this._scriptingManager) {
           this._scriptingManager.setDocument(pdfDocument);
         }
 
@@ -10273,7 +10331,7 @@ class BaseViewer {
       this._pageLabels = null;
     } else if (!(Array.isArray(labels) && this.pdfDocument.numPages === labels.length)) {
       this._pageLabels = null;
-      console.error(`${this._name}.setPageLabels: Invalid page labels.`);
+      console.error(`setPageLabels: Invalid page labels.`);
     } else {
       this._pageLabels = labels;
     }
@@ -10348,8 +10406,14 @@ class BaseViewer {
       return;
     }
 
-    for (let i = 0, ii = this._pages.length; i < ii; i++) {
-      this._pages[i].update(newScale);
+    this._doc.style.setProperty("--zoom-factor", newScale);
+
+    const updateArgs = {
+      scale: newScale
+    };
+
+    for (const pageView of this._pages) {
+      pageView.update(updateArgs);
     }
 
     this._currentScale = newScale;
@@ -10437,7 +10501,7 @@ class BaseViewer {
           break;
 
         default:
-          console.error(`${this._name}._setScale: "${value}" is an unknown zoom value.`);
+          console.error(`_setScale: "${value}" is an unknown zoom value.`);
           return;
       }
 
@@ -10484,7 +10548,7 @@ class BaseViewer {
     const pageView = Number.isInteger(pageNumber) && this._pages[pageNumber - 1];
 
     if (!pageView) {
-      console.error(`${this._name}.scrollPageIntoView: ` + `"${pageNumber}" is not a valid pageNumber parameter.`);
+      console.error(`scrollPageIntoView: "${pageNumber}" is not a valid pageNumber parameter.`);
       return;
     }
 
@@ -10501,8 +10565,8 @@ class BaseViewer {
         widthScale,
         heightScale;
     const changeOrientation = pageView.rotation % 180 !== 0;
-    const pageWidth = (changeOrientation ? pageView.height : pageView.width) / pageView.scale / _ui_utils.CSS_UNITS;
-    const pageHeight = (changeOrientation ? pageView.width : pageView.height) / pageView.scale / _ui_utils.CSS_UNITS;
+    const pageWidth = (changeOrientation ? pageView.height : pageView.width) / pageView.scale / _pdfjsLib.PixelsPerInch.PDF_TO_CSS_UNITS;
+    const pageHeight = (changeOrientation ? pageView.width : pageView.height) / pageView.scale / _pdfjsLib.PixelsPerInch.PDF_TO_CSS_UNITS;
     let scale = 0;
 
     switch (destArray[1].name) {
@@ -10548,13 +10612,13 @@ class BaseViewer {
         height = destArray[5] - y;
         const hPadding = this.removePageBorders ? 0 : _ui_utils.SCROLLBAR_PADDING;
         const vPadding = this.removePageBorders ? 0 : _ui_utils.VERTICAL_PADDING;
-        widthScale = (this.container.clientWidth - hPadding) / width / _ui_utils.CSS_UNITS;
-        heightScale = (this.container.clientHeight - vPadding) / height / _ui_utils.CSS_UNITS;
+        widthScale = (this.container.clientWidth - hPadding) / width / _pdfjsLib.PixelsPerInch.PDF_TO_CSS_UNITS;
+        heightScale = (this.container.clientHeight - vPadding) / height / _pdfjsLib.PixelsPerInch.PDF_TO_CSS_UNITS;
         scale = Math.min(Math.abs(widthScale), Math.abs(heightScale));
         break;
 
       default:
-        console.error(`${this._name}.scrollPageIntoView: ` + `"${destArray[1].name}" is not a valid destination type.`);
+        console.error(`scrollPageIntoView: "${destArray[1].name}" is not a valid destination type.`);
         return;
     }
 
@@ -10717,7 +10781,7 @@ class BaseViewer {
     }
 
     if (!(Number.isInteger(pageNumber) && pageNumber > 0 && pageNumber <= this.pagesCount)) {
-      console.error(`${this._name}.isPageVisible: "${pageNumber}" is not a valid page.`);
+      console.error(`isPageVisible: "${pageNumber}" is not a valid page.`);
       return false;
     }
 
@@ -10732,7 +10796,7 @@ class BaseViewer {
     }
 
     if (!(Number.isInteger(pageNumber) && pageNumber > 0 && pageNumber <= this.pagesCount)) {
-      console.error(`${this._name}.isPageCached: "${pageNumber}" is not a valid page.`);
+      console.error(`isPageCached: "${pageNumber}" is not a valid page.`);
       return false;
     }
 
@@ -10793,7 +10857,8 @@ class BaseViewer {
     const visiblePages = currentlyVisiblePages || this._getVisiblePages();
 
     const scrollAhead = this._isScrollModeHorizontal ? this.scroll.right : this.scroll.down;
-    const pageView = this.renderingQueue.getHighestPriority(visiblePages, this._pages, scrollAhead);
+    const preRenderExtra = this._scrollMode === _ui_utils.ScrollMode.VERTICAL && this._spreadMode !== _ui_utils.SpreadMode.NONE && !this.isInPresentationMode;
+    const pageView = this.renderingQueue.getHighestPriority(visiblePages, this._pages, scrollAhead, preRenderExtra);
 
     if (pageView) {
       this._ensurePdfPageLoaded(pageView).then(() => {
@@ -10806,29 +10871,38 @@ class BaseViewer {
     return false;
   }
 
-  createTextLayerBuilder(textLayerDiv, pageIndex, viewport, enhanceTextSelection = false, eventBus) {
+  createTextLayerBuilder(textLayerDiv, pageIndex, viewport, enhanceTextSelection = false, eventBus, highlighter) {
     return new _text_layer_builder.TextLayerBuilder({
       textLayerDiv,
       eventBus,
       pageIndex,
       viewport,
-      findController: this.isInPresentationMode ? null : this.findController,
-      enhanceTextSelection: this.isInPresentationMode ? false : enhanceTextSelection
+      enhanceTextSelection: this.isInPresentationMode ? false : enhanceTextSelection,
+      highlighter
     });
   }
 
-  createAnnotationLayerBuilder(pageDiv, pdfPage, annotationStorage = null, imageResourcesPath = "", renderInteractiveForms = false, l10n = _l10n_utils.NullL10n, enableScripting = null, hasJSActionsPromise = null, mouseState = null) {
+  createTextHighlighter(pageIndex, eventBus) {
+    return new _text_highlighter.TextHighlighter({
+      eventBus,
+      pageIndex,
+      findController: this.isInPresentationMode ? null : this.findController
+    });
+  }
+
+  createAnnotationLayerBuilder(pageDiv, pdfPage, annotationStorage = null, imageResourcesPath = "", renderForms = true, l10n = _l10n_utils.NullL10n, enableScripting = null, hasJSActionsPromise = null, mouseState = null, fieldObjectsPromise = null) {
     return new _annotation_layer_builder.AnnotationLayerBuilder({
       pageDiv,
       pdfPage,
       annotationStorage: annotationStorage || this.pdfDocument?.annotationStorage,
       imageResourcesPath,
-      renderInteractiveForms,
+      renderForms,
       linkService: this.linkService,
       downloadManager: this.downloadManager,
       l10n,
       enableScripting: enableScripting ?? this.enableScripting,
       hasJSActionsPromise: hasJSActionsPromise || this.pdfDocument?.hasJSActions(),
+      fieldObjectsPromise: fieldObjectsPromise || this.pdfDocument?.getFieldObjects(),
       mouseState: mouseState || this._scriptingManager?.mouseState
     });
   }
@@ -10837,7 +10911,8 @@ class BaseViewer {
     return new _xfa_layer_builder.XfaLayerBuilder({
       pageDiv,
       pdfPage,
-      annotationStorage: annotationStorage || this.pdfDocument?.annotationStorage
+      annotationStorage: annotationStorage || this.pdfDocument?.annotationStorage,
+      linkService: this.linkService
     });
   }
 
@@ -10909,9 +10984,12 @@ class BaseViewer {
     }
 
     this._optionalContentConfigPromise = promise;
+    const updateArgs = {
+      optionalContentConfigPromise: promise
+    };
 
     for (const pageView of this._pages) {
-      pageView.update(pageView.scale, pageView.rotation, promise);
+      pageView.update(updateArgs);
     }
 
     this.update();
@@ -11054,7 +11132,7 @@ class BaseViewer {
             let yArray = pageLayout.get(y);
 
             if (!yArray) {
-              pageLayout.set(y, yArray || (yArray = []));
+              pageLayout.set(y, yArray ||= []);
             }
 
             yArray.push(id);
@@ -11185,12 +11263,36 @@ class BaseViewer {
     return true;
   }
 
+  increaseScale(steps = 1) {
+    let newScale = this._currentScale;
+
+    do {
+      newScale = (newScale * _ui_utils.DEFAULT_SCALE_DELTA).toFixed(2);
+      newScale = Math.ceil(newScale * 10) / 10;
+      newScale = Math.min(_ui_utils.MAX_SCALE, newScale);
+    } while (--steps > 0 && newScale < _ui_utils.MAX_SCALE);
+
+    this.currentScaleValue = newScale;
+  }
+
+  decreaseScale(steps = 1) {
+    let newScale = this._currentScale;
+
+    do {
+      newScale = (newScale / _ui_utils.DEFAULT_SCALE_DELTA).toFixed(2);
+      newScale = Math.floor(newScale * 10) / 10;
+      newScale = Math.max(_ui_utils.MIN_SCALE, newScale);
+    } while (--steps > 0 && newScale > _ui_utils.MIN_SCALE);
+
+    this.currentScaleValue = newScale;
+  }
+
 }
 
 exports.BaseViewer = BaseViewer;
 
 /***/ }),
-/* 29 */
+/* 28 */
 /***/ ((__unused_webpack_module, exports, __webpack_require__) => {
 
 
@@ -11200,11 +11302,11 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports.DefaultAnnotationLayerFactory = exports.AnnotationLayerBuilder = void 0;
 
-var _pdfjsLib = __webpack_require__(5);
+var _pdfjsLib = __webpack_require__(4);
 
-var _l10n_utils = __webpack_require__(30);
+var _l10n_utils = __webpack_require__(29);
 
-var _pdf_link_service = __webpack_require__(19);
+var _pdf_link_service = __webpack_require__(18);
 
 class AnnotationLayerBuilder {
   constructor({
@@ -11214,10 +11316,11 @@ class AnnotationLayerBuilder {
     downloadManager,
     annotationStorage = null,
     imageResourcesPath = "",
-    renderInteractiveForms = true,
+    renderForms = true,
     l10n = _l10n_utils.NullL10n,
     enableScripting = false,
     hasJSActionsPromise = null,
+    fieldObjectsPromise = null,
     mouseState = null
   }) {
     this.pageDiv = pageDiv;
@@ -11225,58 +11328,56 @@ class AnnotationLayerBuilder {
     this.linkService = linkService;
     this.downloadManager = downloadManager;
     this.imageResourcesPath = imageResourcesPath;
-    this.renderInteractiveForms = renderInteractiveForms;
+    this.renderForms = renderForms;
     this.l10n = l10n;
     this.annotationStorage = annotationStorage;
     this.enableScripting = enableScripting;
     this._hasJSActionsPromise = hasJSActionsPromise;
+    this._fieldObjectsPromise = fieldObjectsPromise;
     this._mouseState = mouseState;
     this.div = null;
     this._cancelled = false;
   }
 
-  render(viewport, intent = "display") {
-    return Promise.all([this.pdfPage.getAnnotations({
+  async render(viewport, intent = "display") {
+    const [annotations, hasJSActions = false, fieldObjects = null] = await Promise.all([this.pdfPage.getAnnotations({
       intent
-    }), this._hasJSActionsPromise]).then(([annotations, hasJSActions = false]) => {
-      if (this._cancelled) {
-        return;
-      }
+    }), this._hasJSActionsPromise, this._fieldObjectsPromise]);
 
-      if (annotations.length === 0) {
-        return;
-      }
+    if (this._cancelled || annotations.length === 0) {
+      return;
+    }
 
-      const parameters = {
-        viewport: viewport.clone({
-          dontFlip: true
-        }),
-        div: this.div,
-        annotations,
-        page: this.pdfPage,
-        imageResourcesPath: this.imageResourcesPath,
-        renderInteractiveForms: this.renderInteractiveForms,
-        linkService: this.linkService,
-        downloadManager: this.downloadManager,
-        annotationStorage: this.annotationStorage,
-        enableScripting: this.enableScripting,
-        hasJSActions,
-        mouseState: this._mouseState
-      };
+    const parameters = {
+      viewport: viewport.clone({
+        dontFlip: true
+      }),
+      div: this.div,
+      annotations,
+      page: this.pdfPage,
+      imageResourcesPath: this.imageResourcesPath,
+      renderForms: this.renderForms,
+      linkService: this.linkService,
+      downloadManager: this.downloadManager,
+      annotationStorage: this.annotationStorage,
+      enableScripting: this.enableScripting,
+      hasJSActions,
+      fieldObjects,
+      mouseState: this._mouseState
+    };
 
-      if (this.div) {
-        _pdfjsLib.AnnotationLayer.update(parameters);
-      } else {
-        this.div = document.createElement("div");
-        this.div.className = "annotationLayer";
-        this.pageDiv.appendChild(this.div);
-        parameters.div = this.div;
+    if (this.div) {
+      _pdfjsLib.AnnotationLayer.update(parameters);
+    } else {
+      this.div = document.createElement("div");
+      this.div.className = "annotationLayer";
+      this.pageDiv.appendChild(this.div);
+      parameters.div = this.div;
 
-        _pdfjsLib.AnnotationLayer.render(parameters);
+      _pdfjsLib.AnnotationLayer.render(parameters);
 
-        this.l10n.translate(this.div);
-      }
-    });
+      this.l10n.translate(this.div);
+    }
   }
 
   cancel() {
@@ -11296,17 +11397,18 @@ class AnnotationLayerBuilder {
 exports.AnnotationLayerBuilder = AnnotationLayerBuilder;
 
 class DefaultAnnotationLayerFactory {
-  createAnnotationLayerBuilder(pageDiv, pdfPage, annotationStorage = null, imageResourcesPath = "", renderInteractiveForms = true, l10n = _l10n_utils.NullL10n, enableScripting = false, hasJSActionsPromise = null, mouseState = null) {
+  createAnnotationLayerBuilder(pageDiv, pdfPage, annotationStorage = null, imageResourcesPath = "", renderForms = true, l10n = _l10n_utils.NullL10n, enableScripting = false, hasJSActionsPromise = null, mouseState = null, fieldObjectsPromise = null) {
     return new AnnotationLayerBuilder({
       pageDiv,
       pdfPage,
       imageResourcesPath,
-      renderInteractiveForms,
+      renderForms,
       linkService: new _pdf_link_service.SimpleLinkService(),
       l10n,
       annotationStorage,
       enableScripting,
       hasJSActionsPromise,
+      fieldObjectsPromise,
       mouseState
     });
   }
@@ -11316,7 +11418,7 @@ class DefaultAnnotationLayerFactory {
 exports.DefaultAnnotationLayerFactory = DefaultAnnotationLayerFactory;
 
 /***/ }),
-/* 30 */
+/* 29 */
 /***/ ((__unused_webpack_module, exports) => {
 
 
@@ -11444,7 +11546,7 @@ const NullL10n = {
 exports.NullL10n = NullL10n;
 
 /***/ }),
-/* 31 */
+/* 30 */
 /***/ ((__unused_webpack_module, exports, __webpack_require__) => {
 
 
@@ -11454,17 +11556,17 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports.PDFPageView = void 0;
 
-var _ui_utils = __webpack_require__(4);
+var _pdfjsLib = __webpack_require__(4);
 
-var _pdfjsLib = __webpack_require__(5);
+var _ui_utils = __webpack_require__(3);
 
-var _l10n_utils = __webpack_require__(30);
+var _app_options = __webpack_require__(1);
 
-var _pdf_rendering_queue = __webpack_require__(8);
+var _l10n_utils = __webpack_require__(29);
 
-var _viewer_compatibility = __webpack_require__(2);
+var _pdf_rendering_queue = __webpack_require__(7);
 
-const MAX_CANVAS_PIXELS = _viewer_compatibility.viewerCompatibilityParams.maxCanvasPixels || 16777216;
+const MAX_CANVAS_PIXELS = _app_options.compatibilityParams.maxCanvasPixels || 16777216;
 
 class PDFPageView {
   constructor(options) {
@@ -11480,9 +11582,9 @@ class PDFPageView {
     this.pdfPageRotate = defaultViewport.rotation;
     this._optionalContentConfigPromise = options.optionalContentConfigPromise || null;
     this.hasRestrictedScaling = false;
-    this.textLayerMode = Number.isInteger(options.textLayerMode) ? options.textLayerMode : _ui_utils.TextLayerMode.ENABLE;
+    this.textLayerMode = options.textLayerMode ?? _ui_utils.TextLayerMode.ENABLE;
+    this._annotationMode = options.annotationMode ?? _pdfjsLib.AnnotationMode.ENABLE_FORMS;
     this.imageResourcesPath = options.imageResourcesPath || "";
-    this.renderInteractiveForms = options.renderInteractiveForms !== false;
     this.useOnlyCssZoom = options.useOnlyCssZoom || false;
     this.maxCanvasPixels = options.maxCanvasPixels || MAX_CANVAS_PIXELS;
     this.eventBus = options.eventBus;
@@ -11490,6 +11592,7 @@ class PDFPageView {
     this.textLayerFactory = options.textLayerFactory;
     this.annotationLayerFactory = options.annotationLayerFactory;
     this.xfaLayerFactory = options.xfaLayerFactory;
+    this.textHighlighter = options.textHighlighterFactory?.createTextHighlighter(this.id - 1, this.eventBus);
     this.structTreeLayerFactory = options.structTreeLayerFactory;
     this.renderer = options.renderer || _ui_utils.RendererType.CANVAS;
     this.l10n = options.l10n || _l10n_utils.NullL10n;
@@ -11498,6 +11601,7 @@ class PDFPageView {
     this.renderingState = _pdf_rendering_queue.RenderingStates.INITIAL;
     this.resume = null;
     this._renderError = null;
+    this._isStandalone = !this.renderingQueue?.hasViewer();
     this.annotationLayer = null;
     this.textLayer = null;
     this.zoomLayer = null;
@@ -11523,7 +11627,7 @@ class PDFPageView {
     this.pdfPageRotate = pdfPage.rotate;
     const totalRotation = (this.rotation + this.pdfPageRotate) % 360;
     this.viewport = pdfPage.getViewport({
-      scale: this.scale * _ui_utils.CSS_UNITS,
+      scale: this.scale * _pdfjsLib.PixelsPerInch.PDF_TO_CSS_UNITS,
       rotation: totalRotation
     });
     this.reset();
@@ -11557,7 +11661,11 @@ class PDFPageView {
     let error = null;
 
     try {
-      await this.xfaLayer.render(this.viewport, "display");
+      const result = await this.xfaLayer.render(this.viewport, "display");
+
+      if (this.textHighlighter) {
+        this._buildXfaTextContentItems(result.textDivs);
+      }
     } catch (ex) {
       error = ex;
     } finally {
@@ -11567,6 +11675,18 @@ class PDFPageView {
         error
       });
     }
+  }
+
+  async _buildXfaTextContentItems(textDivs) {
+    const text = await this.pdfPage.getTextContent();
+    const items = [];
+
+    for (const item of text.items) {
+      items.push(item.str);
+    }
+
+    this.textHighlighter.setTextMapping(textDivs, items);
+    this.textHighlighter.enable();
   }
 
   _resetZoomLayer(removeFromDOM = false) {
@@ -11652,10 +11772,24 @@ class PDFPageView {
     div.appendChild(this.loadingIconDiv);
   }
 
-  update(scale, rotation, optionalContentConfigPromise = null) {
+  update({
+    scale = 0,
+    rotation = null,
+    optionalContentConfigPromise = null
+  }) {
+    if (typeof arguments[0] !== "object") {
+      console.error("PDFPageView.update called with separate parameters, please use an object instead.");
+      this.update({
+        scale: arguments[0],
+        rotation: arguments[1],
+        optionalContentConfigPromise: arguments[2]
+      });
+      return;
+    }
+
     this.scale = scale || this.scale;
 
-    if (typeof rotation !== "undefined") {
+    if (typeof rotation === "number") {
       this.rotation = rotation;
     }
 
@@ -11663,9 +11797,14 @@ class PDFPageView {
       this._optionalContentConfigPromise = optionalContentConfigPromise;
     }
 
+    if (this._isStandalone) {
+      const doc = document.documentElement;
+      doc.style.setProperty("--zoom-factor", this.scale);
+    }
+
     const totalRotation = (this.rotation + this.pdfPageRotate) % 360;
     this.viewport = this.viewport.clone({
-      scale: this.scale * _ui_utils.CSS_UNITS,
+      scale: this.scale * _pdfjsLib.PixelsPerInch.PDF_TO_CSS_UNITS,
       rotation: totalRotation
     });
 
@@ -11755,6 +11894,7 @@ class PDFPageView {
     if (this.xfaLayer && (!keepXfaLayer || !this.xfaLayer.div)) {
       this.xfaLayer.cancel();
       this.xfaLayer = null;
+      this.textHighlighter?.disable();
     }
 
     if (this._onTextLayerRendered) {
@@ -11897,7 +12037,7 @@ class PDFPageView {
         div.appendChild(textLayerDiv);
       }
 
-      textLayer = this.textLayerFactory.createTextLayerBuilder(textLayerDiv, this.id - 1, this.viewport, this.textLayerMode === _ui_utils.TextLayerMode.ENABLE_ENHANCE, this.eventBus);
+      textLayer = this.textLayerFactory.createTextLayerBuilder(textLayerDiv, this.id - 1, this.viewport, this.textLayerMode === _ui_utils.TextLayerMode.ENABLE_ENHANCE, this.eventBus, this.textHighlighter);
     }
 
     this.textLayer = textLayer;
@@ -11976,9 +12116,9 @@ class PDFPageView {
       return finishPaintTask(reason);
     });
 
-    if (this.annotationLayerFactory) {
+    if (this._annotationMode !== _pdfjsLib.AnnotationMode.DISABLE && this.annotationLayerFactory) {
       if (!this.annotationLayer) {
-        this.annotationLayer = this.annotationLayerFactory.createAnnotationLayerBuilder(div, pdfPage, null, this.imageResourcesPath, this.renderInteractiveForms, this.l10n, null, null, null);
+        this.annotationLayer = this.annotationLayerFactory.createAnnotationLayerBuilder(div, pdfPage, null, this.imageResourcesPath, this._annotationMode === _pdfjsLib.AnnotationMode.ENABLE_FORMS, this.l10n, null, null, null, null);
       }
 
       this._renderAnnotationLayer();
@@ -12071,7 +12211,7 @@ class PDFPageView {
 
     if (this.useOnlyCssZoom) {
       const actualSizeViewport = viewport.clone({
-        scale: _ui_utils.CSS_UNITS
+        scale: _pdfjsLib.PixelsPerInch.PDF_TO_CSS_UNITS
       });
       outputScale.sx *= actualSizeViewport.width / viewport.width;
       outputScale.sy *= actualSizeViewport.height / viewport.height;
@@ -12104,7 +12244,7 @@ class PDFPageView {
       canvasContext: ctx,
       transform,
       viewport: this.viewport,
-      renderInteractiveForms: this.renderInteractiveForms,
+      annotationMode: this._annotationMode,
       optionalContentConfigPromise: this._optionalContentConfigPromise
     };
     const renderTask = this.pdfPage.render(renderContext);
@@ -12140,11 +12280,13 @@ class PDFPageView {
 
     const pdfPage = this.pdfPage;
     const actualSizeViewport = this.viewport.clone({
-      scale: _ui_utils.CSS_UNITS
+      scale: _pdfjsLib.PixelsPerInch.PDF_TO_CSS_UNITS
     });
-    const promise = pdfPage.getOperatorList().then(opList => {
+    const promise = pdfPage.getOperatorList({
+      annotationMode: this._annotationMode
+    }).then(opList => {
       ensureNotCancelled();
-      const svgGfx = new _pdfjsLib.SVGGraphics(pdfPage.commonObjs, pdfPage.objs, _viewer_compatibility.viewerCompatibilityParams.disableCreateObjectURL);
+      const svgGfx = new _pdfjsLib.SVGGraphics(pdfPage.commonObjs, pdfPage.objs, _app_options.compatibilityParams.disableCreateObjectURL);
       return svgGfx.getSVG(opList, actualSizeViewport).then(svg => {
         ensureNotCancelled();
         this.svg = svg;
@@ -12184,7 +12326,7 @@ class PDFPageView {
 exports.PDFPageView = PDFPageView;
 
 /***/ }),
-/* 32 */
+/* 31 */
 /***/ ((__unused_webpack_module, exports) => {
 
 
@@ -12310,89 +12452,47 @@ class DefaultStructTreeLayerFactory {
 exports.DefaultStructTreeLayerFactory = DefaultStructTreeLayerFactory;
 
 /***/ }),
-/* 33 */
-/***/ ((__unused_webpack_module, exports, __webpack_require__) => {
+/* 32 */
+/***/ ((__unused_webpack_module, exports) => {
 
 
 
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.TextLayerBuilder = exports.DefaultTextLayerFactory = void 0;
+exports.TextHighlighter = void 0;
 
-var _pdfjsLib = __webpack_require__(5);
-
-const EXPAND_DIVS_TIMEOUT = 300;
-
-class TextLayerBuilder {
+class TextHighlighter {
   constructor({
-    textLayerDiv,
+    findController,
     eventBus,
-    pageIndex,
-    viewport,
-    findController = null,
-    enhanceTextSelection = false
+    pageIndex
   }) {
-    this.textLayerDiv = textLayerDiv;
-    this.eventBus = eventBus;
-    this.textContent = null;
-    this.textContentItemsStr = [];
-    this.textContentStream = null;
-    this.renderingDone = false;
-    this.pageIdx = pageIndex;
-    this.pageNumber = this.pageIdx + 1;
-    this.matches = [];
-    this.viewport = viewport;
-    this.textDivs = [];
     this.findController = findController;
-    this.textLayerRenderTask = null;
-    this.enhanceTextSelection = enhanceTextSelection;
+    this.matches = [];
+    this.eventBus = eventBus;
+    this.pageIdx = pageIndex;
     this._onUpdateTextLayerMatches = null;
-
-    this._bindMouse();
+    this.textDivs = null;
+    this.textContentItemsStr = null;
+    this.enabled = false;
   }
 
-  _finishRendering() {
-    this.renderingDone = true;
-
-    if (!this.enhanceTextSelection) {
-      const endOfContent = document.createElement("div");
-      endOfContent.className = "endOfContent";
-      this.textLayerDiv.appendChild(endOfContent);
-    }
-
-    this.eventBus.dispatch("textlayerrendered", {
-      source: this,
-      pageNumber: this.pageNumber,
-      numTextDivs: this.textDivs.length
-    });
+  setTextMapping(divs, texts) {
+    this.textDivs = divs;
+    this.textContentItemsStr = texts;
   }
 
-  render(timeout = 0) {
-    if (!(this.textContent || this.textContentStream) || this.renderingDone) {
-      return;
+  enable() {
+    if (!this.textDivs || !this.textContentItemsStr) {
+      throw new Error("Text divs and strings have not been set.");
     }
 
-    this.cancel();
-    this.textDivs = [];
-    const textLayerFrag = document.createDocumentFragment();
-    this.textLayerRenderTask = (0, _pdfjsLib.renderTextLayer)({
-      textContent: this.textContent,
-      textContentStream: this.textContentStream,
-      container: textLayerFrag,
-      viewport: this.viewport,
-      textDivs: this.textDivs,
-      textContentItemsStr: this.textContentItemsStr,
-      timeout,
-      enhanceTextSelection: this.enhanceTextSelection
-    });
-    this.textLayerRenderTask.promise.then(() => {
-      this.textLayerDiv.appendChild(textLayerFrag);
+    if (this.enabled) {
+      throw new Error("TextHighlighter is already enabled.");
+    }
 
-      this._finishRendering();
-
-      this._updateMatches();
-    }, function (reason) {});
+    this.enabled = true;
 
     if (!this._onUpdateTextLayerMatches) {
       this._onUpdateTextLayerMatches = evt => {
@@ -12403,29 +12503,22 @@ class TextLayerBuilder {
 
       this.eventBus._on("updatetextlayermatches", this._onUpdateTextLayerMatches);
     }
+
+    this._updateMatches();
   }
 
-  cancel() {
-    if (this.textLayerRenderTask) {
-      this.textLayerRenderTask.cancel();
-      this.textLayerRenderTask = null;
+  disable() {
+    if (!this.enabled) {
+      return;
     }
+
+    this.enabled = false;
 
     if (this._onUpdateTextLayerMatches) {
       this.eventBus._off("updatetextlayermatches", this._onUpdateTextLayerMatches);
 
       this._onUpdateTextLayerMatches = null;
     }
-  }
-
-  setTextContentStream(readableStream) {
-    this.cancel();
-    this.textContentStream = readableStream;
-  }
-
-  setTextContent(textContent) {
-    this.cancel();
-    this.textContent = textContent;
   }
 
   _convertMatches(matches, matchesLength) {
@@ -12483,7 +12576,9 @@ class TextLayerBuilder {
 
     const {
       findController,
-      pageIdx,
+      pageIdx
+    } = this;
+    const {
       textContentItemsStr,
       textDivs
     } = this;
@@ -12503,7 +12598,16 @@ class TextLayerBuilder {
     }
 
     function appendTextToDiv(divIdx, fromOffset, toOffset, className) {
-      const div = textDivs[divIdx];
+      let div = textDivs[divIdx];
+
+      if (div.nodeType === Node.TEXT_NODE) {
+        const span = document.createElement("span");
+        div.parentNode.insertBefore(span, div);
+        span.appendChild(div);
+        textDivs[divIdx] = span;
+        div = span;
+      }
+
       const content = textContentItemsStr[divIdx].substring(fromOffset, toOffset);
       const node = document.createTextNode(content);
 
@@ -12577,14 +12681,16 @@ class TextLayerBuilder {
   }
 
   _updateMatches() {
-    if (!this.renderingDone) {
+    if (!this.enabled) {
       return;
     }
 
     const {
       findController,
       matches,
-      pageIdx,
+      pageIdx
+    } = this;
+    const {
       textContentItemsStr,
       textDivs
     } = this;
@@ -12612,6 +12718,113 @@ class TextLayerBuilder {
     this.matches = this._convertMatches(pageMatches, pageMatchesLength);
 
     this._renderMatches(this.matches);
+  }
+
+}
+
+exports.TextHighlighter = TextHighlighter;
+
+/***/ }),
+/* 33 */
+/***/ ((__unused_webpack_module, exports, __webpack_require__) => {
+
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports.TextLayerBuilder = exports.DefaultTextLayerFactory = void 0;
+
+var _pdfjsLib = __webpack_require__(4);
+
+const EXPAND_DIVS_TIMEOUT = 300;
+
+class TextLayerBuilder {
+  constructor({
+    textLayerDiv,
+    eventBus,
+    pageIndex,
+    viewport,
+    highlighter = null,
+    enhanceTextSelection = false
+  }) {
+    this.textLayerDiv = textLayerDiv;
+    this.eventBus = eventBus;
+    this.textContent = null;
+    this.textContentItemsStr = [];
+    this.textContentStream = null;
+    this.renderingDone = false;
+    this.pageNumber = pageIndex + 1;
+    this.viewport = viewport;
+    this.textDivs = [];
+    this.textLayerRenderTask = null;
+    this.highlighter = highlighter;
+    this.enhanceTextSelection = enhanceTextSelection;
+
+    this._bindMouse();
+  }
+
+  _finishRendering() {
+    this.renderingDone = true;
+
+    if (!this.enhanceTextSelection) {
+      const endOfContent = document.createElement("div");
+      endOfContent.className = "endOfContent";
+      this.textLayerDiv.appendChild(endOfContent);
+    }
+
+    this.eventBus.dispatch("textlayerrendered", {
+      source: this,
+      pageNumber: this.pageNumber,
+      numTextDivs: this.textDivs.length
+    });
+  }
+
+  render(timeout = 0) {
+    if (!(this.textContent || this.textContentStream) || this.renderingDone) {
+      return;
+    }
+
+    this.cancel();
+    this.textDivs.length = 0;
+    this.highlighter?.setTextMapping(this.textDivs, this.textContentItemsStr);
+    const textLayerFrag = document.createDocumentFragment();
+    this.textLayerRenderTask = (0, _pdfjsLib.renderTextLayer)({
+      textContent: this.textContent,
+      textContentStream: this.textContentStream,
+      container: textLayerFrag,
+      viewport: this.viewport,
+      textDivs: this.textDivs,
+      textContentItemsStr: this.textContentItemsStr,
+      timeout,
+      enhanceTextSelection: this.enhanceTextSelection
+    });
+    this.textLayerRenderTask.promise.then(() => {
+      this.textLayerDiv.appendChild(textLayerFrag);
+
+      this._finishRendering();
+
+      this.highlighter?.enable();
+    }, function (reason) {});
+  }
+
+  cancel() {
+    if (this.textLayerRenderTask) {
+      this.textLayerRenderTask.cancel();
+      this.textLayerRenderTask = null;
+    }
+
+    this.highlighter?.disable();
+  }
+
+  setTextContentStream(readableStream) {
+    this.cancel();
+    this.textContentStream = readableStream;
+  }
+
+  setTextContent(textContent) {
+    this.cancel();
+    this.textContent = textContent;
   }
 
   _bindMouse() {
@@ -12674,13 +12887,14 @@ class TextLayerBuilder {
 exports.TextLayerBuilder = TextLayerBuilder;
 
 class DefaultTextLayerFactory {
-  createTextLayerBuilder(textLayerDiv, pageIndex, viewport, enhanceTextSelection = false, eventBus) {
+  createTextLayerBuilder(textLayerDiv, pageIndex, viewport, enhanceTextSelection = false, eventBus, highlighter) {
     return new TextLayerBuilder({
       textLayerDiv,
       pageIndex,
       viewport,
       enhanceTextSelection,
-      eventBus
+      eventBus,
+      highlighter
     });
   }
 
@@ -12699,19 +12913,23 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports.XfaLayerBuilder = exports.DefaultXfaLayerFactory = void 0;
 
-var _pdfjsLib = __webpack_require__(5);
+var _pdf_link_service = __webpack_require__(18);
+
+var _pdfjsLib = __webpack_require__(4);
 
 class XfaLayerBuilder {
   constructor({
     pageDiv,
     pdfPage,
-    xfaHtml,
-    annotationStorage
+    annotationStorage,
+    linkService,
+    xfaHtml
   }) {
     this.pageDiv = pageDiv;
     this.pdfPage = pdfPage;
-    this.xfaHtml = xfaHtml;
     this.annotationStorage = annotationStorage;
+    this.linkService = linkService;
+    this.xfaHtml = xfaHtml;
     this.div = null;
     this._cancelled = false;
   }
@@ -12726,20 +12944,23 @@ class XfaLayerBuilder {
         xfa: this.xfaHtml,
         page: null,
         annotationStorage: this.annotationStorage,
+        linkService: this.linkService,
         intent
       };
       const div = document.createElement("div");
       this.pageDiv.appendChild(div);
       parameters.div = div;
 
-      _pdfjsLib.XfaLayer.render(parameters);
+      const result = _pdfjsLib.XfaLayer.render(parameters);
 
-      return Promise.resolve();
+      return Promise.resolve(result);
     }
 
     return this.pdfPage.getXfa().then(xfa => {
-      if (this._cancelled) {
-        return;
+      if (this._cancelled || !xfa) {
+        return {
+          textDivs: []
+        };
       }
 
       const parameters = {
@@ -12750,18 +12971,18 @@ class XfaLayerBuilder {
         xfa,
         page: this.pdfPage,
         annotationStorage: this.annotationStorage,
+        linkService: this.linkService,
         intent
       };
 
       if (this.div) {
-        _pdfjsLib.XfaLayer.update(parameters);
-      } else {
-        this.div = document.createElement("div");
-        this.pageDiv.appendChild(this.div);
-        parameters.div = this.div;
-
-        _pdfjsLib.XfaLayer.render(parameters);
+        return _pdfjsLib.XfaLayer.update(parameters);
       }
+
+      this.div = document.createElement("div");
+      this.pageDiv.appendChild(this.div);
+      parameters.div = this.div;
+      return _pdfjsLib.XfaLayer.render(parameters);
     }).catch(error => {
       console.error(error);
     });
@@ -12789,6 +13010,7 @@ class DefaultXfaLayerFactory {
       pageDiv,
       pdfPage,
       annotationStorage,
+      linkService: new _pdf_link_service.SimpleLinkService(),
       xfaHtml
     });
   }
@@ -12808,9 +13030,9 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports.SecondaryToolbar = void 0;
 
-var _ui_utils = __webpack_require__(4);
+var _ui_utils = __webpack_require__(3);
 
-var _pdf_cursor_tools = __webpack_require__(6);
+var _pdf_cursor_tools = __webpack_require__(5);
 
 var _pdf_single_page_viewer = __webpack_require__(36);
 
@@ -13127,9 +13349,9 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports.PDFSinglePageViewer = void 0;
 
-var _base_viewer = __webpack_require__(28);
+var _base_viewer = __webpack_require__(27);
 
-var _pdfjsLib = __webpack_require__(5);
+var _pdfjsLib = __webpack_require__(4);
 
 class PDFSinglePageViewer extends _base_viewer.BaseViewer {
   constructor(options) {
@@ -13256,11 +13478,9 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports.Toolbar = void 0;
 
-var _ui_utils = __webpack_require__(4);
+var _ui_utils = __webpack_require__(3);
 
 const PAGE_NUMBER_LOADING_INDICATOR = "visiblePageIsLoading";
-const SCALE_SELECT_CONTAINER_WIDTH = 140;
-const SCALE_SELECT_WIDTH = 162;
 
 class Toolbar {
   constructor(options, eventBus, l10n) {
@@ -13298,7 +13518,6 @@ class Toolbar {
     this.items = {
       numPages: options.numPages,
       pageNumber: options.pageNumber,
-      scaleSelectContainer: options.scaleSelectContainer,
       scaleSelect: options.scaleSelect,
       customScaleOption: options.customScaleOption,
       previous: options.previous,
@@ -13480,17 +13699,16 @@ class Toolbar {
       l10n
     } = this;
     const predefinedValuesPromise = Promise.all([l10n.get("page_scale_auto"), l10n.get("page_scale_actual"), l10n.get("page_scale_fit"), l10n.get("page_scale_width")]);
+    const style = getComputedStyle(items.scaleSelect),
+          scaleSelectContainerWidth = parseInt(style.getPropertyValue("--scale-select-container-width"), 10),
+          scaleSelectOverflow = parseInt(style.getPropertyValue("--scale-select-overflow"), 10);
     let canvas = document.createElement("canvas");
     canvas.mozOpaque = true;
     let ctx = canvas.getContext("2d", {
       alpha: false
     });
     await _ui_utils.animationStarted;
-    const {
-      fontSize,
-      fontFamily
-    } = getComputedStyle(items.scaleSelect);
-    ctx.font = `${fontSize} ${fontFamily}`;
+    ctx.font = `${style.fontSize} ${style.fontFamily}`;
     let maxWidth = 0;
 
     for (const predefinedValue of await predefinedValuesPromise) {
@@ -13503,12 +13721,11 @@ class Toolbar {
       }
     }
 
-    const overflow = SCALE_SELECT_WIDTH - SCALE_SELECT_CONTAINER_WIDTH;
-    maxWidth += 2 * overflow;
+    maxWidth += 2 * scaleSelectOverflow;
 
-    if (maxWidth > SCALE_SELECT_CONTAINER_WIDTH) {
-      items.scaleSelect.style.width = `${maxWidth + overflow}px`;
-      items.scaleSelectContainer.style.width = `${maxWidth}px`;
+    if (maxWidth > scaleSelectContainerWidth) {
+      const doc = document.documentElement;
+      doc.style.setProperty("--scale-select-container-width", `${maxWidth}px`);
     }
 
     canvas.width = 0;
@@ -13570,11 +13787,11 @@ class ViewHistory {
 
   async _writeToStorage() {
     const databaseStr = JSON.stringify(this.database);
-    // localStorage.setItem("pdfjs.history", databaseStr);
+    localStorage.setItem("pdfjs.history", databaseStr);
   }
 
   async _readFromStorage() {
-    return // localStorage.getItem("pdfjs.history");
+    return localStorage.getItem("pdfjs.history");
   }
 
   async set(name, val) {
@@ -13626,7 +13843,7 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports.GenericCom = void 0;
 
-var _app = __webpack_require__(3);
+var _app = __webpack_require__(2);
 
 var _preferences = __webpack_require__(40);
 
@@ -13642,11 +13859,11 @@ exports.GenericCom = GenericCom;
 
 class GenericPreferences extends _preferences.BasePreferences {
   async _writeToStorage(prefObj) {
-    // localStorage.setItem("pdfjs.preferences", JSON.stringify(prefObj));
+    localStorage.setItem("pdfjs.preferences", JSON.stringify(prefObj));
   }
 
   async _readFromStorage(prefObj) {
-    return // JSON.parse(localStorage.getItem("pdfjs.preferences"));
+    return JSON.parse(localStorage.getItem("pdfjs.preferences"));
   }
 
 }
@@ -13697,6 +13914,7 @@ class BasePreferences {
 
     Object.defineProperty(this, "defaults", {
       value: Object.freeze({
+        "annotationMode": 2,
         "cursorToolOnLoad": 0,
         "defaultZoomValue": "",
         "disablePageLabels": false,
@@ -13708,7 +13926,6 @@ class BasePreferences {
         "ignoreDestinationZoom": false,
         "pdfBugEnabled": false,
         "renderer": "canvas",
-        "renderInteractiveForms": true,
         "sidebarViewOnLoad": -1,
         "scrollModeOnLoad": -1,
         "spreadModeOnLoad": -1,
@@ -13720,7 +13937,7 @@ class BasePreferences {
         "disableFontFace": false,
         "disableRange": false,
         "disableStream": false,
-        "enableXfa": false
+        "enableXfa": true
       }),
       writable: false,
       enumerable: true,
@@ -13820,9 +14037,9 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports.DownloadManager = void 0;
 
-var _pdfjsLib = __webpack_require__(5);
+var _pdfjsLib = __webpack_require__(4);
 
-var _viewer_compatibility = __webpack_require__(2);
+var _app_options = __webpack_require__(1);
 
 ;
 
@@ -13852,6 +14069,7 @@ class DownloadManager {
 
   downloadUrl(url, filename) {
     if (!(0, _pdfjsLib.createValidAbsoluteUrl)(url, "http://example.com")) {
+      console.error(`downloadUrl - not a valid URL: ${url}`);
       return;
     }
 
@@ -13859,7 +14077,7 @@ class DownloadManager {
   }
 
   downloadData(data, filename, contentType) {
-    const blobUrl = (0, _pdfjsLib.createObjectURL)(data, contentType, _viewer_compatibility.viewerCompatibilityParams.disableCreateObjectURL);
+    const blobUrl = (0, _pdfjsLib.createObjectURL)(data, contentType, _app_options.compatibilityParams.disableCreateObjectURL);
     download(blobUrl, filename);
   }
 
@@ -13867,7 +14085,7 @@ class DownloadManager {
     const isPdfData = (0, _pdfjsLib.isPdfFile)(filename);
     const contentType = isPdfData ? "application/pdf" : "";
 
-    if (isPdfData && !_viewer_compatibility.viewerCompatibilityParams.disableCreateObjectURL) {
+    if (isPdfData && !_app_options.compatibilityParams.disableCreateObjectURL) {
       let blobUrl = this._openBlobUrls.get(element);
 
       if (!blobUrl) {
@@ -13897,7 +14115,7 @@ class DownloadManager {
   }
 
   download(blob, url, filename, sourceEventType = "download") {
-    if (_viewer_compatibility.viewerCompatibilityParams.disableCreateObjectURL) {
+    if (_app_options.compatibilityParams.disableCreateObjectURL) {
       this.downloadUrl(url, filename);
       return;
     }
@@ -13923,7 +14141,7 @@ exports.GenericL10n = void 0;
 
 __webpack_require__(43);
 
-var _l10n_utils = __webpack_require__(30);
+var _l10n_utils = __webpack_require__(29);
 
 const webL10n = document.webL10n;
 
@@ -14587,7 +14805,7 @@ document.webL10n = function (window, document, undefined) {
     var data = gL10nData[key];
 
     if (!data) {
-      // console.warn('#' + key + ' is undefined.');
+      console.warn('#' + key + ' is undefined.');
 
       if (!fallback) {
         return null;
@@ -14652,7 +14870,7 @@ document.webL10n = function (window, document, undefined) {
     var data = getL10nData(l10n.id, l10n.args);
 
     if (!data) {
-      // console.warn('#' + l10n.id + ' is undefined.');
+      console.warn('#' + l10n.id + ' is undefined.');
       return;
     }
 
@@ -14795,7 +15013,7 @@ Object.defineProperty(exports, "__esModule", ({
 exports.docPropertiesLookup = docPropertiesLookup;
 exports.GenericScripting = void 0;
 
-var _pdfjsLib = __webpack_require__(5);
+var _pdfjsLib = __webpack_require__(4);
 
 async function docPropertiesLookup(pdfDocument) {
   const url = "",
@@ -14862,18 +15080,20 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports.PDFPrintService = PDFPrintService;
 
-var _app = __webpack_require__(3);
+var _pdfjsLib = __webpack_require__(4);
+
+var _app = __webpack_require__(2);
+
+var _app_options = __webpack_require__(1);
 
 var _print_utils = __webpack_require__(46);
-
-var _viewer_compatibility = __webpack_require__(2);
 
 let activeService = null;
 let overlayManager = null;
 
 function renderPage(activeServiceOnEntry, pdfDocument, pageNumber, size, printResolution, optionalContentConfigPromise) {
   const scratchCanvas = activeService.scratchCanvas;
-  const PRINT_UNITS = printResolution / 72.0;
+  const PRINT_UNITS = printResolution / _pdfjsLib.PixelsPerInch.PDF;
   scratchCanvas.width = Math.floor(size.width * PRINT_UNITS);
   scratchCanvas.height = Math.floor(size.height * PRINT_UNITS);
   const ctx = scratchCanvas.getContext("2d");
@@ -14890,7 +15110,7 @@ function renderPage(activeServiceOnEntry, pdfDocument, pageNumber, size, printRe
         rotation: size.rotation
       }),
       intent: "print",
-      includeAnnotationStorage: true,
+      annotationMode: _pdfjsLib.AnnotationMode.ENABLE_STORAGE,
       optionalContentConfigPromise
     };
     return pdfPage.render(renderContext).promise;
@@ -14985,7 +15205,7 @@ PDFPrintService.prototype = {
     const img = document.createElement("img");
     const scratchCanvas = this.scratchCanvas;
 
-    if ("toBlob" in scratchCanvas && !_viewer_compatibility.viewerCompatibilityParams.disableCreateObjectURL) {
+    if ("toBlob" in scratchCanvas && !_app_options.compatibilityParams.disableCreateObjectURL) {
       scratchCanvas.toBlob(function (blob) {
         img.src = URL.createObjectURL(blob);
       });
@@ -15095,9 +15315,6 @@ function renderProgress(index, total, l10n) {
 
 window.addEventListener("keydown", function (event) {
   if (event.keyCode === 80 && (event.ctrlKey || event.metaKey) && !event.altKey && (!event.shiftKey || window.chrome || window.opera)) {
-    if (window.parent !== window) {
-      return;
-    }
     window.print();
     event.preventDefault();
 
@@ -15162,16 +15379,14 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports.getXfaHtmlForPrinting = getXfaHtmlForPrinting;
 
-var _ui_utils = __webpack_require__(4);
+var _pdfjsLib = __webpack_require__(4);
 
 var _xfa_layer_builder = __webpack_require__(34);
-
-var _pdfjsLib = __webpack_require__(5);
 
 function getXfaHtmlForPrinting(printContainer, pdfDocument) {
   const xfaHtml = pdfDocument.allXfaHtml;
   const factory = new _xfa_layer_builder.DefaultXfaLayerFactory();
-  const scale = Math.round(_ui_utils.CSS_UNITS * 100) / 100;
+  const scale = Math.round(_pdfjsLib.PixelsPerInch.PDF_TO_CSS_UNITS * 100) / 100;
 
   for (const xfaPage of xfaHtml.children) {
     const page = document.createElement("div");
@@ -15237,10 +15452,10 @@ Object.defineProperty(exports, "PDFViewerApplication", ({
 
 var _app_options = __webpack_require__(1);
 
-var _app = __webpack_require__(3);
+var _app = __webpack_require__(2);
 
-const pdfjsVersion = '2.10.377';
-const pdfjsBuild = '156762c48';
+const pdfjsVersion = '2.11.338';
+const pdfjsBuild = 'dedff3c98';
 window.PDFViewerApplication = _app.PDFViewerApplication;
 window.PDFViewerApplicationOptions = _app_options.AppOptions;
 ;
@@ -15272,7 +15487,6 @@ function getViewerConfiguration() {
       container: document.getElementById("toolbarViewer"),
       numPages: document.getElementById("numPages"),
       pageNumber: document.getElementById("pageNumber"),
-      scaleSelectContainer: document.getElementById("scaleSelectContainer"),
       scaleSelect: document.getElementById("scaleSelect"),
       customScaleOption: document.getElementById("customScaleOption"),
       previous: document.getElementById("previous"),
@@ -15386,7 +15600,7 @@ function webViewerLoad() {
   try {
     parent.document.dispatchEvent(event);
   } catch (ex) {
-    // console.error(`webviewerloaded: ${ex}`);
+    console.error(`webviewerloaded: ${ex}`);
     document.dispatchEvent(event);
   }
 

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -96,7 +96,7 @@ const defaultOptions = {
     kind: OptionKind.VIEWER + OptionKind.PREFERENCE
   },
   enableScripting: {
-    value: true,
+    value: false,
     kind: OptionKind.VIEWER + OptionKind.PREFERENCE
   },
   externalLinkRel: {
@@ -169,7 +169,7 @@ const defaultOptions = {
     kind: OptionKind.API
   },
   cMapUrl: {
-    value: "../web/cmaps/",
+    value: "/cmaps/",
     kind: OptionKind.API
   },
   disableAutoFetch: {
@@ -213,7 +213,7 @@ const defaultOptions = {
     kind: OptionKind.API
   },
   standardFontDataUrl: {
-    value: "../web/standard_fonts/",
+    value: "/standard_fonts/",
     kind: OptionKind.API
   },
   verbosity: {
@@ -221,11 +221,11 @@ const defaultOptions = {
     kind: OptionKind.API
   },
   workerPort: {
-    value: null,
+    value: new Worker('/build/pdf.worker.js'),
     kind: OptionKind.WORKER
   },
   workerSrc: {
-    value: "../build/pdf.worker.js",
+    value: "/build/pdf.worker.js",
     kind: OptionKind.WORKER
   }
 };
@@ -890,7 +890,7 @@ const PDFViewerApplication = {
       }
     }
 
-    this.setTitle(title);
+    // this.setTitle(title);
   },
 
   setTitle(title) {
@@ -8630,7 +8630,7 @@ class PDFSidebar {
       return;
     }
 
-    if (!this._switchView(view, true)) {
+    if (!this._switchView(view, false)) {
       this._dispatchEvent();
     }
   }
@@ -9919,7 +9919,7 @@ class BaseViewer {
     this.downloadManager = options.downloadManager || null;
     this.findController = options.findController || null;
     this._scriptingManager = options.scriptingManager || null;
-    this.removePageBorders = options.removePageBorders || false;
+    this.removePageBorders = options.removePageBorders || true;
     this.textLayerMode = options.textLayerMode ?? _ui_utils.TextLayerMode.ENABLE;
     this._annotationMode = options.annotationMode ?? _pdfjsLib.AnnotationMode.ENABLE_FORMS;
     this.imageResourcesPath = options.imageResourcesPath || "";
@@ -13787,11 +13787,11 @@ class ViewHistory {
 
   async _writeToStorage() {
     const databaseStr = JSON.stringify(this.database);
-    localStorage.setItem("pdfjs.history", databaseStr);
+    // localStorage.setItem("pdfjs.history", databaseStr);
   }
 
   async _readFromStorage() {
-    return localStorage.getItem("pdfjs.history");
+    return // localStorage.getItem("pdfjs.history");
   }
 
   async set(name, val) {
@@ -13859,11 +13859,11 @@ exports.GenericCom = GenericCom;
 
 class GenericPreferences extends _preferences.BasePreferences {
   async _writeToStorage(prefObj) {
-    localStorage.setItem("pdfjs.preferences", JSON.stringify(prefObj));
+    // localStorage.setItem("pdfjs.preferences", JSON.stringify(prefObj));
   }
 
   async _readFromStorage(prefObj) {
-    return JSON.parse(localStorage.getItem("pdfjs.preferences"));
+    return // JSON.parse(localStorage.getItem("pdfjs.preferences"));
   }
 
 }
@@ -14805,7 +14805,7 @@ document.webL10n = function (window, document, undefined) {
     var data = gL10nData[key];
 
     if (!data) {
-      console.warn('#' + key + ' is undefined.');
+      // console.warn('#' + key + ' is undefined.');
 
       if (!fallback) {
         return null;
@@ -14870,7 +14870,7 @@ document.webL10n = function (window, document, undefined) {
     var data = getL10nData(l10n.id, l10n.args);
 
     if (!data) {
-      console.warn('#' + l10n.id + ' is undefined.');
+      // console.warn('#' + l10n.id + ' is undefined.');
       return;
     }
 
@@ -15315,6 +15315,9 @@ function renderProgress(index, total, l10n) {
 
 window.addEventListener("keydown", function (event) {
   if (event.keyCode === 80 && (event.ctrlKey || event.metaKey) && !event.altKey && (!event.shiftKey || window.chrome || window.opera)) {
+    if (window.parent !== window) {
+      return;
+    }
     window.print();
     event.preventDefault();
 
@@ -15600,7 +15603,7 @@ function webViewerLoad() {
   try {
     parent.document.dispatchEvent(event);
   } catch (ex) {
-    console.error(`webviewerloaded: ${ex}`);
+    // console.error(`webviewerloaded: ${ex}`);
     document.dispatchEvent(event);
   }
 


### PR DESCRIPTION
Update PDF.js to v2.11.338

We make the download button available on the secondary toolbar, allowing users to save forms.

- https://github.com/mozilla/pdf.js/pull/14005
