### PR TITLE
Faster AST-based structure construction

### DIFF
--- a/package.json
+++ b/package.json
@@ -1314,6 +1314,12 @@
           ],
           "markdownDescription": "The names of the commands to be shown in the outline/structure views. The commands must be called in the form `\\commandname{arg}`. Reload vscode to make any change in this configuration effective."
         },
+        "latex-workshop.view.outline.fastparse.enabled": {
+          "scope": "window",
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "[Experimental] Use fast LaTeX parsing algorithm to build outline/structure. This is done by inheritly removing texts and comments before building AST. Enabling this will not tamper the document, but may result in incomplete outline/structure."
+        },
         "latex-workshop.view.outline.floats.enabled": {
           "scope": "window",
           "type": "boolean",

--- a/src/providers/structure.ts
+++ b/src/providers/structure.ts
@@ -3,9 +3,9 @@ import * as path from 'path'
 import { latexParser,bibtexParser } from 'latex-utensils'
 
 import type { Extension } from '../main'
-import { resolveFile } from '../utils/utils'
+import { resolveFile, stripText } from '../utils/utils'
 import { InputFileRegExp } from '../utils/inputfilepath'
-import type {LoggerLocator, ManagerLocator, UtensilsParserLocator} from '../interfaces'
+import type { LoggerLocator, ManagerLocator, UtensilsParserLocator } from '../interfaces'
 
 interface IExtension extends
     LoggerLocator,
@@ -148,8 +148,11 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
             return []
         }
 
+        const configuration = vscode.workspace.getConfiguration('latex-workshop')
+        const fastparse = configuration.get('view.outline.fastparse.enabled') as boolean
+
         // Use `latex-utensils` to generate the AST.
-        const ast = await this.extension.pegParser.parseLatex(content).catch((e) => {
+        const ast = await this.extension.pegParser.parseLatex(fastparse ? stripText(content) : content).catch((e) => {
             if (latexParser.isSyntaxError(e)) {
                 const line = e.location.start.line
                 this.extension.logger.addLogMessage(`Error parsing LaTeX during structuring: line ${line} in ${file}.`)

--- a/test/unittests/providers/structure.test.ts
+++ b/test/unittests/providers/structure.test.ts
@@ -10,6 +10,7 @@ async function resetConfig() {
     await config.update('latex-workshop.view.outline.numbers.enabled', undefined)
     await config.update('latex-workshop.view.outline.sections', undefined)
     await config.update('latex-workshop.view.outline.floats.enabled', undefined)
+    await config.update('latex-workshop.view.outline.fastparse.enabled', undefined)
 }
 
 suite('unit test suite', () => {
@@ -95,6 +96,36 @@ suite('unit test suite', () => {
         assert.strictEqual(sections[5].children[0].label, 'Frame: Frame Title 1')
         assert.strictEqual(sections[5].children[1].label, 'Frame: Frame Title 2')
         assert.strictEqual(sections[5].children[2].label, 'Frame: Untitled')
+    })
+
+    runUnitTestWithFixture('fixture020_structure', 'view.outline.fastparse.enabled', async () => {
+        const fixtureDir = getFixtureDir()
+        const texFilePath = path.join(fixtureDir, 'main.tex')
+        const config = vscode.workspace.getConfiguration()
+        await config.update('latex-workshop.view.outline.fastparse.enabled', true)
+        const extension = (await waitLatexWorkshopActivated()).exports.realExtension
+        assert.ok(extension)
+        extension.manager.rootFile = texFilePath
+        const structure = new SectionNodeProvider(extension)
+        await structure.update(true)
+        const sections = structure.ds
+        assert.ok(sections)
+        assert.strictEqual(sections.length, 6)
+        assert.strictEqual(sections[0].children.length, 3)
+        assert.strictEqual(sections[0].children[1].children.length, 2)
+        assert.strictEqual(sections[0].children[1].children[0].label, '#label: sec11')
+        assert.strictEqual(sections[0].children[1].children[0].lineNumber, 8)
+        assert.strictEqual(sections[1].children.length, 1)
+        assert.strictEqual(sections[1].children[0].label, '2.0.1 2.0.1')
+        assert.strictEqual(sections[3].label, '4 4 A long title split over two lines')
+        assert.strictEqual(sections[4].label, '* No \\textit{Number} Section')
+        assert.strictEqual(sections[5].label, '5 Section pdf Caption')
+        assert.strictEqual(sections[5].children[0].label, 'Figure: Untitled')
+        assert.strictEqual(sections[5].children[1].label, 'Figure: Figure Caption')
+        assert.strictEqual(sections[5].children[2].label, 'Table: Table Caption')
+        assert.strictEqual(sections[5].children[3].label, 'Frame: Frame Title 1')
+        assert.strictEqual(sections[5].children[4].label, 'Frame: Frame Title 2')
+        assert.strictEqual(sections[5].children[5].label, 'Frame: Untitled')
     })
 
     teardown(async () => {


### PR DESCRIPTION
This PR adds a new config item `latex-workshop.view.outline.fastparse.enabled` to control whether a fast AST parsing scheme should be used for outline/structure building. The config is default to `false`, so no change to the current user experience.

The key is to use a new funtion in `utils.ts` to strip all plain texts and comments from the document to be parsed, so that `latex-utensils` parser won't be trapped by numerous `text.string` in a typical document. An extreme case can be found in #3399.

I have tested on some real documents of my own and figured no problem. A test case is also added. Yet I am not very sure whether the regex suits for every edge case. So the config is labeled "experimental" for now.