### PR TITLE
Add '%' comments to bibtex

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,8 @@
         ],
         "extensions": [
           ".bib"
-        ]
+        ],
+        "configuration": "./syntax/bibtex-language-configuration.json"
       },
       {
         "id": "bibtex-style",

--- a/syntax/Bibtex.tmLanguage.json
+++ b/syntax/Bibtex.tmLanguage.json
@@ -3,6 +3,9 @@
 	"name": "BibTeX",
 	"patterns": [
 		{
+			"include": "#comment"
+		},
+		{
 			"begin": "@Comment",
 			"beginCaptures": {
 				"0": {
@@ -95,6 +98,9 @@
 			"name": "meta.entry.braces.bibtex",
 			"patterns": [
 				{
+					"include": "#comment"
+				},
+				{
 					"begin": "([a-zA-Z0-9\\!\\$\\&\\*\\+\\-\\.\\/\\:\\;\\<\\>\\?\\[\\]\\^\\_\\`\\|]+)\\s*(\\=)",
 					"beginCaptures": {
 						"1": {
@@ -177,6 +183,16 @@
 		}
 	],
 	"repository": {
+		"comment": {
+			"begin": "%",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.definition.comment.bibtex"
+				}
+			},
+			"end": "$\\n?",
+			"name": "comment.line.percentage.bibtex"
+		},
 		"integer": {
 			"match": "\\d+",
 			"name": "constant.numeric.bibtex"

--- a/syntax/bibtex-language-configuration.json
+++ b/syntax/bibtex-language-configuration.json
@@ -1,0 +1,35 @@
+{
+	"comments": {
+		"lineComment": "%"
+	},
+	"brackets": [
+		["{", "}"],
+		["[", "]"],
+		["(", ")"],
+	],
+	"autoClosingPairs": [
+		["{", "}"],
+		["[", "]"],
+		["(", ")"],
+		["`", "'"]
+	],
+	"surroundingPairs": [
+		["{", "}"],
+		["[", "]"],
+		["(", ")"],
+		["\"", "\""],
+		["'", "'"],
+		["`", "'"],
+		["$", "$"]
+	],
+	"folding": {
+		"markers": {
+			"start": "^\\s*%?\\s*region\\b",
+			"end": "^\\s*%?\\s*endregion\\b"
+		}
+	},
+	"wordPattern": {
+		"pattern": "(__)|(\\*\\*)|(\\.\\.\\.)|(\\p{Alphabetic}|\\p{Number}|\\p{Nonspacing_Mark}){2,}",
+		"flags": "u"
+	}
+}


### PR DESCRIPTION
This PR defines a language configuration for bibtex to enable comment toggling. To make this fully functional, the bibtex syntax has to be updated to recognise `%` as the beginning of a comment. Using `%` to define comments is only valid with `biber`, not `bibtex`.

Note that the bibtex syntax is hosted on https://github.com/jlelong/vscode-latex-basics but I want users feedback before pushing the change to https://github.com/jlelong/vscode-latex-basics, which is used by VSCode to provide built-in support for the `latex` and `bitex` grammars.

@bwegge could you test the PR?