### PR TITLE
fix(mathsymbols_cmd.json): leftrightarrow symbol

### DIFF
--- a/data/packages/latex-mathsymbols_cmd.json
+++ b/data/packages/latex-mathsymbols_cmd.json
@@ -554,8 +554,8 @@
     "command": "leftrightarrow",
     "package": "latex-mathsymbols",
     "snippet": "leftrightarrow",
-    "detail": "⇆",
-    "documentation": "left arrow over right arrow"
+    "detail": "↔",
+    "documentation": "bidirectional arrow"
   },
   "lfloor": {
     "command": "lfloor",


### PR DESCRIPTION
The stacked version is for \leftrightarrows.

\leftrightarrow: $\leftrightarrow$
\leftrightarrows: $\leftrightarrows$