### PR TITLE
Use customEditor api

### DIFF
--- a/src/commander.ts
+++ b/src/commander.ts
@@ -206,12 +206,12 @@ export class Commander {
         this.extension.builder.kill()
     }
 
-    pdf(uri: vscode.Uri | undefined) {
+    pdf(uri: vscode.Uri | undefined, panelIn?: vscode.WebviewPanel) {
         this.extension.logger.addLogMessage('PDF command invoked.')
         if (uri === undefined || !uri.fsPath.endsWith('.pdf')) {
             return
         }
-        return this.extension.viewer.openPdfInTab(uri, 'current', false)
+        return this.extension.viewer.openPdfInTab(uri, panelIn)
     }
 
     synctex() {

--- a/src/components/viewerlib/pdfviewerhook.ts
+++ b/src/components/viewerlib/pdfviewerhook.ts
@@ -17,11 +17,11 @@ export class PdfViewerHookProvider implements vscode.CustomReadonlyEditorProvide
     }
 
     resolveCustomEditor(document: vscode.CustomDocument, webviewPanel: vscode.WebviewPanel) {
-        webviewPanel.webview.html = 'LaTeX Workshop PDF Viewer is opening a PDF file...'
-        setTimeout(() => {
-            webviewPanel.dispose()
-            void this.extension.commander.pdf(document.uri)
-        }, 1000)
+        webviewPanel.webview.options = {
+            ...webviewPanel.webview.options,
+            enableScripts: true
+        }
+        void this.extension.commander.pdf(document.uri, webviewPanel)
     }
 
 }

--- a/src/components/viewerlib/pdfviewerpanel.ts
+++ b/src/components/viewerlib/pdfviewerpanel.ts
@@ -83,9 +83,9 @@ export class PdfViewerPanelService {
         return this.extension.server.pdfFilePathEncoder.encodePathWithPrefix(pdfFileUri)
     }
 
-    async createPdfViewerPanel(pdfFileUri: vscode.Uri, viewColumn: vscode.ViewColumn): Promise<PdfViewerPanel> {
+    async createPdfViewerPanel(pdfFileUri: vscode.Uri, panel?: vscode.WebviewPanel): Promise<PdfViewerPanel> {
         const htmlContent = await this.getPDFViewerContent(pdfFileUri)
-        const panel = vscode.window.createWebviewPanel('latex-workshop-pdf', path.basename(pdfFileUri.path), viewColumn, {
+        panel ||= vscode.window.createWebviewPanel('latex-workshop-pdf', path.basename(pdfFileUri.path), vscode.ViewColumn.Active, {
             enableScripts: true,
             retainContextWhenHidden: true
         })

--- a/src/main.ts
+++ b/src/main.ts
@@ -238,7 +238,16 @@ export function activate(context: vscode.ExtensionContext): ReturnType<typeof ge
     }))
 
     context.subscriptions.push(vscode.window.registerWebviewPanelSerializer('latex-workshop-pdf', extension.viewer.pdfViewerPanelSerializer))
-    context.subscriptions.push(vscode.window.registerCustomEditorProvider('latex-workshop-pdf-hook', new PdfViewerHookProvider(extension), {supportsMultipleEditorsPerDocument: true}))
+    context.subscriptions.push(vscode.window.registerCustomEditorProvider(
+        'latex-workshop-pdf-hook',
+        new PdfViewerHookProvider(extension),
+        {
+            supportsMultipleEditorsPerDocument: true,
+            webviewOptions: {
+                retainContextWhenHidden: true
+            }
+        }
+    ))
     context.subscriptions.push(vscode.window.registerWebviewPanelSerializer('latex-workshop-mathpreview', extension.mathPreviewPanel.mathPreviewPanelSerializer))
 
     context.subscriptions.push(vscode.languages.registerHoverProvider(latexSelector, new HoverProvider(extension)))

--- a/src/utils/webview.ts
+++ b/src/utils/webview.ts
@@ -54,16 +54,18 @@ export async function openWebviewPanel(
             break
         }
     }
-    // Then, we set the focus back to the .tex file
-    const configuration = vscode.workspace.getConfiguration('latex-workshop')
-    const delay = configuration.get('view.pdf.tab.openDelay', 1000)
-    setTimeout(async () => {
-        if (!preserveFocus) {
-            return
-        }
-        if (focusAction) {
-            await vscode.commands.executeCommand(focusAction)
-        }
-        await vscode.window.showTextDocument(activeDocument, vscode.ViewColumn.Active)
-    }, delay)
+    if(activeDocument){
+        // Then, we set the focus back to the .tex file
+        const configuration = vscode.workspace.getConfiguration('latex-workshop')
+        const delay = configuration.get('view.pdf.tab.openDelay', 1000)
+        setTimeout(async () => {
+            if (!preserveFocus) {
+                return
+            }
+            if (focusAction) {
+                await vscode.commands.executeCommand(focusAction)
+            }
+            await vscode.window.showTextDocument(activeDocument, vscode.ViewColumn.Active)
+        }, delay)
+    }
 }


### PR DESCRIPTION
This PR modifies the methods `openPdfInTab` etc. to open pdfs using vscode's CustomEditor api. Previously, this api was only used to show `'LaTeX Workshop PDF Viewer is opening a PDF file...'` and then opening a separately managed webview. Advantages of showing pdfs as custom editors include:
* Avoids opening the same pdf multiple times (though this is still possible if intended)
* Does not steal focus from the explorer view after opening a pdf. This can get a bit annoying when trying to e.g. click on a pdf file and then `del` to delete it.
* Pdf icon in the file tab is supported

I've tested this on windows 10 and ubuntu 18.04 using WSL. The only disadvantage I'm aware of is
* It is no longer possible to specify 'left'/'top'/'bottom' as locations for the panel. However, when opening a file from the explorer view this can be done using e.g. `open to the side`.

