### PR TITLE
support for haskell language highlighting with minted

### DIFF
--- a/syntax/LaTeX.tmLanguage.json
+++ b/syntax/LaTeX.tmLanguage.json
@@ -381,6 +381,25 @@
 					"end": "(\\\\end\\{minted\\})"
 				},
 				{
+					"begin": "(\\\\begin\\{minted\\}(?:\\[.*\\])?\\{(haskell|hs)\\})",
+					"captures": {
+						"1": {
+							"patterns": [
+								{
+									"include": "#env-mandatory-arg"
+								}
+							]
+						}
+					},
+					"contentName": "source.haskell",
+					"patterns": [
+						{
+							"include": "source.haskell"
+						}
+					],
+					"end": "(\\\\end\\{minted\\})"
+				},
+				{
 					"begin": "(\\\\begin\\{(?:lstlisting|minted|pyglist)\\}(?:\\[.*\\])?)",
 					"captures": {
 						"1": {


### PR DESCRIPTION
Besides 'hscode', haskell code blocks with minted are currently not highlighted as haskell code.
With this small change, `\begin{minted}{haskell}` and `\begin{minted}{hs}` will now be recognized
as markers to switch syntax-highlighting accordingly.