### PR TITLE
Refactor glossary intellisense data scanning

### DIFF
--- a/src/providers/completer/glossary.ts
+++ b/src/providers/completer/glossary.ts
@@ -104,7 +104,6 @@ export class Glossary implements IProvider {
      * @return the pair (label, description)
      */
     private getLongNodeLabelDescription(node: latexParser.Command): GlossaryEntry {
-        const arr: string[] = []
         let description: string | undefined = undefined
         let label: string | undefined = undefined
 
@@ -112,15 +111,7 @@ export class Glossary implements IProvider {
         const labelNode = hasOptionalArg ? node.args[1] : node.args[0]
         const descriptionNode = hasOptionalArg ? node.args[3] : node.args[2]
         if (latexParser.isGroup(descriptionNode)) {
-            descriptionNode.content.forEach(subNode => {
-                if (latexParser.isTextString(subNode)) {
-                    arr.push(latexParser.stringify(subNode))
-                }
-            })
-        }
-
-        if (arr.length > 0) {
-            description = arr.join(' ')
+            description = latexParser.stringify(descriptionNode).slice(1, -1)
         }
 
         if (latexParser.isGroup(labelNode)) {

--- a/src/providers/completer/glossary.ts
+++ b/src/providers/completer/glossary.ts
@@ -123,8 +123,8 @@ export class Glossary implements IProvider {
             description = arr.join(' ')
         }
 
-        if (latexParser.isGroup(labelNode) && latexParser.isTextString(labelNode.content[0])) {
-            label = latexParser.stringify(labelNode.content[0])
+        if (latexParser.isGroup(labelNode)) {
+            label = latexParser.stringify(labelNode).slice(1, -1)
         }
 
         return {label, description}

--- a/src/providers/completer/glossary.ts
+++ b/src/providers/completer/glossary.ts
@@ -108,13 +108,13 @@ export class Glossary implements IProvider {
         let description: string | undefined = undefined
         let label: string | undefined = undefined
 
-        const hasOptionalArg: boolean = node.args[0].kind === 'arg.optional'
+        const hasOptionalArg: boolean = latexParser.isOptionalArg(node.args[0])
         const labelNode = hasOptionalArg ? node.args[1] : node.args[0]
         const descriptionNode = hasOptionalArg ? node.args[3] : node.args[2]
-        if (descriptionNode?.kind === 'arg.group') {
+        if (latexParser.isGroup(descriptionNode)) {
             descriptionNode.content.forEach(subNode => {
-                if (subNode.kind === 'text.string') {
-                    arr.push(subNode.content)
+                if (latexParser.isTextString(subNode)) {
+                    arr.push(latexParser.stringify(subNode))
                 }
             })
         }
@@ -123,8 +123,8 @@ export class Glossary implements IProvider {
             description = arr.join(' ')
         }
 
-        if (labelNode.kind === 'arg.group' && labelNode.content[0].kind === 'text.string') {
-            label = labelNode.content[0].content
+        if (latexParser.isGroup(labelNode) && latexParser.isTextString(labelNode.content[0])) {
+            label = latexParser.stringify(labelNode.content[0])
         }
 
         return {label, description}
@@ -151,19 +151,19 @@ export class Glossary implements IProvider {
         let label: string | undefined = undefined
         let lastNodeWasDescription = false
 
-        if (node.args[1]?.kind === 'arg.group') {
+        if (latexParser.isGroup(node.args[1])) {
             node.args[1].content.forEach(subNode => {
-                if (subNode.kind === 'text.string') {
+                if (latexParser.isTextString(subNode)) {
                     // check if we have a description of the form description=single_word
                     if ((result = /description=(.*)/.exec(subNode.content)) !== null) {
                         arr.push(result[1]) // possibly undefined
                         lastNodeWasDescription = true
                     }
                     // otherwise we might have description={group of words}
-                } else if (lastNodeWasDescription && subNode.kind === 'arg.group') {
+                } else if (lastNodeWasDescription && latexParser.isGroup(subNode)) {
                     subNode.content.forEach(subSubNode => {
-                        if (subSubNode.kind === 'text.string') {
-                            arr.push(subSubNode.content)
+                        if (latexParser.isTextString(subSubNode)) {
+                            arr.push(latexParser.stringify(subSubNode))
                         }
                     })
                     lastNodeWasDescription = false
@@ -175,8 +175,8 @@ export class Glossary implements IProvider {
             description = arr.join(' ')
         }
 
-        if (node.args[0].kind === 'arg.group' && node.args[0].content[0].kind === 'text.string') {
-            label = node.args[0].content[0].content
+        if (latexParser.isGroup(node.args[0]) && latexParser.isTextString(node.args[0].content[0])) {
+            label = latexParser.stringify(node.args[0].content[0])
         }
 
         return {label, description}

--- a/src/providers/completer/glossary.ts
+++ b/src/providers/completer/glossary.ts
@@ -107,7 +107,17 @@ export class Glossary implements IProvider {
         let description: string | undefined = undefined
         let label: string | undefined = undefined
 
+        // We expect 3 arguments + 1 optional argument
+        if (node.args.length < 3 || node.args.length > 4) {
+            return {label: undefined, description: undefined}
+        }
         const hasOptionalArg: boolean = latexParser.isOptionalArg(node.args[0])
+
+        // First arg is optional, we must have 4 arguments
+        if (hasOptionalArg && node.args.length !== 4) {
+            return {label: undefined, description: undefined}
+        }
+
         const labelNode = hasOptionalArg ? node.args[1] : node.args[0]
         const descriptionNode = hasOptionalArg ? node.args[3] : node.args[2]
         if (latexParser.isGroup(descriptionNode)) {
@@ -140,6 +150,11 @@ export class Glossary implements IProvider {
         let description: string | undefined = undefined
         let label: string | undefined = undefined
         let lastNodeWasDescription = false
+
+        // We expect 2 arguments
+        if (node.args.length !== 2) {
+            return {label: undefined, description: undefined}
+        }
 
         // Get label
         if (latexParser.isGroup(node.args[0])) {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode'
 import * as path from 'path'
 import * as fs from 'fs'
 
-import type {latexParser} from 'latex-utensils'
+import {latexParser} from 'latex-utensils'
 
 
 export function sleep(ms: number) {
@@ -246,7 +246,7 @@ export type NewCommand = {
 
 export function isNewCommand(node: latexParser.Node | undefined): node is NewCommand {
     const regex = /^(renewcommand|newcommand|providecommand|DeclareMathOperator)(\*)?$/
-    if (!!node && node.kind === 'command' && node.name.match(regex)) {
+    if (latexParser.isCommand(node) && node.name.match(regex)) {
         return true
     }
     return false

--- a/test/completion.test.ts
+++ b/test/completion.test.ts
@@ -13,7 +13,7 @@ import {
 } from './utils/ciutils'
 
 
-function assertCompletionItemContains(items: vscode.CompletionItem[], prefix: string, snippet: string): void {
+function assertCompletionItemContainsSnippet(items: vscode.CompletionItem[], prefix: string, snippet: string): void {
     const matches = items.find(item =>
         item.label === prefix &&
         item.insertText instanceof vscode.SnippetString &&
@@ -21,7 +21,7 @@ function assertCompletionItemContains(items: vscode.CompletionItem[], prefix: st
     assert.ok(matches !== undefined, `Snippet (${prefix}, ${snippet}) not found`)
 }
 
-function assertCompletionItemDoesNotContain(items: vscode.CompletionItem[], prefix: string, snippet?: string): void {
+function assertCompletionItemDoesNotContainSnippet(items: vscode.CompletionItem[], prefix: string, snippet?: string): void {
     if (snippet) {
         const matches = items.find(item =>
             item.label === prefix &&
@@ -34,6 +34,12 @@ function assertCompletionItemDoesNotContain(items: vscode.CompletionItem[], pref
     }
 }
 
+function assertCompletionItemContains(items: vscode.CompletionItem[], label: string, detail: string): void {
+    const matches = items.find(item =>
+        item.label === label &&
+        item.detail === detail)
+    assert.ok(matches !== undefined, `Snippet (${label}, ${detail}) not found`)
+}
 
 suite('Completion test suite', () => {
 
@@ -81,10 +87,10 @@ suite('Completion test suite', () => {
             }
         )
         assert.ok(items && items.length > 0)
-        assertCompletionItemContains(items, '@+', '\\sum')
-        assertCompletionItemDoesNotContain(items, '@+', '\\bigcup')
-        assertCompletionItemContains(items, '@M', '\\sum')
-        assertCompletionItemDoesNotContain(items, '@8')
+        assertCompletionItemContainsSnippet(items, '@+', '\\sum')
+        assertCompletionItemDoesNotContainSnippet(items, '@+', '\\bigcup')
+        assertCompletionItemContainsSnippet(items, '@M', '\\sum')
+        assertCompletionItemDoesNotContainSnippet(items, '@8')
     })
 
     runTestWithFixture('fixture003', '@-snippet completion with trigger #', async () => {
@@ -104,10 +110,34 @@ suite('Completion test suite', () => {
             }
         )
         assert.ok(items && items.length > 0)
-        assertCompletionItemContains(items, '#+', '\\sum')
-        assertCompletionItemContains(items, '#ve', '\\varepsilon')
-        assertCompletionItemDoesNotContain(items, '@+', '\\bigcup')
-        assertCompletionItemDoesNotContain(items, '#+', '\\bigcup')
-        assertCompletionItemDoesNotContain(items, '#8')
+        assertCompletionItemContainsSnippet(items, '#+', '\\sum')
+        assertCompletionItemContainsSnippet(items, '#ve', '\\varepsilon')
+        assertCompletionItemDoesNotContainSnippet(items, '@+', '\\bigcup')
+        assertCompletionItemDoesNotContainSnippet(items, '#+', '\\bigcup')
+        assertCompletionItemDoesNotContainSnippet(items, '#8')
+    })
+
+    runTestWithFixture('fixture004', 'glossary completion', async () => {
+        const fixtureDir = getFixtureDir()
+        const texFileName = 't.tex'
+        const texFilePath = vscode.Uri.file(path.join(fixtureDir, texFileName))
+        const doc = await vscode.workspace.openTextDocument(texFilePath)
+        await vscode.window.showTextDocument(doc)
+        const extension = await waitLatexWorkshopActivated()
+        const pos = new vscode.Position(6,5)
+        const token = new vscode.CancellationTokenSource().token
+        const items = extension.exports.realExtension?.completer.provideCompletionItems(
+            doc, pos, token,
+            {
+                triggerKind: vscode.CompletionTriggerKind.Invoke,
+                triggerCharacter: undefined
+            }
+        )
+        assert.ok(items && items.length === 5)
+        assertCompletionItemContains(items, 'rf', 'radio-frequency')
+        assertCompletionItemContains(items, 'te', 'Transverse Magnetic')
+        assertCompletionItemContains(items, 'E_P', 'Elastic $\\varepsilon$ toto')
+        assertCompletionItemContains(items, 'lw', 'What this extension is $\\mathbb{A}$')
+        assertCompletionItemContains(items, 'vs_code', 'Editor')
     })
 })

--- a/test/fixtures/completion/fixture004/glossary.tex
+++ b/test/fixtures/completion/fixture004/glossary.tex
@@ -1,0 +1,8 @@
+\newacronym{rf}{RF}{radio-frequency}
+\newacronym{te}{TM}{Transverse Magnetic}
+\newacronym{E_P}{E}{Elastic $\varepsilon$ toto}
+% Badly formed entry
+\newacronym[argopt]{EPE_x}{E}
+
+\newglossaryentry{lw}{name={LaTeX Workshop}, description={What this extension is $\mathbb{A}$}}
+\newglossaryentry{vs_code}{name=VSCode, description=Editor}

--- a/test/fixtures/completion/fixture004/t.tex
+++ b/test/fixtures/completion/fixture004/t.tex
@@ -1,0 +1,9 @@
+\documentclass{article}
+\usepackage{glossaries}
+\makeglossaries
+\loadglsentries{glossary}
+
+\begin{document}
+\gls{}
+
+\end{document}


### PR DESCRIPTION
This PR refactors the scanning par t of `Glossary` class.

- Stop directly accessing `node.kind`. Instead use the `latexParser.isXXX` methods.
- Use `stringify` to recompute labels and descriptions. Close #3280