### PR TITLE
Refactor commands duplication detection for intellisense

### DIFF
--- a/src/providers/completer/command.ts
+++ b/src/providers/completer/command.ts
@@ -95,6 +95,10 @@ export class CommandSignatureDuplicationDetector {
 export class CommandNameDuplicationDetector {
     private readonly cmdSignatureList: Set<string> = new Set<string>()
 
+    constructor(suggestions: Suggestion[] = []) {
+        this.cmdSignatureList = new Set<string>(suggestions.map(s => s.name()))
+    }
+
     add(cmd: Suggestion): void
     add(cmdName: string): void
     add(cmd: any): void {
@@ -232,8 +236,7 @@ export class Command implements IProvider {
 
         // Start working on commands in tex. To avoid over populating suggestions, we do not include
         // user defined commands, whose name matches a default command or one provided by a package
-        const commandNameDuplicationDetector = new CommandNameDuplicationDetector()
-        suggestions.forEach(e => commandNameDuplicationDetector.add(e))
+        const commandNameDuplicationDetector = new CommandNameDuplicationDetector(suggestions)
         this.extension.manager.getIncludedTeX().forEach(tex => {
             const cmds = this.extension.manager.getCachedContent(tex)?.element.command
             if (cmds !== undefined) {

--- a/src/providers/completer/command.ts
+++ b/src/providers/completer/command.ts
@@ -6,6 +6,7 @@ import type {Extension} from '../../main'
 import {Environment, EnvSnippetType} from './environment'
 import type {IProvider, ILwCompletionItem} from './interface'
 import {CommandFinder, isTriggerSuggestNeeded, resolveCmdEnvFile} from './commandlib/commandfinder'
+import {CommandSignatureDuplicationDetector, CommandNameDuplicationDetector} from './commandlib/commandfinder'
 import {SurroundCommand} from './commandlib/surround'
 
 type DataUnimathSymbolsJsonType = typeof import('../../../data/unimathsymbols.json')
@@ -77,50 +78,6 @@ export class Suggestion extends vscode.CompletionItem implements ILwCompletionIt
 
     hasOptionalArgs(): boolean {
         return this.signature.args.includes('[')
-    }
-}
-
-export class CommandSignatureDuplicationDetector {
-    private readonly cmdSignatureList: Set<string> = new Set<string>()
-
-    add(cmd: Suggestion) {
-        this.cmdSignatureList.add(cmd.signatureAsString())
-    }
-
-    has(cmd: Suggestion): boolean {
-        return this.cmdSignatureList.has(cmd.signatureAsString())
-    }
-}
-
-export class CommandNameDuplicationDetector {
-    private readonly cmdSignatureList: Set<string> = new Set<string>()
-
-    constructor(suggestions: Suggestion[] = []) {
-        this.cmdSignatureList = new Set<string>(suggestions.map(s => s.name()))
-    }
-
-    add(cmd: Suggestion): void
-    add(cmdName: string): void
-    add(cmd: any): void {
-        if (cmd instanceof Suggestion) {
-            this.cmdSignatureList.add(cmd.name())
-        } else if (typeof(cmd) === 'string') {
-            this.cmdSignatureList.add(cmd)
-        } else {
-            throw new Error('Unaccepted argument type')
-        }
-    }
-
-    has(cmd: Suggestion): boolean
-    has(cmd: string): boolean
-    has(cmd: any): boolean {
-        if (cmd instanceof Suggestion) {
-            return this.cmdSignatureList.has(cmd.name())
-        } else if (typeof(cmd) === 'string') {
-            return this.cmdSignatureList.has(cmd)
-        } else {
-            throw new Error('Unaccepted argument type')
-        }
     }
 }
 

--- a/src/providers/completer/commandlib/commandfinder.ts
+++ b/src/providers/completer/commandlib/commandfinder.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode'
 import * as fs from 'fs'
 import {latexParser} from 'latex-utensils'
 
-import {Suggestion} from '../command'
+import {Suggestion, CommandDuplicationDetector} from '../command'
 import type {Extension} from '../../../main'
 import type {ILwCompletionItem} from '../interface'
 
@@ -273,7 +273,7 @@ export class CommandFinder {
                 }
                 for (const pkg of cachedPkgs) {
                     const commands: ILwCompletionItem[] = []
-                    this.extension.completer.command.provideCmdInPkg(pkg, commands, new Set<string>())
+                    this.extension.completer.command.provideCmdInPkg(pkg, commands, new CommandDuplicationDetector())
                     for (const cmd of commands) {
                         const label = cmd.label.slice(1)
                         if (label.startsWith(cmdName) &&

--- a/src/providers/completer/commandlib/commandfinder.ts
+++ b/src/providers/completer/commandlib/commandfinder.ts
@@ -1,7 +1,6 @@
 import * as vscode from 'vscode'
 import * as fs from 'fs'
 import {latexParser} from 'latex-utensils'
-
 import {Suggestion, CommandSignatureDuplicationDetector, CommandNameDuplicationDetector} from '../command'
 import type {Extension} from '../../../main'
 import type {ILwCompletionItem} from '../interface'
@@ -260,7 +259,7 @@ export class CommandFinder {
 
     /**
      * Return the name of the package providing cmdName among all the packages
-     * including in the rootFile. If no package matches, return ''
+     * included in the rootFile. If no package matches, return ''
      *
      * @param cmdName the name of a command (without the leading '\')
      */

--- a/src/providers/completer/commandlib/commandfinder.ts
+++ b/src/providers/completer/commandlib/commandfinder.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode'
 import * as fs from 'fs'
 import {latexParser} from 'latex-utensils'
-import {Suggestion, CommandSignatureDuplicationDetector, CommandNameDuplicationDetector} from '../command'
+import {Suggestion} from '../command'
 import type {Extension} from '../../../main'
 import type {ILwCompletionItem} from '../interface'
 
@@ -289,3 +289,50 @@ export class CommandFinder {
     }
 
 }
+
+
+export class CommandSignatureDuplicationDetector {
+    private readonly cmdSignatureList: Set<string> = new Set<string>()
+
+    add(cmd: Suggestion) {
+        this.cmdSignatureList.add(cmd.signatureAsString())
+    }
+
+    has(cmd: Suggestion): boolean {
+        return this.cmdSignatureList.has(cmd.signatureAsString())
+    }
+}
+
+export class CommandNameDuplicationDetector {
+    private readonly cmdSignatureList: Set<string> = new Set<string>()
+
+    constructor(suggestions: Suggestion[] = []) {
+        this.cmdSignatureList = new Set<string>(suggestions.map(s => s.name()))
+    }
+
+    add(cmd: Suggestion): void
+    add(cmdName: string): void
+    add(cmd: any): void {
+        if (cmd instanceof Suggestion) {
+            this.cmdSignatureList.add(cmd.name())
+        } else if (typeof(cmd) === 'string') {
+            this.cmdSignatureList.add(cmd)
+        } else {
+            throw new Error('Unaccepted argument type')
+        }
+    }
+
+    has(cmd: Suggestion): boolean
+    has(cmd: string): boolean
+    has(cmd: any): boolean {
+        if (cmd instanceof Suggestion) {
+            return this.cmdSignatureList.has(cmd.name())
+        } else if (typeof(cmd) === 'string') {
+            return this.cmdSignatureList.has(cmd)
+        } else {
+            throw new Error('Unaccepted argument type')
+        }
+    }
+}
+
+

--- a/src/providers/completer/environment.ts
+++ b/src/providers/completer/environment.ts
@@ -5,7 +5,7 @@ import {latexParser} from 'latex-utensils'
 import type {Extension} from '../../main'
 import type {IProvider} from './interface'
 import {resolveCmdEnvFile} from './commandlib/commandfinder'
-import {Suggestion, splitSignatureString, CommandDuplicationDetector} from './command'
+import {Suggestion, splitSignatureString, CommandSignatureDuplicationDetector} from './command'
 
 type DataEnvsJsonType = typeof import('../../../data/environments.json')
 
@@ -157,7 +157,7 @@ export class Environment implements IProvider {
      * Environments can be inserted using `\envname`.
      * This function is called by Command.provide to compute these commands for every package in use.
      */
-    provideEnvsAsCommandInPkg(pkg: string, suggestions: vscode.CompletionItem[], cmdDuplicationDetector: CommandDuplicationDetector) {
+    provideEnvsAsCommandInPkg(pkg: string, suggestions: vscode.CompletionItem[], cmdDuplicationDetector: CommandSignatureDuplicationDetector) {
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         const useOptionalArgsEntries = configuration.get('intellisense.optionalArgsEntries.enabled')
 

--- a/src/providers/completer/environment.ts
+++ b/src/providers/completer/environment.ts
@@ -4,8 +4,8 @@ import {latexParser} from 'latex-utensils'
 
 import type {Extension} from '../../main'
 import type {IProvider} from './interface'
-import {resolveCmdEnvFile} from './commandlib/commandfinder'
-import {Suggestion, splitSignatureString, CommandSignatureDuplicationDetector} from './command'
+import {resolveCmdEnvFile, CommandSignatureDuplicationDetector} from './commandlib/commandfinder'
+import {Suggestion, splitSignatureString} from './command'
 
 type DataEnvsJsonType = typeof import('../../../data/environments.json')
 

--- a/src/providers/completer/environment.ts
+++ b/src/providers/completer/environment.ts
@@ -5,7 +5,7 @@ import {latexParser} from 'latex-utensils'
 import type {Extension} from '../../main'
 import type {IProvider} from './interface'
 import {resolveCmdEnvFile} from './commandlib/commandfinder'
-import {Suggestion, splitSignatureString} from './command'
+import {Suggestion, splitSignatureString, CommandDuplicationDetector} from './command'
 
 type DataEnvsJsonType = typeof import('../../../data/environments.json')
 
@@ -157,7 +157,7 @@ export class Environment implements IProvider {
      * Environments can be inserted using `\envname`.
      * This function is called by Command.provide to compute these commands for every package in use.
      */
-    provideEnvsAsCommandInPkg(pkg: string, suggestions: vscode.CompletionItem[], cmdSignatureList: Set<string>) {
+    provideEnvsAsCommandInPkg(pkg: string, suggestions: vscode.CompletionItem[], cmdDuplicationDetector: CommandDuplicationDetector) {
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         const useOptionalArgsEntries = configuration.get('intellisense.optionalArgsEntries.enabled')
 
@@ -186,9 +186,9 @@ export class Environment implements IProvider {
             if (!useOptionalArgsEntries && env.hasOptionalArgs()) {
                 return
             }
-            if (!cmdSignatureList.has(env.signatureAsString())) {
+            if (!cmdDuplicationDetector.has(env)) {
                 suggestions.push(env)
-                cmdSignatureList.add(env.signatureAsString())
+                cmdDuplicationDetector.add(env)
             }
         })
     }


### PR DESCRIPTION
This PR refactors the duplication detection for command intellisense. It introduces two new classes
- `CommandSignatureDuplicationDetector`: the complete signature is used.
- `CommandNameDuplicationDetector`: only the command name is used.