### PR TITLE
Add a new `latex-workshop.shell` config to define shell of `spawn`

### DIFF
--- a/package.json
+++ b/package.json
@@ -2446,6 +2446,12 @@
           "type": "number",
           "default": 20000,
           "markdownDescription": "Delay to wait for GitHub Codespaces Authentication of port forwarding to be resolved, in milliseconds."
+        },
+        "latex-workshop.shell": {
+          "scope": "window",
+          "type": "string",
+          "default": "",
+          "markdownDescription": "[Caution] Set the shell to run all commands. This config changes the `shell` option of [`child_process.spawn`](https://nodejs.org/api/child_process.html#child_processspawncommand-args-options). Default empty string passes the default `false` (no shell) to `spawn`. Don't change this config unless you are familiar with the function."
         }
       }
     },

--- a/src/components/builder.ts
+++ b/src/components/builder.ts
@@ -270,7 +270,6 @@ export class Builder implements IBuilder {
                 command += ' ' + args[0]
             }
             this.extension.logger.addLogMessage(`cwd: ${path.dirname(rootFile)}`)
-            // The shell option below should be true. Cannot recall why. Need to check. @James @22-Sep-14
             this.currentProcess = cs.spawn(command, [], {cwd: path.dirname(rootFile), env: envVars, shell: getShell() || true})
         } else {
             let workingDirectory: string

--- a/src/components/builder.ts
+++ b/src/components/builder.ts
@@ -270,7 +270,8 @@ export class Builder implements IBuilder {
                 command += ' ' + args[0]
             }
             this.extension.logger.addLogMessage(`cwd: ${path.dirname(rootFile)}`)
-            this.currentProcess = cs.spawn(command, [], {cwd: path.dirname(rootFile), env: envVars, shell: getShell()})
+            // The shell option below should be true. Cannot recall why. Need to check. @James @22-Sep-14
+            this.currentProcess = cs.spawn(command, [], {cwd: path.dirname(rootFile), env: envVars, shell: getShell() || true})
         } else {
             let workingDirectory: string
             if (steps[index].command === 'latexmk' && rootFile === this.extension.manager.localRootFile && this.extension.manager.rootDir) {

--- a/src/components/builder.ts
+++ b/src/components/builder.ts
@@ -6,7 +6,7 @@ import * as cs from 'cross-spawn'
 import * as os from 'os'
 import * as tmp from 'tmp'
 import {Mutex} from '../lib/await-semaphore'
-import {replaceArgumentPlaceholders} from '../utils/utils'
+import {getShell, replaceArgumentPlaceholders} from '../utils/utils'
 
 import type {Extension} from '../main'
 import {BuildFinished} from './eventbus'
@@ -124,8 +124,8 @@ export class Builder implements IBuilder {
             args = args.map(replaceArgumentPlaceholders(rootFile, this.tmpDir))
         }
         this.extension.logger.logCommand('Build using external command', command, args)
-        this.extension.logger.addLogMessage(`cwd: ${wd}`)
-        this.currentProcess = cs.spawn(command, args, {cwd: wd})
+        this.extension.logger.addLogMessage(`cwd: ${wd}, shell: ${getShell()}`)
+        this.currentProcess = cs.spawn(command, args, {cwd: wd, shell: getShell()})
         const pid = this.currentProcess.pid
         this.extension.logger.addLogMessage(`External build process spawned. PID: ${pid}.`)
 
@@ -270,7 +270,7 @@ export class Builder implements IBuilder {
                 command += ' ' + args[0]
             }
             this.extension.logger.addLogMessage(`cwd: ${path.dirname(rootFile)}`)
-            this.currentProcess = cs.spawn(command, [], {cwd: path.dirname(rootFile), env: envVars, shell: true})
+            this.currentProcess = cs.spawn(command, [], {cwd: path.dirname(rootFile), env: envVars, shell: getShell()})
         } else {
             let workingDirectory: string
             if (steps[index].command === 'latexmk' && rootFile === this.extension.manager.localRootFile && this.extension.manager.rootDir) {
@@ -279,7 +279,7 @@ export class Builder implements IBuilder {
                 workingDirectory = path.dirname(rootFile)
             }
             this.extension.logger.addLogMessage(`cwd: ${workingDirectory}`)
-            this.currentProcess = cs.spawn(steps[index].command, steps[index].args, {cwd: workingDirectory, env: envVars})
+            this.currentProcess = cs.spawn(steps[index].command, steps[index].args, {cwd: workingDirectory, env: envVars, shell: getShell()})
         }
         const pid = this.currentProcess.pid
         this.extension.logger.addLogMessage(`LaTeX build process spawned. PID: ${pid}.`)

--- a/src/components/cleaner.ts
+++ b/src/components/cleaner.ts
@@ -5,7 +5,7 @@ import glob from 'glob'
 import * as cs from 'cross-spawn'
 
 import type {Extension} from '../main'
-import {replaceArgumentPlaceholders} from '../utils/utils'
+import {getShell, replaceArgumentPlaceholders} from '../utils/utils'
 
 
 /**
@@ -166,7 +166,7 @@ export class Cleaner {
         }
         this.extension.logger.logCommand('Clean temporary files command', command, args)
         return new Promise((resolve, _reject) => {
-            const proc = cs.spawn(command, args, {cwd: path.dirname(rootFile), detached: true})
+            const proc = cs.spawn(command, args, {cwd: path.dirname(rootFile), detached: true, shell: getShell()})
             let stderr = ''
             proc.stderr.on('data', newStderr => {
                 stderr += newStderr

--- a/src/components/counter.ts
+++ b/src/components/counter.ts
@@ -4,6 +4,7 @@ import * as path from 'path'
 import * as cs from 'cross-spawn'
 
 import type {Extension} from '../main'
+import { getShell } from '../utils/utils'
 
 export class Counter {
     private readonly extension: Extension
@@ -115,7 +116,7 @@ export class Counter {
         }
         args.push(path.basename(file))
         this.extension.logger.logCommand('Count words using command', command, args)
-        const proc = cs.spawn(command, args, {cwd: path.dirname(file)})
+        const proc = cs.spawn(command, args, {cwd: path.dirname(file), shell: getShell()})
         proc.stdout.setEncoding('utf8')
         proc.stderr.setEncoding('utf8')
 

--- a/src/components/locator.ts
+++ b/src/components/locator.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs'
 import * as path from 'path'
 import * as cs from 'cross-spawn'
 import {SyncTexJs} from './locatorlib/synctex'
-import {replaceArgumentPlaceholders} from '../utils/utils'
+import {getShell, replaceArgumentPlaceholders} from '../utils/utils'
 import {isSameRealPath} from '../utils/pathnormalize'
 
 import type {ClientRequest} from '../../types/latex-workshop-protocol-types'
@@ -193,7 +193,7 @@ export class Locator {
                 fs.chmodSync(command, 0o755)
             }
         }
-        const proc = cs.spawn(command, args, {cwd: path.dirname(pdfFile)})
+        const proc = cs.spawn(command, args, {cwd: path.dirname(pdfFile), shell: getShell()})
         proc.stdout.setEncoding('utf8')
         proc.stderr.setEncoding('utf8')
 
@@ -250,7 +250,7 @@ export class Locator {
                 fs.chmodSync(command, 0o755)
             }
         }
-        const proc = cs.spawn(command, args, {cwd: path.dirname(pdfPath)})
+        const proc = cs.spawn(command, args, {cwd: path.dirname(pdfPath), shell: getShell()})
         proc.stdout.setEncoding('utf8')
         proc.stderr.setEncoding('utf8')
 
@@ -499,7 +499,7 @@ export class Locator {
         }
         this.extension.logger.addLogMessage(`Open external viewer for syncTeX from ${pdfFile}`)
         this.extension.logger.logCommand('Execute external SyncTeX command', command, args)
-        const proc = cs.spawn(command, args)
+        const proc = cs.spawn(command, args, {shell: getShell()})
         let stdout = ''
         proc.stdout.on('data', newStdout => {
             stdout += newStdout

--- a/src/components/texdoc.ts
+++ b/src/components/texdoc.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode'
 import * as cs from 'cross-spawn'
 import type {LoggerLocator, ManagerLocator} from '../interfaces'
+import { getShell } from '../utils/utils'
 
 interface IExtension extends
     LoggerLocator,
@@ -19,7 +20,7 @@ export class TeXDoc {
         const texdocArgs = Array.from(configuration.get('texdoc.args') as string[])
         texdocArgs.push(pkg)
         this.extension.logger.logCommand('Run texdoc command', texdocPath, texdocArgs)
-        const proc = cs.spawn(texdocPath, texdocArgs)
+        const proc = cs.spawn(texdocPath, texdocArgs, {shell: getShell()})
 
         let stdout = ''
         proc.stdout.on('data', newStdout => {

--- a/src/components/viewer.ts
+++ b/src/components/viewer.ts
@@ -15,6 +15,7 @@ import {PdfViewerPanel, PdfViewerPanelSerializer, PdfViewerPanelService} from '.
 import {PdfViewerManagerService} from './viewerlib/pdfviewermanager'
 import {PdfViewerPagesLoaded} from './eventbus'
 import type {IViewer} from '../interfaces'
+import { getShell } from '../utils/utils'
 export {PdfViewerHookProvider} from './viewerlib/pdfviewerhook'
 
 
@@ -202,7 +203,7 @@ export class Viewer implements IViewer {
         }
         this.extension.logger.addLogMessage(`Open external viewer for ${pdfFile}`)
         this.extension.logger.logCommand('Execute the external PDF viewer command', command, args)
-        const proc = cs.spawn(command, args, {cwd: path.dirname(sourceFile), detached: true})
+        const proc = cs.spawn(command, args, {cwd: path.dirname(sourceFile), detached: true, shell: getShell()})
         let stdout = ''
         proc.stdout.on('data', newStdout => {
             stdout += newStdout

--- a/src/providers/latexformatter.ts
+++ b/src/providers/latexformatter.ts
@@ -5,7 +5,7 @@ import * as fs from 'fs'
 import * as os from 'os'
 
 import {Mutex} from '../lib/await-semaphore'
-import {replaceArgumentPlaceholders} from '../utils/utils'
+import {getShell, replaceArgumentPlaceholders} from '../utils/utils'
 import type {BuilderLocator, ExtensionRootLocator, LoggerLocator, ManagerLocator} from '../interfaces'
 
 const fullRange = (doc: vscode.TextDocument) => doc.validateRange(new vscode.Range(0, 0, Number.MAX_VALUE, Number.MAX_VALUE))
@@ -110,7 +110,7 @@ export class LaTexFormatter {
 
         return new Promise((resolve, _reject) => {
             this.extension.logger.addLogMessage(`Checking latexindent: ${checker} ${this.formatter}`)
-            const check1 = cs.spawn(checker, [this.formatter])
+            const check1 = cs.spawn(checker, [this.formatter], {shell: getShell()})
             let stdout1: string = ''
             let stderr1: string = ''
             check1.stdout.setEncoding('utf8')
@@ -122,7 +122,7 @@ export class LaTexFormatter {
                     this.extension.logger.addLogMessage(`Error when checking latexindent: ${stderr1}`)
                     this.formatter += fileExt
                     this.extension.logger.addLogMessage(`Checking latexindent: ${checker} ${this.formatter}`)
-                    const check2 = cs.spawn(checker, [this.formatter])
+                    const check2 = cs.spawn(checker, [this.formatter], {shell: getShell()})
                     let stdout2: string = ''
                     let stderr2: string = ''
                     check2.stdout.setEncoding('utf8')
@@ -188,7 +188,7 @@ export class LaTexFormatter {
 
             this.extension.logger.logCommand('Format with command', this.formatter, this.formatterArgs)
             this.extension.logger.addLogMessage(`Format args: ${JSON.stringify(args)}`)
-            const worker = cs.spawn(this.formatter, args, { stdio: 'pipe', cwd: documentDirectory })
+            const worker = cs.spawn(this.formatter, args, { stdio: 'pipe', cwd: documentDirectory, shell: getShell() })
             // handle stdout/stderr
             const stdoutBuffer: string[] = []
             const stderrBuffer: string[] = []

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -277,7 +277,7 @@ export function replaceArgumentPlaceholders(rootFile: string, tmpDir: string): (
     }
 }
 
-export function getShell(): boolean | string {
+export function getShell(): false | string {
     const shellConfig = vscode.workspace.getConfiguration('latex-workshop').get('shell') as string
     return shellConfig || false
 }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -277,6 +277,11 @@ export function replaceArgumentPlaceholders(rootFile: string, tmpDir: string): (
     }
 }
 
+export function getShell(): boolean | string {
+    const shellConfig = vscode.workspace.getConfiguration('latex-workshop').get('shell') as string
+    return shellConfig || false
+}
+
 export type NewCommand = {
     kind: 'command',
     name: 'renewcommand|newcommand|providecommand|DeclareMathOperator|renewcommand*|newcommand*|providecommand*|DeclareMathOperator*',


### PR DESCRIPTION
This PR adds a new `latex-workshop.shell` config to control the shell option of all `child_process.spawn` (in fact, `cross-spawn.spawn`).

Currently we may have an issue on Linux compiling, working on it now.