### PR TITLE
Count words on save

### DIFF
--- a/package.json
+++ b/package.json
@@ -1581,7 +1581,7 @@
             "never"
           ],
           "enumDescriptions": [
-           "Count words in the LaTeX documents of the entire project from the root file",
+           "Count words in the current document",
            "Never automatically call texcount"
           ],
           "default": "never",

--- a/package.json
+++ b/package.json
@@ -1147,7 +1147,7 @@
         "latex-workshop.latex.autoBuild.interval": {
           "type": "integer",
           "default": 1000,
-          "markdownDescription": "The minimal time interval between two consecutive auto builds in millisecond."
+          "markdownDescription": "The minimal time interval between two consecutive auto builds in milliseconds."
         },
         "latex-workshop.latex.autoBuild.cleanAndRetry.enabled": {
           "type": "boolean",
@@ -1573,6 +1573,24 @@
           },
           "default": [],
           "markdownDescription": "TeXCount arguments to count words in LaTeX document of the entire project from the root file, or the current document.\nArguments must be in separate strings in the array. Additional arguments, i.e., `-merge %DOC%` for the project and the current document path for counting current file will be appended when constructing the command."
+        },
+        "latex-workshop.texcount.run": {
+          "type": "string",
+          "enum": [
+            "onSave",
+            "manually"
+          ],
+          "enumDescriptions": [
+           "Count words in the current document",
+           "Only call texcount from the TeX badge"
+          ],
+          "default": "manually",
+          "markdownDescription": "When to call `texcount`. Default is manually."
+        },
+        "latex-workshop.texcount.autorun.interval": {
+          "type": "number",
+          "default": 1000,
+          "markdownDescription": "The minimal time interval between two consecutive runs of `texcount` in milliseconds when `latex-workshop.texcount.run` is set to ònSave`."
         },
         "latex-workshop.intellisense.update.aggressive.enabled": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -1572,20 +1572,20 @@
             "type": "string"
           },
           "default": [],
-          "markdownDescription": "TeXCount arguments to count words in LaTeX document of the entire project from the root file, or the current document.\nArguments must be in separate strings in the array. Additional arguments, i.e., `-merge %DOC%` for the project and the current document path for counting current file will be appended when constructing the command."
+          "markdownDescription": "TeXCount arguments to count words in the LaTeX documents of the entire project from the root file, or the current document.\nArguments must be in separate strings in the array. Additional arguments, i.e., `-merge %DOC%` for the project and the current document path for counting current file will be appended when constructing the command."
         },
-        "latex-workshop.texcount.run": {
+        "latex-workshop.texcount.autorun": {
           "type": "string",
           "enum": [
             "onSave",
-            "manually"
+            "never"
           ],
           "enumDescriptions": [
-           "Count words in the current document",
-           "Only call texcount from the TeX badge"
+           "Count words in the LaTeX documents of the entire project from the root file",
+           "Never automatically call texcount"
           ],
-          "default": "manually",
-          "markdownDescription": "When to call `texcount`. Default is manually."
+          "default": "never",
+          "markdownDescription": "When to call `texcount`. Default is never."
         },
         "latex-workshop.texcount.autorun.interval": {
           "type": "number",

--- a/package.json
+++ b/package.json
@@ -1587,10 +1587,10 @@
           "default": "never",
           "markdownDescription": "When to call `texcount`. Default is never."
         },
-        "latex-workshop.texcount.autorun.interval": {
+        "latex-workshop.texcount.interval": {
           "type": "number",
           "default": 1000,
-          "markdownDescription": "The minimal time interval between two consecutive runs of `texcount` in milliseconds when `latex-workshop.texcount.run` is set to ònSave`."
+          "markdownDescription": "The minimal time interval between two consecutive runs of `texcount` in milliseconds when `latex-workshop.texcount.run` is set to `onSave`."
         },
         "latex-workshop.intellisense.update.aggressive.enabled": {
           "type": "boolean",

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -282,12 +282,12 @@ export class Commander {
         if (!vscode.window.activeTextEditor || !this.extension.manager.hasTexId(vscode.window.activeTextEditor.document.languageId) ||
             this.extension.manager.rootFile === vscode.window.activeTextEditor.document.fileName) {
             if (this.extension.manager.rootFile) {
-                void this.extension.counter.count(this.extension.manager.rootFile)
+                this.extension.counter.count(this.extension.manager.rootFile)
             } else {
                 this.extension.logger.addLogMessage('WORDCOUNT: No rootFile defined.')
             }
         } else {
-            void this.extension.counter.count(vscode.window.activeTextEditor.document.fileName, false)
+            this.extension.counter.count(vscode.window.activeTextEditor.document.fileName, false)
         }
     }
 

--- a/src/components/counter.ts
+++ b/src/components/counter.ts
@@ -19,8 +19,8 @@ export class Counter {
 
     constructor(extension: Extension) {
         this.extension = extension
-        // gotoLine status item has priority 100.5
-        this.status = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100.6)
+        // gotoLine status item has priority 100.5 and selectIndentation item has priority 100.4
+        this.status = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100.45)
         this.loadConfiguration()
         vscode.workspace.onDidChangeConfiguration(e => {
             if (e.affectsConfiguration('latex-workshop.texcount') || e.affectsConfiguration('latex-workshop.docker.enabled')) {

--- a/src/components/counter.ts
+++ b/src/components/counter.ts
@@ -70,6 +70,7 @@ export class Counter {
             args.push('-merge')
         }
         args.push(path.basename(file))
+        this.extension.logger.logCommand('Count words using command', command, args)
         const proc = cp.spawn(command, args, {cwd: path.dirname(file)})
         proc.stdout.setEncoding('utf8')
         proc.stderr.setEncoding('utf8')

--- a/src/components/counter.ts
+++ b/src/components/counter.ts
@@ -104,13 +104,6 @@ export class Counter {
                     }
                     void vscode.window.showInformationMessage(`There are ${words[1]} words ${floatMsg}in the ${merge ? 'LaTeX project' : 'opened LaTeX file'}.`)
                 }
-                let msg: string
-                if (stdout === '') {
-                    msg = ''
-                } else {
-                    msg = '\n' + stdout
-                }
-                this.extension.logger.addLogMessage(`TeXCount log:${msg}`)
             }
         })
     }

--- a/src/components/counter.ts
+++ b/src/components/counter.ts
@@ -68,7 +68,7 @@ export class Counter {
         }
     }
 
