### PR TITLE
Use keys from `latex-workshop.intellisense.citation.format` to filter text in citation intellisense

### DIFF
--- a/package.json
+++ b/package.json
@@ -1727,11 +1727,11 @@
             "authors"
           ],
           "default": "bibtex key",
-          "markdownDescription": "Defines what to show as suggestion labels when intellisense provides citation suggestions.",
+          "markdownDescription": "Defines what to show as suggestion labels when intellisense provides citation suggestions in inline mode.",
           "enumDescriptions": [
-            "Show bibtex keys in the inline intellisense.",
-            "Show publication titles in the inline intellisense.",
-            "Show publication authors in the inline intellisense."
+            "Show bibtex keys in the inline mode.",
+            "Show publication titles in the inline mode.",
+            "Show publication authors in the inline mode."
           ]
         },
         "latex-workshop.intellisense.citation.format": {

--- a/package.json
+++ b/package.json
@@ -1748,7 +1748,7 @@
             "booktitle",
             "year"
           ],
-          "markdownDescription": "List of fields to display for citation preview and intellisense. Reload vscode to make any change in this configuration effective."
+          "markdownDescription": "List of fields to display for citation preview and intellisense. This list is also used as the filter text to narrow down the intellisense suggestions. Reload vscode to make any change in this configuration effective."
         },
         "latex-workshop.intellisense.citation.maxfilesizeMB": {
           "scope": "window",

--- a/package.json
+++ b/package.json
@@ -1719,7 +1719,7 @@
           ]
         },
         "latex-workshop.intellisense.citation.label": {
-          "scope": "window",
+          "scope": "resource",
           "type": "string",
           "enum": [
             "bibtex key",
@@ -1735,7 +1735,7 @@
           ]
         },
         "latex-workshop.intellisense.citation.format": {
-          "scope": "window",
+          "scope": "resource",
           "type": "array",
           "items": {
             "type": "string"
@@ -1748,7 +1748,7 @@
             "booktitle",
             "year"
           ],
-          "markdownDescription": "List of fields to display for citation preview and intellisense. This list is also used as the filter text to narrow down the intellisense suggestions. Reload vscode to make any change in this configuration effective."
+          "markdownDescription": "List of fields to display for citation preview and intellisense. This list is also used as the filter text to narrow down the intellisense suggestions."
         },
         "latex-workshop.intellisense.citation.maxfilesizeMB": {
           "scope": "window",

--- a/src/providers/completer/citation.ts
+++ b/src/providers/completer/citation.ts
@@ -82,20 +82,18 @@ export class Citation implements IProvider {
         return this.provide(args)
     }
 
-    private provide(args?: {document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken, context: vscode.CompletionContext}): ILwCompletionItem[] {
+    private provide(args: {document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken, context: vscode.CompletionContext}): ILwCompletionItem[] {
         // Compile the suggestion array to vscode completion array
         const configuration = vscode.workspace.getConfiguration('latex-workshop', args?.document.uri)
         const label = configuration.get('intellisense.citation.label') as string
         const fields = readFields(configuration)
         let range: vscode.Range | undefined = undefined
-        if (args) {
-            const line = args.document.lineAt(args.position).text
-            const curlyStart = line.lastIndexOf('{', args.position.character)
-            const commaStart = line.lastIndexOf(',', args.position.character)
-            const startPos = Math.max(curlyStart, commaStart)
-            if (startPos >= 0) {
-                range = new vscode.Range(args.position.line, startPos + 1, args.position.line, args.position.character)
-            }
+        const line = args.document.lineAt(args.position).text
+        const curlyStart = line.lastIndexOf('{', args.position.character)
+        const commaStart = line.lastIndexOf(',', args.position.character)
+        const startPos = Math.max(curlyStart, commaStart)
+        if (startPos >= 0) {
+            range = new vscode.Range(args.position.line, startPos + 1, args.position.line, args.position.character)
         }
         return this.updateAll(this.getIncludedBibs(this.extension.manager.rootFile)).map(item => {
             // Compile the completion item label

--- a/src/providers/completer/citation.ts
+++ b/src/providers/completer/citation.ts
@@ -91,7 +91,7 @@ export class Citation implements IProvider {
 
     private provide(args: {document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken, context: vscode.CompletionContext}): ILwCompletionItem[] {
         // Compile the suggestion array to vscode completion array
-        const configuration = vscode.workspace.getConfiguration('latex-workshop', args?.document.uri)
+        const configuration = vscode.workspace.getConfiguration('latex-workshop', args.document.uri)
         const label = configuration.get('intellisense.citation.label') as string
         const fields = readCitationFormat(configuration)
         let range: vscode.Range | undefined = undefined

--- a/test/completion.test.ts
+++ b/test/completion.test.ts
@@ -54,7 +54,7 @@ suite('Completion test suite', () => {
         const extension = await waitLatexWorkshopActivated()
         const pos = new vscode.Position(3,1)
         const token = new vscode.CancellationTokenSource().token
-        const items = await extension.exports.realExtension?.completer.provideCompletionItems?.(
+        const items = extension.exports.realExtension?.completer.provideCompletionItems?.(
             doc, pos, token,
             {
                 triggerKind: vscode.CompletionTriggerKind.Invoke,
@@ -73,7 +73,7 @@ suite('Completion test suite', () => {
         const extension = await waitLatexWorkshopActivated()
         const pos = new vscode.Position(3,1)
         const token = new vscode.CancellationTokenSource().token
-        const items = await extension.exports.realExtension?.atSuggestionCompleter.provideCompletionItems(
+        const items = extension.exports.realExtension?.atSuggestionCompleter.provideCompletionItems(
             doc, pos, token,
             {
                 triggerKind: vscode.CompletionTriggerKind.Invoke,
@@ -96,7 +96,7 @@ suite('Completion test suite', () => {
         const extension = await waitLatexWorkshopActivated()
         const pos = new vscode.Position(3,1)
         const token = new vscode.CancellationTokenSource().token
-        const items = await extension.exports.realExtension?.atSuggestionCompleter.provideCompletionItems(
+        const items = extension.exports.realExtension?.atSuggestionCompleter.provideCompletionItems(
             doc, pos, token,
             {
                 triggerKind: vscode.CompletionTriggerKind.Invoke,

--- a/test/fixtures/multiroot-ws/fixture040/A/.vscode/settings.json
+++ b/test/fixtures/multiroot-ws/fixture040/A/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+	"latex-workshop.intellisense.citation.label": "title"
+}

--- a/test/fixtures/multiroot-ws/fixture040/A/A.bib
+++ b/test/fixtures/multiroot-ws/fixture040/A/A.bib
@@ -1,0 +1,32 @@
+@article{art1,
+  title       = {A fake article},
+  author      = {Davis, J. and Jones, M.},
+  journal     = {Journal of CI tests},
+  year        = {2022},
+  description = {hintFake}
+}
+
+@book{lamport1994latex,
+  title        = {LATEX: A Document Preparation System : User's Guide and Reference Manual},
+  author       = {Lamport, L. and Bibby, D. and Pearson Education},
+  isbn         = {9780201529838},
+  lccn         = {93039691},
+  series       = {Addison-Wesley Series on Tools},
+  url          = {https://books.google.ch/books?id=khVUAAAAMAAJ},
+  year         = {1994},
+  publisher    = {Addison-Wesley},
+  description = {hintLaTex}
+}
+
+@book{MR1241645,
+  author      = {Rubinstein, Reuven Y. and Shapiro, Alexander},
+  title       = {Discrete event systems},
+  series      = {Wiley Series in Probability and Mathematical Statistics:
+                 Probability and Mathematical Statistics},
+  note        = {Sensitivity analysis and stochastic optimization by the score
+                 function method},
+  publisher   = {John Wiley \& Sons Ltd.},
+  address     = {Chichester},
+  year        = 1993,
+  description = {hintRubi}
+}

--- a/test/fixtures/multiroot-ws/fixture040/A/A.tex
+++ b/test/fixtures/multiroot-ws/fixture040/A/A.tex
@@ -1,0 +1,6 @@
+\documentclass{article}
+
+\begin{document}
+    \cite{}
+    \bibliography{A.bib}
+\end{document}

--- a/test/fixtures/multiroot-ws/fixture040/B/B.bib
+++ b/test/fixtures/multiroot-ws/fixture040/B/B.bib
@@ -1,0 +1,32 @@
+@article{art1,
+  title       = {A fake article},
+  author      = {Davis, J. and Jones, M.},
+  journal     = {Journal of CI tests},
+  year        = {2022},
+  description = {hintFake}
+}
+
+@book{lamport1994latex,
+  title        = {LATEX: A Document Preparation System : User's Guide and Reference Manual},
+  author       = {Lamport, L. and Bibby, D. and Pearson Education},
+  isbn         = {9780201529838},
+  lccn         = {93039691},
+  series       = {Addison-Wesley Series on Tools},
+  url          = {https://books.google.ch/books?id=khVUAAAAMAAJ},
+  year         = {1994},
+  publisher    = {Addison-Wesley},
+  description = {hintLaTex}
+}
+
+@book{MR1241645,
+  author      = {Rubinstein, Reuven Y. and Shapiro, Alexander},
+  title       = {Discrete event systems},
+  series      = {Wiley Series in Probability and Mathematical Statistics:
+                 Probability and Mathematical Statistics},
+  note        = {Sensitivity analysis and stochastic optimization by the score
+                 function method},
+  publisher   = {John Wiley \& Sons Ltd.},
+  address     = {Chichester},
+  year        = 1993,
+  description = {hintRubi}
+}

--- a/test/fixtures/multiroot-ws/fixture040/B/B.tex
+++ b/test/fixtures/multiroot-ws/fixture040/B/B.tex
@@ -1,0 +1,6 @@
+\documentclass{article}
+
+\begin{document}
+    \cite{}
+    \bibliography{B.bib}
+\end{document}

--- a/test/fixtures/multiroot-ws/fixture040/resource.code-workspace
+++ b/test/fixtures/multiroot-ws/fixture040/resource.code-workspace
@@ -1,0 +1,19 @@
+{
+	"folders": [
+		{
+			"path": "A"
+		},
+		{
+			"path": "B"
+		}
+	],
+	"settings": {
+		"latex-workshop.intellisense.citation.label":"bibtex key",
+		"latex-workshop.intellisense.citation.format": [
+			"author",
+			"title",
+			"journal",
+			"description"
+		]
+	}
+}

--- a/test/multiroot-ws.test.ts
+++ b/test/multiroot-ws.test.ts
@@ -304,7 +304,7 @@ suite('Multi-root workspace test suite', () => {
         const extension = await waitLatexWorkshopActivated()
         await waitGivenRootFile(docA.fileName)
         await sleep(1000)
-        const itemsA = await getCompletionItems(extension, docA, pos)
+        const itemsA = getCompletionItems(extension, docA, pos)
         const expectedLabelsA = [
             'A fake article',
             'LATEX: A Document Preparation System : User\'s Guide and Reference Manual',
@@ -318,7 +318,7 @@ suite('Multi-root workspace test suite', () => {
         await vscode.window.showTextDocument(docB)
         await waitGivenRootFile(docB.fileName)
         await sleep(1000)
-        const itemsB = await getCompletionItems(extension, docB, pos)
+        const itemsB = getCompletionItems(extension, docB, pos)
         const expectedLabelsB = [
             'art1',
             'lamport1994latex',

--- a/test/multiroot-ws.test.ts
+++ b/test/multiroot-ws.test.ts
@@ -29,7 +29,7 @@ function getCompletionItems(extension: vscode.Extension<ReturnType<typeof activa
 function assertCompletionLabelsEqual(items: vscode.CompletionItem[] | undefined, labels: string[]) {
     assert.ok(items !== undefined, 'Undefined completionItems')
     assert.strictEqual(items.length, labels.length, 'Completion array has wrong length')
-    for(const i in items) {
+    for(let i = 0; i<items.length; i++) {
         assert.strictEqual(items[i].label, labels[i], 'Wrong label')
     }
 }
@@ -37,7 +37,7 @@ function assertCompletionLabelsEqual(items: vscode.CompletionItem[] | undefined,
 function assertCompletionFilterTextContains(items: vscode.CompletionItem[] | undefined, filterTexts: string[]) {
     assert.ok(items !== undefined, 'Undefined completionItems')
     assert.strictEqual(items.length, filterTexts.length, 'Completion array has wrong length')
-    for(const i in items) {
+    for(let i = 0; i<items.length; i++) {
         assert.ok(items[i].filterText && items[i].filterText?.includes(filterTexts[i]), `Wrong filterText: \n${items[i].filterText}\n${filterTexts[i]}`)
     }
 }


### PR DESCRIPTION
This a POC related to #3214 

In browser mode, display all the fields from `latex-workshop.intellisense.citation.format` on the second line. Order  in the array matters. In browser and inline mode, narrow down the search using all the fields listed in `latex-workshop.intellisense.citation.format`

<img width="860" alt="Capture d’écran 2022-03-23 à 07 31 12" src="https://user-images.githubusercontent.com/2910140/159637431-d033d253-d57f-403c-8286-eeaa88df0565.png">


<img width="685" alt="Capture d’écran 2022-03-23 à 07 30 03" src="https://user-images.githubusercontent.com/2910140/159637328-6eb16a24-e211-4c72-9a82-5c6d7999b34e.png">


<img width="690" alt="Capture d’écran 2022-03-23 à 07 30 10" src="https://user-images.githubusercontent.com/2910140/159637297-3349037e-6ec9-4cd9-a1e7-fcdee7b2091e.png">

