### PR TITLE
Stop exposing SectionNodeProvider at the Extension level

### DIFF
--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -356,8 +356,7 @@ export class Manager {
                 // We need to parse the fls to discover file dependencies when defined by TeX macro
                 // It happens a lot with subfiles, https://tex.stackexchange.com/questions/289450/path-of-figures-in-different-directories-with-subfile-latex
                 await this.parseFlsFile(this.rootFile)
-                this.extension.structureProvider.refresh()
-                this.extension.structureProvider.update()
+                this.extension.structureViewer.update()
             } else {
                 this.extension.logger.addLogMessage(`Keep using the same root file: ${this.rootFile}`)
             }

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,7 +32,7 @@ import {MathPreview} from './providers/preview/mathpreview'
 import {MathPreviewPanel} from './components/mathpreviewpanel'
 import {DocSymbolProvider} from './providers/docsymbol'
 import {ProjectSymbolProvider} from './providers/projectsymbol'
-import {SectionNodeProvider, StructureTreeView} from './providers/structure'
+import {StructureTreeView} from './providers/structure'
 import {DefinitionProvider} from './providers/definition'
 import {LatexFormatterProvider} from './providers/latexformatter'
 import {FoldingProvider, WeaveFoldingProvider} from './providers/folding'
@@ -150,8 +150,7 @@ export function activate(context: vscode.ExtensionContext): ReturnType<typeof ge
             extension.logger.addLogMessage(`onDidSaveTextDocument triggered: ${e.uri.toString(true)}`)
             extension.manager.updateCachedContent(e)
             extension.linter.lintRootFileIfEnabled()
-            extension.structureProvider.refresh()
-            extension.structureProvider.update()
+            extension.structureViewer.update()
             void extension.manager.buildOnSaveIfEnabled(e.fileName)
             extension.counter.countOnSaveIfEnabled(e.fileName)
         }
