### PR TITLE
add texlive as default container image

### DIFF
--- a/package.json
+++ b/package.json
@@ -1825,7 +1825,7 @@
         },
         "latex-workshop.docker.image.latex": {
           "type": "string",
-          "default": "",
+          "default": "texlive/texlive",
           "markdownDescription": "Define the image for `latexmk`, `synctex`, `texcount`, and `latexindent`."
         },
         "latex-workshop.showContextMenu": {


### PR DESCRIPTION
With empty default container image, the following error will prompt:
```bash
Unable to find image 'latexmk:latest' locally
```
This issue has been mentioned somewhere else: https://www.reddit.com/r/LaTeX/comments/r9smni/why_is_latex_in_vscode_requiring_docker_to_build/

Add `texlive/texlive` as default container image to eliminate error prompt for first time use.