### PR TITLE
Make sure to populate documentation before returning a citation entry

### DIFF
--- a/src/providers/completer/citation.ts
+++ b/src/providers/completer/citation.ts
@@ -168,6 +168,17 @@ export class Citation implements IProvider {
         return entry
     }
 
+    getEntryWithDocumentation(key: string, configurationScope: vscode.ConfigurationScope | undefined): Suggestion | undefined {
+        const entry = this.getEntry(key)
+        if (entry && !(entry.detail || entry.documentation)) {
+            const configuration = vscode.workspace.getConfiguration('latex-workshop', configurationScope)
+            const fields = readCitationFormat(configuration)
+            // We need two spaces to ensure md newline
+            entry.documentation = new vscode.MarkdownString( '\n' + entry.fields.join(fields, true, '  \n') + '\n\n')
+        }
+        return entry
+    }
+
     /**
      * Returns the array of the paths of `.bib` files referenced from `file`.
      *

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -53,7 +53,7 @@ export class HoverProvider implements vscode.HoverProvider {
             const hover = await this.extension.mathPreview.provideHoverOnRef(document, position, refData, token, ctoken)
             return hover
         }
-        const cite = this.extension.completer.citation.getEntry(token)
+        const cite = this.extension.completer.citation.getEntryWithDocumentation(token, document.uri)
         if (hovCitation && cite) {
             const range = document.getWordRangeAtPosition(position, /\{.*?\}/)
             const md = cite.documentation || cite.detail


### PR DESCRIPTION
The documentation or detail fields are required by hover.

Close #3346