### PR TITLE
Add pdflatex-only compiler

### DIFF
--- a/package.json
+++ b/package.json
@@ -824,6 +824,12 @@
               "tools": [
                 "tectonic"
               ]
+            },
+            {
+              "name": "pdflatex",
+              "tools": [
+                "pdflatex"
+              ]
             }
           ],
           "markdownDescription": "Define LaTeX compiling recipes. Each recipe in the list is an object containing its name and the names of tools to be used sequentially, which are defined in `#latex-workshop.latex.tools#`. By default, the first recipe is used to compile the project. For details, please visit https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#latex-recipes."


### PR DESCRIPTION
This PR adds compilation with pdflatex only. I am working on Windows using MiKTeX without Perl and this recipe works well. Not sure if this was considered before or not but I couldn't find info [here](https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#misc).