### PR TITLE
Enhance glossary completion

### DIFF
--- a/src/providers/completer/glossary.ts
+++ b/src/providers/completer/glossary.ts
@@ -56,29 +56,15 @@ export class Glossary implements IProvider {
 
         nodes.forEach(node => {
             if (latexParser.isCommand(node) && node.args.length > 0) {
-                switch (node.name) {
-                    case 'newglossaryentry':
-                        type = GlossaryType.glossary
-                        entry = this.getShortNodeDescription(node)
-                        break
-                    case 'provideglossaryentry':
-                        type = GlossaryType.glossary
-                        entry = this.getShortNodeDescription(node)
-                        break
-                    case 'longnewglossaryentry':
-                        type = GlossaryType.glossary
-                        entry = this.getLongNodeLabelDescription(node)
-                        break
-                    case 'longprovideglossaryentry':
-                        type = GlossaryType.glossary
-                        entry = this.getLongNodeLabelDescription(node)
-                        break
-                    case 'newacronym':
-                        type = GlossaryType.acronym
-                        entry = this.getLongNodeLabelDescription(node)
-                        break
-                    default:
-                        break
+                if (['newglossaryentry', 'provideglossaryentry'].includes(node.name)) {
+                    type = GlossaryType.glossary
+                    entry = this.getShortNodeDescription(node)
+                } else if(['longnewglossaryentry', 'longprovideglossaryentry'].includes(node.name)) {
+                    type = GlossaryType.glossary
+                    entry = this.getLongNodeLabelDescription(node)
+                } else if(['newacronym', 'newabbreviation', 'newabbr'].includes(node.name)) {
+                    type = GlossaryType.acronym
+                    entry = this.getLongNodeLabelDescription(node)
                 }
                 if (type !== undefined && entry.description !== undefined && entry.label !== undefined) {
                     glossaries.push({

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -193,7 +193,7 @@ export class Completer implements vscode.CompletionItemProvider {
                 provider = this.subImport
                 break
             case 'glossary':
-                reg = /\\(gls(?:pl|text|first|plural|firstplural|name|symbol|desc|user(?:i|ii|iii|iv|v|vi))?|Acr(?:long|full|short)?(?:pl)?|ac[slf]?p?)(?:\[[^[\]]*\])?{([^}]*)$/i
+                reg = /\\(gls(?:pl|text|first|plural|firstplural|name|symbol|desc|disp|user(?:i|ii|iii|iv|v|vi))?|Acr(?:long|full|short)?(?:pl)?|ac[slf]?p?)(?:\[[^[\]]*\])?{([^}]*)$/i
                 provider = this.glossary
                 break
             default:

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -193,7 +193,7 @@ export class Completer implements vscode.CompletionItemProvider {
                 provider = this.subImport
                 break
             case 'glossary':
-                reg = /\\(gls(?:pl|text|first|plural|firstplural|name|symbol|desc|disp|user(?:i|ii|iii|iv|v|vi))?|Acr(?:long|full|short)?(?:pl)?|ac[slf]?p?)(?:\[[^[\]]*\])?{([^}]*)$/i
+                reg = /\\(gls(?:pl|text|first|fmt(?:text|short|long)|plural|firstplural|name|symbol|desc|disp|user(?:i|ii|iii|iv|v|vi))?|Acr(?:long|full|short)?(?:pl)?|ac[slf]?p?)(?:\[[^[\]]*\])?{([^}]*)$/i
                 provider = this.glossary
                 break
             default:

--- a/test/completion.test.ts
+++ b/test/completion.test.ts
@@ -142,11 +142,13 @@ suite('Completion test suite', () => {
                 triggerCharacter: undefined
             }
         )
-        assert.ok(items && items.length === 5)
+        assert.ok(items && items.length === 7)
         assertCompletionItemContains(items, 'rf', 'radio-frequency')
         assertCompletionItemContains(items, 'te', 'Transverse Magnetic')
         assertCompletionItemContains(items, 'E_P', 'Elastic $\\varepsilon$ toto')
         assertCompletionItemContains(items, 'lw', 'What this extension is $\\mathbb{A}$')
         assertCompletionItemContains(items, 'vs_code', 'Editor')
+        assertCompletionItemContains(items, 'abbr_y', 'A second abbreviation')
+        assertCompletionItemContains(items, 'abbr_x', 'A first abbreviation')
     }, () => os.platform() === 'win32')
 })

--- a/test/fixtures/completion/fixture004/glossary.tex
+++ b/test/fixtures/completion/fixture004/glossary.tex
@@ -6,3 +6,5 @@
 
 \newglossaryentry{lw}{name={LaTeX Workshop}, description={What this extension is $\mathbb{A}$}}
 \newglossaryentry{vs_code}{name=VSCode, description=Editor}
+\newabbr{abbr_x}{Ebbr}{A first abbreviation}
+\newabbreviation[optional arg]{abbr_y}{Ybbr}{A second abbreviation}


### PR DESCRIPTION
This PR adds support for the following commands from `glossaries-extra`

- `newabbrevation` / `newabbr`
- `glsfmt(?:text|short|long)`
- `glsdisp`