### PR TITLE
Use the VS Code task feature to execute multiple watches

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,6 @@
             ],
             "type": "pwa-node"
         },
-
         {
             "name": "Python: Current File",
             "type": "python",
@@ -32,21 +31,7 @@
                 "${workspaceFolder}/out/src/**/*.js"
             ],
             "debugWebviews": true,
-            "preLaunchTask": "npm: watch"
-        },
-        {
-            "name": "Run Extension Alias",
-            "type": "extensionHost",
-            "request": "launch",
-            "runtimeExecutable": "${execPath}",
-            "args": [
-                "--extensionDevelopmentPath=${workspaceFolder}"
-            ],
-            "outFiles": [
-                "${workspaceFolder}/out/src/**/*.js"
-            ],
-            "debugWebviews": true,
-            "preLaunchTask": "npm: watch-alias"
+            "preLaunchTask": "task-watch-all"
         },
         {
             "name": "Run Extension With Sample",
@@ -60,7 +45,7 @@
             "outFiles": [
                 "${workspaceFolder}/out/src/**/*.js"
             ],
-            "preLaunchTask": "npm: watch"
+            "preLaunchTask": "task-watch-all"
         },
         {
             "name": "Run Extension Tests",
@@ -74,7 +59,7 @@
             "outFiles": [
                 "${workspaceFolder}/out/test/**/*.js"
             ],
-            "preLaunchTask": "npm: watch"
+            "preLaunchTask": "task-watch-all"
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,35 +1,46 @@
 // See https://go.microsoft.com/fwlink/?LinkId=733558
 // for the documentation about the tasks.json format
 {
-    "version":"2.0.0",
-    "tasks":[
+    "version": "2.0.0",
+    "tasks": [
         {
-            "type":"npm",
-            "script":"watch",
-            "problemMatcher":"$tsc-watch",
-            "isBackground":true,
-            "presentation":{
-                "reveal":"silent"
+            "label": "task-watch-src",
+            "type": "npm",
+            "script": "watch-src",
+            "problemMatcher": "$tsc-watch",
+            "isBackground": true,
+            "presentation": {
+                "reveal": "never"
             },
-            "group":{
-                "kind":"build",
-                "isDefault":true
+            "group": {
+                "kind": "build",
+                "isDefault": true
             },
-            "detail": "Reveal the terminal on errors."
+            "detail": "Watch ./src"
         },
         {
-            "type":"npm",
-            "script":"watch-alias",
-            "problemMatcher":"$tsc-watch",
-            "isBackground":true,
-            "presentation":{
-                "reveal":"never"
+            "label": "task-watch-viewer",
+            "type": "npm",
+            "script": "watch-viewer",
+            "problemMatcher": "$tsc-watch",
+            "isBackground": true,
+            "presentation": {
+                "reveal": "never"
             },
-            "group":{
-                "kind":"build",
-                "isDefault":true
+            "group": {
+                "kind": "build",
+                "isDefault": true
             },
-            "detail": "Never reveal the terminal on errors."
+            "detail": "Watch ./viewer"
+        },
+        {
+            "label": "task-watch-all",
+            "dependsOn": [
+                "task-watch-src",
+                "task-watch-viewer"
+            ],
+            "detail": "Watch ./src and ./viewer",
+            "problemMatcher": []
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -13,8 +13,7 @@
                 "reveal": "never"
             },
             "group": {
-                "kind": "build",
-                "isDefault": true
+                "kind": "build"
             },
             "detail": "Watch ./src"
         },
@@ -28,8 +27,7 @@
                 "reveal": "never"
             },
             "group": {
-                "kind": "build",
-                "isDefault": true
+                "kind": "build"
             },
             "detail": "Watch ./viewer"
         },
@@ -39,6 +37,10 @@
                 "task-watch-src",
                 "task-watch-viewer"
             ],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
             "detail": "Watch ./src and ./viewer",
             "problemMatcher": []
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,6 @@
         "@typescript-eslint/eslint-plugin": "5.19.0",
         "@typescript-eslint/parser": "5.19.0",
         "@vscode/test-electron": "2.1.3",
-        "concurrently": "7.1.0",
         "eslint": "8.13.0",
         "mocha": "9.2.2",
         "rimraf": "3.0.2",
@@ -1012,43 +1011,6 @@
         "typedarray": "^0.0.6"
       }
     },
-    "node_modules/concurrently": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-7.1.0.tgz",
-      "integrity": "sha512-Bz0tMlYKZRUDqJlNiF/OImojMB9ruKUz6GCfmhFnSapXgPe+3xzY4byqoKG9tUZ7L2PGEUjfLPOLfIX3labnmw==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "date-fns": "^2.16.1",
-        "lodash": "^4.17.21",
-        "rxjs": "^6.6.3",
-        "spawn-command": "^0.0.2-1",
-        "supports-color": "^8.1.0",
-        "tree-kill": "^1.2.2",
-        "yargs": "^16.2.0"
-      },
-      "bin": {
-        "concurrently": "dist/bin/concurrently.js"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.0 || >=16.0.0"
-      }
-    },
-    "node_modules/concurrently/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
     "node_modules/console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
