### PR TITLE
Support GitHub Codespaces on browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -2306,6 +2306,12 @@
           "type": "boolean",
           "default": true,
           "markdownDescription": "Enable AST based smart selection. Command ids are `editor.action.smartSelect.expand` and `editor.action.smartSelect.shrink`."
+        },
+        "latex-workshop.codespaces.portforwarding.openDelay": {
+          "scope": "window",
+          "type": "number",
+          "default": 20000,
+          "markdownDescription": "Delay to wait for GitHub Codespaces Authentication of port forwarding to be resolved, in milliseconds."
         }
       }
     },

--- a/resources/snippetview/snippetview.css
+++ b/resources/snippetview/snippetview.css
@@ -157,7 +157,6 @@ input[type='text']:focus {
 #Symbols .grid div {
     display: inline-block;
     position: relative;
-    min-width: 2ex;
     cursor: pointer;
 }
 

--- a/resources/snippetview/snippetview.css
+++ b/resources/snippetview/snippetview.css
@@ -157,6 +157,7 @@ input[type='text']:focus {
 #Symbols .grid div {
     display: inline-block;
     position: relative;
+    min-width: 2ex;
     cursor: pointer;
 }
 

--- a/src/components/server.ts
+++ b/src/components/server.ts
@@ -74,7 +74,7 @@ export class Server {
 
     private get validOrigin(): string {
         if (this.validOriginUri) {
-            return `http://${this.validOriginUri.authority}`
+            return `${this.validOriginUri.scheme}://${this.validOriginUri.authority}`
         } else {
             throw new Error('[Server] validOrigin is undefined')
         }

--- a/src/components/viewer.ts
+++ b/src/components/viewer.ts
@@ -100,8 +100,6 @@ export class Viewer {
             return
         }
         const url = `http://127.0.0.1:${this.extension.server.port}/viewer.html?file=${this.encodePathWithPrefix(pdfFile)}`
-        this.extension.logger.addLogMessage(`Serving PDF file at ${url}`)
-        this.extension.logger.addLogMessage(`The encoded path is ${pdfFile}`)
         return url
     }
 
@@ -119,6 +117,7 @@ export class Viewer {
         this.createClientSet(pdfFileUri)
         this.extension.manager.watchPdfFile(pdfFileUri)
         try {
+            this.extension.logger.addLogMessage(`Serving PDF file at ${url}`)
             await vscode.env.openExternal(vscode.Uri.parse(url, true))
             this.extension.logger.addLogMessage(`Open PDF viewer for ${pdfFileUri.toString(true)}`)
         } catch (e: unknown) {

--- a/src/components/viewerlib/pdfviewerpanel.ts
+++ b/src/components/viewerlib/pdfviewerpanel.ts
@@ -3,7 +3,7 @@ import * as path from 'path'
 
 import type {Extension} from '../../main'
 import type {PanelRequest, PdfViewerState} from '../../../types/latex-workshop-protocol-types/index'
-import {escapeHtml} from '../../utils/utils'
+import {escapeHtml, sleep} from '../../utils/utils'
 import type {PdfViewerManagerService} from './pdfviewermanager'
 import {PdfViewerStatusChanged} from '../eventbus'
 
@@ -79,6 +79,7 @@ export class PdfViewerPanelSerializer implements vscode.WebviewPanelSerializer {
 
 export class PdfViewerPanelService {
     private readonly extension: Extension
+    private alreadyOpened = false
 
     constructor(extension: Extension) {
         this.extension = extension
@@ -86,6 +87,19 @@ export class PdfViewerPanelService {
 
     private encodePathWithPrefix(pdfFileUri: vscode.Uri): string {
         return this.extension.server.pdfFilePathEncoder.encodePathWithPrefix(pdfFileUri)
+    }
+
+    private async tweakForCodespaces(url: vscode.Uri) {
+        if (this.alreadyOpened) {
+            return
+        }
+        if (vscode.env.remoteName === 'codespaces' && vscode.env.uiKind === vscode.UIKind.Web) {
+            const configuration = vscode.workspace.getConfiguration('latex-workshop')
+            const delay = configuration.get('codespaces.portforwarding.openDelay', 20000)
+            await vscode.env.openExternal(url)
+            await sleep(delay)
+        }
+        this.alreadyOpened = true
     }
 
     async createPdfViewerPanel(pdfFileUri: vscode.Uri, viewColumn: vscode.ViewColumn): Promise<PdfViewerPanel> {
@@ -124,6 +138,7 @@ export class PdfViewerPanelService {
         const url = await vscode.env.asExternalUri(vscode.Uri.parse(origUrl, true))
         const iframeSrcOrigin = `${url.scheme}://${url.authority}`
         const iframeSrcUrl = url.toString(true)
+        await this.tweakForCodespaces(url)
         this.extension.logger.addLogMessage(`The internal PDF viewer url: ${iframeSrcUrl}`)
         const rebroadcast: boolean = this.getKeyboardEventConfig()
         return `

--- a/src/components/viewerlib/pdfviewerpanel.ts
+++ b/src/components/viewerlib/pdfviewerpanel.ts
@@ -96,6 +96,7 @@ export class PdfViewerPanelService {
         if (vscode.env.remoteName === 'codespaces' && vscode.env.uiKind === vscode.UIKind.Web) {
             const configuration = vscode.workspace.getConfiguration('latex-workshop')
             const delay = configuration.get('codespaces.portforwarding.openDelay', 20000)
+            // We have to open the url in a browser tab for the authentication of port forwarding through githubpreview.dev.
             await vscode.env.openExternal(url)
             await sleep(delay)
         }

--- a/viewer/README.md
+++ b/viewer/README.md
@@ -211,3 +211,28 @@ When reloading a PDF file. In order.
 1. textlayerrendered
 1. pagerendered
 1. textlayerrendered
+
+## GitHub Codespaces
+```mermaid
+flowchart TB
+  subgraph Remote["Remote machine"]
+    subgraph ExtensionHost["VS Code Server (Extension Host)"]
+      LW["LaTeX Workshop"]
+      Server["Server for PDF viewer\n(Files and WebSocket)\n127.0.0.1 at remote"]
+      LW --- Server
+    end
+    PortForwarder
+  end
+  GitHub["github.dev"]
+  GitHubPreview["githubpreview.dev"]
+  subgraph Browser
+    subgraph WebView["parent iframe"]
+      PDFViewer["PDF viewer (viewer.html)"]
+    end
+  end
+  ExtensionHost <--> GitHub
+  Server <--> PortForwarder
+  PortForwarder <--> GitHubPreview
+  GitHub <--> Browser
+  GitHubPreview <--> PDFViewer
+```

--- a/viewer/components/connection.ts
+++ b/viewer/components/connection.ts
@@ -19,7 +19,8 @@ export class WebSocketPort implements IConnectionPort {
 
     constructor(lwApp: ILatexWorkshopPdfViewer) {
         this.lwApp = lwApp
-        const server = `ws://${window.location.hostname}:${window.location.port}`
+        const scheme = 'https:' === window.location.protocol ? 'wss' : 'ws'
+        const server = `${scheme}://${window.location.hostname}:${window.location.port}`
         this.server = server
         this.socket = new Promise((resolve, reject) => {
             const sock = new WebSocket(server)

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -25,7 +25,7 @@ See https://github.com/adobe-type-tools/cmap-resources
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <meta name="google" content="notranslate">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'none'; connect-src 'self' ws://127.0.0.1:*; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'none'; connect-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:;">
     <title>PDF.js viewer</title>
 
     <!--


### PR DESCRIPTION
Support GitHub Codespaces on browsers. The user experience is not smooth. I recommend users use the service through [the VS Code extension](https://marketplace.visualstudio.com/items?itemName=GitHub.codespaces).

- https://github.blog/2022-05-09-prepare-for-next-semester-with-github-global-campus-and-codespaces/

We will not support [the github.dev web-based editor](https://docs.github.com/en/codespaces/the-githubdev-web-based-editor).