### PR TITLE
Make Suggestion class names more explicit

### DIFF
--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -12,7 +12,7 @@ import type {Extension} from '../main'
 import * as eventbus from './eventbus'
 import type {CmdEnvSuggestion as CmdEnvEntry} from '../providers/completer/command'
 import type {CiteSuggestion as CiteEntry} from '../providers/completer/citation'
-import type {Suggestion as GlossEntry} from '../providers/completer/glossary'
+import type {GlossarySuggestion as GlossaryEntry} from '../providers/completer/glossary'
 import type {ILwCompletionItem} from '../providers/completer/interface'
 
 import {PdfWatcher} from './managerlib/pdfwatcher'
@@ -38,7 +38,7 @@ interface Content {
          */
         element: {
             reference?: ILwCompletionItem[],
-            glossary?: GlossEntry[],
+            glossary?: GlossaryEntry[],
             environment?: CmdEnvEntry[],
             bibitem?: CiteEntry[],
             command?: CmdEnvEntry[],

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -10,9 +10,9 @@ import {InputFileRegExp} from '../utils/inputfilepath'
 
 import type {Extension} from '../main'
 import * as eventbus from './eventbus'
-import type {CmdEnvSuggestion as CmdEnvEntry} from '../providers/completer/command'
-import type {CiteSuggestion as CiteEntry} from '../providers/completer/citation'
-import type {GlossarySuggestion as GlossaryEntry} from '../providers/completer/glossary'
+import type {CmdEnvSuggestion} from '../providers/completer/command'
+import type {CiteSuggestion} from '../providers/completer/citation'
+import type {GlossarySuggestion} from '../providers/completer/glossary'
 import type {ILwCompletionItem} from '../providers/completer/interface'
 
 import {PdfWatcher} from './managerlib/pdfwatcher'
@@ -38,10 +38,10 @@ interface Content {
          */
         element: {
             reference?: ILwCompletionItem[],
-            glossary?: GlossaryEntry[],
-            environment?: CmdEnvEntry[],
-            bibitem?: CiteEntry[],
-            command?: CmdEnvEntry[],
+            glossary?: GlossarySuggestion[],
+            environment?: CmdEnvSuggestion[],
+            bibitem?: CiteSuggestion[],
+            command?: CmdEnvSuggestion[],
             package?: Set<string>
         },
         /**

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -10,8 +10,8 @@ import {InputFileRegExp} from '../utils/inputfilepath'
 
 import type {Extension} from '../main'
 import * as eventbus from './eventbus'
-import type {Suggestion as CiteEntry} from '../providers/completer/citation'
 import type {CmdEnvSuggestion as CmdEnvEntry} from '../providers/completer/command'
+import type {CiteSuggestion as CiteEntry} from '../providers/completer/citation'
 import type {Suggestion as GlossEntry} from '../providers/completer/glossary'
 import type {ILwCompletionItem} from '../providers/completer/interface'
 

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -11,7 +11,7 @@ import {InputFileRegExp} from '../utils/inputfilepath'
 import type {Extension} from '../main'
 import * as eventbus from './eventbus'
 import type {Suggestion as CiteEntry} from '../providers/completer/citation'
-import type {Suggestion as CmdEnvEntry} from '../providers/completer/command'
+import type {CmdEnvSuggestion as CmdEnvEntry} from '../providers/completer/command'
 import type {Suggestion as GlossEntry} from '../providers/completer/glossary'
 import type {ILwCompletionItem} from '../providers/completer/interface'
 

--- a/src/providers/completer/citation.ts
+++ b/src/providers/completer/citation.ts
@@ -54,7 +54,7 @@ class Fields extends Map<string, string> {
 
 }
 
-export interface Suggestion extends ILwCompletionItem {
+export interface CiteSuggestion extends ILwCompletionItem {
     key: string,
     fields: Fields,
     file: string,
@@ -79,7 +79,7 @@ export class Citation implements IProvider {
     /**
      * Bib entries in each bib `file`.
      */
-    private readonly bibEntries = new Map<string, Suggestion[]>()
+    private readonly bibEntries = new Map<string, CiteSuggestion[]>()
 
     constructor(extension: Extension) {
         this.extension = extension
@@ -162,13 +162,13 @@ export class Citation implements IProvider {
         })
     }
 
-    getEntry(key: string): Suggestion | undefined {
+    getEntry(key: string): CiteSuggestion | undefined {
         const suggestions = this.updateAll()
         const entry = suggestions.find((elm) => elm.key === key)
         return entry
     }
 
-    getEntryWithDocumentation(key: string, configurationScope: vscode.ConfigurationScope | undefined): Suggestion | undefined {
+    getEntryWithDocumentation(key: string, configurationScope: vscode.ConfigurationScope | undefined): CiteSuggestion | undefined {
         const entry = this.getEntry(key)
         if (entry && !(entry.detail || entry.documentation)) {
             const configuration = vscode.workspace.getConfiguration('latex-workshop', configurationScope)
@@ -214,8 +214,8 @@ export class Citation implements IProvider {
      *
      * @param bibFiles The array of the paths of `.bib` files. If `undefined`, the keys of `bibEntries` are used.
      */
-    private updateAll(bibFiles?: string[]): Suggestion[] {
-        let suggestions: Suggestion[] = []
+    private updateAll(bibFiles?: string[]): CiteSuggestion[] {
+        let suggestions: CiteSuggestion[] = []
         // From bib files
         if (bibFiles === undefined) {
             bibFiles = Array.from(this.bibEntries.keys())
@@ -257,7 +257,7 @@ export class Citation implements IProvider {
             this.bibEntries.delete(file)
             return
         }
-        const newEntry: Suggestion[] = []
+        const newEntry: CiteSuggestion[] = []
         const bibtex = fs.readFileSync(file).toString()
         const ast = await this.extension.pegParser.parseBibtex(bibtex).catch((e) => {
             if (bibtexParser.isSyntaxError(e)) {
@@ -272,7 +272,7 @@ export class Citation implements IProvider {
                 if (entry.internalKey === undefined) {
                     return
                 }
-                const item: Suggestion = {
+                const item: CiteSuggestion = {
                     key: entry.internalKey,
                     label: entry.internalKey,
                     file,
@@ -311,9 +311,9 @@ export class Citation implements IProvider {
         }
     }
 
-    private parseContent(file: string, content: string): Suggestion[] {
+    private parseContent(file: string, content: string): CiteSuggestion[] {
         const itemReg = /^(?!%).*\\bibitem(?:\[[^[\]{}]*\])?{([^}]*)}/gm
-        const items: Suggestion[] = []
+        const items: CiteSuggestion[] = []
         while (true) {
             const result = itemReg.exec(content)
             if (result === null) {

--- a/src/providers/completer/command.ts
+++ b/src/providers/completer/command.ts
@@ -48,7 +48,7 @@ export function splitSignatureString(signature: string): CmdSignature {
     }
 }
 
-export class Suggestion extends vscode.CompletionItem implements ILwCompletionItem {
+export class CmdEnvSuggestion extends vscode.CompletionItem implements ILwCompletionItem {
     label: string
     package: string
     signature: CmdSignature
@@ -87,9 +87,9 @@ export class Command implements IProvider {
     private readonly commandFinder: CommandFinder
     private readonly surroundCommand: SurroundCommand
 
-    private readonly defaultCmds: Suggestion[] = []
-    private readonly defaultSymbols: Suggestion[] = []
-    private readonly packageCmds = new Map<string, Suggestion[]>()
+    private readonly defaultCmds: CmdEnvSuggestion[] = []
+    private readonly defaultSymbols: CmdEnvSuggestion[] = []
+    private readonly packageCmds = new Map<string, CmdEnvSuggestion[]>()
 
     constructor(extension: Extension, environment: Environment) {
         this.extension = extension
@@ -145,7 +145,7 @@ export class Command implements IProvider {
                 range = new vscode.Range(position.line, startPos + 1, position.line, position.character)
             }
         }
-        const suggestions: Suggestion[] = []
+        const suggestions: CmdEnvSuggestion[] = []
         const cmdDuplicationDetector = new CommandSignatureDuplicationDetector()
         // Insert default commands
         this.defaultCmds.forEach(cmd => {
@@ -345,12 +345,12 @@ export class Command implements IProvider {
     }
 
 
-    private entryCmdToCompletion(itemKey: string, item: CmdItemEntry): Suggestion {
+    private entryCmdToCompletion(itemKey: string, item: CmdItemEntry): CmdEnvSuggestion {
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         const useTabStops = configuration.get('intellisense.useTabStops.enabled')
         const backslash = item.command.startsWith(' ') ? '' : '\\'
         const label = item.label ? `${item.label}` : `${backslash}${item.command}`
-        const suggestion = new Suggestion(label, 'latex', splitSignatureString(itemKey), vscode.CompletionItemKind.Function)
+        const suggestion = new CmdEnvSuggestion(label, 'latex', splitSignatureString(itemKey), vscode.CompletionItemKind.Function)
 
         if (item.snippet) {
             if (useTabStops) {
@@ -386,7 +386,7 @@ export class Command implements IProvider {
         // Load command in pkg
         if (!this.packageCmds.has(pkg)) {
             const filePath: string | undefined = resolveCmdEnvFile(`${pkg}_cmd.json`, `${this.extension.extensionRoot}/data/packages/`)
-            const pkgEntry: Suggestion[] = []
+            const pkgEntry: CmdEnvSuggestion[] = []
             if (filePath !== undefined) {
                 try {
                     const cmds = JSON.parse(fs.readFileSync(filePath).toString()) as {[key: string]: CmdItemEntry}

--- a/src/providers/completer/glossary.ts
+++ b/src/providers/completer/glossary.ts
@@ -14,7 +14,7 @@ interface GlossaryEntry {
     description: string | undefined
 }
 
-export interface Suggestion extends ILwCompletionItem {
+export interface GlossarySuggestion extends ILwCompletionItem {
     type: GlossaryType,
     file: string,
     position: vscode.Position
@@ -23,8 +23,8 @@ export interface Suggestion extends ILwCompletionItem {
 export class Glossary implements IProvider {
     private readonly extension: Extension
     // use object for deduplication
-    private readonly glossaries = new Map<string, Suggestion>()
-    private readonly acronyms = new Map<string, Suggestion>()
+    private readonly glossaries = new Map<string, GlossarySuggestion>()
+    private readonly acronyms = new Map<string, GlossarySuggestion>()
 
     constructor(extension: Extension) {
         this.extension = extension
@@ -36,7 +36,7 @@ export class Glossary implements IProvider {
 
     private provide(result: RegExpMatchArray): vscode.CompletionItem[] {
         this.updateAll()
-        let suggestions: Map<string, Suggestion>
+        let suggestions: Map<string, GlossarySuggestion>
 
         if (result[1] && result[1].match(/^ac/i)) {
             suggestions = this.acronyms
@@ -49,8 +49,8 @@ export class Glossary implements IProvider {
         return items
     }
 
-    private getGlossaryFromNodeArray(nodes: latexParser.Node[], file: string): Suggestion[] {
-        const glossaries: Suggestion[] = []
+    private getGlossaryFromNodeArray(nodes: latexParser.Node[], file: string): GlossarySuggestion[] {
+        const glossaries: GlossarySuggestion[] = []
         let entry: GlossaryEntry
         let type: GlossaryType | undefined
 
@@ -226,13 +226,13 @@ export class Glossary implements IProvider {
         }
     }
 
-    getEntry(token: string): Suggestion | undefined {
+    getEntry(token: string): GlossarySuggestion | undefined {
         this.updateAll()
         return this.glossaries.get(token) || this.acronyms.get(token)
     }
 
-    getGlossaryFromContent(content: string, file: string): Suggestion[] {
-        const glossaries: Suggestion[] = []
+    getGlossaryFromContent(content: string, file: string): GlossarySuggestion[] {
+        const glossaries: GlossarySuggestion[] = []
         const glossaryList: string[] = []
 
         // We assume that the label is always result[1] and use getDescription(result) for the description


### PR DESCRIPTION
This PR renames the different `Suggestion` classes with a more explicit name

- `CiteSuggestion`
- `CmdEnvSuggestion`
- `GlossarySuggestion`
