### PR TITLE
Refactor bibtexUtils and set resource scope to all bibtex settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -2127,7 +2127,7 @@
           "markdownDescription": "Many snippets use PlaceHolders of the form `${\\d:some_tex`}` for their argument. You may prefer to use TabStops `${\\d}` instead, which allows for direct call to intellisense again. Default is true. Reload vscode to make any change in this configuration effective."
         },
         "latex-workshop.intellisense.citation.backend": {
-          "scope": "window",
+          "scope": "resource",
           "type": "string",
           "enum": [
             "bibtex",
@@ -2137,7 +2137,7 @@
           "markdownDescription": "Backend to use for citation intellisense."
         },
         "latex-workshop.intellisense.bibtexJSON.replace": {
-          "scope": "window",
+          "scope": "resource",
           "type": "object",
           "additionalProperties": {
             "type": "array",
@@ -2149,7 +2149,7 @@
           "markdownDescription": "Dictionary of `\"entry name\": [\"array\", \"of\", \"fields\"]` to replace the default fields used in `data/bibtex-entries.json`. See `data/bibtex-entries.json` for the list of fields for each entry. This variable is used when `latex-workshop.intellisense.citation.backend` is set to `biblatex`. Reload vscode to make any change in this configuration effective."
         },
         "latex-workshop.intellisense.biblatexJSON.replace": {
-          "scope": "window",
+          "scope": "resource",
           "type": "object",
           "additionalProperties": {
             "type": "array",
@@ -2193,13 +2193,13 @@
           "markdownDescription": "Defines the maximum bibtex file size for the extension to parse in MB."
         },
         "latex-workshop.bibtex-format.tab": {
-          "scope": "window",
+          "scope": "resource",
           "type": "string",
           "default": "2 spaces",
           "markdownDescription": "Indentation for each field. The string can be `\"tab\"` or of the form `\"X spaces\"` or simply `\"X\"` where `X` is a number. Reload vscode to make any change in this configuration effective."
         },
         "latex-workshop.bibtex-format.surround": {
-          "scope": "window",
+          "scope": "resource",
           "type": "string",
           "enum": [
             "Curly braces",
@@ -2209,7 +2209,7 @@
           "description": "Surround each field value with either {Curly braces} or \"Quotation marks\". Reload vscode to make any change in this configuration effective."
         },
         "latex-workshop.bibtex-format.case": {
-          "scope": "window",
+          "scope": "resource",
           "type": "string",
           "enum": [
             "UPPERCASE",
@@ -2219,13 +2219,13 @@
           "description": "Determines if field names should be formatted like 'AUTHOR' or 'author'. Reload vscode to make any change in this configuration effective."
         },
         "latex-workshop.bibtex-format.trailingComma": {
-          "scope": "window",
+          "scope": "resource",
           "type": "boolean",
           "default": false,
           "description": "Keep the trailing comma of the last field item. Reload vscode to make any change in this configuration effective."
         },
         "latex-workshop.bibtex-format.sortby": {
-          "scope": "window",
+          "scope": "resource",
           "type": "array",
           "items": {
             "type": "string"
@@ -2236,7 +2236,7 @@
           ]
         },
         "latex-workshop.bibtex-format.handleDuplicates": {
-          "scope": "window",
+          "scope": "resource",
           "type": "string",
           "enum": [
             "Ignore Duplicates",
@@ -2247,7 +2247,7 @@
           "markdownDescription": "How to handle duplicates found by the bibtex sorting functions. Duplicates are decided according to the `bibtex-format.sortby` config. Reload vscode to make any change in this configuration effective."
         },
         "latex-workshop.bibtex-format.sort.enabled": {
-          "scope": "window",
+          "scope": "resource",
           "type": "boolean",
           "default": false,
           "markdownDescription": "Sort content when calling VSCode format on a .bib file. Reload vscode to make any change in this configuration effective."
@@ -2258,7 +2258,7 @@
           "markdownDescription": "Align equal signs when calling VSCode format on a .bib file. Reload vscode to make any change in this configuration effective."
         },
         "latex-workshop.bibtex-entries.first": {
-          "scope": "window",
+          "scope": "resource",
           "type": "array",
           "items": {
             "type": "string"
@@ -2270,13 +2270,13 @@
           "markdownDescription": "When `latex-workshop.bibtex-fields.sort.enabled` is true, these fields are put at the top, in the order defined by the array. Reload vscode to make any change in this configuration effective."
         },
         "latex-workshop.bibtex-fields.sort.enabled": {
-          "scope": "window",
+          "scope": "resource",
           "type": "boolean",
           "default": false,
           "markdownDescription": "Sort fields inside every entry. The sorting order is defined by `latex-workshop.bibtex-fields.order`. This variable only has effect when formatting bibtex aligns fields. It is not possible to sort entries without aligning them. Reload vscode to make any change in this configuration effective."
         },
         "latex-workshop.bibtex-fields.order": {
-          "scope": "window",
+          "scope": "resource",
           "type": "array",
           "items": {
             "type": "string"

--- a/package.json
+++ b/package.json
@@ -2146,7 +2146,7 @@
             }
           },
           "default": {},
-          "markdownDescription": "Dictionary of `\"entry name\": [\"array\", \"of\", \"fields\"]` to replace the default fields used in `data/bibtex-entries.json`. See `data/bibtex-entries.json` for the list of fields for each entry. This variable is used when `latex-workshop.intellisense.citation.backend` is set to `biblatex`. Reload vscode to make any change in this configuration effective."
+          "markdownDescription": "Dictionary of `\"entry name\": [\"array\", \"of\", \"fields\"]` to replace the default fields used in `data/bibtex-entries.json`. See `data/bibtex-entries.json` for the list of fields for each entry. This variable is used when `latex-workshop.intellisense.citation.backend` is set to `biblatex`."
         },
         "latex-workshop.intellisense.biblatexJSON.replace": {
           "scope": "resource",
@@ -2158,7 +2158,7 @@
             }
           },
           "default": {},
-          "markdownDescription": "Dictionary of `\"entry name\": [\"array\", \"of\", \"fields\"]` to replace the default fields used in `data/biblatex-entries.json`. See `data/biblatex-entries.json` for the list of fields for each entry. This variable is used when `latex-workshop.intellisense.citation.backend` is set to `bibtex`. Reload vscode to make any change in this configuration effective."
+          "markdownDescription": "Dictionary of `\"entry name\": [\"array\", \"of\", \"fields\"]` to replace the default fields used in `data/biblatex-entries.json`. See `data/biblatex-entries.json` for the list of fields for each entry. This variable is used when `latex-workshop.intellisense.citation.backend` is set to `bibtex`."
         },
         "latex-workshop.intellisense.commandsJSON.replace": {
           "scope": "window",
@@ -2196,7 +2196,7 @@
           "scope": "resource",
           "type": "string",
           "default": "2 spaces",
-          "markdownDescription": "Indentation for each field. The string can be `\"tab\"` or of the form `\"X spaces\"` or simply `\"X\"` where `X` is a number. Reload vscode to make any change in this configuration effective."
+          "markdownDescription": "Indentation for each field. The string can be `\"tab\"` or of the form `\"X spaces\"` or simply `\"X\"` where `X` is a number."
         },
         "latex-workshop.bibtex-format.surround": {
           "scope": "resource",
@@ -2206,7 +2206,7 @@
             "Quotation marks"
           ],
           "default": "Curly braces",
-          "description": "Surround each field value with either {Curly braces} or \"Quotation marks\". Reload vscode to make any change in this configuration effective."
+          "description": "Surround each field value with either {Curly braces} or \"Quotation marks\"."
         },
         "latex-workshop.bibtex-format.case": {
           "scope": "resource",
@@ -2216,13 +2216,13 @@
             "lowercase"
           ],
           "default": "lowercase",
-          "description": "Determines if field names should be formatted like 'AUTHOR' or 'author'. Reload vscode to make any change in this configuration effective."
+          "description": "Determines if field names should be formatted like 'AUTHOR' or 'author'."
         },
         "latex-workshop.bibtex-format.trailingComma": {
           "scope": "resource",
           "type": "boolean",
           "default": false,
-          "description": "Keep the trailing comma of the last field item. Reload vscode to make any change in this configuration effective."
+          "description": "Keep the trailing comma of the last field item."
         },
         "latex-workshop.bibtex-format.sortby": {
           "scope": "resource",
@@ -2230,7 +2230,7 @@
           "items": {
             "type": "string"
           },
-          "markdownDescription": "An array of strings to sort by. Either a bibtex field name (title, author, year, etc.), or `\"year-desc\"` to sort by year in descending order, or `\"key\"` for the entry key, or `\"type\"` for the entry type (article, book, misc, etc.). E.g. `[\"author\", \"year-desc\", \"title\"]`. Reload vscode to make any change in this configuration effective.",
+          "markdownDescription": "An array of strings to sort by. Either a bibtex field name (title, author, year, etc.), or `\"year-desc\"` to sort by year in descending order, or `\"key\"` for the entry key, or `\"type\"` for the entry type (article, book, misc, etc.). E.g. `[\"author\", \"year-desc\", \"title\"]`.",
           "default": [
             "key"
           ]
@@ -2244,18 +2244,18 @@
             "Comment Duplicates"
           ],
           "default": "Highlight Duplicates",
-          "markdownDescription": "How to handle duplicates found by the bibtex sorting functions. Duplicates are decided according to the `bibtex-format.sortby` config. Reload vscode to make any change in this configuration effective."
+          "markdownDescription": "How to handle duplicates found by the bibtex sorting functions. Duplicates are decided according to the `bibtex-format.sortby` config."
         },
         "latex-workshop.bibtex-format.sort.enabled": {
           "scope": "resource",
           "type": "boolean",
           "default": false,
-          "markdownDescription": "Sort content when calling VSCode format on a .bib file. Reload vscode to make any change in this configuration effective."
+          "markdownDescription": "Sort content when calling VSCode format on a .bib file."
         },
         "latex-workshop.bibtex-format.align-equal.enabled": {
           "type": "boolean",
           "default": true,
-          "markdownDescription": "Align equal signs when calling VSCode format on a .bib file. Reload vscode to make any change in this configuration effective."
+          "markdownDescription": "Align equal signs when calling VSCode format on a .bib file."
         },
         "latex-workshop.bibtex-entries.first": {
           "scope": "resource",
@@ -2267,13 +2267,13 @@
             "string",
             "xdata"
           ],
-          "markdownDescription": "When `latex-workshop.bibtex-fields.sort.enabled` is true, these fields are put at the top, in the order defined by the array. Reload vscode to make any change in this configuration effective."
+          "markdownDescription": "When `latex-workshop.bibtex-fields.sort.enabled` is true, these fields are put at the top, in the order defined by the array."
         },
         "latex-workshop.bibtex-fields.sort.enabled": {
           "scope": "resource",
           "type": "boolean",
           "default": false,
-          "markdownDescription": "Sort fields inside every entry. The sorting order is defined by `latex-workshop.bibtex-fields.order`. This variable only has effect when formatting bibtex aligns fields. It is not possible to sort entries without aligning them. Reload vscode to make any change in this configuration effective."
+          "markdownDescription": "Sort fields inside every entry. The sorting order is defined by `latex-workshop.bibtex-fields.order`. This variable only has effect when formatting bibtex aligns fields. It is not possible to sort entries without aligning them."
         },
         "latex-workshop.bibtex-fields.order": {
           "scope": "resource",
@@ -2282,7 +2282,7 @@
             "type": "string"
           },
           "default": [],