-    async countOnSaveIfEnabled(file: string) {
+    countOnSaveIfEnabled(file: string) {
         if (!this.autoRunEnabled) {
             return
         }
@@ -79,14 +79,7 @@ export class Counter {
         this.extension.logger.addLogMessage(`Auto texcount started on saving file: ${file}`)
         this.disableCountAfterSave = true
         setTimeout(() => this.disableCountAfterSave = false, this.autoRunInterval)
-        if (this.extension.manager.rootFile === undefined) {
-            await this.extension.manager.findRoot()
-        }
-        if (this.extension.manager.rootFile === undefined) {
-            this.extension.logger.addLogMessage('Cannot find root file')
-            return
-        }
-        void this.runTeXCount(this.extension.manager.rootFile).then(() => {
+        void this.runTeXCount(file).then(() => {
             this.updateWordCount()
         })
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -161,7 +161,7 @@ export function activate(context: vscode.ExtensionContext): ReturnType<typeof ge
                     void extension.manager.buildOnSave(e.fileName)
                 }
             }
-            void extension.counter.countOnSaveIfEnabled(e.fileName)
+            extension.counter.countOnSaveIfEnabled(e.fileName)
         }
     }))
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -161,7 +161,7 @@ export function activate(context: vscode.ExtensionContext): ReturnType<typeof ge
                     void extension.manager.buildOnSave(e.fileName)
                 }
             }
-            if (configuration.get('texcount.run') as string === 'onSave') {
+            if (configuration.get('texcount.autorun') as string === 'onSave') {
                 if (extension.counter.disableCountAfterSave) {
                     extension.logger.addLogMessage('Auto texcount is temporarily disabled during a second.')
                 } else {

--- a/src/main.ts
+++ b/src/main.ts
@@ -161,15 +161,7 @@ export function activate(context: vscode.ExtensionContext): ReturnType<typeof ge
                     void extension.manager.buildOnSave(e.fileName)
                 }
             }
-            if (configuration.get('texcount.autorun') as string === 'onSave') {
-                if (extension.counter.disableCountAfterSave) {
-                    extension.logger.addLogMessage('Auto texcount is temporarily disabled during a second.')
-                } else {
-                    extension.logger.addLogMessage(`Auto texcount started on saving file: ${e.fileName}`)
-                    void extension.counter.countOnSave()
-                }
-
-            }
+            void extension.counter.countOnSaveIfEnabled(e.fileName)
         }
     }))
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -156,10 +156,19 @@ export function activate(context: vscode.ExtensionContext): ReturnType<typeof ge
             if (configuration.get('latex.autoBuild.run') as string === BuildEvents.onSave) {
                 if (extension.builder.disableBuildAfterSave) {
                     extension.logger.addLogMessage('Auto Build Run is temporarily disabled during a second.')
-                    return
+                } else {
+                    extension.logger.addLogMessage(`Auto build started on saving file: ${e.fileName}`)
+                    void extension.manager.buildOnSave(e.fileName)
                 }
-                extension.logger.addLogMessage(`Auto build started on saving file: ${e.fileName}`)
-                void extension.manager.buildOnSave(e.fileName)
+            }
+            if (configuration.get('texcount.run') as string === 'onSave') {
+                if (extension.counter.disableCountAfterSave) {
+                    extension.logger.addLogMessage('Auto texcount is temporarily disabled during a second.')
+                } else {
+                    extension.logger.addLogMessage(`Auto texcount started on saving file: ${e.fileName}`)
+                    void extension.counter.countOnSave()
+                }
+
             }
         }
     }))


### PR DESCRIPTION
This PR adds a configuration variable `latex-workshop.texcount.autorun` to enable `texcount`to be automatically called on the entire project on fie save.

Close #3041