### PR TITLE
onEnterKey supports multi-cursors when all selected lines start with \item

### DIFF
--- a/src/commander.ts
+++ b/src/commander.ts
@@ -437,7 +437,7 @@ export class Commander {
             return vscode.commands.executeCommand('type', { source: 'keyboard', text: '\n' })
         }
 
-        void editor.edit(editBuilder => {
+        return editor.edit(editBuilder => {
             // If we arrive here, all the cursors are at the end of a line starting with `\s*\\item`.
             // Yet, we keep the conditions for the sake of maintenance.
             for (const selection of editor.selections) {
@@ -462,7 +462,6 @@ export class Commander {
                 }
             }
         })
-        return
     }
 
     /**

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -443,22 +443,22 @@ export class Commander {
             for (const selection of editor.selections) {
                 const cursorPos = selection.active
                 const line = editor.document.lineAt(cursorPos.line)
-                let matches: RegExpExecArray | null
 
-                if (/^\s*\\item(\[\s*\])?\s*$/.exec(line.text)) {
+                if (/^\s*\\item(\[\s*\])?\s*$/.test(line.text)) {
                     // The line is an empty \item or \item[]
                     const rangeToDelete = line.range.with(cursorPos.with(line.lineNumber, line.firstNonWhitespaceCharacterIndex), line.range.end)
                     editBuilder.delete(rangeToDelete)
-                } else if((matches = /^\s*\\item(\[[^[\]]*\])?\s*[^\s]+$/.exec(line.text)) !== null) {
-                    // The line starts with \item and has more text
-                    let itemString = ' '.repeat(line.firstNonWhitespaceCharacterIndex)
-                    // is there an optional parameter to \item
-                    if (matches[1]) {
-                        itemString += '\\item[] '
-                    } else {
-                        itemString += '\\item '
-                    }
+                } else if(/^\s*\\item\[[^[\]]*\]/.test(line.text)) {
+                    // The line starts with \item[blabla] or \item[] blabla
+                    const itemString = ' '.repeat(line.firstNonWhitespaceCharacterIndex) + '\\item[] '
                     editBuilder.insert(cursorPos, '\n' + itemString)
+                } else if(/^\s*\\item\s*[^\s]+.*$/.test(line.text)) {
+                    // The line starts with \item blabla
+                    const itemString = ' '.repeat(line.firstNonWhitespaceCharacterIndex) + '\\item '
+                    editBuilder.insert(cursorPos, '\n' + itemString)
+                } else {
+                    // If we do not know what to do, insert a newline and indent using the current indentation
+                    editBuilder.insert(cursorPos, '\n' + ' '.repeat(line.firstNonWhitespaceCharacterIndex))
                 }
             }
         })


### PR DESCRIPTION
Fix #3278. This PR is a followup on #3255, which turned to be buggy.

Multi-cursors is only partially supported because of a limitation of vscode's API to insert a new line and indent it. So `onEnterKey` only works when all the selected lines start with `\s*\\item`. If not, we simply return a normal `Enter` keystroke.