-          "markdownDescription": "When `latex-workshop.bibtex-fields.sort.enabled` is true, sort fields according the order defined here and then alphabetically for non listed fields. Reload vscode to make any change in this configuration effective."
+          "markdownDescription": "When `latex-workshop.bibtex-fields.sort.enabled` is true, sort fields according the order defined here and then alphabetically for non listed fields."
         },
         "latex-workshop.mathpreviewpanel.cursor.enabled": {
           "scope": "window",

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -313,6 +313,16 @@ export class Manager {
         return ['tex', 'latex', 'latex-expl3', 'doctex', 'jlweave', 'rsweave'].includes(id)
     }
 
+    /**
+     * Returns `true` if the language of `id` is bibtex
+     *
+     * @param id The identifier of language.
+     */
+    hasBibtexId(id: string) {
+        return id === 'bibtex'
+    }
+
+
     private findWorkspace(): vscode.Uri | undefined {
         const firstDir = vscode.workspace.workspaceFolders?.[0]
         // If no workspace is opened.

--- a/src/providers/bibtexcompletion.ts
+++ b/src/providers/bibtexcompletion.ts
@@ -1,8 +1,7 @@
 import * as vscode from 'vscode'
 import * as fs from 'fs'
 
-import {BibtexUtils} from './bibtexformatterlib/bibtexutils'
-import type {BibtexFormatConfig} from './bibtexformatterlib/bibtexutils'
+import {BibtexFormatConfig} from './bibtexformatterlib/bibtexutils'
 import type {Extension} from '../main'
 
 type DataBibtexJsonType = typeof import('../../data/bibtex-entries.json')
@@ -10,14 +9,43 @@ type DataBibtexOptionalJsonType = typeof import('../../data/bibtex-optional-entr
 
 export class BibtexCompleter implements vscode.CompletionItemProvider {
     private readonly extension: Extension
+    private scope: vscode.ConfigurationScope | undefined = undefined
     private readonly entryItems: vscode.CompletionItem[] = []
     private readonly optFieldItems = Object.create(null) as { [key: string]: vscode.CompletionItem[] }
-    private readonly bibtexUtils: BibtexUtils
+    private readonly bibtexFormatConfig: BibtexFormatConfig
 
     constructor(extension: Extension) {
         this.extension = extension
-        this.bibtexUtils = new BibtexUtils(extension)
-        const configuration = vscode.workspace.getConfiguration('latex-workshop')
+        if (vscode.window.activeTextEditor) {
+            this.scope = vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri)
+        } else {
+            this.scope = vscode.workspace.workspaceFolders?.[0]
+        }
+        this.bibtexFormatConfig = new BibtexFormatConfig(extension, this.scope)
+        this.initialize()
+        vscode.workspace.onDidChangeConfiguration((e: vscode.ConfigurationChangeEvent) => {
+            if (e.affectsConfiguration('latex-workshop.bibtex-format', this.scope) ||
+                e.affectsConfiguration('latex-workshop.bibtex-entries', this.scope) ||
+                e.affectsConfiguration('latex-workshop.bibtex-fields', this.scope) ||
+                e.affectsConfiguration('latex-workshop.intellisense', this.scope)) {
+                    this.bibtexFormatConfig.loadConfiguration(this.scope)
+                    this.initialize()
+                }
+        })
+        vscode.window.onDidChangeActiveTextEditor((e: vscode.TextEditor | undefined) => {
+            if (e && this.extension.manager.hasBibtexId(e.document.languageId)) {
+                const wsFolder = vscode.workspace.getWorkspaceFolder(e.document.uri)
+                if (wsFolder !== this.scope) {
+                    this.scope = wsFolder
+                    this.bibtexFormatConfig.loadConfiguration(this.scope)
+                    this.initialize()
+                }
+            }
+        })
+    }
+
+    private initialize() {
+        const configuration = vscode.workspace.getConfiguration('latex-workshop', this.scope)
         const citationBackend = configuration.get('intellisense.citation.backend')
         let entriesFile: string = ''
         let optEntriesFile: string = ''
@@ -50,19 +78,20 @@ export class BibtexCompleter implements vscode.CompletionItemProvider {
 
         const maxLengths: {[key: string]: number} = this.computeMaxLengths(entries, optFields)
         const entriesList: string[] = []
+        this.entryItems.length = 0
         Object.keys(entries).forEach(entry => {
             if (entry in entriesList) {
                 return
             }
             if (entry in entriesReplacements) {
-                this.entryItems.push(this.entryToCompletion(entry, entriesReplacements[entry], this.bibtexUtils.bibtexFormatConfig, maxLengths))
+                this.entryItems.push(this.entryToCompletion(entry, entriesReplacements[entry], this.bibtexFormatConfig, maxLengths))
             } else {
-                this.entryItems.push(this.entryToCompletion(entry, entries[entry], this.bibtexUtils.bibtexFormatConfig, maxLengths))
+                this.entryItems.push(this.entryToCompletion(entry, entries[entry], this.bibtexFormatConfig, maxLengths))
             }
             entriesList.push(entry)
         })
         Object.keys(optFields).forEach(entry => {
-            this.optFieldItems[entry] = this.fieldsToCompletion(entry, optFields[entry], this.bibtexUtils.bibtexFormatConfig, maxLengths)
+            this.optFieldItems[entry] = this.fieldsToCompletion(entry, optFields[entry], this.bibtexFormatConfig, maxLengths)
         })
     }
 

--- a/src/providers/bibtexcompletion.ts
+++ b/src/providers/bibtexcompletion.ts
@@ -122,7 +122,7 @@ export class BibtexCompleter implements vscode.CompletionItemProvider {
         // Find the longest field name in entry
         let s: string = itemName + '{${0:key}'
         itemFields.forEach(field => {
-            s += ',\n' + config.tab + (config.case === 'lowercase' ? field : field.toUpperCase())
+            s += ',\n' + config.tab + (config.case === 'lowercase' ? field.toLowerCase() : field.toUpperCase())
             s += ' '.repeat(maxLengths[itemName] - field.length) + ' = '
             s += config.left + `$${count}` + config.right
             count++


### PR DESCRIPTION
Related to #3191. 

This PR turns the `BibtexFormatConfig` interface into a class and changes `BibtexFormatter` and `BibtexCompleter` to allow all `bibtex-*` settings and `intellisense.citation.backend` to have `resource` scope.

- `BibtexFormatter` uses a new instance of `BibtexFormatConfig` every time it is called. The overhead is negligible and it avoids complicated monitoring code
- In `BibtexCompleter`, we monitor the current `workspace.ConfigurationScope` and reload `bibtexFormatConfig` every time the scope changes.

Close https://github.com/jlelong/LaTeX-Workshop/issues/5