### PR TITLE
Add deprecated config alert on activating extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -1542,7 +1542,7 @@
           "type": "string",
           "default": "#ffffff",
           "markdownDeprecationMessage": "**Deprecated**: Please use `#latex-workshop.view.pdf.color.light.backgroundColor#` and `#latex-workshop.view.pdf.color.dark.backgroundColor#` instead.",
-          "deprecationMessage": "Deprecated: Please use `#latex-workshop.view.pdf.color.light.backgroundColor#` and `#latex-workshop.view.pdf.color.dark.backgroundColor#` instead."
+          "deprecationMessage": "Please use \"latex-workshop.view.pdf.color.light.backgroundColor\" and \"latex-workshop.view.pdf.color.dark.backgroundColor\" instead."
         },
         "latex-workshop.view.pdf.color.light.pageColorsForeground": {
           "scope": "window",
@@ -1629,7 +1629,7 @@
           "type": "string",
           "default": "",
           "markdownDeprecationMessage": "**Deprecated**: Please use `#latex-workshop.chktex.exec.path#` instead.",
-          "deprecationMessage": "Deprecated: Please use `#latex-workshop.chktex.exec.path#` instead."
+          "deprecationMessage": "Please use \"latex-workshop.chktex.exec.path\" instead."
         },
         "latex-workshop.chktex.exec.args": {
           "scope": "resource",
@@ -1654,7 +1654,7 @@
           },
           "default": [],
           "markdownDeprecationMessage": "**Deprecated**: Please use `#latex-workshop.chktex.exec.args#` instead.",
-          "deprecationMessage": "Deprecated: Please use `#latex-workshop.chktex.exec.args#` instead."
+          "deprecationMessage": "Please use \"latex-workshop.chktex.exec.args\" instead."
         },
         "latex-workshop.chktex.args.root": {
           "scope": "resource",
@@ -1664,7 +1664,7 @@
           },
           "default": [],
           "markdownDeprecationMessage": "**Deprecated**: Please use `#latex-workshop.chktex.exec.args#` instead.",
-          "deprecationMessage": "Deprecated: Please use `#latex-workshop.chktex.exec.args#` instead."
+          "deprecationMessage": "Please use \"latex-workshop.chktex.exec.args\" instead."
         },
         "latex-workshop.chktex.delay": {
           "scope": "resource",
@@ -1789,7 +1789,7 @@
           "default": 5,
           "markdownDescription": "Defines the maximum bibtex file size for the extension to parse in MB.",
           "markdownDeprecationMessage": "**Deprecated**: Please use `#latex-workshop.bibtex.maxFileSize#` instead.",
-          "deprecationMessage": "Deprecated: Please use `#latex-workshop.bibtex.maxFileSize#` instead."
+          "deprecationMessage": "Please use \"latex-workshop.bibtex.maxFileSize\" instead."
         },
         "latex-workshop.intellisense.triggers.latex": {
           "scope": "window",
@@ -1808,7 +1808,7 @@
           "default": "@",
           "markdownDescription": "Character to trigger snippet suggestions as part of intellisense. Set this variable to `''` to deactivate these snippets. Reload vscode to make any change in this configuration effective.",
           "markdownDeprecationMessage": "**Deprecated**: Please use `#latex-workshop.intellisense.atSuggestion.trigger.latex#` instead.",
-          "deprecationMessage": "Deprecated: Please use `#latex-workshop.intellisense.atSuggestion.trigger.latex#` instead."
+          "deprecationMessage": "Please use \"latex-workshop.intellisense.atSuggestion.trigger.latex\" instead."
         },
         "latex-workshop.intellisense.atSuggestion.trigger.latex": {
           "scope": "window",


### PR DESCRIPTION
This PR add a function to check if any of the deprecated configs are assigned with values different from the default one. If so, a warning is displayed to alert the user.

This PR prepares itself for #2393, which may involve many config changes. It's hard to request users to always read the changelog.