### PR TITLE
Sort folders in descending dictionary order for nested hierarchy before cleaning

### DIFF
--- a/src/components/cleaner.ts
+++ b/src/components/cleaner.ts
@@ -100,6 +100,9 @@ export class Cleaner {
         const explicitFolderPathsToRemove: string[] = pathPairsToRemove.filter(
             ([globPathResult, realPath]) => realPath.endsWith(path.sep) && matchExplicitFolderGlobs(globPathResult)
         ).map(([_, realPath]) => realPath)
+        // Sort by descending dictionary order, make sure the children folders are sorted before the parents
+        // For example: [..., 'out/folder1/folder2/', 'out/folder1/', ...] ('out/folder1/folder2/' > 'out/folder1/' in directory order)
+        .sort((a, b) => b.localeCompare(a))
 
         // Remove files
         for (const realPath of filePathsToRemove) {


### PR DESCRIPTION
After refactoring the logic in PR #3353 into a two-stage manner:

1. Clean files.
2. Clean folders if it's empty, in arbitrary order.

I removed the order sorting in https://github.com/James-Yu/LaTeX-Workshop/pull/3353#discussion_r909566927.

------

After careful consideration, I found that order sorting is still required for nested folders. We should remove the deeper folders (the children) first, then the shallower ones (the parent folders).