### PR TITLE
Fix hover and provide definition for commands

### DIFF
--- a/src/providers/definition.ts
+++ b/src/providers/definition.ts
@@ -55,6 +55,14 @@ export class DefinitionProvider implements vscode.DefinitionProvider {
         if (token === undefined) {
             return
         }
+
+        if (token.startsWith('\\')) {
+            const command = this.extension.completer.command.definedCmds.get(token.slice(1))
+            if (command) {
+                return command.location
+            }
+            return undefined
+        }
         const ref = this.extension.completer.reference.getRef(token)
         if (ref) {
             return new vscode.Location(vscode.Uri.file(ref.file), ref.position)
@@ -62,10 +70,6 @@ export class DefinitionProvider implements vscode.DefinitionProvider {
         const cite = this.extension.completer.citation.getEntry(token)
         if (cite) {
             return new vscode.Location( vscode.Uri.file(cite.file), cite.position )
-        }
-        const command = this.extension.completer.command.definedCmds.get(token)
-        if (command) {
-            return command.location
         }
         if (vscode.window.activeTextEditor && token.includes('.')) {
             // We skip graphics files

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -82,7 +82,7 @@ export class HoverProvider implements vscode.HoverProvider {
                     }
                     const doc = cmd.documentation
                     const packageName = cmd.package
-                    if (packageName && (!pkgs.includes(packageName))) {
+                    if (packageName && packageName !== 'user-defined' && (!pkgs.includes(packageName))) {
                         pkgs.push(packageName)
                     }
                     signatures.push(doc)

--- a/src/providers/tokenizer.ts
+++ b/src/providers/tokenizer.ts
@@ -9,7 +9,13 @@ import * as utils from '../utils/utils'
  * @param position The position to be scanned at.
  */
 function commandTokenizer(document: vscode.TextDocument, position: vscode.Position): string | undefined {
-    const startResult = document.getText(new vscode.Range(new vscode.Position(position.line, 0), position)).match(/\\(?=[^\\{},[\]]*$)/)
+    let startRegex: RegExp
+    if (document.languageId === 'latex-expl3') {
+        startRegex = /\\(?=[^\\{},[\]]*$)/
+    } else {
+        startRegex = /\\(?=[a-zA-Z]*$)/
+    }
+    const startResult = document.getText(new vscode.Range(new vscode.Position(position.line, 0), position)).match(startRegex)
     if (startResult === null || startResult.index === undefined || startResult.index < 0) {
         return undefined
     }

--- a/src/providers/tokenizer.ts
+++ b/src/providers/tokenizer.ts
@@ -2,6 +2,55 @@ import * as vscode from 'vscode'
 import * as utils from '../utils/utils'
 
 /**
+ * If a string on `position` is like `\command`, `\command{` or `\command[`,
+ * return `\command`.
+ *
+ * @param document The document to be scanned.
+ * @param position The position to be scanned at.
+ */
+function commandTokenizer(document: vscode.TextDocument, position: vscode.Position): string | undefined {
+    const startResult = document.getText(new vscode.Range(new vscode.Position(position.line, 0), position)).match(/\\(?=[^\\{},[\]]*$)/)
+    if (startResult === null || startResult.index === undefined || startResult.index < 0) {
+        return undefined
+    }
+    const firstBracket = document.getText(new vscode.Range(position, new vscode.Position(position.line, 65535))).match(/[{]/)
+    if (firstBracket && firstBracket.index !== undefined && firstBracket.index > 0) {
+        return document.getText(new vscode.Range(
+                new vscode.Position(position.line, startResult.index),
+                new vscode.Position(position.line, position.character + firstBracket.index)
+            )).trim()
+    }
+    const wordRange = document.getWordRangeAtPosition(position)
+    if (wordRange) {
+        return document.getText(wordRange.with(new vscode.Position(position.line, startResult.index))).trim()
+    }
+    return undefined
+}
+
+/**
+ * If a string on `position` surround by `{...}` or `[...]`,
+ * return the string inside brackets.
+ *
+ * @param document The document to be scanned.
+ * @param position The position to be scanned at.
+ */
+function argTokenizer(document: vscode.TextDocument, position: vscode.Position): string | undefined {
+    const startResult = document.getText(new vscode.Range(new vscode.Position(position.line, 0), position)).match(/[{,[](?=[^{},[\]]*$)/)
+    if (startResult === null || startResult.index === undefined || startResult.index < 0) {
+        return undefined
+    }
+    const endResult = document.getText(new vscode.Range(position, new vscode.Position(position.line, 65535))).match(/[}\],]/)
+    if (endResult === null || endResult.index === undefined || endResult.index < 0) {
+        return undefined
+    }
+    return document.getText(new vscode.Range(
+        new vscode.Position(position.line, startResult.index + 1),
+        new vscode.Position(position.line, position.character + endResult.index)
+    )).trim()
+}
+
+
+/**
  * If a string on `position` is like `\command{` or `\command[`, then
  * returns the `\command`. If it is like `{...}` or `[...]`, then
  * returns the string inside brackets.
@@ -10,18 +59,18 @@ import * as utils from '../utils/utils'
  * @param position The position to be scanned at.
  */
 export function tokenizer(document: vscode.TextDocument, position: vscode.Position): string | undefined {
-    const startResult = document.getText(new vscode.Range(new vscode.Position(position.line, 0), position)).match(/[\\{,](?=[^\\{,]*$)/)
-    const endResult = document.getText(new vscode.Range(position, new vscode.Position(position.line, 65535))).match(/[{}[\],]/)
-    if (startResult === null || endResult === null ||
-        startResult.index === undefined || endResult.index === undefined ||
-        startResult.index < 0 || endResult.index < 0) {
-        return undefined
+    // \command case
+    const commandToken = commandTokenizer(document, position)
+    if (commandToken) {
+        return commandToken
     }
-    const startIndex = startResult[0] === '\\' ? startResult.index : startResult.index + 1
-    return document.getText(new vscode.Range(
-        new vscode.Position(position.line, startIndex),
-        new vscode.Position(position.line, position.character + endResult.index)
-    )).trim()
+
+    // Inside {...} or [...]
+    const argToken = argTokenizer(document, position)
+    if (argToken) {
+        return argToken
+    }
+    return undefined
 }
 
 /**


### PR DESCRIPTION
- Refactor the `tokenizer` used to determine the command under cursor, if any. A LaTeX command name can only contain letters
- Fix `provideDefinition` for commands : tokenized commands start with `\`. This actually solves #3294.
- Do not show link or texdoc command for `'user-defined'` package: this is the package used for commands defined directly in the file.