### PR TITLE
Add unit tests for checking the content of all `.json` files used for completion

### DIFF
--- a/test/runTest.ts
+++ b/test/runTest.ts
@@ -22,7 +22,7 @@ function writeSettingsJson(userDataDir: string) {
     fs.writeFileSync(settingFilePath, settingsJson)
 }
 
-async function runTestsOnEachFixture(targetName: 'build' | 'rootfile' | 'viewer' | 'completion' | 'multiroot-ws') {
+async function runTestsOnEachFixture(targetName: 'build' | 'rootfile' | 'viewer' | 'completion' | 'multiroot-ws' | 'unittest') {
     const extensionDevelopmentPath = path.resolve(__dirname, '../../')
     const extensionTestsPath = path.resolve(__dirname, `./${targetName}.index`)
     const tmpdir = tmpFile.dirSync({ unsafeCleanup: true })
@@ -75,6 +75,7 @@ async function main() {
         await runTestsOnEachFixture('viewer')
         await runTestsOnEachFixture('completion')
         await runTestsOnEachFixture('multiroot-ws')
+        await runTestsOnEachFixture('unittest')
     } catch (err) {
         console.error('Failed to run tests')
         process.exit(1)

--- a/test/unittest.index.ts
+++ b/test/unittest.index.ts
@@ -1,0 +1,38 @@
+import * as path from 'path'
+import Mocha from 'mocha'
+import glob from 'glob'
+
+export function run(): Promise<void> {
+    // Create the mocha test
+    const mocha = new Mocha({
+        ui: 'tdd',
+        color: true,
+        timeout: 0
+    })
+    const testsRoot = path.resolve(__dirname, '.')
+
+    return new Promise((resolve, reject) => {
+        glob('**/unittest.test.js', { cwd: testsRoot }, (err, files) => {
+            if (err) {
+                return reject(err)
+            }
+
+            // Add files to the test suite
+            files.forEach(f => mocha.addFile(path.resolve(testsRoot, f)))
+
+            try {
+                // Run the mocha test
+                mocha.run(failures => {
+                    if (failures > 0) {
+                        reject(new Error(`${failures} tests failed.`))
+                    } else {
+                        resolve()
+                    }
+                })
+            } catch (e) {
+                console.error(e)
+                reject(e)
+            }
+        })
+    })
+}

--- a/test/unittest.test.ts
+++ b/test/unittest.test.ts
@@ -1,0 +1,28 @@
+import * as assert from 'assert'
+import * as process from 'process'
+import * as vscode from 'vscode'
+
+import {stripComments} from '../src/utils/utils'
+
+import {
+    runTestWithFixture,
+} from './utils'
+
+suite('unit test suite', () => {
+
+    suiteSetup(() => {
+        const config = vscode.workspace.getConfiguration()
+        if (process.env['LATEXWORKSHOP_CI_ENABLE_DOCKER']) {
+            return config.update('latex-workshop.docker.enabled', true, vscode.ConfigurationTarget.Global)
+        }
+        return
+    })
+
+    runTestWithFixture('fixture001', 'basic unit tests', () => {
+        assert.strictEqual(
+            stripComments('abc % comment'),
+            'abc'
+        )
+        return Promise.resolve()
+    })
+})

--- a/test/unittest.test.ts
+++ b/test/unittest.test.ts
@@ -8,7 +8,6 @@ import * as glob from 'glob'
 
 import {
     runTestWithFixture,
-    checkDictkeys as checkDictKeys
 } from './utils'
 
 type EnvType = {
@@ -28,6 +27,10 @@ type CmdType = {
     label?: string
 }
 
+function checkDictKeys(keys: string[], expectedKeys: string[], optKeys: string[] = []): boolean {
+    return keys.every(k => expectedKeys.includes(k) || optKeys.includes(k)) && expectedKeys.every(k => keys.includes(k))
+}
+
 suite('unit test suite', () => {
 
     suiteSetup(() => {
@@ -44,7 +47,14 @@ suite('unit test suite', () => {
         const envs = JSON.parse(fs.readFileSync(file, {encoding: 'utf8'})) as {[key: string]: EnvType}
         assert.ok(Object.keys(envs).length > 0)
         Object.keys(envs).forEach(name => {
-            assert.ok(checkDictKeys(Object.keys(envs[name]), ['name'] , ['snippet', 'detail']), file + ': ' + JSON.stringify(envs[name]))
+            assert.ok(
+                checkDictKeys(
+                    Object.keys(envs[name]),
+                    ['name'],
+                    ['snippet', 'detail']
+                ),
+                file + ': ' + JSON.stringify(envs[name])
+            )
         })
         return Promise.resolve()
     })
@@ -56,7 +66,13 @@ suite('unit test suite', () => {
             const envs = JSON.parse(fs.readFileSync(path.join(extensionRoot, file), {encoding: 'utf8'})) as {[key: string]: EnvType}
             assert.ok(Object.keys(envs).length > 0)
             Object.keys(envs).forEach(name => {
-                assert.ok(checkDictKeys(Object.keys(envs[name]), ['name', 'snippet', 'detail', 'package']), file + ': ' + JSON.stringify(envs[name]))
+                assert.ok(
+                    checkDictKeys(
+                        Object.keys(envs[name]),
+                        ['name', 'snippet', 'detail', 'package']
+                    ),
+                    file + ': ' + JSON.stringify(envs[name])
+                )
             })
         })
         return Promise.resolve()
@@ -68,7 +84,14 @@ suite('unit test suite', () => {
         const cmds = JSON.parse(fs.readFileSync(file, {encoding: 'utf8'})) as {[key: string]: CmdType}
         assert.ok(Object.keys(cmds).length > 0)
         Object.keys(cmds).forEach(name => {
-            assert.ok(checkDictKeys(Object.keys(cmds[name]), ['command'] , ['snippet', 'documentation', 'detail', 'postAction', 'label']), file + ': ' + JSON.stringify(cmds[name]))
+            assert.ok(
+                checkDictKeys(
+                    Object.keys(cmds[name]),
+                    ['command'],
+                    ['snippet', 'documentation', 'detail', 'postAction', 'label']
+                ),
+                file + ': ' + JSON.stringify(cmds[name])
+            )
         })
         return Promise.resolve()
     })
@@ -80,7 +103,14 @@ suite('unit test suite', () => {
             const cmds = JSON.parse(fs.readFileSync(path.join(extensionRoot, file), {encoding: 'utf8'})) as {[key: string]: CmdType}
             assert.ok(Object.keys(cmds).length > 0)
             Object.keys(cmds).forEach(name => {
-                assert.ok(checkDictKeys(Object.keys(cmds[name]), ['command', 'snippet'] , ['documentation', 'detail', 'postAction', 'package', 'label']), file + ': ' + JSON.stringify(cmds[name]))
+                assert.ok(
+                    checkDictKeys(
+                        Object.keys(cmds[name]),
+                        ['command', 'snippet'],
+                        ['documentation', 'detail', 'postAction', 'package', 'label']
+                    ),
+                    file + ': ' + JSON.stringify(cmds[name])
+                )
             })
         })
         return Promise.resolve()

--- a/test/unittest.test.ts
+++ b/test/unittest.test.ts
@@ -1,12 +1,32 @@
 import * as assert from 'assert'
 import * as process from 'process'
 import * as vscode from 'vscode'
+import * as fs from 'fs'
+import * as path from 'path'
+import * as glob from 'glob'
 
-import {stripComments} from '../src/utils/utils'
 
 import {
     runTestWithFixture,
+    checkDictkeys as checkDictKeys
 } from './utils'
+
+type EnvType = {
+    name: string,
+    snippet?: string,
+    detail?: string,
+    package?: string
+}
+
+type CmdType = {
+    command: string,
+    snippet?: string,
+    documentation?: string,
+    package?: string,
+    detail?: string,
+    postAction?: string,
+    label?: string
+}
 
 suite('unit test suite', () => {
 
@@ -18,11 +38,53 @@ suite('unit test suite', () => {
         return
     })
 
-    runTestWithFixture('fixture001', 'basic unit tests', () => {
-        assert.strictEqual(
-            stripComments('abc % comment'),
-            'abc'
-        )
+    runTestWithFixture('fixture001', 'check default environment .json completion file', () => {
+        const extensionRoot = path.resolve(__dirname, '../../')
+        const file = `${extensionRoot}/data/environments.json`
+        const envs = JSON.parse(fs.readFileSync(file, {encoding: 'utf8'})) as {[key: string]: EnvType}
+        assert.ok(Object.keys(envs).length > 0)
+        Object.keys(envs).forEach(name => {
+            assert.ok(checkDictKeys(Object.keys(envs[name]), ['name'] , ['snippet', 'detail']), file + ': ' + JSON.stringify(envs[name]))
+        })
         return Promise.resolve()
     })
+
+    runTestWithFixture('fixture001', 'check environments from package .json completion files', () => {
+        const extensionRoot = path.resolve(__dirname, '../../')
+        const files = glob.sync('data/packages/*_env.json', {cwd: extensionRoot})
+        files.forEach(file => {
+            const envs = JSON.parse(fs.readFileSync(path.join(extensionRoot, file), {encoding: 'utf8'})) as {[key: string]: EnvType}
+            assert.ok(Object.keys(envs).length > 0)
+            Object.keys(envs).forEach(name => {
+                assert.ok(checkDictKeys(Object.keys(envs[name]), ['name', 'snippet', 'detail', 'package']), file + ': ' + JSON.stringify(envs[name]))
+            })
+        })
+        return Promise.resolve()
+    })
+
+    runTestWithFixture('fixture001', 'check default commands .json completion file', () => {
+        const extensionRoot = path.resolve(__dirname, '../../')
+        const file = `${extensionRoot}/data/commands.json`
+        const cmds = JSON.parse(fs.readFileSync(file, {encoding: 'utf8'})) as {[key: string]: CmdType}
+        assert.ok(Object.keys(cmds).length > 0)
+        Object.keys(cmds).forEach(name => {
+            assert.ok(checkDictKeys(Object.keys(cmds[name]), ['command'] , ['snippet', 'documentation', 'detail', 'postAction', 'label']), file + ': ' + JSON.stringify(cmds[name]))
+        })
+        return Promise.resolve()
+    })
+
+    runTestWithFixture('fixture001', 'check commands from package .json completion files', () => {
+        const extensionRoot = path.resolve(__dirname, '../../')
+        const files = glob.sync('data/packages/*_cmd.json', {cwd: extensionRoot})
+        files.forEach(file => {
+            const cmds = JSON.parse(fs.readFileSync(path.join(extensionRoot, file), {encoding: 'utf8'})) as {[key: string]: CmdType}
+            assert.ok(Object.keys(cmds).length > 0)
+            Object.keys(cmds).forEach(name => {
+                assert.ok(checkDictKeys(Object.keys(cmds[name]), ['command', 'snippet'] , ['documentation', 'detail', 'postAction', 'package', 'label']), file + ': ' + JSON.stringify(cmds[name]))
+            })
+        })
+        return Promise.resolve()
+    })
+
+
 })

--- a/test/unittest.test.ts
+++ b/test/unittest.test.ts
@@ -27,8 +27,11 @@ type CmdType = {
     label?: string
 }
 
-function checkDictKeys(keys: string[], expectedKeys: string[], optKeys: string[] = []): boolean {
-    return keys.every(k => expectedKeys.includes(k) || optKeys.includes(k)) && expectedKeys.every(k => keys.includes(k))
+function assertDictKeyNames(keys: string[], expectedKeys: string[], optKeys: string[] = [], message: string): void {
+    assert.ok(
+        keys.every(k => expectedKeys.includes(k) || optKeys.includes(k)) && expectedKeys.every(k => keys.includes(k)),
+        message
+    )
 }
 
 suite('unit test suite', () => {
@@ -47,12 +50,10 @@ suite('unit test suite', () => {
         const envs = JSON.parse(fs.readFileSync(file, {encoding: 'utf8'})) as {[key: string]: EnvType}
         assert.ok(Object.keys(envs).length > 0)
         Object.keys(envs).forEach(name => {
-            assert.ok(
-                checkDictKeys(
-                    Object.keys(envs[name]),
-                    ['name'],
-                    ['snippet', 'detail']
-                ),
+            assertDictKeyNames(
+                Object.keys(envs[name]),
+                ['name'],
+                ['snippet', 'detail'],
                 file + ': ' + JSON.stringify(envs[name])
             )
         })
@@ -66,11 +67,10 @@ suite('unit test suite', () => {
             const envs = JSON.parse(fs.readFileSync(path.join(extensionRoot, file), {encoding: 'utf8'})) as {[key: string]: EnvType}
             assert.ok(Object.keys(envs).length > 0)
             Object.keys(envs).forEach(name => {
-                assert.ok(
-                    checkDictKeys(
-                        Object.keys(envs[name]),
-                        ['name', 'snippet', 'detail', 'package']
-                    ),
+                assertDictKeyNames(
+                    Object.keys(envs[name]),
+                    ['name', 'snippet', 'detail', 'package'],
+                    [],
                     file + ': ' + JSON.stringify(envs[name])
                 )
             })
@@ -84,12 +84,10 @@ suite('unit test suite', () => {
         const cmds = JSON.parse(fs.readFileSync(file, {encoding: 'utf8'})) as {[key: string]: CmdType}
         assert.ok(Object.keys(cmds).length > 0)
         Object.keys(cmds).forEach(name => {
-            assert.ok(
-                checkDictKeys(
-                    Object.keys(cmds[name]),
-                    ['command'],
-                    ['snippet', 'documentation', 'detail', 'postAction', 'label']
-                ),
+            assertDictKeyNames(
+                Object.keys(cmds[name]),
+                ['command'],
+                ['snippet', 'documentation', 'detail', 'postAction', 'label'],
                 file + ': ' + JSON.stringify(cmds[name])
             )
         })
@@ -103,12 +101,10 @@ suite('unit test suite', () => {
             const cmds = JSON.parse(fs.readFileSync(path.join(extensionRoot, file), {encoding: 'utf8'})) as {[key: string]: CmdType}
             assert.ok(Object.keys(cmds).length > 0)
             Object.keys(cmds).forEach(name => {
-                assert.ok(
-                    checkDictKeys(
-                        Object.keys(cmds[name]),
-                        ['command', 'snippet'],
-                        ['documentation', 'detail', 'postAction', 'package', 'label']
-                    ),
+                assertDictKeyNames(
+                    Object.keys(cmds[name]),
+                    ['command', 'snippet'],
+                    ['documentation', 'detail', 'postAction', 'package', 'label'],
                     file + ': ' + JSON.stringify(cmds[name])
                 )
             })

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -178,7 +178,3 @@ export async function getViewerStatus(pdfFilePath: string) {
         }
     }, process.platform === 'win32' ? 600 : undefined)
 }
-
-export function checkDictkeys(keys: string[], expectedKeys: string[], optKeys: string[] = []): boolean {
-    return keys.every(k => expectedKeys.includes(k) || optKeys.includes(k)) && expectedKeys.every(k => keys.includes(k))
-}

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -178,3 +178,7 @@ export async function getViewerStatus(pdfFilePath: string) {
         }
     }, process.platform === 'win32' ? 600 : undefined)
 }
+
+export function checkDictkeys(keys: string[], expectedKeys: string[], optKeys: string[] = []): boolean {
+    return keys.every(k => expectedKeys.includes(k) || optKeys.includes(k)) && expectedKeys.every(k => keys.includes(k))
+}


### PR DESCRIPTION
@tamuratak Based on https://github.com/tamuratak/LaTeX-Workshop/tree/unittest, I have written some tests to check that every entry in the `.json` files used for completion contain the correct keys and only them.