### PR TITLE
Refactor structure to add caching

### DIFF
--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -307,7 +307,7 @@ export class Manager {
     /**
      * Returns `true` if the language of `id` is one of supported languages.
      *
-     * @param id The identifier of language.
+     * @param id The language identifier
      */
     hasTexId(id: string) {
         return ['tex', 'latex', 'latex-expl3', 'doctex', 'jlweave', 'rsweave'].includes(id)
@@ -316,7 +316,7 @@ export class Manager {
     /**
      * Returns `true` if the language of `id` is bibtex
      *
-     * @param id The identifier of language.
+     * @param id The language identifier
      */
     hasBibtexId(id: string) {
         return id === 'bibtex'
@@ -374,7 +374,7 @@ export class Manager {
                 // We need to parse the fls to discover file dependencies when defined by TeX macro
                 // It happens a lot with subfiles, https://tex.stackexchange.com/questions/289450/path-of-figures-in-different-directories-with-subfile-latex
                 await this.parseFlsFile(this.rootFile)
-                this.extension.structureViewer.update()
+                await this.extension.structureViewer.computeTreeStructure()
                 this.extension.latexCommanderTreeView.update()
                 this.extension.eventBus.fire(eventbus.RootFileChanged, rootFile)
             } else {

--- a/src/providers/docsymbol.ts
+++ b/src/providers/docsymbol.ts
@@ -21,7 +21,7 @@ export class DocSymbolProvider implements vscode.DocumentSymbolProvider {
 
     provideDocumentSymbols(document: vscode.TextDocument): vscode.ProviderResult<vscode.DocumentSymbol[]> {
         if (document.languageId === 'bibtex') {
-            return this.sectionNodeProvider.buildBibTeXModel().then(() => this.sectionToSymbols(this.sectionNodeProvider.ds))
+            return this.sectionNodeProvider.buildBibTeXModel().then((sections: Section[]) => this.sectionToSymbols(sections))
         }
         if (this.extension.lwfs.isVirtualUri(document.uri)) {
             return []


### PR DESCRIPTION
This PR caches the last latex and bibtex structures. 

Prior to this PR, every time an editor was revealed or saved, the structure was computed twice

- https://github.com/James-Yu/LaTeX-Workshop/blob/87666b1fe8194a398b02ad8cee9c397d0fa78fee/src/main.ts#L167
- https://github.com/James-Yu/LaTeX-Workshop/blob/6970e5d3a29b9328e2070ed5c91cfef0291f5e03/src/providers/structure.ts#L226 because a `onDidChangeTreeData` event is fired

Worse than that, when switching latex files inside a project, the structure of the whole project is recomputed twice

https://github.com/James-Yu/LaTeX-Workshop/blob/87666b1fe8194a398b02ad8cee9c397d0fa78fee/src/main.ts#L219-L223

The next step (in a separate PR) will be to investigate the use of `ast` to compute the structure of LaTeX projects.