### PR TITLE
Activate LaTeX keybindings and commands in `latex-expl3`

### DIFF
--- a/package.json
+++ b/package.json
@@ -498,25 +498,25 @@
         "key": "ctrl+l alt+m",
         "mac": "cmd+l alt+m",
         "command": "latex-workshop.toggleMathPreviewPanel",
-        "when": "editorLangId =~ /latex|rsweave|jlweave/ && config.latex-workshop.bind.altKeymap.enabled"
+        "when": "editorLangId =~ /latex|latex-expl3|rsweave|jlweave/ && config.latex-workshop.bind.altKeymap.enabled"
       },
       {
         "key": "ctrl+l alt+b",
         "mac": "cmd+l alt+b",
         "command": "latex-workshop.build",
-        "when": "editorLangId =~ /latex|rsweave|jlweave/ && config.latex-workshop.bind.altKeymap.enabled && !virtualWorkspace"
+        "when": "editorLangId =~ /latex|latex-expl3|rsweave|jlweave/ && config.latex-workshop.bind.altKeymap.enabled && !virtualWorkspace"
       },
       {
         "key": "ctrl+l alt+c",
         "mac": "cmd+l alt+c",
         "command": "latex-workshop.clean",
-        "when": "editorLangId =~ /latex|rsweave|jlweave/ && config.latex-workshop.bind.altKeymap.enabled && !virtualWorkspace"
+        "when": "editorLangId =~ /latex|latex-expl3|rsweave|jlweave/ && config.latex-workshop.bind.altKeymap.enabled && !virtualWorkspace"
       },
       {
         "key": "ctrl+l alt+v",
         "mac": "cmd+l alt+v",
         "command": "latex-workshop.view",
-        "when": "editorLangId =~ /latex|rsweave|jlweave/ && config.latex-workshop.bind.altKeymap.enabled && !virtualWorkspace"
+        "when": "editorLangId =~ /latex|latex-expl3|rsweave|jlweave/ && config.latex-workshop.bind.altKeymap.enabled && !virtualWorkspace"
       },
       {
         "key": "ctrl+l alt+j",
@@ -534,25 +534,25 @@
         "key": "ctrl+alt+m",
         "mac": "cmd+alt+m",
         "command": "latex-workshop.toggleMathPreviewPanel",
-        "when": "editorLangId =~ /latex|rsweave|jlweave/ && !config.latex-workshop.bind.altKeymap.enabled"
+        "when": "editorLangId =~ /latex|latex-expl3|rsweave|jlweave/ && !config.latex-workshop.bind.altKeymap.enabled"
       },
       {
         "key": "ctrl+alt+b",
         "mac": "cmd+alt+b",
         "command": "latex-workshop.build",
-        "when": "editorLangId =~ /latex|rsweave|jlweave/ && !config.latex-workshop.bind.altKeymap.enabled && !virtualWorkspace"
+        "when": "editorLangId =~ /latex|latex-expl3|rsweave|jlweave/ && !config.latex-workshop.bind.altKeymap.enabled && !virtualWorkspace"
       },
       {
         "key": "ctrl+alt+c",
         "mac": "cmd+alt+c",
         "command": "latex-workshop.clean",
-        "when": "editorLangId =~ /latex|rsweave|jlweave/ && !config.latex-workshop.bind.altKeymap.enabled && !virtualWorkspace"
+        "when": "editorLangId =~ /latex|latex-expl3|rsweave|jlweave/ && !config.latex-workshop.bind.altKeymap.enabled && !virtualWorkspace"
       },
       {
         "key": "ctrl+alt+v",
         "mac": "cmd+alt+v",
         "command": "latex-workshop.view",
-        "when": "editorLangId =~ /latex|rsweave|jlweave/ && !config.latex-workshop.bind.altKeymap.enabled && !virtualWorkspace"
+        "when": "editorLangId =~ /latex|latex-expl3|rsweave|jlweave/ && !config.latex-workshop.bind.altKeymap.enabled && !virtualWorkspace"
       },
       {
         "key": "ctrl+alt+j",
@@ -569,188 +569,188 @@
       {
         "key": "ctrl+l [",
         "mac": "cmd+l [",
-        "when": "config.latex-workshop.bind.altKeymap.enabled && editorTextFocus && !editorReadonly && editorLangId =~ /latex|rsweave|jlweave/",
+        "when": "config.latex-workshop.bind.altKeymap.enabled && editorTextFocus && !editorReadonly && editorLangId =~ /latex|latex-expl3|rsweave|jlweave/",
         "command": "latex-workshop.promote-sectioning"
       },
       {
         "key": "ctrl+l ]",
         "mac": "cmd+l ]",
-        "when": "config.latex-workshop.bind.altKeymap.enabled && editorTextFocus && !editorReadonly && editorLangId =~ /latex|rsweave|jlweave/",
+        "when": "config.latex-workshop.bind.altKeymap.enabled && editorTextFocus && !editorReadonly && editorLangId =~ /latex|latex-expl3|rsweave|jlweave/",
         "command": "latex-workshop.demote-sectioning"
       },
       {
         "key": "ctrl+alt+[",
         "mac": "cmd+alt+[",
-        "when": "!config.latex-workshop.bind.altKeymap.enabled && editorTextFocus && !editorReadonly && editorLangId =~ /latex|rsweave|jlweave/",
+        "when": "!config.latex-workshop.bind.altKeymap.enabled && editorTextFocus && !editorReadonly && editorLangId =~ /latex|latex-expl3|rsweave|jlweave/",
         "command": "latex-workshop.promote-sectioning"
       },
       {
         "key": "ctrl+alt+]",
         "mac": "cmd+alt+]",
-        "when": "!config.latex-workshop.bind.altKeymap.enabled && editorTextFocus && !editorReadonly && editorLangId =~ /latex|rsweave|jlweave/",
+        "when": "!config.latex-workshop.bind.altKeymap.enabled && editorTextFocus && !editorReadonly && editorLangId =~ /latex|latex-expl3|rsweave|jlweave/",
         "command": "latex-workshop.demote-sectioning"
       },
       {
         "key": "ctrl+l ctrl+enter",
         "mac": "cmd+l cmd+enter",
-        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /latex|rsweave|jlweave/",
+        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /latex|latex-expl3|rsweave|jlweave/",
         "command": "latex-workshop.shortcut.item"
       },
       {
         "key": "ctrl+l ctrl+b",
         "mac": "cmd+l cmd+b",
-        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /latex|rsweave|jlweave/",
+        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /latex|latex-expl3|rsweave|jlweave/",
         "command": "latex-workshop.shortcut.textbf"
       },
       {
         "key": "ctrl+l ctrl+i",
         "mac": "cmd+l cmd+i",
-        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /latex|rsweave|jlweave/",
+        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /latex|latex-expl3|rsweave|jlweave/",
         "command": "latex-workshop.shortcut.textit"
       },
       {
         "key": "ctrl+l ctrl+u",
         "mac": "cmd+l cmd+u",
-        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /latex|rsweave|jlweave/",
+        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /latex|latex-expl3|rsweave|jlweave/",
         "command": "latex-workshop.shortcut.underline"
       },
       {
         "key": "ctrl+l ctrl+e",
         "mac": "cmd+l cmd+e",
-        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /latex|rsweave|jlweave/",
+        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /latex|latex-expl3|rsweave|jlweave/",
         "command": "latex-workshop.shortcut.emph"
       },
       {
         "key": "ctrl+l ctrl+r",
         "mac": "cmd+l cmd+r",
-        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /latex|rsweave|jlweave/",
+        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /latex|latex-expl3|rsweave|jlweave/",
         "command": "latex-workshop.shortcut.textrm"
       },
       {
         "key": "ctrl+l ctrl+t",
         "mac": "cmd+l cmd+t",
-        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /latex|rsweave|jlweave/",
+        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /latex|latex-expl3|rsweave|jlweave/",
         "command": "latex-workshop.shortcut.texttt"
       },
       {
         "key": "ctrl+l ctrl+s",
         "mac": "cmd+l cmd+s",
-        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /latex|rsweave|jlweave/",
+        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /latex|latex-expl3|rsweave|jlweave/",
         "command": "latex-workshop.shortcut.textsl"
       },
       {
         "key": "ctrl+l ctrl+c",
         "mac": "cmd+l cmd+c",
-        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /latex|rsweave|jlweave/",
+        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /latex|latex-expl3|rsweave|jlweave/",
         "command": "latex-workshop.shortcut.textsc"
       },
       {
         "key": "ctrl+l ctrl+n",
         "mac": "cmd+l cmd+n",
-        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /latex|rsweave|jlweave/",
+        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /latex|latex-expl3|rsweave|jlweave/",
         "command": "latex-workshop.shortcut.textnormal"
       },
       {
         "key": "ctrl+l ctrl+6",
         "mac": "cmd+l cmd+6",
-        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /latex|rsweave|jlweave/",
+        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /latex|latex-expl3|rsweave|jlweave/",
         "command": "latex-workshop.shortcut.textsuperscript"
       },
       {
         "key": "ctrl+l ctrl+oem_minus",
         "mac": "cmd+l cmd+oem_minus",
-        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /latex|rsweave|jlweave/",
+        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /latex|latex-expl3|rsweave|jlweave/",
         "command": "latex-workshop.shortcut.textsubscript"
       },
       {
         "key": "ctrl+m ctrl+b",
         "mac": "cmd+m cmd+b",
-        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /latex|rsweave|jlweave/",
+        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /latex|latex-expl3|rsweave|jlweave/",
         "command": "latex-workshop.shortcut.mathbf"
       },
       {
         "key": "ctrl+m ctrl+i",
         "mac": "cmd+m cmd+i",
-        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /latex|rsweave|jlweave/",
+        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /latex|latex-expl3|rsweave|jlweave/",
         "command": "latex-workshop.shortcut.mathit"
       },
       {
         "key": "ctrl+m ctrl+r",
         "mac": "cmd+m cmd+r",
-        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /latex|rsweave|jlweave/",
+        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /latex|latex-expl3|rsweave|jlweave/",
         "command": "latex-workshop.shortcut.mathrm"
       },
       {
         "key": "ctrl+m ctrl+t",
         "mac": "cmd+m cmd+t",
-        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /latex|rsweave|jlweave/",
+        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /latex|latex-expl3|rsweave|jlweave/",
         "command": "latex-workshop.shortcut.mathtt"
       },
       {
         "key": "ctrl+m ctrl+s",
         "mac": "cmd+m cmd+s",
-        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /latex|rsweave|jlweave/",
+        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /latex|latex-expl3|rsweave|jlweave/",
         "command": "latex-workshop.shortcut.mathsf"
       },
       {
         "key": "ctrl+m ctrl+shift+b",
         "mac": "cmd+m cmd+shift+b",
-        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /latex|rsweave|jlweave/",
+        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /latex|latex-expl3|rsweave|jlweave/",
         "command": "latex-workshop.shortcut.mathbb"
       },
       {
         "key": "ctrl+m ctrl+c",
         "mac": "cmd+m cmd+c",
-        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /latex|rsweave|jlweave/",
+        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /latex|latex-expl3|rsweave|jlweave/",
         "command": "latex-workshop.shortcut.mathcal"
       },
       {
         "command": "expandLineSelection",
         "key": "ctrl+l ctrl+l",
         "mac": "cmd+l cmd+l",
-        "when": "textInputFocus && editorLangId =~ /latex|rsweave|jlweave/"
+        "when": "textInputFocus && editorLangId =~ /latex|latex-expl3|rsweave|jlweave/"
       },
       {
         "command": "editor.action.toggleTabFocusMode",
         "key": "ctrl+l ctrl+m",
         "mac": "cmd+l cmd+m",
-        "when": "textInputFocus && editorLangId =~ /latex|rsweave|jlweave/"
+        "when": "textInputFocus && editorLangId =~ /latex|latex-expl3|rsweave|jlweave/"
       },
       {
         "key": "ctrl+l ctrl+w",
         "mac": "cmd+l cmd+w",
-        "when": "editorTextFocus && !editorReadonly && editorHasSelection && editorLangId =~ /latex|rsweave|jlweave/",
+        "when": "editorTextFocus && !editorReadonly && editorHasSelection && editorLangId =~ /latex|latex-expl3|rsweave|jlweave/",
         "command": "latex-workshop.surround"
       },
       {
         "command": "latex-workshop.onEnterKey",
         "key": "enter",
-        "when": "config.latex-workshop.bind.enter.key && editorTextFocus && acceptSuggestionOnEnter && !suggestWidgetVisible && !editorReadonly && editorLangId =~ /latex|rsweave|jlweave/ && vim.active && vim.mode == 'Insert'"
+        "when": "config.latex-workshop.bind.enter.key && editorTextFocus && acceptSuggestionOnEnter && !suggestWidgetVisible && !editorReadonly && editorLangId =~ /latex|latex-expl3|rsweave|jlweave/ && vim.active && vim.mode == 'Insert'"
       },
       {
         "command": "latex-workshop.onEnterKey",
         "key": "enter",
-        "when": "config.latex-workshop.bind.enter.key && editorTextFocus && !acceptSuggestionOnEnter && !editorReadonly && editorLangId =~ /latex|rsweave|jlweave/ && vim.active && vim.mode == 'Insert'"
+        "when": "config.latex-workshop.bind.enter.key && editorTextFocus && !acceptSuggestionOnEnter && !editorReadonly && editorLangId =~ /latex|latex-expl3|rsweave|jlweave/ && vim.active && vim.mode == 'Insert'"
       },
       {
         "command": "latex-workshop.onEnterKey",
         "key": "enter",
-        "when": "config.latex-workshop.bind.enter.key && editorTextFocus && acceptSuggestionOnEnter && !suggestWidgetVisible && !editorReadonly && editorLangId =~ /latex|rsweave|jlweave/ && !vim.active"
+        "when": "config.latex-workshop.bind.enter.key && editorTextFocus && acceptSuggestionOnEnter && !suggestWidgetVisible && !editorReadonly && editorLangId =~ /latex|latex-expl3|rsweave|jlweave/ && !vim.active"
       },
       {
         "command": "latex-workshop.onEnterKey",
         "key": "enter",
-        "when": "config.latex-workshop.bind.enter.key && editorTextFocus && !acceptSuggestionOnEnter && !editorReadonly && editorLangId =~ /latex|rsweave|jlweave/ && !vim.active"
+        "when": "config.latex-workshop.bind.enter.key && editorTextFocus && !acceptSuggestionOnEnter && !editorReadonly && editorLangId =~ /latex|latex-expl3|rsweave|jlweave/ && !vim.active"
       },
       {
         "command": "latex-workshop.onAltEnterKey",
         "key": "alt+enter",
-        "when": "config.latex-workshop.bind.enter.key && editorTextFocus && acceptSuggestionOnEnter && !suggestWidgetVisible && !editorReadonly && editorLangId =~ /latex|rsweave|jlweave/"
+        "when": "config.latex-workshop.bind.enter.key && editorTextFocus && acceptSuggestionOnEnter && !suggestWidgetVisible && !editorReadonly && editorLangId =~ /latex|latex-expl3|rsweave|jlweave/"
       },
       {
         "command": "latex-workshop.onAltEnterKey",
         "key": "alt+enter",
-        "when": "config.latex-workshop.bind.enter.key && editorTextFocus && !acceptSuggestionOnEnter && !editorReadonly && editorLangId =~ /latex|rsweave|jlweave/"
+        "when": "config.latex-workshop.bind.enter.key && editorTextFocus && !acceptSuggestionOnEnter && !editorReadonly && editorLangId =~ /latex|latex-expl3|rsweave|jlweave/"
       }
     ],
     "configurationDefaults": {
@@ -2139,24 +2139,24 @@
     "menus": {
       "editor/context": [
         {
-          "when": "config.latex-workshop.showContextMenu && editorLangId == latex && !virtualWorkspace",
+          "when": "config.latex-workshop.showContextMenu && editorLangId =~ /latex|latex-expl3|rsweave|jlweave/ && !virtualWorkspace",
           "command": "latex-workshop.build",
           "group": "navigation@100"
         },
         {
-          "when": "config.latex-workshop.showContextMenu && editorLangId == latex && !virtualWorkspace",
+          "when": "config.latex-workshop.showContextMenu && editorLangId =~ /latex|latex-expl3|rsweave|jlweave/ && !virtualWorkspace",
           "command": "latex-workshop.synctex",
           "group": "navigation@101"
         }
       ],
       "editor/title": [
         {
-          "when": "editorLangId =~ /latex|rsweave|jlweave/ && !virtualWorkspace",
+          "when": "editorLangId =~ /latex|latex-expl3|rsweave|jlweave/ && !virtualWorkspace",
           "command": "latex-workshop.view",
           "group": "navigation@2"
         },
         {
-          "when": "editorLangId =~ /latex|rsweave|jlweave/ && !virtualWorkspace",
+          "when": "editorLangId =~ /latex|latex-expl3|rsweave|jlweave/ && !virtualWorkspace",
           "command": "latex-workshop.build",
           "group": "navigation@1"
         }


### PR DESCRIPTION
Close #3171

I will handle the renaming of `latex-expl3` into `latex3` in a separate PR.