### PR TITLE
Add indentation to display math

### DIFF
--- a/data/commands.json
+++ b/data/commands.json
@@ -100,7 +100,7 @@
   },
   "[": {
     "command": "[",
-    "snippet": "[${1}\\]",
+    "snippet": "[\n\t${1}\n\\]",
     "detail": "display math \\[ ... \\]"
   },
   "{": {


### PR DESCRIPTION
I propose to treat display math like an environment in terms of code indentation:
```
\[
    \int_M d\omega = \int_{\partial M} \omega
\]
```

- This increases code readability, as it provides additional visual distinction between `\(...\)` and `\[...\]`
- It also resembles the output of display math to some extend
- It is the old TextMate behaviour (might help converts like me)

Personally, I would also appreciate to have this snippet trigger on `$$` (as in TextMate…), but I did not manage achieving that.

Thanks for the awesome work on this extension!