### PR TITLE
Add EventBus

### DIFF
--- a/src/components/eventbus.ts
+++ b/src/components/eventbus.ts
@@ -1,0 +1,69 @@
+import {EventEmitter} from 'stream'
+import type {PdfViewerState} from 'viewer/components/protocol'
+import type {Disposable} from 'vscode'
+
+export const BuildFinished = 'buildfinished'
+export const PdfViewerPagesLoaded = 'pdfviewerpagesloaded'
+export const PdfViewerStatusChanged = 'pdfviewerstatuschanged'
+export const RootFileChanged = 'rootfilechanged'
+export const FindRootFileEnd = 'findrootfileend'
+export const SyncTexForwardEnd = 'synctexforwardend'
+
+type EventArgTypeMap = {
+    [PdfViewerStatusChanged]: PdfViewerState,
+    [RootFileChanged]: string
+}
+
+export type EventName = typeof BuildFinished
+                    | typeof PdfViewerPagesLoaded
+                    | typeof PdfViewerStatusChanged
+                    | typeof RootFileChanged
+                    | typeof FindRootFileEnd
+                    | typeof SyncTexForwardEnd
+
+export class EventBus {
+    private readonly eventEmitter = new EventEmitter()
+
+    dispose() {
+        this.eventEmitter.removeAllListeners()
+    }
+
+    fire<T extends keyof EventArgTypeMap>(eventName: T, arg: EventArgTypeMap[T]): void
+    fire(eventName: EventName): void
+    fire(eventName: EventName, arg?: any): void {
+        this.eventEmitter.emit(eventName, arg)
+    }
+
+    onDidChangeRootFile(cb: (rootFile: EventArgTypeMap['rootfilechanged']) => void): Disposable {
+        return this.registerLisneter('rootfilechanged', cb)
+    }
+
+    onDidEndFindRootFile(cb: () => void): Disposable {
+        return this.registerLisneter('findrootfileend', cb)
+    }
+
+    onDidChangePdfViewerStatus(cb: (status: EventArgTypeMap['pdfviewerstatuschanged']) => void): Disposable {
+        return this.registerLisneter('pdfviewerstatuschanged', cb)
+    }
+
+    private registerLisneter<T extends keyof EventArgTypeMap>(
+        eventName: T,
+        cb: (arg: EventArgTypeMap[T]) => void
+    ): Disposable
+    private registerLisneter<T extends EventName>(
+        eventName: T,
+        cb: () => void
+    ): Disposable
+    private registerLisneter<T extends EventName>(
+        eventName: T,
+        cb: (arg?: any) => void
+    ): Disposable
+     {
+        this.eventEmitter.on(eventName, cb)
+        const disposable = {
+            dispose: () => { this.eventEmitter.removeListener(eventName, cb) }
+        }
+        return disposable
+    }
+
+}

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -8,6 +8,7 @@ import type {latexParser} from 'latex-utensils'
 import * as utils from '../utils/utils'
 
 import type {Extension} from '../main'
+import * as eventbus from './eventbus'
 import type {Suggestion as CiteEntry} from '../providers/completer/citation'
 import type {Suggestion as CmdEntry} from '../providers/completer/command'
 import type {Suggestion as EnvEntry} from '../providers/completer/environment'
@@ -123,6 +124,7 @@ export class Manager {
         this.finderUtils = new FinderUtils(extension)
         this.pathUtils = new PathUtils(extension)
         this.registerSetEnvVar()
+        this.extension.eventBus.onDidChangeRootFile(() => this.logWatchedFiles())
     }
 
     getCachedContent(filePath: string): Content[string] | undefined {
@@ -358,12 +360,14 @@ export class Manager {
                 await this.parseFlsFile(this.rootFile)
                 this.extension.structureViewer.update()
                 this.extension.latexCommanderTreeView.update()
+                this.extension.eventBus.fire(eventbus.RootFileChanged, rootFile)
             } else {
                 this.extension.logger.addLogMessage(`Keep using the same root file: ${this.rootFile}`)
             }
-            this.logWatchedFiles()
+            this.extension.eventBus.fire(eventbus.FindRootFileEnd)
             return rootFile
         }
+        this.extension.eventBus.fire(eventbus.FindRootFileEnd)
         return undefined
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,7 @@ import {CompilerLogParser} from './components/parser/compilerlog'
 import {LinterLogParser} from './components/parser/linterlog'
 import {UtensilsParser as PEGParser} from './components/parser/syntax'
 import {Configuration} from './components/configuration'
+import {EventBus} from './components/eventbus'
 
 import {Completer, SnippetCompleter} from './providers/completion'
 import {BibtexCompleter} from './providers/bibtexcompletion'
@@ -278,6 +279,7 @@ export function activate(context: vscode.ExtensionContext): ReturnType<typeof ge
 export class Extension {
     readonly extensionRoot: string
     readonly logger: Logger
+    readonly eventBus = new EventBus()
     readonly lwfs: LwFileSystem
     readonly commander: Commander
     readonly configuration: Configuration


### PR DESCRIPTION
@jlelong 

Add EventBus, which allows us to register listeners for events.

For example, we keep adding lines to `findRoot`. They are called when the root file changes:

https://github.com/James-Yu/LaTeX-Workshop/blob/18f09066d90e0b032d3a5430f0fb6bd98b50c1a1/src/components/manager.ts#L354-L360

It reduces the maintainability of `findRoot`. With `EventBus`, we fire the `rootfilechanged` event in `findRoot`, and register listeners for the event.

Notice that we should not overuse `EventBus`. We should not use it for a task that must finish when `findRoot` ends.

Primary use cases of `EventBus` are CI tests. With `EventBus`, we can precisely know when the status of LaTeX Workshop changes.
