### PR TITLE
Remove `cref` and `cpageref` from default commands

### DIFF
--- a/data/commands.json
+++ b/data/commands.json
@@ -641,10 +641,6 @@
     "command": "times",
     "detail": "×"
   },
-  "cdots": {
-    "command": "cdots",
-    "detail": "···"
-  },
   "cap": {
     "command": "cap",
     "detail": "∩"
@@ -700,10 +696,6 @@
     "command": "ddot{text}",
     "snippet": "ddot{$1}"
   },
-  "cdot": {
-    "command": "cdot",
-    "detail": "·"
-  },
   "acute{}": {
     "command": "acute{text}",
     "snippet": "acute{$1}",
@@ -755,21 +747,6 @@
   "vec{}": {
     "command": "vec{text}",
     "snippet": "vec{$1}"
-  },
-  "input": {
-    "command": "input",
-    "snippet": "input{$1}",
-    "postAction": "editor.action.triggerSuggest"
-  },
-  "include{}": {
-    "command": "include{file}",
-    "snippet": "include{$1}",
-    "postAction": "editor.action.triggerSuggest"
-  },
-  "includegraphics{}": {
-    "command": "includegraphics{file}",
-    "snippet": "includegraphics{$1}",
-    "postAction": "editor.action.triggerSuggest"
   },
   "addcontentsline{}{}{}": {
     "command": "addcontentsline{file}{secunit}{entry}",
@@ -839,6 +816,18 @@
     "command": "contentsname{text}",
     "snippet": "contentsname{${1:name}}"
   },
+  "cdot": {
+    "command": "cdot",
+    "detail": "·"
+  },
+  "cdots": {
+    "command": "cdots",
+    "detail": "···"
+  },
+  "ldots": {
+    "command": "ldots",
+    "snippet": "ldots"
+  },
   "ddots": {
     "command": "ddots",
     "snippet": "ddots",
@@ -888,6 +877,21 @@
     "command": "hlinefill",
     "snippet": "hlinefill"
   },
+  "input": {
+    "command": "input",
+    "snippet": "input{$1}",
+    "postAction": "editor.action.triggerSuggest"
+  },
+  "include{}": {
+    "command": "include{file}",
+    "snippet": "include{$1}",
+    "postAction": "editor.action.triggerSuggest"
+  },
+  "includegraphics{}": {
+    "command": "includegraphics{file}",
+    "snippet": "includegraphics{$1}",
+    "postAction": "editor.action.triggerSuggest"
+  },
   "includegraphics[]{}": {
     "command": "includegraphics[options]{name}",
     "snippet": "includegraphics[${2:options}]{${1:name}}",
@@ -920,10 +924,6 @@
   "LaTeX": {
     "command": "LaTeX",
     "snippet": "LaTeX"
-  },
-  "ldots": {
-    "command": "ldots",
-    "snippet": "ldots"
   },
   "linebreak": {
     "command": "linebreak",

--- a/data/commands.json
+++ b/data/commands.json
@@ -241,19 +241,9 @@
     "command": "label{...}",
     "snippet": "label{${1}}"
   },
-  "cref{}": {
-    "command": "cref{key}",
-    "snippet": "cref{${1}}",
-    "postAction": "editor.action.triggerSuggest"
-  },
   "ref{}": {
     "command": "ref{key}",
     "snippet": "ref{${1}}",
-    "postAction": "editor.action.triggerSuggest"
-  },
-  "cpageref{}": {
-    "command": "cpageref{key}",
-    "snippet": "cpageref{$1}",
     "postAction": "editor.action.triggerSuggest"
   },
   "pageref{}": {

--- a/data/packages/cleveref_cmd.json
+++ b/data/packages/cleveref_cmd.json
@@ -1,4 +1,9 @@
 {
+  "cref{}": {
+    "command": "cref{label}",
+    "package": "cleveref",
+    "snippet": "cref{${1:label}}"
+  },
   "Cref{}": {
     "command": "Cref{label}",
     "package": "cleveref",
@@ -33,6 +38,11 @@
     "command": "Crefrange*{label1}{label2}",
     "package": "cleveref",
     "snippet": "Crefrange*{${1:label1}}{${2:label2}}"
+  },
+  "cpageref{}": {
+    "command": "cpageref{label}",
+    "package": "cleveref",
+    "snippet": "cpageref{${1:label}}"
   },
   "Cpageref{}": {
     "command": "Cpageref{label}",

--- a/dev/pkgcommand.py
+++ b/dev/pkgcommand.py
@@ -19,14 +19,14 @@ OUT_DIR = CWD.joinpath('../data/packages').resolve()
 INFILES = None
 
 parser = argparse.ArgumentParser()
-parser.add_argument('-o', '--outdir', help='Directory where to write the JSON files. Default is {}'.format(OUT_DIR), type=str)
+parser.add_argument('-o', '--outdir', help=f'Directory where to write the JSON files. Default is {OUT_DIR}', type=str)
 parser.add_argument('-i', '--infile', help='Files to process. Default is the content of https://github.com/LaTeXing/LaTeX-cwl/', type=str, nargs='+')
 args = parser.parse_args()
 
 if args.outdir:
     OUT_DIR = Path(args.outdir).expanduser().resolve()
     if not OUT_DIR.is_dir():
-        print('The path passed to --outdir is not a directory: {}'.format(args.outdir))
+        print(f'The path passed to --outdir is not a directory: {args.outdir}')
         sys.exit(0)
 if args.infile:
     INFILES = args.infile

--- a/dev/pyintel/pkgcommand.py
+++ b/dev/pyintel/pkgcommand.py
@@ -50,7 +50,7 @@ class PlaceHolder:
 
     :count: The number of tabstops that have already been replaced.
     :usePlaceHolders: When True, keep the placeholder name in the snippet
-    :keepDelimiters: When True, keep the delimiters (usually {} or []) surrounding every placelholder
+    :keepDelimiters: When True, keep the delimiters (usually {} or []) surrounding every placeholder
     """
 
     def __init__(self):
@@ -106,13 +106,13 @@ class CwlIntel:
         self.unimathsymbols = Path(unimathsymbols)
         try:
             self.commands = json.load(open(commands_file, encoding='utf8'))
-        except:
-            print('Cannot read JSON file {}'.format(commands_file))
+        except (OSError, json.JSONDecodeError):
+            print(f'Cannot read JSON file {commands_file}')
             self.commands = []
         try:
             self.envs = json.load(open(envs_file, encoding='utf8'))
-        except:
-            print('Cannot read JSON file {}'.format(envs_file))
+        except (OSError, json.JSONDecodeError):
+            print(f'Cannot read JSON file {envs_file}')
             self.envs = []
         self.compute_unimathsymbols()
 
@@ -152,10 +152,10 @@ class CwlIntel:
         :param file_path: Path to the .cwl file to parse
         :param remove_spaces: If true, spaces are removed to compute the name of the snippet
         """
-        if type(file_path) == str:
+        if isinstance(file_path, str):
             file_path = Path(file_path)
         if not file_path.exists():
-            print('File {} does not exist'.format(file_path.as_posix))
+            print(f'File {file_path.as_posix} does not exist')
             return ({}, {})
         package = file_path.stem
         with file_path.open(encoding='utf8') as f:

--- a/dev/pyintel/uni.py
+++ b/dev/pyintel/uni.py
@@ -61,7 +61,7 @@ def generate_unimathsymbols_intel(infile, json_out):
                 'documentation': remove_relation_character(segments[7]).capitalize()
             }
             if segments[6] != '' and segments[6][0] != '-':
-                data[segments[3]]['detail'] += ' ("{}" command)'.format(segments[6])
+                data[segments[3]]['detail'] += f' ("{segments[6]}" command)'
 
     json.dump(data, open(json_out, 'w', encoding='utf-8'),
             indent=2, separators=(',', ': '), sort_keys=True, ensure_ascii=False)


### PR DESCRIPTION
These commands are provided by the `cleveref` package.

Close #3227