### PR TITLE
Use eventbus to manage structure updates

### DIFF
--- a/src/components/eventbus.ts
+++ b/src/components/eventbus.ts
@@ -7,6 +7,7 @@ export const PdfViewerPagesLoaded = 'pdfviewerpagesloaded'
 export const PdfViewerStatusChanged = 'pdfviewerstatuschanged'
 export const RootFileChanged = 'rootfilechanged'
 export const FindRootFileEnd = 'findrootfileend'
+export const CachedContentUpdated = 'cachedcontentupdated'
 
 type EventArgTypeMap = {
     [PdfViewerStatusChanged]: PdfViewerState,
@@ -18,6 +19,7 @@ export type EventName = typeof BuildFinished
                     | typeof PdfViewerStatusChanged
                     | typeof RootFileChanged
                     | typeof FindRootFileEnd
+                    | typeof CachedContentUpdated
 
 export class EventBus {
     private readonly eventEmitter = new EventEmitter()
@@ -38,6 +40,10 @@ export class EventBus {
 
     onDidEndFindRootFile(cb: () => void): Disposable {
         return this.registerListener('findrootfileend', cb)
+    }
+
+    onDidUpdateCachedContent(cb: () => void): Disposable {
+        return this.registerListener('cachedcontentupdated', cb)
     }
 
     onDidChangePdfViewerStatus(cb: (status: EventArgTypeMap['pdfviewerstatuschanged']) => void): Disposable {

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -156,6 +156,7 @@ export class Manager {
         if (cache !== undefined) {
             cache.content = document.getText()
         }
+        this.extension.eventBus.fire(eventbus.CachedContentUpdated)
     }
 
     getFilesWatched() {
@@ -374,8 +375,6 @@ export class Manager {
                 // We need to parse the fls to discover file dependencies when defined by TeX macro
                 // It happens a lot with subfiles, https://tex.stackexchange.com/questions/289450/path-of-figures-in-different-directories-with-subfile-latex
                 await this.parseFlsFile(this.rootFile)
-                await this.extension.structureViewer.computeTreeStructure()
-                this.extension.latexCommanderTreeView.update()
                 this.extension.eventBus.fire(eventbus.RootFileChanged, rootFile)
             } else {
                 this.extension.logger.addLogMessage(`Keep using the same root file: ${this.rootFile}`)

--- a/src/main.ts
+++ b/src/main.ts
@@ -164,13 +164,8 @@ export function activate(context: vscode.ExtensionContext): ReturnType<typeof ge
             extension.logger.addLogMessage(`onDidSaveTextDocument triggered: ${e.uri.toString(true)}`)
             extension.manager.updateCachedContent(e)
             extension.linter.lintRootFileIfEnabled()
-            // Make sure to update cacheContent before calling structureViewer.computeTreeStructure
-            void extension.structureViewer.computeTreeStructure()
             void extension.manager.buildOnSaveIfEnabled(e.fileName)
             extension.counter.countOnSaveIfEnabled(e.fileName)
-        }
-        if (e.languageId === 'bibtex') {
-            void extension.structureViewer.computeTreeStructure()
         }
     }))
 
@@ -231,12 +226,8 @@ export function activate(context: vscode.ExtensionContext): ReturnType<typeof ge
         }
         if (e && extension.manager.hasTexId(e.document.languageId)) {
             await extension.manager.findRoot()
-            // Make sure to wait for findRoot to finish before calling refreshView
-            await extension.structureViewer.refreshView()
             extension.linter.lintRootFileIfEnabled()
-        } else if (e && extension.manager.hasBibtexId(e.document.languageId)) {
-            await extension.structureViewer.refreshView()
-        } else {
+        } else if (!e || !extension.manager.hasBibtexId(e.document.languageId)) {
             isLaTeXActive = false
         }
     }))

