### PR TITLE
Add .dtx file type while inferring a language ID

### DIFF
--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -280,6 +280,8 @@ export class Manager implements IManager {
             return 'jlweave'
         } else if (this.rsweaveExt.includes(ext)) {
             return 'rsweave'
+        } else if (ext === '.dtx') {
+            return 'doctex'
         } else {
             return undefined
         }


### PR DESCRIPTION
The modified code can infer a dtx file automatically, so it may help users to create their own recipes to compile dtx files instead of encountering a wrong message saying `Cannot find LaTeX root file`.