### PR TITLE
Use String.substring instead of the deprecated method String.substr

### DIFF
--- a/src/commander.ts
+++ b/src/commander.ts
@@ -432,7 +432,7 @@ export class Commander {
         const line = editor.document.lineAt(cursorPos.line)
 
         // if the cursor is not followed by only spaces/eol, insert a plain newline
-        if (line.text.substr(cursorPos.character).split(' ').length - 1 !== line.range.end.character - cursorPos.character) {
+        if (line.text.substring(cursorPos.character).split(' ').length - 1 !== line.range.end.character - cursorPos.character) {
             return editor.edit(() =>
                 vscode.commands.executeCommand('type', { source: 'keyboard', text: '\n' })
             )

--- a/src/components/locator.ts
+++ b/src/components/locator.ts
@@ -48,11 +48,11 @@ export class Locator {
             if (pos < 0) {
                 continue
             }
-            const key = line.substr(0, pos).toLowerCase()
+            const key = line.substring(0, pos).toLowerCase()
             if (key !== 'page' && key !== 'x' && key !== 'y' ) {
                 continue
             }
-            const value = line.substr(pos + 1)
+            const value = line.substring(pos + 1)
             record[key] = Number(value)
         }
         if (record.page !== undefined && record.x !== undefined && record.y !== undefined) {
@@ -80,11 +80,11 @@ export class Locator {
             if (pos < 0) {
                 continue
             }
-            const key = line.substr(0, pos).toLowerCase()
+            const key = line.substring(0, pos).toLowerCase()
             if (key !== 'input' && key !== 'line' && key !== 'column' ) {
                 continue
             }
-            const value = line.substr(pos + 1)
+            const value = line.substring(pos + 1)
             if (key === 'line' || key === 'column') {
                 record[key] = Number(value)
                 continue

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -277,7 +277,7 @@ export class Manager {
         if (respectOutDir) {
             outDir = this.getOutDir(texPath)
         }
-        return path.resolve(path.dirname(texPath), outDir, path.basename(`${texPath.substr(0, texPath.lastIndexOf('.'))}.pdf`))
+        return path.resolve(path.dirname(texPath), outDir, path.basename(`${texPath.substring(0, texPath.lastIndexOf('.'))}.pdf`))
     }
 
     ignorePdfFile(rootFile: string) {

--- a/src/components/parser/latexlog.ts
+++ b/src/components/parser/latexlog.ts
@@ -211,7 +211,7 @@ export class LatexLogParser {
     private parseLaTeXFileStack(line: string, fileStack: string[], nested: number): number {
         const result = line.match(/(\(|\))/)
         if (result && result.index !== undefined && result.index > -1) {
-            line = line.substr(result.index + 1)
+            line = line.substring(result.index + 1)
             if (result[1] === '(') {
                 const pathResult = line.match(/^"?((?:(?:[a-zA-Z]:|\.|\/)?(?:\/|\\\\?))[^"()[\]]*)/)
                 const mikTeXPathResult = line.match(/^"?([^"()[\]]*\.[a-z]{3,})/)

--- a/src/providers/completer/command.ts
+++ b/src/providers/completer/command.ts
@@ -209,7 +209,7 @@ export class Command implements IProvider {
         const name = item.filterText ? item.filterText : label
         if (removeArgs) {
             const i = name.search(/[[{]/)
-            return i > -1 ? name.substr(0, i): name
+            return i > -1 ? name.substring(0, i): name
         }
         return name
     }

--- a/src/providers/completer/commandlib/commandfinder.ts
+++ b/src/providers/completer/commandlib/commandfinder.ts
@@ -230,7 +230,7 @@ export class CommandFinder {
                 file,
                 location: new vscode.Location(
                     vscode.Uri.file(file),
-                    new vscode.Position(content.substr(0, result.index).split('\n').length - 1, 0))
+                    new vscode.Position(content.substring(0, result.index).split('\n').length - 1, 0))
             })
         }
 

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -84,7 +84,7 @@ export class Completer implements vscode.CompletionItemProvider {
         if (position.character > 1 && currentLine[position.character - 1] === '\\' && currentLine[position.character - 2] === '\\') {
             return
         }
-        const line = document.lineAt(position.line).text.substr(0, position.character)
+        const line = document.lineAt(position.line).text.substring(0, position.character)
         // Note that the order of the following array affects the result.
         // 'command' must be at the last because it matches any commands.
         for (const type of ['citation', 'reference', 'environment', 'package', 'documentclass', 'input', 'subimport', 'import', 'includeonly', 'glossary', 'command']) {
@@ -225,7 +225,7 @@ export class SnippetCompleter implements vscode.CompletionItemProvider {
         token: vscode.CancellationToken,
         context: vscode.CompletionContext
     ): vscode.CompletionItem[] | undefined {
-        const line = document.lineAt(position.line).text.substr(0, position.character)
+        const line = document.lineAt(position.line).text.substring(0, position.character)
         return this.completion(line, {document, position, token, context})
     }
 

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -98,7 +98,7 @@ export class HoverProvider implements vscode.HoverProvider {
                 const pkg = encodeURIComponent(JSON.stringify(p))
                 pkgLink += `[${p}](command:latex-workshop.texdoc?${pkg}),`
             })
-            pkgLink = pkgLink.substr(0, pkgLink.lastIndexOf(',')) + '.'
+            pkgLink = pkgLink.substring(0, pkgLink.lastIndexOf(',')) + '.'
         }
         if (signatures.length > 0) {
             const mdLink = new vscode.MarkdownString(signatures.join('  \n')) // We need two spaces to ensure md newline

--- a/src/providers/preview/mathpreviewlib/texmathenvfinder.ts
+++ b/src/providers/preview/mathpreviewlib/texmathenvfinder.ts
@@ -109,7 +109,7 @@ export class TeXMathEnvFinder {
     //  ^                          ^
     //  return pos                 endPos1
     private findBeginPair(document: vscode.TextDocument | TextDocumentLike, beginPat: RegExp, endPos1: vscode.Position, limit: number): vscode.Position | undefined {
-        const currentLine = document.lineAt(endPos1).text.substr(0, endPos1.character)
+        const currentLine = document.lineAt(endPos1).text.substring(0, endPos1.character)
         let l = utils.stripCommentsAndVerbatim(currentLine)
         let m = l.match(beginPat)
         if (m && m.index !== undefined) {

--- a/src/providers/structure.ts
+++ b/src/providers/structure.ts
@@ -87,7 +87,7 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
         content = utils.stripCommentsAndVerbatim(content)
         const endPos = content.search(/\\end{document}/gm)
         if (endPos > -1) {
-            content = content.substr(0, endPos)
+            content = content.substring(0, endPos)
         }
 
         const structureModel = new StructureModel(this.extension, filePath, rootStack, children, newFileStack, sectionNumber)


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr and https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring