### PR TITLE
 Clarify with type annotations that Extension is a kind of service locator

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -54,6 +54,7 @@
         "@typescript-eslint/semi": ["error", "never", { "beforeStatementContinuationChars": "always" }],
         "@typescript-eslint/type-annotation-spacing": ["error", { "before": false, "after": true, "overrides": { "arrow": { "before": true, "after": true }}}],
         "@typescript-eslint/consistent-type-assertions": ["error", { "assertionStyle": "as", "objectLiteralTypeAssertions": "never" }],
+        "@typescript-eslint/no-empty-interface": [ "error", { "allowSingleExtends": true } ],
         "@typescript-eslint/no-floating-promises": "error",
         "@typescript-eslint/no-invalid-void-type": "error",
         "@typescript-eslint/no-misused-promises": [ "error", { "checksVoidReturn": { "arguments": false } } ],

--- a/src/components/builder.ts
+++ b/src/components/builder.ts
@@ -10,12 +10,13 @@ import {replaceArgumentPlaceholders} from '../utils/utils'
 
 import type {Extension} from '../main'
 import {BuildFinished} from './eventbus'
+import type {IBuilder} from '../interfaces'
 
 const maxPrintLine = '10000'
 const texMagicProgramName = 'TeXMagicProgram'
 const bibMagicProgramName = 'BibMagicProgram'
 
-export class Builder {
+export class Builder implements IBuilder {
     private readonly extension: Extension
     readonly tmpDir: string
     private currentProcess: cp.ChildProcessWithoutNullStreams | undefined

--- a/src/components/linter.ts
+++ b/src/components/linter.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode'
 
-import type {Extension} from '../main'
+import type {ExtensionRootLocator, LoggerLocator, ManagerLocator} from '../interfaces'
 import { ChkTeX } from './linterlib/chktex'
 import { LaCheck } from './linterlib/lacheck'
 export interface ILinter {
@@ -10,11 +10,16 @@ export interface ILinter {
     parseLog(log: string, filePath?: string): void
 }
 
+interface IExtension extends
+    ExtensionRootLocator,
+    LoggerLocator,
+    ManagerLocator { }
+
 export class Linter {
     readonly #linters: Map<string, ILinter> = new Map()
     private linterTimeout?: NodeJS.Timer
 
-    constructor(private readonly extension: Extension) {}
+    constructor(private readonly extension: IExtension) {}
 
     private get chktex(): ILinter {
         const linterId = 'chktex'

--- a/src/components/linterlib/chktex.ts
+++ b/src/components/linterlib/chktex.ts
@@ -3,17 +3,21 @@ import * as path from 'path'
 import * as fs from 'fs'
 import * as os from 'os'
 
-import type { Extension } from '../../main'
 import type { ILinter } from '../linter'
 import { LinterUtil } from './linterutil'
 import { convertFilenameEncoding } from '../../utils/convertfilename'
+import type {LoggerLocator, ManagerLocator} from '../../interfaces'
+
+interface IExtension extends
+    LoggerLocator,
+    ManagerLocator { }
 
 export class ChkTeX implements ILinter {
     readonly #linterName = 'ChkTeX'
     readonly linterDiagnostics: vscode.DiagnosticCollection = vscode.languages.createDiagnosticCollection(this.#linterName)
     readonly #linterUtil: LinterUtil
 
-    constructor(private readonly extension: Extension) {
+    constructor(private readonly extension: IExtension) {
         this.#linterUtil = new LinterUtil(extension)
     }
 

--- a/src/components/linterlib/lacheck.ts
+++ b/src/components/linterlib/lacheck.ts
@@ -2,17 +2,21 @@ import * as vscode from 'vscode'
 import * as path from 'path'
 import * as fs from 'fs'
 
-import type { Extension } from '../../main'
 import type { ILinter } from '../linter'
 import { LinterUtil } from './linterutil'
 import { convertFilenameEncoding } from '../../utils/convertfilename'
+import type {LoggerLocator, ManagerLocator} from '../../interfaces'
+
+interface IExtension extends
+    LoggerLocator,
+    ManagerLocator { }
 
 export class LaCheck implements ILinter {
     readonly #linterName = 'LaCheck'
     readonly linterDiagnostics: vscode.DiagnosticCollection = vscode.languages.createDiagnosticCollection(this.#linterName)
     readonly #linterUtil: LinterUtil
 
-    constructor(private readonly extension: Extension) {
+    constructor(private readonly extension: IExtension) {
         this.#linterUtil = new LinterUtil(extension)
     }
 

--- a/src/components/linterlib/linterutil.ts
+++ b/src/components/linterlib/linterutil.ts
@@ -1,12 +1,15 @@
 import {ChildProcessWithoutNullStreams, spawn} from 'child_process'
 import {EOL} from 'os'
+import type {LoggerLocator} from '../../interfaces'
 
-import type {Extension} from '../../main'
+
+interface IExtension extends
+    LoggerLocator { }
 
 export class LinterUtil {
     readonly #currentProcesses = Object.create(null) as { [linterId: string]: ChildProcessWithoutNullStreams }
 
-    constructor(private readonly extension: Extension) {
+    constructor(private readonly extension: IExtension) {
     }
 
     processWrapper(linterId: string, command: string, args: string[], options: {cwd: string}, stdin?: string): Promise<string> {

--- a/src/components/locator.ts
+++ b/src/components/locator.ts
@@ -6,8 +6,8 @@ import {SyncTexJs} from './locatorlib/synctex'
 import {replaceArgumentPlaceholders} from '../utils/utils'
 import {isSameRealPath} from '../utils/pathnormalize'
 
-import type {Extension} from '../main'
 import type {ClientRequest} from '../../types/latex-workshop-protocol-types'
+import type {BuilderLocator, ExtensionRootLocator, LoggerLocator, ManagerLocator, ViewerLocator} from '../interfaces'
 
 export type SyncTeXRecordForward = {
     page: number,
@@ -21,11 +21,18 @@ export type SyncTeXRecordBackward = {
     column: number
 }
 
+interface IExtension extends
+    ExtensionRootLocator,
+    BuilderLocator,
+    LoggerLocator,
+    ManagerLocator,
+    ViewerLocator { }
+
 export class Locator {
-    private readonly extension: Extension
+    private readonly extension: IExtension
     private readonly synctexjs: SyncTexJs
 
-    constructor(extension: Extension) {
+    constructor(extension: IExtension) {
         this.extension = extension
         this.synctexjs = new SyncTexJs(extension)
     }

--- a/src/components/locatorlib/synctex.ts
+++ b/src/components/locatorlib/synctex.ts
@@ -6,7 +6,7 @@ import type { SyncTeXRecordForward, SyncTeXRecordBackward } from '../locator'
 import { PdfSyncObject, parseSyncTex, Block, SyncTexJsError } from '../../lib/synctexjs'
 import {iconvLiteSupportedEncodings} from '../../utils/convertfilename'
 import {isSameRealPath} from '../../utils/pathnormalize'
-import type {ILogger} from '../interfaces'
+import type {LoggerLocator} from '../../interfaces'
 
 
 class Rectangle {
@@ -71,9 +71,7 @@ class Rectangle {
     }
 }
 
-interface IExtension {
-    logger: ILogger
-}
+interface IExtension extends LoggerLocator { }
 
 export class SyncTexJs {
     private readonly extension: IExtension

--- a/src/components/logger.ts
+++ b/src/components/logger.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode'
-import type {ILogger} from './interfaces'
+import type {ILogger} from '../interfaces'
 
 export class Logger implements ILogger {
     private readonly logPanel: vscode.OutputChannel

--- a/src/components/lwfs.ts
+++ b/src/components/lwfs.ts
@@ -1,10 +1,8 @@
 import * as vscode from 'vscode'
 import * as fs from 'fs'
-import type {ILogger, ILwFileSystem} from './interfaces'
+import type {ILwFileSystem, LoggerLocator} from '../interfaces'
 
-interface IExtension {
-    logger: ILogger
-}
+interface IExtension extends LoggerLocator { }
 
 export class LwFileSystem implements ILwFileSystem {
     private readonly extension: IExtension

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -14,7 +14,7 @@ import type {CmdEnvSuggestion} from '../providers/completer/command'
 import type {CiteSuggestion} from '../providers/completer/citation'
 import type {GlossarySuggestion} from '../providers/completer/glossary'
 import type {ILwCompletionItem} from '../providers/completer/interface'
-import type {IManager} from './interfaces'
+import type {IManager} from '../interfaces'
 
 import {PdfWatcher} from './managerlib/pdfwatcher'
 import {BibWatcher} from './managerlib/bibwatcher'

--- a/src/components/managerlib/finderutils.ts
+++ b/src/components/managerlib/finderutils.ts
@@ -2,13 +2,12 @@ import * as vscode from 'vscode'
 import * as path from 'path'
 import * as utils from '../../utils/utils'
 
-import type {ILogger, ILwFileSystem, IManager} from '../interfaces'
+import type {LoggerLocator, LwfsLocator, ManagerLocator} from '../../interfaces'
 
-interface IExtension {
-    logger: ILogger,
-    lwfs: ILwFileSystem,
-    manager: IManager
-}
+interface IExtension extends
+    LoggerLocator,
+    LwfsLocator,
+    ManagerLocator { }
 
 export class FinderUtils {
     private readonly extension: IExtension

--- a/src/components/managerlib/pathutils.ts
+++ b/src/components/managerlib/pathutils.ts
@@ -4,12 +4,11 @@ import * as cs from 'cross-spawn'
 import * as fs from 'fs'
 import * as utils from '../../utils/utils'
 
-import type {ILogger, IManager} from '../interfaces'
+import type {LoggerLocator, ManagerLocator} from '../../interfaces'
 
-interface IExtension {
-    manager: IManager,
-    logger: ILogger
-}
+interface IExtension extends
+    LoggerLocator,
+    ManagerLocator { }
 
 export class PathUtils {
     private readonly extension: IExtension

--- a/src/components/parser/syntax.ts
+++ b/src/components/parser/syntax.ts
@@ -3,7 +3,7 @@ import * as path from 'path'
 import * as workerpool from 'workerpool'
 import type {Proxy} from 'workerpool'
 import type {ISyntaxWorker} from './syntax_worker'
-import type {IUtensilsParser} from '../interfaces'
+import type {IUtensilsParser} from '../../interfaces'
 
 export class UtensilsParser implements IUtensilsParser {
     private readonly pool: workerpool.WorkerPool

--- a/src/components/section.ts
+++ b/src/components/section.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode'
-import type { Extension } from '../main'
+import type {LoggerLocator} from '../interfaces'
 import { stripCommentsAndVerbatim } from '../utils/utils'
 
 interface MatchSection {
@@ -7,13 +7,16 @@ interface MatchSection {
     pos: vscode.Position
 }
 
+interface IExtension extends
+    LoggerLocator { }
+
 export class Section {
-    private readonly extension: Extension
+    private readonly extension: IExtension
     private readonly levels: string[] = ['part', 'chapter', 'section', 'subsection', 'subsubsection', 'paragraph', 'subparagraph']
     private readonly upperLevels = Object.create(null) as {[key: string]: string}
     private readonly lowerLevels = Object.create(null) as {[key: string]: string}
 
-    constructor(extension: Extension) {
+    constructor(extension: IExtension) {
         this.extension = extension
         for (let i = 0; i < this.levels.length; i++) {
             const current = this.levels[i]

--- a/src/components/texdoc.ts
+++ b/src/components/texdoc.ts
@@ -1,11 +1,15 @@
 import * as vscode from 'vscode'
 import * as cs from 'cross-spawn'
-import type {Extension} from '../main'
+import type {LoggerLocator, ManagerLocator} from '../interfaces'
+
+interface IExtension extends
+    LoggerLocator,
+    ManagerLocator { }
 
 export class TeXDoc {
-    private readonly extension: Extension
+    private readonly extension: IExtension
 
-    constructor(e: Extension) {
+    constructor(e: IExtension) {
         this.extension = e
     }
 

--- a/src/components/viewer.ts
+++ b/src/components/viewer.ts
@@ -14,10 +14,11 @@ import {Client} from './viewerlib/client'
 import {PdfViewerPanel, PdfViewerPanelSerializer, PdfViewerPanelService} from './viewerlib/pdfviewerpanel'
 import {PdfViewerManagerService} from './viewerlib/pdfviewermanager'
 import {PdfViewerPagesLoaded} from './eventbus'
+import type {IViewer} from '../interfaces'
 export {PdfViewerHookProvider} from './viewerlib/pdfviewerhook'
 
 
-export class Viewer {
+export class Viewer implements IViewer {
     private readonly extension: Extension
     readonly pdfViewerPanelSerializer: PdfViewerPanelSerializer
     private readonly panelService: PdfViewerPanelService

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,7 +1,34 @@
 import type fs from 'fs'
 import type {latexParser, bibtexParser} from 'latex-utensils'
 import type vscode from 'vscode'
-import type {Content} from './manager'
+import type {SyncTeXRecordForward} from './components/locator'
+import type {Content} from './components/manager'
+import type {ICommand} from './providers/completer/interface'
+
+export interface CommandLocator {
+    readonly command: ICommand
+}
+
+export interface CompleterLocator {
+    readonly completer: CommandLocator
+}
+
+export interface ExtensionRootLocator {
+    readonly extensionRoot: string
+}
+
+export interface BuilderLocator {
+    readonly builder: IBuilder
+}
+
+export interface IBuilder {
+    readonly tmpDir: string,
+    readonly disableBuildAfterSave: boolean
+}
+
+export interface LoggerLocator {
+    readonly logger: ILogger
+}
 
 export interface ILogger {
     addLogMessage(message: string): void,
@@ -24,6 +51,10 @@ export interface ILogger {
     showCompilerLog(): void
 }
 
+export interface LwfsLocator {
+    readonly lwfs: ILwFileSystem
+}
+
 export interface ILwFileSystem {
     isLocalUri(uri: vscode.Uri): boolean,
     isVirtualUri(uri: vscode.Uri): boolean,
@@ -34,17 +65,29 @@ export interface ILwFileSystem {
     stat(fileUri: vscode.Uri): Promise<fs.Stats | vscode.FileStat>
 }
 
+export interface ManagerLocator {
+    readonly manager: IManager
+}
+
 export interface IManager {
     readonly rootDir: string | undefined,
     rootFile: string | undefined,
     rootFileUri: vscode.Uri | undefined,
+    readonly cachedFilePaths: string[],
     getOutDir(texPath?: string): string,
     getCachedContent(filePath: string): Content[string] | undefined,
     hasTexId(id: string): boolean,
+    hasBibtexId(id: string): boolean,
     findRoot(): Promise<string | undefined>,
     getIncludedBib(file?: string, includedBib?: string[], children?: string[]): string[],
     getIncludedTeX(file?: string, includedTeX?: string[]): string[],
-    getDirtyContent(file: string): string | undefined
+    getDirtyContent(file: string): string | undefined,
+    getWorkspaceFolderRootDir(): vscode.WorkspaceFolder | undefined,
+    tex2pdf(texPath: string, respectOutDir?: boolean): string
+}
+
+export interface UtensilsParserLocator {
+    readonly pegParser: IUtensilsParser
 }
 
 export interface IUtensilsParser {
@@ -52,4 +95,12 @@ export interface IUtensilsParser {
     parseLatex(s: string, options?: latexParser.ParserOptions): Promise<latexParser.LatexAst | undefined>,
     parseLatexPreamble(s: string): Promise<latexParser.AstPreamble>,
     parseBibtex(s: string, options?: bibtexParser.ParserOptions): Promise<bibtexParser.BibtexAst>
+}
+
+export interface ViewerLocator {
+    readonly viewer: IViewer
+}
+
+export interface IViewer {
+    syncTeX(pdfFile: string, record: SyncTeXRecordForward): void
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,6 +39,7 @@ import {FoldingProvider, WeaveFoldingProvider} from './providers/folding'
 import {SelectionRangeProvider} from './providers/selection'
 import { BibtexFormatter, BibtexFormatterProvider } from './providers/bibtexformatter'
 import {SnippetView} from './components/snippetview'
+import type {ExtensionRootLocator, BuilderLocator, LoggerLocator, LwfsLocator, ManagerLocator, UtensilsParserLocator, CompleterLocator, ViewerLocator} from './interfaces'
 
 
 function conflictExtensionCheck() {
@@ -314,7 +315,17 @@ function registerProviders(extension: Extension, context: vscode.ExtensionContex
     )
 }
 
-export class Extension {
+interface IExtension extends
+    ExtensionRootLocator,
+    BuilderLocator,
+    CompleterLocator,
+    LoggerLocator,
+    LwfsLocator,
+    ManagerLocator,
+    UtensilsParserLocator,
+    ViewerLocator { }
+
+export class Extension implements IExtension {
     readonly extensionRoot: string
     readonly logger: Logger
     readonly eventBus = new EventBus()

--- a/src/providers/bibtexcompletion.ts
+++ b/src/providers/bibtexcompletion.ts
@@ -2,19 +2,24 @@ import * as vscode from 'vscode'
 import * as fs from 'fs'
 
 import {BibtexFormatConfig} from './bibtexformatterlib/bibtexutils'
-import type {Extension} from '../main'
+import type {ExtensionRootLocator, LoggerLocator, ManagerLocator} from '../interfaces'
 
 type DataBibtexJsonType = typeof import('../../data/bibtex-entries.json')
 type DataBibtexOptionalJsonType = typeof import('../../data/bibtex-optional-entries.json')
 
+interface IExtension extends
+    ExtensionRootLocator,
+    LoggerLocator,
+    ManagerLocator { }
+
 export class BibtexCompleter implements vscode.CompletionItemProvider {
-    private readonly extension: Extension
+    private readonly extension: IExtension
     private scope: vscode.ConfigurationScope | undefined = undefined
     private readonly entryItems: vscode.CompletionItem[] = []
     private readonly optFieldItems = Object.create(null) as { [key: string]: vscode.CompletionItem[] }
     private readonly bibtexFormatConfig: BibtexFormatConfig
 
-    constructor(extension: Extension) {
+    constructor(extension: IExtension) {
         this.extension = extension
         if (vscode.window.activeTextEditor) {
             this.scope = vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri)

--- a/src/providers/bibtexformatter.ts
+++ b/src/providers/bibtexformatter.ts
@@ -4,15 +4,19 @@ import {performance} from 'perf_hooks'
 
 import {BibtexUtils} from './bibtexformatterlib/bibtexutils'
 import type {BibtexEntry} from './bibtexformatterlib/bibtexutils'
-import type {Extension} from '../main'
+import type {LoggerLocator, UtensilsParserLocator} from '../interfaces'
+
+interface IExtension extends
+    LoggerLocator,
+    UtensilsParserLocator { }
 
 export class BibtexFormatter {
 
-    private readonly extension: Extension
+    private readonly extension: IExtension
     readonly duplicatesDiagnostics: vscode.DiagnosticCollection
     diags: vscode.Diagnostic[]
 
-    constructor(extension: Extension) {
+    constructor(extension: IExtension) {
         this.extension = extension
         this.duplicatesDiagnostics = vscode.languages.createDiagnosticCollection('BibTeX')
         this.diags = []
@@ -154,9 +158,9 @@ export class BibtexFormatter {
 
 export class BibtexFormatterProvider implements vscode.DocumentFormattingEditProvider, vscode.DocumentRangeFormattingEditProvider {
     private readonly formatter: BibtexFormatter
-    extension: Extension
+    extension: IExtension
 
-    constructor(extension: Extension) {
+    constructor(extension: IExtension) {
         this.extension = extension
         this.formatter = new BibtexFormatter(extension)
     }

--- a/src/providers/bibtexformatterlib/bibtexutils.ts
+++ b/src/providers/bibtexformatterlib/bibtexutils.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode'
 import {bibtexParser} from 'latex-utensils'
-import type {Extension} from '../../main'
+
+import type {LoggerLocator} from '../../interfaces'
 
 
 export declare type BibtexEntry = bibtexParser.Entry | bibtexParser.StringEntry
@@ -25,8 +26,10 @@ function getBibtexFormatTab(tab: string): string | undefined {
     }
 }
 
+interface IExtension extends LoggerLocator { }
+
 export class BibtexFormatConfig {
-    private readonly extension: Extension
+    private readonly extension: IExtension
     // private scope: vscode.WorkspaceFolder | undefined
     tab !: string
     left !: string
@@ -39,7 +42,7 @@ export class BibtexFormatConfig {
     fieldsOrder !: string[]
     firstEntries !: string[]
 
-    constructor(extension: Extension, scope: vscode.ConfigurationScope | undefined) {
+    constructor(extension: IExtension, scope: vscode.ConfigurationScope | undefined) {
         this.extension = extension
         this.loadConfiguration(scope)
     }
@@ -87,7 +90,7 @@ export class BibtexFormatConfig {
 export class BibtexUtils {
     readonly bibtexFormatConfig: BibtexFormatConfig
 
-    constructor(extension: Extension, scope: vscode.ConfigurationScope | undefined) {
+    constructor(extension: IExtension, scope: vscode.ConfigurationScope | undefined) {
         this.bibtexFormatConfig = new BibtexFormatConfig(extension, scope)
     }
 

--- a/src/providers/completer/atsuggestion.ts
+++ b/src/providers/completer/atsuggestion.ts
@@ -1,9 +1,9 @@
 import * as vscode from 'vscode'
 import * as fs from 'fs'
 
-import type {Extension} from '../../main'
 import type {IProvider} from './interface'
 import {escapeRegExp} from '../../utils/utils'
+import type {ExtensionRootLocator} from '../../interfaces'
 
 export interface AtSuggestionItemEntry {
     prefix: string,
@@ -13,13 +13,15 @@ export interface AtSuggestionItemEntry {
 
 type DataAtSuggestionJsonType = typeof import('../../../data/at-suggestions.json')
 
+interface IExtension extends ExtensionRootLocator { }
+
 export class AtSuggestion implements IProvider {
-    private readonly extension: Extension
+    private readonly extension: IExtension
     private readonly triggerCharacter: string
     private readonly escapedTriggerCharacter: string
     private readonly suggestions: vscode.CompletionItem[] = []
 
-    constructor(extension: Extension, triggerCharacter: string) {
+    constructor(extension: IExtension, triggerCharacter: string) {
         this.extension = extension
         this.triggerCharacter = triggerCharacter
         this.escapedTriggerCharacter = escapeRegExp(this.triggerCharacter)

--- a/src/providers/completer/citation.ts
+++ b/src/providers/completer/citation.ts
@@ -4,8 +4,8 @@ import {bibtexParser} from 'latex-utensils'
 import {trimMultiLineString} from '../../utils/utils'
 import type {ILwCompletionItem} from './interface'
 
-import type {Extension} from '../../main'
 import type {IProvider} from './interface'
+import type {LoggerLocator, ManagerLocator, UtensilsParserLocator} from '../../interfaces'
 
 
 class Fields extends Map<string, string> {
@@ -74,14 +74,19 @@ function readCitationFormat(configuration: vscode.WorkspaceConfiguration, exclud
     return fields
 }
 
+interface IExtension extends
+    LoggerLocator,
+    ManagerLocator,
+    UtensilsParserLocator { }
+
 export class Citation implements IProvider {
-    private readonly extension: Extension
+    private readonly extension: IExtension
     /**
      * Bib entries in each bib `file`.
      */
     private readonly bibEntries = new Map<string, CiteSuggestion[]>()
 
-    constructor(extension: Extension) {
+    constructor(extension: IExtension) {
         this.extension = extension
     }
 

--- a/src/providers/completer/command.ts
+++ b/src/providers/completer/command.ts
@@ -2,12 +2,12 @@ import * as vscode from 'vscode'
 import * as fs from 'fs'
 import {latexParser} from 'latex-utensils'
 
-import type {Extension} from '../../main'
 import {Environment, EnvSnippetType} from './environment'
-import type {IProvider, ILwCompletionItem} from './interface'
+import type {IProvider, ILwCompletionItem, ICommand} from './interface'
 import {CommandFinder, isTriggerSuggestNeeded, resolveCmdEnvFile} from './commandlib/commandfinder'
 import {CommandSignatureDuplicationDetector, CommandNameDuplicationDetector} from './commandlib/commandfinder'
 import {SurroundCommand} from './commandlib/surround'
+import type {CompleterLocator, ExtensionRootLocator, LoggerLocator, ManagerLocator} from '../../interfaces'
 
 type DataUnimathSymbolsJsonType = typeof import('../../../data/unimathsymbols.json')
 
@@ -81,8 +81,14 @@ export class CmdEnvSuggestion extends vscode.CompletionItem implements ILwComple
     }
 }
 
-export class Command implements IProvider {
-    private readonly extension: Extension
+interface IExtension extends
+    ExtensionRootLocator,
+    CompleterLocator,
+    LoggerLocator,
+    ManagerLocator { }
+
+export class Command implements IProvider, ICommand {
+    private readonly extension: IExtension
     private readonly environment: Environment
     private readonly commandFinder: CommandFinder
     private readonly surroundCommand: SurroundCommand
@@ -91,7 +97,7 @@ export class Command implements IProvider {
     private readonly defaultSymbols: CmdEnvSuggestion[] = []
     private readonly packageCmds = new Map<string, CmdEnvSuggestion[]>()
 
-    constructor(extension: Extension, environment: Environment) {
+    constructor(extension: IExtension, environment: Environment) {
         this.extension = extension
         this.environment = environment
         this.commandFinder = new CommandFinder(extension)

--- a/src/providers/completer/commandlib/commandfinder.ts
+++ b/src/providers/completer/commandlib/commandfinder.ts
@@ -2,8 +2,8 @@ import * as vscode from 'vscode'
 import * as fs from 'fs'
 import {latexParser} from 'latex-utensils'
 import {CmdEnvSuggestion} from '../command'
-import type {Extension} from '../../../main'
 import type {ILwCompletionItem} from '../interface'
+import type {CompleterLocator, ManagerLocator} from '../../../interfaces'
 
 
 export function isTriggerSuggestNeeded(name: string): boolean {
@@ -34,11 +34,15 @@ export function resolveCmdEnvFile(name: string, dataDir: string): string | undef
     return undefined
 }
 
+interface IExtension extends
+    CompleterLocator,
+    ManagerLocator { }
+
 export class CommandFinder {
-    private readonly extension: Extension
+    private readonly extension: IExtension
     definedCmds = new Map<string, {file: string, location: vscode.Location}>()
 
-    constructor(extension: Extension) {
+    constructor(extension: IExtension) {
         this.extension = extension
     }
 

--- a/src/providers/completer/documentclass.ts
+++ b/src/providers/completer/documentclass.ts
@@ -1,8 +1,8 @@
 import * as vscode from 'vscode'
 import * as fs from 'fs'
 
-import type {Extension} from '../../main'
 import type {IProvider} from './interface'
+import type {ExtensionRootLocator} from '../../interfaces'
 
 type DataClassnamesJsonType = typeof import('../../../data/classnames.json')
 
@@ -12,11 +12,14 @@ type ClassItemEntry = {
     documentation: string
 }
 
+interface IExtension extends
+    ExtensionRootLocator { }
+
 export class DocumentClass implements IProvider {
-    private readonly extension: Extension
+    private readonly extension: IExtension
     private readonly suggestions: vscode.CompletionItem[] = []
 
-    constructor(extension: Extension) {
+    constructor(extension: IExtension) {
         this.extension = extension
     }
 

--- a/src/providers/completer/environment.ts
+++ b/src/providers/completer/environment.ts
@@ -2,10 +2,10 @@ import * as vscode from 'vscode'
 import * as fs from 'fs'
 import {latexParser} from 'latex-utensils'
 
-import type {Extension} from '../../main'
 import type {IProvider} from './interface'
 import {resolveCmdEnvFile, CommandSignatureDuplicationDetector} from './commandlib/commandfinder'
 import {CmdEnvSuggestion, splitSignatureString} from './command'
+import type {CompleterLocator, ExtensionRootLocator, LoggerLocator, ManagerLocator} from '../../interfaces'
 
 type DataEnvsJsonType = typeof import('../../../data/environments.json')
 
@@ -22,8 +22,14 @@ function isEnvItemEntry(obj: any): obj is EnvItemEntry {
 
 export enum EnvSnippetType { AsName, AsCommand, ForBegin, }
 
+interface IExtension extends
+    ExtensionRootLocator,
+    CompleterLocator,
+    LoggerLocator,
+    ManagerLocator { }
+
 export class Environment implements IProvider {
-    private readonly extension: Extension
+    private readonly extension: IExtension
     private defaultEnvsAsName: CmdEnvSuggestion[] = []
     private defaultEnvsAsCommand: CmdEnvSuggestion[] = []
     private defaultEnvsForBegin: CmdEnvSuggestion[] = []
@@ -31,7 +37,7 @@ export class Environment implements IProvider {
     private readonly packageEnvsAsCommand = new Map<string, CmdEnvSuggestion[]>()
     private readonly packageEnvsForBegin= new Map<string, CmdEnvSuggestion[]>()
 
-    constructor(extension: Extension) {
+    constructor(extension: IExtension) {
         this.extension = extension
     }
 

--- a/src/providers/completer/glossary.ts
+++ b/src/providers/completer/glossary.ts
@@ -1,8 +1,8 @@
 import * as vscode from 'vscode'
 import {latexParser} from 'latex-utensils'
 
-import type {Extension} from '../../main'
 import type {IProvider, ILwCompletionItem} from './interface'
+import type {ManagerLocator} from '../../interfaces'
 
 enum GlossaryType {
     glossary,
@@ -20,13 +20,16 @@ export interface GlossarySuggestion extends ILwCompletionItem {
     position: vscode.Position
 }
 
+interface IExtension extends
+    ManagerLocator { }
+
 export class Glossary implements IProvider {
-    private readonly extension: Extension
+    private readonly extension: IExtension
     // use object for deduplication
     private readonly glossaries = new Map<string, GlossarySuggestion>()
     private readonly acronyms = new Map<string, GlossarySuggestion>()
 
-    constructor(extension: Extension) {
+    constructor(extension: IExtension) {
         this.extension = extension
     }
 

--- a/src/providers/completer/input.ts
+++ b/src/providers/completer/input.ts
@@ -3,17 +3,21 @@ import * as fs from 'fs'
 import * as path from 'path'
 import * as micromatch from 'micromatch'
 
-import type {Extension} from '../../main'
 import type {IProvider} from './interface'
 import {stripCommentsAndVerbatim} from '../../utils/utils'
+import type {LoggerLocator, ManagerLocator} from '../../interfaces'
 
 const ignoreFiles = ['**/.vscode', '**/.vscodeignore', '**/.gitignore']
 
+interface IExtension extends
+    LoggerLocator,
+    ManagerLocator { }
+
 abstract class InputAbstract implements IProvider {
-    protected readonly extension: Extension
+    protected readonly extension: IExtension
     graphicsPath: string[] = []
 
-    constructor(extension: Extension) {
+    constructor(extension: IExtension) {
         this.extension = extension
     }
 
@@ -142,7 +146,7 @@ abstract class InputAbstract implements IProvider {
 
 export class Input extends InputAbstract {
 
-    constructor(extension: Extension) {
+    constructor(extension: IExtension) {
         super(extension)
     }
 
@@ -186,7 +190,7 @@ export class Input extends InputAbstract {
 
 export class Import extends InputAbstract {
 
-    constructor(extension: Extension) {
+    constructor(extension: IExtension) {
         super(extension)
     }
 
@@ -206,7 +210,7 @@ export class Import extends InputAbstract {
 
 export class SubImport extends InputAbstract {
 
-    constructor(extension: Extension) {
+    constructor(extension: IExtension) {
         super(extension)
     }
 

--- a/src/providers/completer/interface.ts
+++ b/src/providers/completer/interface.ts
@@ -1,4 +1,5 @@
 import type * as vscode from 'vscode'
+import type {CommandSignatureDuplicationDetector} from './commandlib/commandfinder'
 
 export interface IProvider {
 
@@ -13,4 +14,9 @@ export interface IProvider {
 
 export interface ILwCompletionItem extends vscode.CompletionItem {
     label: string
+}
+
+export interface ICommand {
+    getExtraPkgs(languageId: string): string[],
+    provideCmdInPkg(pkg: string, suggestions: vscode.CompletionItem[], cmdDuplicationDetector: CommandSignatureDuplicationDetector): void
 }

--- a/src/providers/completer/package.ts
+++ b/src/providers/completer/package.ts
@@ -1,8 +1,8 @@
 import * as vscode from 'vscode'
 import * as fs from 'fs'
 
-import type {Extension} from '../../main'
 import type {IProvider} from './interface'
+import type {ExtensionRootLocator} from '../../interfaces'
 
 type DataPackagesJsonType = typeof import('../../../data/packagenames.json')
 
@@ -12,11 +12,14 @@ type PackageItemEntry = {
     documentation: string
 }
 
+interface IExtension extends
+    ExtensionRootLocator { }
+
 export class Package implements IProvider {
-    private readonly extension: Extension
+    private readonly extension: IExtension
     private readonly suggestions: vscode.CompletionItem[] = []
 
-    constructor(extension: Extension) {
+    constructor(extension: IExtension) {
         this.extension = extension
     }
 

--- a/src/providers/completer/reference.ts
+++ b/src/providers/completer/reference.ts
@@ -4,8 +4,8 @@ import * as path from 'path'
 import {latexParser} from 'latex-utensils'
 import {stripEnvironments, isNewCommand} from '../../utils/utils'
 
-import type {Extension} from '../../main'
 import type {IProvider, ILwCompletionItem} from './interface'
+import type {ManagerLocator} from '../../interfaces'
 
 export interface ReferenceEntry extends ILwCompletionItem {
     /**
@@ -31,14 +31,17 @@ export type ReferenceDocType = {
     prevIndex: ReferenceEntry['prevIndex']
 }
 
+interface IExtension extends
+    ManagerLocator { }
+
 export class Reference implements IProvider {
-    private readonly extension: Extension
+    private readonly extension: IExtension
     // Here we use an object instead of an array for de-duplication
     private readonly suggestions = new Map<string, ReferenceEntry>()
     private prevIndexObj = new Map<string, {refNumber: string, pageNumber: string}>()
     private readonly envsToSkip = ['tikzpicture']
 
-    constructor(extension: Extension) {
+    constructor(extension: IExtension) {
         this.extension = extension
     }
 

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -16,12 +16,13 @@ import {Input, Import, SubImport} from './completer/input'
 import {Glossary} from './completer/glossary'
 import type {ReferenceDocType} from './completer/reference'
 import {escapeRegExp} from '../utils/utils'
+import type {CommandLocator} from '../interfaces'
 
 type DataEnvsJsonType = typeof import('../../data/environments.json')
 type DataCmdsJsonType = typeof import('../../data/commands.json')
 type DataLatexMathSymbolsJsonType = typeof import('../../data/packages/latex-mathsymbols_cmd.json')
 
-export class Completer implements vscode.CompletionItemProvider {
+export class Completer implements vscode.CompletionItemProvider, CommandLocator {
     private readonly extension: Extension
     readonly citation: Citation
     readonly command: Command

--- a/src/providers/docsymbol.ts
+++ b/src/providers/docsymbol.ts
@@ -1,15 +1,21 @@
 import * as vscode from 'vscode'
 
-import type {Extension} from '../main'
 import {Section, SectionNodeProvider} from './structure'
+import type {LoggerLocator, LwfsLocator, ManagerLocator, UtensilsParserLocator} from '../interfaces'
+
+interface IExtension extends
+    LoggerLocator,
+    LwfsLocator,
+    ManagerLocator,
+    UtensilsParserLocator { }
 
 export class DocSymbolProvider implements vscode.DocumentSymbolProvider {
-    private readonly extension: Extension
+    private readonly extension: IExtension
     private readonly sectionNodeProvider: SectionNodeProvider
 
     private sections: string[] = []
 
-    constructor(extension: Extension) {
+    constructor(extension: IExtension) {
         this.extension = extension
         this.sectionNodeProvider = new SectionNodeProvider(extension)
 

--- a/src/providers/latexformatter.ts
+++ b/src/providers/latexformatter.ts
@@ -5,9 +5,9 @@ import * as path from 'path'
 import * as fs from 'fs'
 import * as os from 'os'
 
-import type { Extension } from '../main'
 import {Mutex} from '../lib/await-semaphore'
 import {replaceArgumentPlaceholders} from '../utils/utils'
+import type {BuilderLocator, ExtensionRootLocator, LoggerLocator, ManagerLocator} from '../interfaces'
 
 const fullRange = (doc: vscode.TextDocument) => doc.validateRange(new vscode.Range(0, 0, Number.MAX_VALUE, Number.MAX_VALUE))
 
@@ -27,15 +27,21 @@ const windows: OperatingSystem = new OperatingSystem('win32', '.exe', 'where')
 const linux: OperatingSystem = new OperatingSystem('linux', '.pl', 'which')
 const mac: OperatingSystem = new OperatingSystem('darwin', '.pl', 'which')
 
+interface IExtension extends
+    ExtensionRootLocator,
+    BuilderLocator,
+    LoggerLocator,
+    ManagerLocator { }
+
 export class LaTexFormatter {
-    private readonly extension: Extension
+    private readonly extension: IExtension
     private readonly machineOs: string
     private readonly currentOs?: OperatingSystem
     private readonly formatMutex: Mutex = new Mutex()
     private formatter: string = ''
     private formatterArgs: string[] = []
 
-    constructor(extension: Extension) {
+    constructor(extension: IExtension) {
         this.extension = extension
         this.machineOs = os.platform()
         if (this.machineOs === windows.name) {
@@ -219,7 +225,7 @@ export class LaTexFormatter {
 export class LatexFormatterProvider implements vscode.DocumentFormattingEditProvider, vscode.DocumentRangeFormattingEditProvider {
     private readonly formatter: LaTexFormatter
 
-    constructor(extension: Extension) {
+    constructor(extension: IExtension) {
         this.formatter = new LaTexFormatter(extension)
     }
 

--- a/src/providers/preview/mathpreview.ts
+++ b/src/providers/preview/mathpreview.ts
@@ -2,7 +2,6 @@ import * as vscode from 'vscode'
 
 import {MathJaxPool} from './mathjaxpool'
 import * as utils from '../../utils/svg'
-import type {Extension} from '../../main'
 import type {ReferenceEntry} from '../completer/reference'
 import {getCurrentThemeLightness} from '../../utils/theme'
 
@@ -12,12 +11,19 @@ import {NewCommandFinder} from './mathpreviewlib/newcommandfinder'
 import {TexMathEnv, TeXMathEnvFinder} from './mathpreviewlib/texmathenvfinder'
 import {HoverPreviewOnRefProvider} from './mathpreviewlib/hoverpreviewonref'
 import {MathPreviewUtils} from './mathpreviewlib/mathpreviewutils'
+import type {LoggerLocator, LwfsLocator, ManagerLocator, UtensilsParserLocator} from '../../interfaces'
 
 export type {TexMathEnv} from './mathpreviewlib/texmathenvfinder'
 
 
+interface IExtension extends
+    LoggerLocator,
+    LwfsLocator,
+    ManagerLocator,
+    UtensilsParserLocator { }
+
 export class MathPreview {
-    private readonly extension: Extension
+    private readonly extension: IExtension
     private color: string = '#000000'
     private readonly mj: MathJaxPool
     private readonly cursorRenderer: CursorRenderer
@@ -26,7 +32,7 @@ export class MathPreview {
     private readonly hoverPreviewOnRefProvider: HoverPreviewOnRefProvider
     private readonly mputils: MathPreviewUtils
 
-    constructor(extension: Extension) {
+    constructor(extension: IExtension) {
         this.extension = extension
         this.mj = new MathJaxPool()
         vscode.workspace.onDidChangeConfiguration(() => this.getColor())

--- a/src/providers/preview/mathpreviewlib/cursorrenderer.ts
+++ b/src/providers/preview/mathpreviewlib/cursorrenderer.ts
@@ -1,15 +1,17 @@
 import {latexParser} from 'latex-utensils'
 import * as vscode from 'vscode'
-import type {Extension} from '../../../main'
 import {TexMathEnv} from './texmathenvfinder'
 
+import type {UtensilsParserLocator} from '../../../interfaces'
+
+interface IExtension extends UtensilsParserLocator { }
 
 export class CursorRenderer {
-    private readonly extension: Extension
+    private readonly extension: IExtension
     private currentTeXString: string | undefined
     private currentAst: latexParser.LatexAst | undefined
 
-    constructor(extension: Extension) {
+    constructor(extension: IExtension) {
         this.extension = extension
     }
 

--- a/src/providers/preview/mathpreviewlib/hoverpreviewonref.ts
+++ b/src/providers/preview/mathpreviewlib/hoverpreviewonref.ts
@@ -2,17 +2,18 @@ import * as vscode from 'vscode'
 import * as utils from '../../../utils/svg'
 import type {MathJaxPool} from '../mathjaxpool'
 import type {ReferenceEntry} from '../../completer/reference'
-import type {Extension} from '../../../main'
 import type {TexMathEnv} from './texmathenvfinder'
 import type {MathPreviewUtils} from './mathpreviewutils'
+import type {LoggerLocator} from '../../../interfaces'
 
+interface IExtension extends LoggerLocator { }
 
 export class HoverPreviewOnRefProvider {
-    private readonly extension: Extension
+    private readonly extension: IExtension
     private readonly mj: MathJaxPool
     private readonly mputils: MathPreviewUtils
 
-    constructor(extension: Extension, mj: MathJaxPool, mputils: MathPreviewUtils) {
+    constructor(extension: IExtension, mj: MathJaxPool, mputils: MathPreviewUtils) {
         this.extension = extension
         this.mj = mj
         this.mputils = mputils

--- a/src/providers/preview/mathpreviewlib/newcommandfinder.ts
+++ b/src/providers/preview/mathpreviewlib/newcommandfinder.ts
@@ -3,14 +3,13 @@ import {latexParser} from 'latex-utensils'
 import {stripCommentsAndVerbatim, isNewCommand, NewCommand} from '../../../utils/utils'
 import * as path from 'path'
 
-import type {ILogger, ILwFileSystem, IManager, IUtensilsParser} from '../../../components/interfaces'
+import type {LoggerLocator, LwfsLocator, ManagerLocator, UtensilsParserLocator} from '../../../interfaces'
 
-interface IExtension {
-    logger: ILogger,
-    lwfs: ILwFileSystem,
-    manager: IManager,
-    pegParser: IUtensilsParser
-}
+interface IExtension extends
+    LoggerLocator,
+    LwfsLocator,
+    ManagerLocator,
+    UtensilsParserLocator { }
 
 export class NewCommandFinder {
     private readonly extension: IExtension

--- a/src/providers/projectsymbol.ts
+++ b/src/providers/projectsymbol.ts
@@ -1,13 +1,19 @@
 import * as vscode from 'vscode'
 
-import type {Extension} from '../main'
 import {Section, SectionNodeProvider} from './structure'
+import type {LoggerLocator, LwfsLocator, ManagerLocator, UtensilsParserLocator} from '../interfaces'
+
+interface IExtension extends
+    LoggerLocator,
+    LwfsLocator,
+    ManagerLocator,
+    UtensilsParserLocator { }
 
 export class ProjectSymbolProvider implements vscode.WorkspaceSymbolProvider {
-    private readonly extension: Extension
+    private readonly extension: IExtension
     private readonly sectionNodeProvider: SectionNodeProvider
 
-    constructor(extension: Extension) {
+    constructor(extension: IExtension) {
         this.extension = extension
         this.sectionNodeProvider = new SectionNodeProvider(extension)
     }

--- a/src/providers/selection.ts
+++ b/src/providers/selection.ts
@@ -1,7 +1,8 @@
 import {latexParser} from 'latex-utensils'
 import * as vscode from 'vscode'
 
-import {Extension} from '../main'
+import type {UtensilsParserLocator} from '../interfaces'
+
 
 interface ILuRange {
     start: ILuPos,
@@ -74,10 +75,11 @@ function toLatexUtensilPosition(pos: vscode.Position): LuPos {
     return new LuPos(pos.line + 1, pos.character + 1)
 }
 
+interface IExtension extends UtensilsParserLocator { }
 
 export class SelectionRangeProvider implements vscode.SelectionRangeProvider {
 
-    constructor(private readonly extension: Extension) {}
+    constructor(private readonly extension: IExtension) {}
 
     async provideSelectionRanges(document: vscode.TextDocument, positions: vscode.Position[]) {
         const content = document.getText()

--- a/src/providers/structure.ts
+++ b/src/providers/structure.ts
@@ -5,6 +5,12 @@ import { latexParser,bibtexParser } from 'latex-utensils'
 import type { Extension } from '../main'
 import { resolveFile } from '../utils/utils'
 import { InputFileRegExp } from '../utils/inputfilepath'
+import type {LoggerLocator, ManagerLocator, UtensilsParserLocator} from '../interfaces'
+
+interface IExtension extends
+    LoggerLocator,
+    ManagerLocator,
+    UtensilsParserLocator { }
 
 export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
 
@@ -25,7 +31,7 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
     private readonly LaTeXSectionDepths: {[cmd: string]: number} = {}
     private readonly LaTeXSectionNumber: boolean
 
-    constructor(private readonly extension: Extension) {
+    constructor(private readonly extension: IExtension) {
         this.onDidChangeTreeData = this._onDidChangeTreeData.event
 
         const configuration = vscode.workspace.getConfiguration('latex-workshop')

--- a/src/utils/webview.ts
+++ b/src/utils/webview.ts
@@ -1,8 +1,9 @@
 import * as vscode from 'vscode'
-import type {Extension} from '../main'
+import type {ExtensionRootLocator} from '../interfaces'
 
+interface IExtension extends ExtensionRootLocator { }
 
-export function replaceWebviewPlaceholders(content: string, extension: Extension, webview: vscode.Webview): string {
+export function replaceWebviewPlaceholders(content: string, extension: IExtension, webview: vscode.Webview): string {
     const extensionRootUri = vscode.Uri.file(extension.extensionRoot)
     const resourcesFolderUri = webview.asWebviewUri(vscode.Uri.joinPath(extensionRootUri, 'resources'))
     const resourcesFolderLink = resourcesFolderUri.toString()

--- a/test/utils/fakecomponents.ts
+++ b/test/utils/fakecomponents.ts
@@ -1,4 +1,4 @@
-import type {ILogger} from '../../src/components/interfaces'
+import type {ILogger} from '../../src/interfaces'
 
 export class FakeLogger implements ILogger {
     addLogMessage() {}


### PR DESCRIPTION
Clarify with type annotations that Extension is a kind of service locator, which makes components testable with fake or mock Extension.

See
- https://martinfowler.com/articles/injection.html#UsingAServiceLocator

Especially, read the section "Using a Segregated Interface for the Locator".
