### PR TITLE
Clean onDidSaveTextDocument

### DIFF
--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -902,11 +902,16 @@ export class Manager {
         return this.autoBuild(file, bibChanged)
     }
 
-    buildOnSave(file: string) {
+    buildOnSaveIfEnabled(file: string) {
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         if (configuration.get('latex.autoBuild.run') as string !== BuildEvents.onSave) {
             return
         }
+        if (this.extension.builder.disableBuildAfterSave) {
+            this.extension.logger.addLogMessage('Auto Build Run is temporarily disabled during a second.')
+            return
+        }
+        this.extension.logger.addLogMessage(`Auto build started on saving file: ${file}`)
         return this.autoBuild(file, false)
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,7 @@ import {Commander} from './commander'
 import {LaTeXCommander} from './components/commander'
 import {Logger} from './components/logger'
 import {LwFileSystem} from './components/lwfs'
-import {Manager, BuildEvents} from './components/manager'
+import {Manager} from './components/manager'
 import {Builder} from './components/builder'
 import {Viewer, PdfViewerHookProvider} from './components/viewer'
 import {Server} from './components/server'
@@ -152,15 +152,7 @@ export function activate(context: vscode.ExtensionContext): ReturnType<typeof ge
             extension.linter.lintRootFileIfEnabled()
             extension.structureProvider.refresh()
             extension.structureProvider.update()
-            const configuration = vscode.workspace.getConfiguration('latex-workshop')
-            if (configuration.get('latex.autoBuild.run') as string === BuildEvents.onSave) {
-                if (extension.builder.disableBuildAfterSave) {
-                    extension.logger.addLogMessage('Auto Build Run is temporarily disabled during a second.')
-                } else {
-                    extension.logger.addLogMessage(`Auto build started on saving file: ${e.fileName}`)
-                    void extension.manager.buildOnSave(e.fileName)
-                }
-            }
+            void extension.manager.buildOnSaveIfEnabled(e.fileName)
             extension.counter.countOnSaveIfEnabled(e.fileName)
         }
     }))


### PR DESCRIPTION
Move all the logic of build on save out of `main.ts`. This is a follow up on https://github.com/James-Yu/LaTeX-Workshop/pull/3046#discussion_r780722659