### PR TITLE
Add highlighting for the optional parameters in labels

### DIFF
--- a/syntax/LaTeX.tmLanguage.json
+++ b/syntax/LaTeX.tmLanguage.json
@@ -1901,7 +1901,7 @@
 			"match": "(?:\\s*)((\\\\)(?:begin|end))(\\{)([a-z]+(?:\\*)?)(\\})(?:(\\[).*(\\]))?"
 		},
 		"definition-label": {
-			"begin": "((\\\\)label)(\\{)",
+			"begin": "((\\\\)label)((?:\\[[^\\[]*?\\])*)(\\{)",
 			"beginCaptures": {
 				"1": {
 					"name": "keyword.control.label.latex"
@@ -1910,6 +1910,13 @@
 					"name": "punctuation.definition.keyword.latex"
 				},
 				"3": {
+					"patterns": [
+						{
+							"include": "#optional-arg"
+						}
+					]
+				},
+				"4": {
 					"name": "punctuation.definition.arguments.begin.latex"
 				}
 			},


### PR DESCRIPTION
Hi, first PR for this project. I noticed that the syntax highlighting didn't work for labels with an optional specification e.g. `\label[diagram]{example}`.  This just adds it as an option