@@ -293,7 +292,6 @@ export class Extension {
     readonly envPair: EnvPair
     readonly section: Section
     readonly latexCommandTreeView: LaTeXCommandTreeView
-    readonly structureProvider: SectionNodeProvider
     readonly structureViewer: StructureTreeView
     readonly snippetView: SnippetView
     readonly graphicsPreview: GraphicsPreview
@@ -328,7 +326,6 @@ export class Extension {
         this.envPair = new EnvPair(this)
         this.section = new Section(this)
         this.latexCommandTreeView = new LaTeXCommandTreeView()
-        this.structureProvider = new SectionNodeProvider(this)
         this.structureViewer = new StructureTreeView(this)
         this.snippetView = new SnippetView(this)
         this.pegParser = new PEGParser()

--- a/src/providers/docsymbol.ts
+++ b/src/providers/docsymbol.ts
@@ -1,15 +1,18 @@
 import * as vscode from 'vscode'
 
 import type {Extension} from '../main'
-import type {Section} from './structure'
+import {Section, SectionNodeProvider} from './structure'
 
 export class DocSymbolProvider implements vscode.DocumentSymbolProvider {
     private readonly extension: Extension
+    private readonly sectionNodeProvider: SectionNodeProvider
 
     private sections: string[] = []
 
     constructor(extension: Extension) {
         this.extension = extension
+        this.sectionNodeProvider = new SectionNodeProvider(extension)
+
         const rawSections = vscode.workspace.getConfiguration('latex-workshop').get('view.outline.sections') as string[]
         rawSections.forEach(section => {
             this.sections = this.sections.concat(section.split('|'))
@@ -20,7 +23,7 @@ export class DocSymbolProvider implements vscode.DocumentSymbolProvider {
         if (this.extension.lwfs.isVirtualUri(document.uri)) {
             return []
         }
-        return this.sectionToSymbols(this.extension.structureProvider.buildModel(new Set<string>(), document.fileName, undefined, undefined, undefined, undefined, false))
+        return this.sectionToSymbols(this.sectionNodeProvider.buildModel(new Set<string>(), document.fileName, undefined, undefined, undefined, undefined, false))
     }
 
     private sectionToSymbols(sections: Section[]): vscode.DocumentSymbol[] {

--- a/src/providers/projectsymbol.ts
+++ b/src/providers/projectsymbol.ts
@@ -1,13 +1,15 @@
 import * as vscode from 'vscode'
 
 import type {Extension} from '../main'
-import type {Section} from './structure'
+import {Section, SectionNodeProvider} from './structure'
 
 export class ProjectSymbolProvider implements vscode.WorkspaceSymbolProvider {
     private readonly extension: Extension
+    private readonly sectionNodeProvider: SectionNodeProvider
 
     constructor(extension: Extension) {
         this.extension = extension
+        this.sectionNodeProvider = new SectionNodeProvider(extension)
     }
 
     provideWorkspaceSymbols(): vscode.SymbolInformation[] {
@@ -19,7 +21,7 @@ export class ProjectSymbolProvider implements vscode.WorkspaceSymbolProvider {
         if (rootFileUri && this.extension.lwfs.isVirtualUri(rootFileUri)) {
             return symbols
         }
-        this.sectionToSymbols(symbols, this.extension.structureProvider.buildModel(new Set<string>(), this.extension.manager.rootFile))
+        this.sectionToSymbols(symbols, this.sectionNodeProvider.buildModel(new Set<string>(), this.extension.manager.rootFile))
         return symbols
     }
 

--- a/src/providers/structure.ts
+++ b/src/providers/structure.ts
@@ -30,7 +30,7 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
 
     }
 
-    refresh(): Section[] {
+    private refresh(): Section[] {
         if (this.extension.manager.rootFile) {
             this.ds = this.buildModel(new Set<string>(), this.extension.manager.rootFile)
             return this.ds
@@ -40,6 +40,7 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
     }
 
     update() {
+        this.refresh()
         this._onDidChangeTreeData.fire(undefined)
     }
 
@@ -449,12 +450,20 @@ export class StructureTreeView {
     private _followCursor: boolean = true
 
 
-    constructor(private readonly extension: Extension) {
-        this._treeDataProvider = this.extension.structureProvider
+    constructor(extension: Extension) {
+        this._treeDataProvider = new SectionNodeProvider(extension)
         this._viewer = vscode.window.createTreeView('latex-workshop-structure', { treeDataProvider: this._treeDataProvider, showCollapseAll: true })
         vscode.commands.registerCommand('latex-workshop.structure-toggle-follow-cursor', () => {
            this._followCursor = ! this._followCursor
         })
+    }
+
+    update() {
+        this._treeDataProvider.update()
+    }
+
+    getTreeData(): Section[] {
+        return this._treeDataProvider.ds
     }
 
     private traverseSectionTree(sections: Section[], fileName: string, lineNumber: number): Section | undefined {

--- a/test/multiroot-ws.test.ts
+++ b/test/multiroot-ws.test.ts
@@ -176,7 +176,7 @@ suite('Multi-root workspace test suite', () => {
         await waitGivenRootFile(docA.fileName)
         await sleep(1000)
 
-        const structure = extension.exports.realExtension?.structureProvider.ds
+        const structure = extension.exports.realExtension?.structureViewer.getTreeData()
         const filesWatched = extension.exports.realExtension?.manager.getFilesWatched()
         const isStructureOK = structure && structure.length > 0 && structure[0].fileName === docA.fileName
         const isWatcherOK = filesWatched && filesWatched.length === 1 && filesWatched[0] === docA.fileName


### PR DESCRIPTION
This is a follow-up on https://github.com/James-Yu/LaTeX-Workshop/pull/3178#discussion_r821360489

In this PR, we refactor the structure tree view and document symbol provider to stop exposing the `SectionNodeProvider` at the `Extension` level.