### PR TITLE
Use `latex-utensils` for structuring

### DIFF
--- a/src/providers/docsymbol.ts
+++ b/src/providers/docsymbol.ts
@@ -19,14 +19,14 @@ export class DocSymbolProvider implements vscode.DocumentSymbolProvider {
         })
     }
 
-    provideDocumentSymbols(document: vscode.TextDocument): vscode.ProviderResult<vscode.DocumentSymbol[]> {
+    async provideDocumentSymbols(document: vscode.TextDocument): Promise<vscode.DocumentSymbol[]> {
         if (document.languageId === 'bibtex') {
             return this.sectionNodeProvider.buildBibTeXModel(document).then((sections: Section[]) => this.sectionToSymbols(sections))
         }
         if (this.extension.lwfs.isVirtualUri(document.uri)) {
             return []
         }
-        return this.sectionToSymbols(this.sectionNodeProvider.buildLaTeXModel(new Set<string>(), document.fileName, false))
+        return this.sectionToSymbols(await this.sectionNodeProvider.buildLaTeXModel(document.fileName, false))
     }
 
     private sectionToSymbols(sections: Section[]): vscode.DocumentSymbol[] {

--- a/src/providers/projectsymbol.ts
+++ b/src/providers/projectsymbol.ts
@@ -12,7 +12,7 @@ export class ProjectSymbolProvider implements vscode.WorkspaceSymbolProvider {
         this.sectionNodeProvider = new SectionNodeProvider(extension)
     }
 
-    provideWorkspaceSymbols(): vscode.SymbolInformation[] {
+    async provideWorkspaceSymbols(): Promise<vscode.SymbolInformation[]> {
         const symbols: vscode.SymbolInformation[] = []
         if (this.extension.manager.rootFile === undefined) {
             return symbols
@@ -21,7 +21,7 @@ export class ProjectSymbolProvider implements vscode.WorkspaceSymbolProvider {
         if (rootFileUri && this.extension.lwfs.isVirtualUri(rootFileUri)) {
             return symbols
         }
-        this.sectionToSymbols(symbols, this.sectionNodeProvider.buildLaTeXModel(new Set<string>(), this.extension.manager.rootFile))
+        this.sectionToSymbols(symbols, await this.sectionNodeProvider.buildLaTeXModel())
         return symbols
     }
 

--- a/src/providers/structure.ts
+++ b/src/providers/structure.ts
@@ -450,7 +450,7 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
 
     private buildLaTeXSectionToLine(structure: Section[], lastLine: number) {
         const sections = structure.filter(section => section.depth >= 0)
-        sections.forEach((section, index) => {
+        sections.forEach(section => {
             const sameFileSections = sections.filter(candidate =>
                 (candidate.fileName === section.fileName) &&
                 (candidate.lineNumber >= section.lineNumber) &&

--- a/src/providers/structure.ts
+++ b/src/providers/structure.ts
@@ -334,10 +334,10 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
 
             caption = 'Untitled Frame'
             captionNode = node.content.filter(latexParser.isCommand).find(subNode => subNode.name.replace(/\*$/, '') === 'frametitle')
+
             // \begin{frame}(whitespace){Title}
-            if (node.args.length > 0) {
-                caption = this.captionify(node.args[0])
-            }
+            const nodeArg = node.args.find(latexParser.isGroup)
+            caption = nodeArg ? this.captionify(nodeArg) : caption
         } else if (node.name.replace(/\*$/, '') === 'figure' || node.name.replace(/\*$/, '') === 'table') {
             // \begin{figure} \caption{Figure Title}
             captionNode = node.content.filter(latexParser.isCommand).find(subNode => subNode.name.replace(/\*$/, '') === 'caption')

--- a/src/providers/structure.ts
+++ b/src/providers/structure.ts
@@ -228,11 +228,11 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
                     ...await this.parseLaTeXSubFileCommand(node, file, subFile, filesBuilt, commands, depths)
                 ]
             }
-        } else if (latexParser.isLabelCommand(node) && node.name === 'label') {
+        } else if (latexParser.isLabelCommand(node) && commands.cmds.includes(node.name)) {
             // \label{this:is_a-label}
             sections.push(new Section(
                 SectionKind.Label,
-                `#${node.label}`, // -> #this:is_a-label
+                `#${node.name}: ${node.label}`, // -> #this:is_a-label
                 vscode.TreeItemCollapsibleState.Expanded,
                 -1,
                 node.location.start.line - 1,

--- a/src/providers/structure.ts
+++ b/src/providers/structure.ts
@@ -140,7 +140,7 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
 
         // Use `latex-utensils` to generate the AST.
         const ast = await this.extension.pegParser.parseLatex(content).catch((e) => {
-            if (bibtexParser.isSyntaxError(e)) {
+            if (latexParser.isSyntaxError(e)) {
                 const line = e.location.start.line
                 this.extension.logger.addLogMessage(`Error parsing LaTeX during structuring: line ${line} in ${file}.`)
             }

--- a/src/providers/structure.ts
+++ b/src/providers/structure.ts
@@ -178,15 +178,28 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
         if (latexParser.isCommand(node)) {
             if (commands.secs.includes(node.name.replace(/\*$/, ''))) {
                 // \section{Title}
-                sections.push(new Section(
-                    node.name.endsWith('*') ? SectionKind.NoNumberSection : SectionKind.Section,
-                    this.captionify(node.args[node.args.length - 1]),
-                    vscode.TreeItemCollapsibleState.Expanded,
-                    depths[node.name.replace(/\*$/, '')],
-                    node.location.start.line - 1,
-                    node.location.end.line - 1,
-                    file
-                ))
+                if (node.args.length > 0) {
+                    // Avoid \section alone
+                    let captionArg: latexParser.Group | undefined
+                    if (node.args.length === 1 && latexParser.isGroup(node.args[0])) {
+                        captionArg = node.args[0]
+                    } else if (node.args.length === 2 && latexParser.isOptionalArg(node.args[0]) && latexParser.isGroup(node.args[1])) {
+                        captionArg = node.args[1]
+                    } else {
+                        captionArg = node.args.find(latexParser.isGroup)
+                    }
+                    if (captionArg) {
+                        sections.push(new Section(
+                            node.name.endsWith('*') ? SectionKind.NoNumberSection : SectionKind.Section,
+                            this.captionify(captionArg),
+                            vscode.TreeItemCollapsibleState.Expanded,
+                            depths[node.name.replace(/\*$/, '')],
+                            node.location.start.line - 1,
+                            node.location.end.line - 1,
+                            file
+                        ))
+                    }
+                }
             } else if (commands.cmds.includes(node.name.replace(/\*$/, ''))) {
                 // \notlabel{Show}{ShowAlso}
                 const caption = node.args.map(arg => {

--- a/src/providers/structure.ts
+++ b/src/providers/structure.ts
@@ -202,10 +202,16 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
                 }
             } else if (commands.cmds.includes(node.name.replace(/\*$/, ''))) {
                 // \notlabel{Show}{ShowAlso}
-                const caption = node.args.map(arg => {
-                    const argContent = latexParser.stringify(arg)
-                    return argContent.slice(1, argContent.length - 1)
-                }).join(', ') // -> Show, ShowAlso
+                // const caption = node.args.map(arg => {
+                    // const argContent = latexParser.stringify(arg)
+                //     return argContent.slice(1, argContent.length - 1)
+                // }).join(', ') // -> Show, ShowAlso
+                let caption = ''
+                const captionArg = node.args.find(latexParser.isGroup)
+                if (captionArg) {
+                    caption = latexParser.stringify(captionArg)
+                    caption = caption.slice(1, caption.length - 1)
+                }
                 sections.push(new Section(
                     SectionKind.Label,
                     `#${node.name}: ${caption}`,

--- a/src/providers/structure.ts
+++ b/src/providers/structure.ts
@@ -178,7 +178,7 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
         if (latexParser.isCommand(node)) {
             if (commands.secs.includes(node.name.replace(/\*$/, ''))) {
                 // \section{Title}
-                const caption = latexParser.stringify(node.args[node.args.length - 1])
+                const caption = latexParser.stringify(node.args[node.args.length - 1]).replace(/\n/, ' ')
                 sections.push(new Section(
                     SectionKind.Section,
                     caption.slice(1, caption.length - 1), // {Title} -> Title
@@ -318,7 +318,7 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
             let caption: string = 'Untitled Frame'
             const captionNodes = node.content.filter(subNode => latexParser.isCommand(subNode) && subNode.name.replace(/\*$/, '') === 'frametitle')
             if (captionNodes.length > 0 && latexParser.hasArgsArray(captionNodes[0])) {
-                caption = latexParser.stringify(captionNodes[0].args[0])
+                caption = latexParser.stringify(captionNodes[0].args[0]).replace(/\n/, ' ')
                 caption = caption.slice(1, caption.length - 1)
             }
             // \begin{frame}(whitespace){Title}
@@ -334,7 +334,7 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
             let caption: string = 'Untitled'
             const captionNodes = node.content.filter(subNode => latexParser.isCommand(subNode) && subNode.name.replace(/\*$/, '') === 'caption')
             if (captionNodes.length > 0 && latexParser.hasArgsArray(captionNodes[0])) {
-                caption = latexParser.stringify(captionNodes[0].args[0])
+                caption = latexParser.stringify(captionNodes[0].args[0]).replace(/\n/, ' ')
                 return caption.slice(1, caption.length - 1)
             }
             return caption

--- a/src/providers/structure.ts
+++ b/src/providers/structure.ts
@@ -354,7 +354,9 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
     private captionify(argNode: latexParser.Group | latexParser.OptionalArg): string {
         for (let index = 0; index < argNode.content.length; ++index){
             const node = argNode.content[index]
-            if (latexParser.isCommand(node) && node.name === 'texorpdfstring' && node.args.length > 1) {
+            if (latexParser.isCommand(node)
+                && node.name === 'texorpdfstring'
+                && node.args.length === 2) {
                 const pdfString = latexParser.stringify(node.args[1])
                 const firstArg = node.args[1].content[0]
                 if (latexParser.isTextString(firstArg)) {

--- a/src/providers/structure.ts
+++ b/src/providers/structure.ts
@@ -180,7 +180,7 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
                 // \section{Title}
                 const caption = latexParser.stringify(node.args[node.args.length - 1]).replace(/\n/, ' ')
                 sections.push(new Section(
-                    SectionKind.Section,
+                    node.name.endsWith('*') ? SectionKind.NoNumberSection : SectionKind.Section,
                     caption.slice(1, caption.length - 1), // {Title} -> Title
                     vscode.TreeItemCollapsibleState.Expanded,
                     depths[node.name.replace(/\*$/, '')],
@@ -387,7 +387,7 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
                     flatSections[flatSections.length - 1].children.push(node)
                 }
             } else {
-                if (showHierarchyNumber) {
+                if (showHierarchyNumber && node.kind === SectionKind.Section) {
                     const depth = node.depth - lowest
                     if (depth + 1 > counter.length) {
                         counter = [...counter, ...new Array(depth + 1 - counter.length).fill(0) as number[]]
@@ -396,6 +396,8 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
                     }
                     counter[counter.length - 1] += 1
                     node.label = `${counter.join('.')} ${node.label}`
+                } else if (showHierarchyNumber && node.kind === SectionKind.NoNumberSection) {
+                    node.label = `* ${node.label}`
                 }
                 flatSections.push(node)
             }
@@ -534,8 +536,9 @@ export enum SectionKind {
     Env = 0,
     Label = 1,
     Section = 2,
-    BibItem = 3,
-    BibField = 4
+    NoNumberSection = 3,
+    BibItem = 4,
+    BibField = 5
 }
 
 export class Section extends vscode.TreeItem {

--- a/src/providers/structure.ts
+++ b/src/providers/structure.ts
@@ -180,14 +180,7 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
                 // \section{Title}
                 if (node.args.length > 0) {
                     // Avoid \section alone
-                    let captionArg: latexParser.Group | undefined
-                    if (node.args.length === 1 && latexParser.isGroup(node.args[0])) {
-                        captionArg = node.args[0]
-                    } else if (node.args.length === 2 && latexParser.isOptionalArg(node.args[0]) && latexParser.isGroup(node.args[1])) {
-                        captionArg = node.args[1]
-                    } else {
-                        captionArg = node.args.find(latexParser.isGroup)
-                    }
+                    const captionArg = node.args.find(latexParser.isGroup)
                     if (captionArg) {
                         sections.push(new Section(
                             node.name.endsWith('*') ? SectionKind.NoNumberSection : SectionKind.Section,

--- a/src/providers/structure.ts
+++ b/src/providers/structure.ts
@@ -321,10 +321,7 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
             }
             // \begin{frame}(whitespace){Title}
             else if (node.args.length > 0) {
-                const captionNode = node.args[0].content[0]
-                if (latexParser.isTextString(captionNode)) {
-                    caption = captionNode.content
-                }
+                caption = this.captionify(node.args[0])
             }
             return caption
         } else if (node.name.replace(/\*$/, '') === 'figure' || node.name.replace(/\*$/, '') === 'table') {
@@ -382,7 +379,10 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
         // Calculate the lowest depth. It's possible that there is no `chapter`
         // in a document. In such a case, `section` is the lowest level with a
         // depth 1. However, later logic is 0-based. So.
-        const lowest = flatStructure.filter(node => node.depth > -1).map(section => section.depth).reduce((min, cur) => Math.min(min, cur))
+        let lowest = 65535
+        flatStructure.filter(node => node.depth > -1).forEach(section => {
+            lowest = lowest < section.depth ? lowest : section.depth
+        })
 
         // Step 1: Put all non-sections into their leading section. This is to
         // make the subsequent logic clearer.

--- a/src/providers/structure.ts
+++ b/src/providers/structure.ts
@@ -288,7 +288,8 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
         let candidate: string | undefined
         // \input{sub.tex}
         if (['input', 'InputIfFileExists', 'include', 'SweaveInput',
-             'subfile', 'loadglsentries'].includes(node.name.replace(/\*$/, ''))) {
+             'subfile', 'loadglsentries'].includes(node.name.replace(/\*$/, ''))
+            && cmdArgs.length > 0) {
             candidate = utils.resolveFile(
                 [path.dirname(file),
                  path.dirname(this.extension.manager.rootFile || ''),
@@ -296,7 +297,8 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
                 cmdArgs[0])
         }
         // \import{sections/}{section1.tex}
-        if (['import', 'inputfrom', 'includefrom'].includes(node.name.replace(/\*$/, ''))) {
+        if (['import', 'inputfrom', 'includefrom'].includes(node.name.replace(/\*$/, ''))
+            && cmdArgs.length > 1) {
             candidate = utils.resolveFile(
                 [cmdArgs[0],
                  path.join(
@@ -305,7 +307,8 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
                 cmdArgs[1])
         }
         // \subimport{01-IntroDir/}{01-Intro.tex}
-        if (['subimport', 'subinputfrom', 'subincludefrom'].includes(node.name.replace(/\*$/, ''))) {
+        if (['subimport', 'subinputfrom', 'subincludefrom'].includes(node.name.replace(/\*$/, ''))
+            && cmdArgs.length > 1) {
             candidate = utils.resolveFile(
                 [path.dirname(file)],
                 path.join(cmdArgs[0], cmdArgs[1]))

--- a/src/providers/structure.ts
+++ b/src/providers/structure.ts
@@ -1,19 +1,14 @@
 import * as vscode from 'vscode'
-import {bibtexParser} from 'latex-utensils'
+import * as path from 'path'
+import {latexParser,bibtexParser} from 'latex-utensils'
 
 import type { Extension } from '../main'
 import * as utils from '../utils/utils'
-import {PathRegExp} from '../components/managerlib/pathutils'
-import type {MatchPath} from '../components/managerlib/pathutils'
 
 export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
 
     private readonly _onDidChangeTreeData: vscode.EventEmitter<Section | undefined> = new vscode.EventEmitter<Section | undefined>()
     readonly onDidChangeTreeData: vscode.Event<Section | undefined>
-    private readonly commandNames: string[]
-    private readonly hierarchy: string[]
-    private readonly showFloats: boolean
-    private readonly showNumbers: boolean
     public root: string = ''
 
     // our data source is a set multi-rooted set of trees
@@ -23,13 +18,6 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
 
     constructor(private readonly extension: Extension) {
         this.onDidChangeTreeData = this._onDidChangeTreeData.event
-        const configuration = vscode.workspace.getConfiguration('latex-workshop')
-
-        this.commandNames = configuration.get('view.outline.commands') as string[]
-        this.hierarchy = configuration.get('view.outline.sections') as string[]
-        this.showFloats = configuration.get('view.outline.floats.enabled') as boolean
-        this.showNumbers = configuration.get('view.outline.numbers.enabled') as boolean
-
     }
 
     private getCachedDataRootFileName(sections: Section[]): string | undefined {
@@ -54,7 +42,7 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
         }
         else if (this.extension.manager.rootFile) {
             if (force) {
-                this.CachedLaTeXData = this.buildLaTeXModel(new Set<string>(), this.extension.manager.rootFile)
+                this.CachedLaTeXData = await this.buildLaTeXModel()
             }
             this.ds = this.CachedLaTeXData
         } else {
@@ -66,6 +54,279 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
     async update(force: boolean) {
         this.ds = await this.build(force)
         this._onDidChangeTreeData.fire(undefined)
+    }
+
+    async buildLaTeXModel(file?: string, subFile = true): Promise<Section[]> {
+        file = file ? file : this.extension.manager.rootFile
+        if (!file) {
+            return []
+        }
+
+        const configuration = vscode.workspace.getConfiguration('latex-workshop')
+        const cmds = configuration.get('view.outline.commands') as string[]
+        const envs = configuration.get('view.outline.floats.enabled') as boolean ? ['figure', 'frame', 'table'] : ['frame']
+
+        const hierarchy = (configuration.get('view.outline.sections') as string[])
+        const depths: {[cmd: string]: number} = {}
+        hierarchy.forEach((sec, index) => {
+            sec.split('|').forEach(cmd => {
+                depths[cmd] = index
+            })
+        })
+        const showHierarchyNumber = subFile ? configuration.get('view.outline.numbers.enabled') as boolean : false
+
+        const filesBuilt = new Set<string>()
+        const flatStructure = await this.buildLaTeXSectionFromFile(file, subFile, filesBuilt, {
+            cmds, envs, secs: hierarchy.map(sec => sec.split('|')).flat(), depths
+        })
+
+        return this.buildLaTeXHierarchy(flatStructure, showHierarchyNumber)
+    }
+
+    async buildLaTeXSectionFromFile(file: string, subFile: boolean, filesBuilt: Set<string>, config: {cmds: string[], envs: string[], secs: string[], depths: {[cmd: string]: number}}): Promise<Section[]> {
+        if (filesBuilt.has(file)) {
+            return []
+        }
+        filesBuilt.add(file)
+
+        const content = this.extension.manager.getDirtyContent(file)
+        if (!content) {
+            this.extension.logger.addLogMessage(`Error loading LaTeX during structuring: ${file}.`)
+            return []
+        }
+
+        const ast = await this.extension.pegParser.parseLatex(content).catch((e) => {
+            if (bibtexParser.isSyntaxError(e)) {
+                const line = e.location.start.line
+                this.extension.logger.addLogMessage(`Error parsing LaTeX during structuring: line ${line} in ${file}.`)
+            }
+            return
+        })
+        if (!ast) {
+            return []
+        }
+
+        let sections: Section[] = []
+        for (const node of ast.content) {
+            sections = [
+                ...sections,
+                ...await this.parseLaTeXNode(node, config, file, subFile, filesBuilt)
+            ]
+        }
+
+        ///////////
+        return sections
+    }
+
+    async parseLaTeXNode(node: latexParser.Node, config: {cmds: string[], envs: string[], secs: string[], depths: {[cmd: string]: number}}, file: string, subFile: boolean, filesBuilt: Set<string>): Promise<Section[]> {
+        let sections: Section[] = []
+        if (latexParser.isCommand(node)) {
+            if (config.secs.includes(node.name.replace('*', ''))) {
+                // \section{Title}
+                const caption = latexParser.stringify(node.args[node.args.length - 1])
+                sections.push(new Section(
+                    SectionKind.Section,
+                    caption.slice(1, caption.length - 1), // {Title} -> Title
+                    vscode.TreeItemCollapsibleState.Expanded,
+                    config.depths[node.name.replace('*', '')],
+                    node.location.start.line - 1,
+                    node.location.end.line - 1,
+                    file
+                ))
+            } else if (config.cmds.includes(node.name.replace('*', ''))) {
+                // \notlabel{Show}{ShowAlso}
+                const caption = node.args.map(arg => {
+                    const argContent = latexParser.stringify(arg)
+                    return argContent.slice(1, argContent.length - 1)
+                }).join(', ')
+                sections.push(new Section(
+                    SectionKind.Label,
+                    `#${node.name}: ${caption}`,
+                    vscode.TreeItemCollapsibleState.Expanded,
+                    -1,
+                    node.location.start.line - 1,
+                    node.location.end.line - 1,
+                    file
+                ))
+            } else {
+                // Check if this command is a subfile one
+                sections = [
+                    ...sections,
+                    ...await this.parseLaTeXSubFileCommand(node, config, file, subFile, filesBuilt)
+                ]
+            }
+        } else if (latexParser.isLabelCommand(node) && node.name === 'label') {
+            // \label{this:is_a-label}
+            sections.push(new Section(
+                SectionKind.Label,
+                `#${node.label}`,
+                vscode.TreeItemCollapsibleState.Expanded,
+                -1,
+                node.location.start.line - 1,
+                node.location.end.line - 1,
+                file
+            ))
+        } else if (latexParser.isEnvironment(node) && config.envs.includes(node.name.replace('*', ''))) {
+            // \begin{figure}...\end{figure}
+            sections.push(new Section(
+                SectionKind.Env,
+                `${node.name.charAt(0).toUpperCase() + node.name.slice(1)}: ${this.findEnvCaption(node)}`,
+                vscode.TreeItemCollapsibleState.Expanded,
+                -1,
+                node.location.start.line - 1,
+                node.location.end.line - 1,
+                file
+            ))
+        }
+        if (latexParser.hasContentArray(node)) {
+            for (const subNode of node.content) {
+                sections = [
+                    ...sections,
+                    ...await this.parseLaTeXNode(subNode, config, file, subFile, filesBuilt)
+                ]
+            }
+        }
+        return sections
+    }
+
+    async parseLaTeXSubFileCommand(node: latexParser.Command, config: {cmds: string[], envs: string[], secs: string[], depths: {[cmd: string]: number}}, file: string, subFile: boolean, filesBuilt: Set<string>): Promise<Section[]> {
+        const cmdArgs: string[] = []
+        node.args.forEach((arg) => {
+            if (latexParser.isOptionalArg(arg)) {
+                return
+            }
+            const argContent = arg.content[0]
+            if (latexParser.isTextString(argContent)) {
+                cmdArgs.push(argContent.content)
+            }
+        })
+
+        const texDirs = vscode.workspace.getConfiguration('latex-workshop').get('latex.texDirs') as string[]
+
+        let candidate: string | undefined
+        // \input{sub.tex}
+        if (['input', 'InputIfFileExists', 'include', 'SweaveInput',
+             'subfile', 'loadglsentries'].includes(node.name.replace('*', ''))) {
+            candidate = utils.resolveFile(
+                [path.dirname(file),
+                 path.dirname(this.extension.manager.rootFile || ''),
+                 ...texDirs],
+                cmdArgs[0])
+        }
+        // \import{sections/}{section1.tex}
+        if (['import', 'inputfrom', 'includefrom'].includes(node.name.replace('*', ''))) {
+            candidate = utils.resolveFile(
+                [cmdArgs[0],
+                 path.join(
+                    path.dirname(this.extension.manager.rootFile || ''),
+                    cmdArgs[0])],
+                cmdArgs[1])
+        }
+        // \subimport{01-IntroDir/}{01-Intro.tex}
+        if (['subimport', 'subinputfrom', 'subincludefrom'].includes(node.name.replace('*', ''))) {
+            candidate = utils.resolveFile(
+                [path.dirname(file)],
+                path.join(cmdArgs[0], cmdArgs[1]))
+        }
+
+        return candidate ? this.buildLaTeXSectionFromFile(candidate, subFile, filesBuilt, config) : []
+    }
+
+    private findEnvCaption(node: latexParser.Environment): string {
+        if (node.name.replace('*', '') === 'frame') {
+            // Frame titles can be specified as either \begin{frame}{Frame Title}
+            // or \begin{frame} \frametitle{Frame Title}
+            // \begin{frame}(whitespace){Title} will set the title as long as the whitespace contains no more than 1 newline
+            // \frametitle can override title set in \begin{frame}{<title>} so we check that first
+
+            // \begin{frame} \frametitle{Frame Title}
+            let caption: string = 'Untitled Frame'
+            const captionNodes = node.content.filter(subNode => latexParser.isCommand(subNode) && subNode.name.replace('*', '') === 'frametitle')
+            if (captionNodes.length > 0 && latexParser.hasArgsArray(captionNodes[0])) {
+                caption = latexParser.stringify(captionNodes[0].args[0])
+                caption = caption.slice(1, caption.length - 1)
+            }
+            // \begin{frame}(whitespace){Title}
+            else if (node.args.length > 0) {
+                const captionNode = node.args[0].content[0]
+                if (latexParser.isTextString(captionNode)) {
+                    caption = captionNode.content
+                }
+            }
+            return caption
+        } else if (node.name.replace('*', '') === 'figure' || node.name.replace('*', '') === 'table') {
+            // \begin{figure} \caption{Figure Title}
+            let caption: string = 'Untitled'
+            const captionNodes = node.content.filter(subNode => latexParser.isCommand(subNode) && subNode.name.replace('*', '') === 'caption')
+            if (captionNodes.length > 0 && latexParser.hasArgsArray(captionNodes[0])) {
+                caption = latexParser.stringify(captionNodes[0].args[0])
+                return caption.slice(1, caption.length - 1)
+            }
+            return caption
+        }
+        return 'Untitled'
+    }
+
+    private buildLaTeXHierarchy(flatStructure: Section[], showHierarchyNumber: boolean): Section[] {
+        if (flatStructure.length === 0) {
+            return []
+        }
+
+        const preambleNodes: Section[] = []
+        const flatSections: Section[] = []
+
+        const lowest = flatStructure.filter(node => node.depth > -1).map(section => section.depth).reduce((min, cur) => Math.min(min, cur))
+
+        let counter: number[] = []
+        flatStructure.forEach(node => {
+            if (node.depth === -1) {
+                // non-section node
+                if (flatSections.length === 0) {
+                    // no section appeared yet
+                    preambleNodes.push(node)
+                } else {
+                    flatSections[flatSections.length - 1].children.push(node)
+                }
+            } else {
+                if (showHierarchyNumber) {
+                    const depth = node.depth - lowest
+                    if (depth + 1 > counter.length) {
+                        counter = [...counter, ...new Array(depth + 1 - counter.length).fill(0) as number[]]
+                    } else {
+                        counter = counter.slice(0, depth + 1)
+                    }
+                    counter[counter.length - 1] += 1
+                    node.label = `${counter.join('.')} ${node.label}`
+                }
+                flatSections.push(node)
+            }
+        })
+
+        const sections: Section[] = preambleNodes
+
+        flatSections.forEach(section => {
+            if (section.depth - lowest === 0) {
+                // base level section
+                sections.push(section)
+            } else if (sections.length === 0) {
+                // non-base level section, no previous sections available, create one
+                sections.push(section)
+            } else {
+                let currentSection = sections[sections.length - 1]
+                while (currentSection.depth < section.depth - 1) {
+                    const children = currentSection.children.filter(candidate => candidate.depth > -1)
+                    if (children.length > 0) {
+                        // If there is a section child
+                        currentSection = children[children.length - 1]
+                    } else {
+                        break
+                    }
+                }
+                currentSection.children.push(section)
+            }
+        })
+
+        return sections
     }
 
     async buildBibTeXModel(document: vscode.TextDocument): Promise<Section[]> {
@@ -108,111 +369,6 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
                 ds.push(bibitem)
             })
         return ds
-    }
-
-    /**
-     * Compute the TOC of a LaTeX project. To only consider the current file, use `imports=false`
-     * @param visitedFiles Set of files already visited. To avoid infinite loops
-     * @param filePath The path of the file being parsed
-     * @param imports Do we parse included files
-     * @param fileStack The list of files inclusion leading to the current file
-     * @param parentStack The list of parent sections
-     * @param parentChildren The list of children of the parent Section
-     * @param sectionNumber The number of the current section stored in an array with the same length this.hierarchy
-     */
-    buildLaTeXModel(visitedFiles: Set<string>, filePath: string, imports: boolean = true, fileStack?: string[], parentStack?: Section[], parentChildren?: Section[], sectionNumber?: number[]): Section[] {
-        if (visitedFiles.has(filePath)) {
-            return []
-        } else {
-            visitedFiles.add(filePath)
-        }
-
-        let rootStack: Section[] = []
-        if (parentStack) {
-            rootStack = parentStack
-        }
-
-        let children: Section[] = []
-        if (parentChildren) {
-            children = parentChildren
-        }
-
-        let newFileStack: string[] = []
-        if (fileStack) {
-            newFileStack = fileStack
-        }
-        newFileStack.push(filePath)
-
-        if (!sectionNumber) {
-            sectionNumber = Array<number>(this.hierarchy.length).fill(0)
-        }
-
-        let content = this.extension.manager.getDirtyContent(filePath)
-        if (!content) {
-            return children
-        }
-        content = utils.stripCommentsAndVerbatim(content.replace(/\r\n|\r/g, '\n'))
-        const endPos = content.search(/\\end{document}/)
-        content = content.substring(0, endPos > -1 ? endPos : undefined)
-        const startPos = content.search(/\\begin{document}/)
-        let startLineNumber = 0
-        if (startPos > -1) {
-            startLineNumber = content.substring(0, startPos).split('\n').length
-        }
-
-        const structureModel = new StructureModel(this.extension, filePath, rootStack, children, newFileStack, sectionNumber)
-        const envNames = this.showFloats ? ['figure', 'frame', 'table'] : ['frame']
-
-        const lines = content.split('\n')
-        for (let lineNumber = startLineNumber; lineNumber < lines.length; lineNumber++) {
-            const line = lines[lineNumber]
-            // Environment part
-            structureModel.buildEnvModel(envNames, lines, lineNumber)
-
-            // Inputs part
-            if (imports) {
-               const inputFilePath = structureModel.buildImportModel(line)
-               if (inputFilePath) {
-                    this.buildLaTeXModel(visitedFiles, inputFilePath, true, newFileStack, rootStack, children, sectionNumber)
-                }
-            }
-
-            // Headings part
-            structureModel.buildHeadingModel(lines, lineNumber, this.showNumbers)
-
-
-            // Commands part
-            structureModel.buildCommandModel(this.commandNames, line, lineNumber, filePath)
-        }
-        this.fixToLines(children)
-        return children
-    }
-
-    /**
-     * Compute the exact ranges of every Section entry
-     */
-    private fixToLines(sections: Section[], parentSection?: Section) {
-        sections.forEach((entry: Section, index: number) => {
-            if (entry.kind !== SectionKind.Section) {
-                return
-            }
-            // Look for the next section with a smaller or equal depth
-            let toLineSet: boolean = false
-            for (let i = index + 1; i < sections.length; i++) {
-                if (entry.fileName === sections[i].fileName && sections[i].kind === SectionKind.Section && sections[i].depth <= entry.depth) {
-                    entry.toLine = sections[i].lineNumber - 1
-                    toLineSet = true
-                    break
-                }
-            }
-            // If no closing section was found, use the parent section if any
-            if (parentSection && !toLineSet && parentSection.fileName === entry.fileName) {
-                entry.toLine = parentSection.toLine
-            }
-            if (entry.children.length > 0) {
-                this.fixToLines(entry.children, entry)
-            }
-        })
     }
 
     getTreeItem(element: Section): vscode.TreeItem {
@@ -268,7 +424,7 @@ export class Section extends vscode.TreeItem {
 
     constructor(
         public readonly kind: SectionKind,
-        public readonly label: string,
+        public label: string,
         public readonly collapsibleState: vscode.TreeItemCollapsibleState,
         public readonly depth: number,
         public readonly lineNumber: number,
@@ -277,240 +433,6 @@ export class Section extends vscode.TreeItem {
         public readonly command?: vscode.Command
     ) {
         super(label, collapsibleState)
-    }
-}
-
-class StructureModel {
-    envStack: {name: string, start: number, end: number}[] = []
-    private readonly hierarchy: string[]
-    private readonly headerPattern: string
-    private readonly sectionDepths = Object.create(null) as { [key: string]: number }
-    private prevSection: Section | undefined = undefined
-
-    constructor(
-        private readonly extension: Extension,
-        private readonly filePath: string,
-        private readonly rootStack: Section[],
-        private readonly children: Section[],
-        private readonly fileStack: string[],
-        private readonly sectionNumber: number[]
-    ) {
-        const configuration = vscode.workspace.getConfiguration('latex-workshop')
-        this.hierarchy = configuration.get('view.outline.sections') as string[]
-        this.hierarchy.forEach((section, index) => {
-            section.split('|').forEach(sec => {
-                this.sectionDepths[sec] = index
-            })
-        })
-        let pattern = '\\\\('
-        this.hierarchy.forEach((section, index) => {
-            pattern += section
-            if (index < this.hierarchy.length - 1) {
-                pattern += '|'
-            }
-        })
-        // To deal with multiline header, capture the whole line starting from the opening '{'
-        // The actual title will be determined later using getLongestBalancedString
-        pattern += ')(\\*)?(?:\\[[^\\[\\]\\{\\}]*\\])?{(.*)$'
-        this.headerPattern = pattern
-    }
-
-    currentRoot(): Section {
-        return this.rootStack[this.rootStack.length - 1]
-    }
-
-    noRoot(): boolean {
-        return this.rootStack.length === 0
-    }
-
-    buildEnvModel(envNames: string[], lines: string[], lineNumber: number) {
-        const envReg = RegExp(`(?:\\\\(begin|end)(?:\\[[^[\\]]*\\])?){(?:(${envNames.join('|')})\\*?)}`)
-        const line = lines[lineNumber]
-        const result = envReg.exec(line)
-        if (result && result[1] === 'begin') {
-            this.envStack.push({name: result[2], start: lineNumber, end: lineNumber})
-        } else if (result && result[2] === this.envStack[this.envStack.length - 1].name) {
-            const env = this.envStack.pop()
-            if (!env) {
-                return
-            }
-            env.end = lineNumber
-            const caption = this.getCaptionOrTitle(lines, env)
-            if (!caption) {
-                return
-            }
-            const depth = this.noRoot() ? 0 : this.currentRoot().depth + 1
-            const newEnv = new Section(SectionKind.Env, `${env.name.charAt(0).toUpperCase() + env.name.slice(1)}: ${caption}`, vscode.TreeItemCollapsibleState.Expanded, depth, env.start, env.end, this.filePath)
-            if (this.noRoot()) {
-                this.children.push(newEnv)
-            } else {
-                this.currentRoot().children.push(newEnv)
-            }
-        }
-    }
-
-    buildImportModel(line: string): string | undefined {
-        const pathRegexp = new PathRegExp()
-        const matchPath: MatchPath | undefined = pathRegexp.exec(line)
-        if (!matchPath) {
-            return undefined
-        }
-        // zoom into this file
-        const inputFilePath: string | undefined = pathRegexp.parseInputFilePath(matchPath, this.filePath, this.extension.manager.rootFile ? this.extension.manager.rootFile : this.filePath)
-        if (!inputFilePath) {
-            this.extension.logger.addLogMessage(`Could not resolve included file ${inputFilePath}`)
-            return undefined
-        }
-        // Avoid circular inclusion
-        if (inputFilePath === this.filePath || this.fileStack.includes(inputFilePath)) {
-            return undefined
-        }
-        if (this.prevSection) {
-            this.prevSection.subfiles.push(inputFilePath)
-        }
-        return inputFilePath
-    }
-
-    buildCommandModel(commandNames: string[], line: string, lineNumber: number, filePath: string) {
-        if (commandNames.length === 0) {
-            return
-        }
-        const commandReg = new RegExp('\\\\(' + commandNames.join('|') + '){([^}]*)}')
-        const result = commandReg.exec(line)
-        if (!result) {
-            return
-        }
-        const depth = this.noRoot() ? 0 : this.currentRoot().depth + 1
-        const newCommand = new Section(SectionKind.Label, `#${result[1]}: ${result[2]}`, vscode.TreeItemCollapsibleState.None, depth, lineNumber, lineNumber, filePath)
-        if (this.noRoot()) {
-            this.children.push(newCommand)
-        } else {
-            this.currentRoot().children.push(newCommand)
-        }
-    }
-
-    buildHeadingModel(lines: string[], lineNumber: number, showNumbers: boolean) {
-        const line = lines[lineNumber]
-        const headerReg = RegExp(this.headerPattern)
-        const result = headerReg.exec(line)
-        if (!result) {
-            return
-        }
-        // is it a section, a subsection, etc?
-        const heading = result[1]
-        const depth = this.sectionDepths[heading]
-        const title = this.getSectionTitle(result[3] + lines.slice(lineNumber + 1).join('\n'))
-        let sectionNumberStr: string = ''
-        if (result[2] === undefined) {
-            this.incrementSectionNumber(depth)
-            sectionNumberStr = this.formatSectionNumber(showNumbers)
-        }
-        const newSection = new Section(SectionKind.Section, sectionNumberStr + title, vscode.TreeItemCollapsibleState.Expanded, depth, lineNumber, lines.length - 1, this.filePath)
-        this.prevSection = newSection
-
-        if (this.noRoot()) {
-            this.children.push(newSection)
-            this.rootStack.push(newSection)
-            return
-        }
-
-        // Find the proper root section
-        while (!this.noRoot() && this.currentRoot().depth >= depth) {
-            this.rootStack.pop()
-        }
-        if (this.noRoot()) {
-            newSection.parent = undefined
-            this.children.push(newSection)
-        } else {
-            newSection.parent = this.currentRoot()
-            this.currentRoot().children.push(newSection)
-        }
-        this.rootStack.push(newSection)
-    }
-
-    getCaptionOrTitle(lines: string[], env: {name: string, start: number, end: number}) {
-        const content = lines.slice(env.start, env.end).join('\n')
-        let result: RegExpExecArray | null = null
-        if (env.name === 'frame') {
-            // Frame titles can be specified as either \begin{frame}{Frame Title}
-            // or \begin{frame} \frametitle{Frame Title}
-            const frametitleRegex = /\\frametitle(?:<[^<>]*>)?(?:\[[^[\]]*\])?{((?:[^{}]|(?:\{[^{}]*\})|\{[^{}]*\{[^{}]*\}[^{}]*\})+)}/gsm
-            // \begin{frame}(whitespace){Title} will set the title as long as the whitespace contains no more than 1 newline
-            const beginframeRegex = /\\begin{frame}(?:<[^<>]*>?)?(?:\[[^[\]]*\]){0,2}[\t ]*(?:(?:\r\n|\r|\n)[\t ]*)?{((?:[^{}]|(?:\{[^{}]*\})|\{[^{}]*\{[^{}]*\}[^{}]*\})+)}/gsm
-
-            // \frametitle can override title set in \begin{frame}{<title>} so we check that first
-            result = frametitleRegex.exec(content)
-            if (!result) {
-                result = beginframeRegex.exec(content)
-            }
-        } else {
-            const captionRegex = /(?:\\caption(?:\[[^[\]]*\])?){((?:(?:[^{}])|(?:\{[^{}]*\}))+)}/gsm
-            let captionResult: RegExpExecArray | null
-            // Take the last caption entry to deal with subfigures.
-            // This works most of the time but not always. A definitive solution should use AST
-            while ((captionResult = captionRegex.exec(content))) {
-                result = captionResult
-            }
-        }
-
-        if (result) {
-            // Remove indentation, newlines and the final '.'
-            return result[1].replace(/^ */gm, ' ').replace(/\r|\n/g, '').replace(/\.$/, '')
-        }
-        return undefined
-    }
-
-    /**
-     * Return the title of a command while only keeping the second argument of \texorpdfstring
-     * @param text a section command
-     */
-    getSectionTitle(text: string): string {
-        let title = utils.getLongestBalancedString(text)
-        let pdfTitle: string = ''
-        const regex = /\\texorpdfstring/
-        let res: RegExpExecArray | null
-        while (true) {
-            res = regex.exec(title)
-            if (!res) {
-                break
-            }
-            pdfTitle += title.slice(0, res.index)
-            title = title.slice(res.index)
-            const arg = utils.getNthArgument(title, 2)
-            if (!arg) {
-                break
-            }
-            pdfTitle += arg.arg
-            // Continue with the remaining text after the second arg
-            title = title.slice(arg.index + arg.arg.length + 2) // 2 counts '{' and '}' around arg
-        }
-        return pdfTitle + title
-    }
-
-    private incrementSectionNumber(depth: number) {
-        this.sectionNumber[depth] += 1
-        this.sectionNumber.forEach((_, index) => {
-            if (index > depth) {
-                this.sectionNumber[index] = 0
-            }
-        })
-    }
-
-    private formatSectionNumber(showNumbers: boolean) {
-        if (! showNumbers) {
-            return ''
-        }
-        let str: string = ''
-        this.sectionNumber.forEach((value) => {
-            if (str === '' && value === 0) {
-                return
-            }
-            if (str !== '') {
-                str += '.'
-            }
-            str += value.toString()
-        })
-        return str.replace(/(\.0)*$/, '') + ' '
     }
 }
 


### PR DESCRIPTION
This PR resolves #3224.

As per previous refactoring in #3252, the computation for structuring a LaTeX project is lighter than before. This PR is a step forward that uses `latex-utensils` to parse the document and provide structure. The performance looks good on my dev computer, which however is somehow quite powerful. So more tests are strongly welcome.

All previous related features are kept after the refactor, at least by design. Code comments are minuscule, and I plan to add comments in the following days to make it maintainable.

Feel free to test and welcome any comments/critisizes.