### PR TITLE
Set resource scope to texcount settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1645,7 +1645,7 @@
           "markdownDescription": "Define the location of TeXCount executive file/script. This command will be joint with `latex-workshop.texcount.args` and required arguments to form a complete command of TeXCount."
         },
         "latex-workshop.texcount.args": {
-          "scope": "window",
+          "scope": "resource",
           "type": "array",
           "items": {
             "type": "string"
@@ -1654,7 +1654,7 @@
           "markdownDescription": "TeXCount arguments to count words in the LaTeX documents of the entire project from the root file, or the current document. Arguments must be in separate strings in the array. Additional arguments, i.e., `-merge %DOC%` for the project and the current document path for counting current file will be appended when constructing the command."
         },
         "latex-workshop.texcount.autorun": {
-          "scope": "window",
+          "scope": "resource",
           "type": "string",
           "enum": [
             "onSave",
@@ -1668,7 +1668,7 @@
           "markdownDescription": "When to call `texcount`. Default is never."
         },
         "latex-workshop.texcount.interval": {
-          "scope": "window",
+          "scope": "resource",
           "type": "number",
           "default": 1000,
           "markdownDescription": "The minimal time interval between two consecutive runs of `texcount` in milliseconds when `latex-workshop.texcount.run` is set to `onSave`."

--- a/src/components/counter.ts
+++ b/src/components/counter.ts
@@ -21,10 +21,10 @@ export class Counter {
         this.extension = extension
         // gotoLine status item has priority 100.5 and selectIndentation item has priority 100.4
         this.status = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100.45)
-        this.loadConfiguration()
+        this.loadConfiguration(vscode.window.activeTextEditor?.document.uri)
         vscode.workspace.onDidChangeConfiguration(e => {
-            if (e.affectsConfiguration('latex-workshop.texcount') || e.affectsConfiguration('latex-workshop.docker.enabled')) {
-                this.loadConfiguration()
+            if (e.affectsConfiguration('latex-workshop.texcount', this.extension.manager.rootFileUri) || e.affectsConfiguration('latex-workshop.docker.enabled')) {
+                this.loadConfiguration(this.extension.manager.rootFileUri)
                 this.updateStatusVisibility()
 
             }
@@ -32,6 +32,7 @@ export class Counter {
         this.updateStatusVisibility()
         vscode.window.onDidChangeActiveTextEditor((e: vscode.TextEditor | undefined) => {
             if (e && extension.manager.hasTexId(e.document.languageId)) {
+                this.loadConfiguration(e.document.uri)
                 this.updateStatusVisibility()
             } else {
                 this.status.hide()
@@ -40,8 +41,8 @@ export class Counter {
 
     }
 
-    private loadConfiguration() {
-        const configuration = vscode.workspace.getConfiguration('latex-workshop')
+    private loadConfiguration(documentUri: vscode.Uri | undefined) {
+        const configuration = vscode.workspace.getConfiguration('latex-workshop', documentUri)
         this.autoRunEnabled = (configuration.get('texcount.autorun') as string === 'onSave')
         this.autoRunInterval = configuration.get('texcount.interval') as number
         this.commandArgs = configuration.get('texcount.args') as string[]

--- a/src/components/counter.ts
+++ b/src/components/counter.ts
@@ -21,10 +21,10 @@ export class Counter {
         this.extension = extension
         // gotoLine status item has priority 100.5 and selectIndentation item has priority 100.4
         this.status = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100.45)
-        this.loadConfiguration(vscode.window.activeTextEditor?.document.uri)
+        this.loadConfiguration(this.getWorkspace())
         vscode.workspace.onDidChangeConfiguration(e => {
-            if (e.affectsConfiguration('latex-workshop.texcount', this.extension.manager.rootFileUri) || e.affectsConfiguration('latex-workshop.docker.enabled')) {
-                this.loadConfiguration(this.extension.manager.rootFileUri)
+            if (e.affectsConfiguration('latex-workshop.texcount', this.getWorkspace()) || e.affectsConfiguration('latex-workshop.docker.enabled')) {
+                this.loadConfiguration(this.getWorkspace())
                 this.updateStatusVisibility()
 
             }
@@ -38,11 +38,17 @@ export class Counter {
                 this.status.hide()
             }
         })
-
     }
 
-    private loadConfiguration(documentUri: vscode.Uri | undefined) {
-        const configuration = vscode.workspace.getConfiguration('latex-workshop', documentUri)
+    private getWorkspace(): vscode.ConfigurationScope | undefined {
+        if (vscode.window.activeTextEditor) {
+            return vscode.window.activeTextEditor.document.uri
+        }
+        return this.extension.manager.getWorkspaceFolderRootDir()
+    }
+
+    private loadConfiguration(scope: vscode.ConfigurationScope | undefined) {
+        const configuration = vscode.workspace.getConfiguration('latex-workshop', scope)
         this.autoRunEnabled = (configuration.get('texcount.autorun') as string === 'onSave')
         this.autoRunInterval = configuration.get('texcount.interval') as number
         this.commandArgs = configuration.get('texcount.args') as string[]


### PR DESCRIPTION
Follow-up on #3122. This PR sets the `resource` scope to

```
latex-workshop.texcount.args
latex-workshop.texcount.autorun
latex-workshop.texcount.interval
```

In #3122, we decided that path settings should keep their `window` scope.
Close jlelong/LaTeX-Workshop#6