### PR TITLE
Use cross-spawn to replace cp.spawn

### DIFF
--- a/src/components/counter.ts
+++ b/src/components/counter.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode'
 import * as fs from 'fs'
 import * as path from 'path'
-import * as cp from 'child_process'
+import * as cs from 'cross-spawn'
 
 import type {Extension} from '../main'
 
@@ -115,7 +115,7 @@ export class Counter {
         }
         args.push(path.basename(file))
         this.extension.logger.logCommand('Count words using command', command, args)
-        const proc = cp.spawn(command, args, {cwd: path.dirname(file)})
+        const proc = cs.spawn(command, args, {cwd: path.dirname(file)})
         proc.stdout.setEncoding('utf8')
         proc.stderr.setEncoding('utf8')
 

--- a/src/components/locator.ts
+++ b/src/components/locator.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode'
 import * as fs from 'fs'
 import * as path from 'path'
-import * as cp from 'child_process'
+import * as cs from 'cross-spawn'
 import {SyncTexJs} from './locatorlib/synctex'
 import {replaceArgumentPlaceholders} from '../utils/utils'
 import {isSameRealPath} from '../utils/pathnormalize'
@@ -193,7 +193,7 @@ export class Locator {
                 fs.chmodSync(command, 0o755)
             }
         }
-        const proc = cp.spawn(command, args, {cwd: path.dirname(pdfFile)})
+        const proc = cs.spawn(command, args, {cwd: path.dirname(pdfFile)})
         proc.stdout.setEncoding('utf8')
         proc.stderr.setEncoding('utf8')
 
@@ -250,7 +250,7 @@ export class Locator {
                 fs.chmodSync(command, 0o755)
             }
         }
-        const proc = cp.spawn(command, args, {cwd: path.dirname(pdfPath)})
+        const proc = cs.spawn(command, args, {cwd: path.dirname(pdfPath)})
         proc.stdout.setEncoding('utf8')
         proc.stderr.setEncoding('utf8')
 
@@ -499,7 +499,7 @@ export class Locator {
         }
         this.extension.logger.addLogMessage(`Open external viewer for syncTeX from ${pdfFile}`)
         this.extension.logger.logCommand('Execute external SyncTeX command', command, args)
-        const proc = cp.spawn(command, args)
+        const proc = cs.spawn(command, args)
         let stdout = ''
         proc.stdout.on('data', newStdout => {
             stdout += newStdout

--- a/src/providers/latexformatter.ts
+++ b/src/providers/latexformatter.ts
@@ -1,5 +1,4 @@
 import * as vscode from 'vscode'
-import * as cp from 'child_process'
 import * as cs from 'cross-spawn'
 import * as path from 'path'
 import * as fs from 'fs'
@@ -111,7 +110,7 @@ export class LaTexFormatter {
 
         return new Promise((resolve, _reject) => {
             this.extension.logger.addLogMessage(`Checking latexindent: ${checker} ${this.formatter}`)
-            const check1 = cp.spawn(checker, [this.formatter])
+            const check1 = cs.spawn(checker, [this.formatter])
             let stdout1: string = ''
             let stderr1: string = ''
             check1.stdout.setEncoding('utf8')
@@ -123,7 +122,7 @@ export class LaTexFormatter {
                     this.extension.logger.addLogMessage(`Error when checking latexindent: ${stderr1}`)
                     this.formatter += fileExt
                     this.extension.logger.addLogMessage(`Checking latexindent: ${checker} ${this.formatter}`)
-                    const check2 = cp.spawn(checker, [this.formatter])
+                    const check2 = cs.spawn(checker, [this.formatter])
                     let stdout2: string = ''
                     let stderr2: string = ''
                     check2.stdout.setEncoding('utf8')


### PR DESCRIPTION
This PR replaces all existing `spawn` calls from `child-process` with `spawn` from `cross-spawn`. The new function is an in-place substitution and has a number of merits listed in the [doc](https://github.com/moxystudio/node-cross-spawn).