@@ -1100,19 +1062,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/date-fns": {
-      "version": "2.28.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
-      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.11"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/date-fns"
       }
     },
     "node_modules/debug": {
@@ -3127,18 +3076,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/rxjs": {
-      "version": "6.6.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^1.9.0"
-      },
-      "engines": {
-        "npm": ">=2.0.0"
-      }
-    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -3298,12 +3235,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/spawn-command": {
-      "version": "0.0.2-1",
-      "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
-      "integrity": "sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A=",
-      "dev": true
     },
     "node_modules/speech-rule-engine": {
       "version": "3.3.3",
@@ -3550,15 +3481,6 @@
       "dev": true,
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/tree-kill": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
-      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
-      "dev": true,
-      "bin": {
-        "tree-kill": "cli.js"
       }
     },
     "node_modules/tslib": {
@@ -4830,33 +4752,6 @@
         "typedarray": "^0.0.6"
       }
     },
-    "concurrently": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-7.1.0.tgz",
-      "integrity": "sha512-Bz0tMlYKZRUDqJlNiF/OImojMB9ruKUz6GCfmhFnSapXgPe+3xzY4byqoKG9tUZ7L2PGEUjfLPOLfIX3labnmw==",
-      "dev": true,
-      "requires": {
-        "chalk": "^4.1.0",
-        "date-fns": "^2.16.1",
-        "lodash": "^4.17.21",
-        "rxjs": "^6.6.3",
-        "spawn-command": "^0.0.2-1",
-        "supports-color": "^8.1.0",
-        "tree-kill": "^1.2.2",
-        "yargs": "^16.2.0"
-      },
-      "dependencies": {
-        "supports-color": {
-          "version": "8.1.1",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
     "console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
@@ -4896,12 +4791,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.1.0.tgz",
       "integrity": "sha512-arSMRWIIFY0hV8pIxZMEfmMI47Wj3R/aWpZDDxWYCPEiOMv6tfOrnpDtgxBYPEQD4V0Y/958+1TdC3iWTFcUPw==",
-      "dev": true
-    },
-    "date-fns": {
-      "version": "2.28.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
-      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==",
       "dev": true
     },
     "debug": {
@@ -6414,15 +6303,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "rxjs": {
-      "version": "6.6.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
-      "dev": true,
-      "requires": {
-        "tslib": "^1.9.0"
-      }
-    },
     "safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -6521,12 +6401,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true
-    },
-    "spawn-command": {
-      "version": "0.0.2-1",
-      "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
-      "integrity": "sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A=",
       "dev": true
     },
     "speech-rule-engine": {
@@ -6736,12 +6610,6 @@
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
       "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
-      "dev": true
-    },
-    "tree-kill": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
-      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
       "dev": true
     },
     "tslib": {

--- a/package.json
+++ b/package.json
@@ -2400,8 +2400,6 @@
     "lint:fix": "eslint --fix --cache --ext .ts,.js .",
     "release": "npm run clean && npm run lint && npm run compile && vsce package",
     "test": "node ./out/test/runTest.js",
-    "watch": "concurrently \"npm:watch-src\" \"npm:watch-viewer\"",
-    "watch-alias": "npm run watch",
     "watch-src": "tsc -watch -p tsconfig.json",
     "watch-viewer": "tsc -watch -p viewer/tsconfig.json"
   },
@@ -2431,7 +2429,6 @@
     "@typescript-eslint/eslint-plugin": "5.19.0",
     "@typescript-eslint/parser": "5.19.0",
     "@vscode/test-electron": "2.1.3",
-    "concurrently": "7.1.0",
     "eslint": "8.13.0",
     "mocha": "9.2.2",
     "rimraf": "3.0.2",


### PR DESCRIPTION
Use the VS Code task feature to execute multiple watches.

@jlelong  @James-Yu,  I removed the `npm run watch` script to reduce devDependencies. Please run `task-watch-all` through `Tasks: Run Task` from the Command Palette.
