### PR TITLE
Add new commands for package siunitx v3

### DIFF
--- a/data/packages/siunitx_cmd.json
+++ b/data/packages/siunitx_cmd.json
@@ -1194,5 +1194,85 @@
     "command": "sisetup{options}",
     "package": "siunitx",
     "snippet": "sisetup{${1:options}}"
+  },
+  "qty{}{}": {
+    "command": "qty{value}{unit commands}",
+    "package": "siunitx",
+    "snippet": "qty{${1:value}}{${2:unit commands}}"
+  },
+  "qty[]{}{}": {
+    "command": "qty[options]{value}{unit commands}",
+    "package": "siunitx",
+    "snippet": "qty[${3:options}]{${1:value}}{${2:unit commands}}"
+  },
+  "qtylist{}{}": {
+    "command": "qtylist{numbers}{unit}",
+    "package": "siunitx",
+    "snippet": "qtylist{${1:numbers}}{${2:unit}}"
+  },
+  "qtylist[]{}{}": {
+    "command": "qtylist[options]{numbers}{unit}",
+    "package": "siunitx",
+    "snippet": "qtylist[${3:options}]{${1:numbers}}{${2:unit}}"
+  },
+  "qtyrange{}{}{}": {
+    "command": "qtyrange{number1}{number2}{unit}",
+    "package": "siunitx",
+    "snippet": "qtyrange{${1:number1}}{${2:number2}}{${3:unit}}"
+  },
+  "qtyrange[]{}{}{}": {
+    "command": "qtyrange[options]{number1}{number2}{unit}",
+    "package": "siunitx",
+    "snippet": "qtyrange[${4:options}]{${1:number1}}{${2:number2}}{${3:unit}}"
+  },
+  "unit{}": {
+    "command": "unit{unit}",
+    "package": "siunitx",
+    "snippet": "unit{${1:unit}}"
+  },
+  "unit[]{}": {
+    "command": "unit[options]{unit}",
+    "package": "siunitx",
+    "snippet": "unit[${2:options}]{${1:unit}}"
+  },
+  "complexnum{}": {
+    "command": "complexnum{number}",
+    "package": "siunitx",
+    "snippet": "complexnum{${1:number}}"
+  },
+  "complexnum[]{}": {
+    "command": "complexnum[options]{number}",
+    "package": "siunitx",
+    "snippet": "complexnum[${2:options}]{${1:number}}"
+  },
+  "complexqty{}{}": {
+    "command": "complexqty{number}{unit}",
+    "package": "siunitx",
+    "snippet": "complexqty{${1:number}}{${2:unit}}"
+  },
+  "complexqty[]{}{}": {
+    "command": "complexqty[options]{number}{unit}",
+    "package": "siunitx",
+    "snippet": "complexqty[${3:options}]{${1:number}}{${2:unit}}"
+  },
+  "qtyproduct{}{}": {
+    "command": "qtyproduct{numbers}{unit}",
+    "package": "siunitx",
+    "snippet": "qtyproduct{${1:numbers}}{${2:unit}}"
+  },
+  "qtyproduct[]{}{}": {
+    "command": "qtyproduct[options]{numbers}{unit}",
+    "package": "siunitx",
+    "snippet": "qtyproduct[${3:options}]{${1:numbers}}{${2:unit}}"
+  },
+  "numproduct{}": {
+    "command": "numproduct{numbers}",
+    "package": "siunitx",
+    "snippet": "numproduct{${1:numbers}}"
+  },
+  "numproduct[]{}": {
+    "command": "numproduct[options]{numbers}",
+    "package": "siunitx",
+    "snippet": "numproduct[${2:options}]{${1:numbers}}"
   }
 }


### PR DESCRIPTION
The author did a larger rewrite of the siunitx package for v3 and also introduced new commands.
For example: `\qty{}{}` is the replacement for the (still working) `\SI{}{}`, and `\unit{}` for `\si{}`.

See also: https://mirror.informatik.hs-fulda.de/tex-archive/macros/latex/contrib/siunitx/siunitx.pdf#section.0.5 about the changes between v2 and v3