### PR TITLE
To enable `-shell-escape` for engine `xelatex`?

### DIFF
--- a/package.json
+++ b/package.json
@@ -897,6 +897,7 @@
                 "-interaction=nonstopmode",
                 "-file-line-error",
                 "-xelatex",
+      					"-shell-escape",
                 "-outdir=%OUTDIR%",
                 "%DOC%"
               ],


### PR DESCRIPTION
To enable `-shell-escape` for engine `xelatex`?