### PR TITLE
Add argument to filecontents snippet

### DIFF
--- a/data/packages/latex-document_env.json
+++ b/data/packages/latex-document_env.json
@@ -55,8 +55,8 @@
   },
   "filecontents": {
     "name": "filecontents",
-    "detail": "filecontents",
-    "snippet": "",
+    "detail": "filecontents{filename}",
+    "snippet": "{${1:filename}}",
     "package": "latex-document"
   },
   "list{}{}": {


### PR DESCRIPTION
The `filecontents` environment takes a mandatory argument as the file name. `texdoc latex2e`:
<img width="390" alt="Screen Shot 2022-05-20 at 15 38 44" src="https://user-images.githubusercontent.com/12290822/169478158-bea74adb-1f87-4b69-a244-156ae4995346.png">

