### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -18,8 +18,15 @@ on:
     # The branches below must be a subset of the branches above
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
+    permissions:
+      actions: read  # for github/codeql-action/init to get workflow details
+      contents: read  # for actions/checkout to fetch code
+      security-events: write  # for github/codeql-action/autobuild to send a status report
     name: Analyze
     runs-on: ubuntu-latest
 

--- a/.github/workflows/texlive_on_linux.yml
+++ b/.github/workflows/texlive_on_linux.yml
@@ -3,6 +3,9 @@ env:
   cache-version: v10
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/texlive_on_mac.yml
+++ b/.github/workflows/texlive_on_mac.yml
@@ -3,6 +3,9 @@ env:
   cache-version: v10
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   macosx:
     runs-on: macos-latest

--- a/.github/workflows/texlive_on_win.yml
+++ b/.github/workflows/texlive_on_win.yml
@@ -3,6 +3,9 @@ env:
   cache-version: v10
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   windows:
     runs-on: windows-latest


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