--- a/src/providers/docsymbol.ts
+++ b/src/providers/docsymbol.ts
@@ -21,7 +21,7 @@ export class DocSymbolProvider implements vscode.DocumentSymbolProvider {
 
     provideDocumentSymbols(document: vscode.TextDocument): vscode.ProviderResult<vscode.DocumentSymbol[]> {
         if (document.languageId === 'bibtex') {
-            return this.sectionNodeProvider.buildBibTeXModel().then((sections: Section[]) => this.sectionToSymbols(sections))
+            return this.sectionNodeProvider.buildBibTeXModel(document).then((sections: Section[]) => this.sectionToSymbols(sections))
         }
         if (this.extension.lwfs.isVirtualUri(document.uri)) {
             return []

--- a/src/providers/structure.ts
+++ b/src/providers/structure.ts
@@ -535,18 +535,12 @@ export class StructureTreeView {
         })
 
         vscode.workspace.onDidSaveTextDocument( (e: vscode.TextDocument) => {
-            if (extension.lwfs.isVirtualUri(e.uri)){
-                return
-            }
             if (extension.manager.hasBibtexId(e.languageId)) {
                 void extension.structureViewer.computeTreeStructure()
             }
         })
 
         vscode.window.onDidChangeActiveTextEditor((e: vscode.TextEditor | undefined) => {
-            if (e && extension.lwfs.isVirtualUri(e.document.uri)){
-                return
-            }
             if (e && extension.manager.hasBibtexId(e.document.languageId)) {
                 void extension.structureViewer.refreshView()
             }

--- a/src/providers/structure.ts
+++ b/src/providers/structure.ts
@@ -550,7 +550,7 @@ export class StructureTreeView {
             void this.computeTreeStructure()
         })
 
-        this.extension.eventBus.onDidChangeRootFile((_rootFile: string) => {
+        this.extension.eventBus.onDidChangeRootFile(() => {
             void this.computeTreeStructure()
         })
 

--- a/src/providers/structure.ts
+++ b/src/providers/structure.ts
@@ -6,7 +6,6 @@ import * as utils from '../utils/utils'
 import {PathRegExp} from '../components/managerlib/pathutils'
 import type {MatchPath} from '../components/managerlib/pathutils'
 
-
 export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
 
     private readonly _onDidChangeTreeData: vscode.EventEmitter<Section | undefined> = new vscode.EventEmitter<Section | undefined>()
@@ -521,16 +520,48 @@ class StructureModel {
 }
 
 export class StructureTreeView {
+    private readonly extension: Extension
     private readonly _viewer: vscode.TreeView<Section | undefined>
     private readonly _treeDataProvider: SectionNodeProvider
     private _followCursor: boolean = true
 
 
     constructor(extension: Extension) {
+        this.extension = extension
         this._treeDataProvider = new SectionNodeProvider(extension)
         this._viewer = vscode.window.createTreeView('latex-workshop-structure', { treeDataProvider: this._treeDataProvider, showCollapseAll: true })
         vscode.commands.registerCommand('latex-workshop.structure-toggle-follow-cursor', () => {
            this._followCursor = ! this._followCursor
+        })
+
+        vscode.workspace.onDidSaveTextDocument( (e: vscode.TextDocument) => {
+            if (extension.lwfs.isVirtualUri(e.uri)){
+                return
+            }
+            if (extension.manager.hasBibtexId(e.languageId)) {
+                void extension.structureViewer.computeTreeStructure()
+            }
+        })
+
+        vscode.window.onDidChangeActiveTextEditor((e: vscode.TextEditor | undefined) => {
+            if (e && extension.lwfs.isVirtualUri(e.document.uri)){
+                return
+            }
+            if (e && extension.manager.hasBibtexId(e.document.languageId)) {
+                void extension.structureViewer.refreshView()
+            }
+        })
+
+        this.extension.eventBus.onDidUpdateCachedContent(() => {
+            void this.computeTreeStructure()
+        })
+
+        this.extension.eventBus.onDidChangeRootFile((_rootFile: string) => {
+            void this.computeTreeStructure()
+        })
+
+        this.extension.eventBus.onDidEndFindRootFile(() => {
+            void this.refreshView()
         })
     }
 

--- a/src/providers/structure.ts
+++ b/src/providers/structure.ts
@@ -48,7 +48,7 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
         const document = vscode.window.activeTextEditor?.document
         if (document?.languageId === 'bibtex') {
             if (force || this.getCachedDataRootFileName(this.CachedBibTeXData) !== document.fileName) {
-                this.CachedBibTeXData = await this.buildBibTeXModel()
+                this.CachedBibTeXData = await this.buildBibTeXModel(document)
             }
             this.ds = this.CachedBibTeXData
         }
@@ -68,12 +68,7 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
         this._onDidChangeTreeData.fire(undefined)
     }
 
-    async buildBibTeXModel(): Promise<Section[]> {
-        const document = vscode.window.activeTextEditor?.document
-        if (!document) {
-            return []
-        }
-
+    async buildBibTeXModel(document: vscode.TextDocument): Promise<Section[]> {
         const configuration = vscode.workspace.getConfiguration('latex-workshop', vscode.Uri.file(document.fileName))
         if (document.getText().length >= (configuration.get('bibtex.maxFileSize') as number) * 1024 * 1024) {
             this.extension.logger.addLogMessage(`Bib file is too large, ignoring it: ${document.fileName}`)


### PR DESCRIPTION
Related to https://github.com/James-Yu/LaTeX-Workshop/pull/3252#discussion_r852681306

- the fucntion `updateCachedContent` fires an `EventBus.CachedContentUpdated`
- the structure provider relies on `EventBus` to properly update the LaTeX project structure (either the data tree or only the view).