### PR TITLE
Make `view.outline` configs responsive w/o reload

### DIFF
--- a/package.json
+++ b/package.json
@@ -1301,7 +1301,7 @@
             "subsection",
             "subsubsection"
           ],
-          "markdownDescription": "The section names of LaTeX outline hierarchy. It is also used by the folding mechanism. This property is an array of case-sensitive strings in the order of document structure hierarchy. For multiple tags in the same level, separate the tags with `|` as delimiters, e.g., `section|alternative`. Reload vscode to make any change in this configuration effective."
+          "markdownDescription": "The section names of LaTeX outline hierarchy. It is also used by the folding mechanism. This property is an array of case-sensitive strings in the order of document structure hierarchy. For multiple tags in the same level, separate the tags with `|` as delimiters, e.g., `section|alternative`."
         },
         "latex-workshop.view.outline.commands": {
           "scope": "window",
@@ -1312,7 +1312,7 @@
           "default": [
             "label"
           ],
-          "markdownDescription": "The names of the commands to be shown in the outline/structure views. The commands must be called in the form `\\commandname{arg}`. Reload vscode to make any change in this configuration effective."
+          "markdownDescription": "The names of the commands to be shown in the outline/structure views. The commands must be called in the form `\\commandname{arg}`."
         },
         "latex-workshop.view.outline.fastparse.enabled": {
           "scope": "window",
@@ -1324,7 +1324,7 @@
           "scope": "window",
           "type": "boolean",
           "default": true,
-          "markdownDescription": "Show the floating objects (figures and tables) in the outline/structure views. Reload vscode to make any change in this configuration effective."
+          "markdownDescription": "Show the floating objects (figures and tables) in the outline/structure views."
         },
         "latex-workshop.view.outline.numbers.enabled": {
           "scope": "window",

--- a/src/providers/docsymbol.ts
+++ b/src/providers/docsymbol.ts
@@ -13,16 +13,9 @@ export class DocSymbolProvider implements vscode.DocumentSymbolProvider {
     private readonly extension: IExtension
     private readonly sectionNodeProvider: SectionNodeProvider
 
-    private sections: string[] = []
-
     constructor(extension: IExtension) {
         this.extension = extension
         this.sectionNodeProvider = new SectionNodeProvider(extension)
-
-        const rawSections = vscode.workspace.getConfiguration('latex-workshop').get('view.outline.sections') as string[]
-        rawSections.forEach(section => {
-            this.sections = this.sections.concat(section.split('|'))
-        })
     }
 
     async provideDocumentSymbols(document: vscode.TextDocument): Promise<vscode.DocumentSymbol[]> {

--- a/src/providers/projectsymbol.ts
+++ b/src/providers/projectsymbol.ts
@@ -19,25 +19,25 @@ export class ProjectSymbolProvider implements vscode.WorkspaceSymbolProvider {
     }
 
     async provideWorkspaceSymbols(): Promise<vscode.SymbolInformation[]> {
-        const symbols: vscode.SymbolInformation[] = []
         if (this.extension.manager.rootFile === undefined) {
-            return symbols
+            return []
         }
         const rootFileUri = this.extension.manager.rootFileUri
         if (rootFileUri && this.extension.lwfs.isVirtualUri(rootFileUri)) {
-            return symbols
+            return []
         }
-        this.sectionToSymbols(symbols, await this.sectionNodeProvider.buildLaTeXModel())
-        return symbols
+        return this.sectionToSymbols(await this.sectionNodeProvider.buildLaTeXModel())
     }
 
-    private sectionToSymbols(symbols: vscode.SymbolInformation[], sections: Section[], containerName: string = 'Document') {
+    private sectionToSymbols(sections: Section[], containerName: string = 'Document'): vscode.SymbolInformation[] {
+        let symbols: vscode.SymbolInformation[] = []
         sections.forEach(section => {
             const location = new vscode.Location(vscode.Uri.file(section.fileName), new vscode.Range(section.lineNumber, 0, section.toLine, 65535))
             symbols.push(new vscode.SymbolInformation(section.label, vscode.SymbolKind.String, containerName, location))
             if (section.children.length > 0) {
-                this.sectionToSymbols(symbols, section.children, section.label)
+                symbols = [...symbols, ...this.sectionToSymbols(section.children, section.label)]
             }
         })
+        return symbols
     }
 }


### PR DESCRIPTION
This PR relaxes the following config items from reload. Now changing values will immediately (or shortly) take effect.
- `latex-workshop.view.outline.sections`
- `latex-workshop.view.outline.commands`
- `latex-workshop.view.outline.floats.enabled`

Previously, these config values were also used and compared in the constructor of `DocSymbolProvider`. This dependency was relaxed long ago, but the reload requirement was not cleared.