### PR TITLE
Add `pageBorderColor` config for pdf viewer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1568,6 +1568,12 @@
           "default": "#ffffff",
           "markdownDescription": "The background color of the viewer when the OS appearance is light. The string must represent a color in HTML. Reload vscode to make any change in this configuration effective."
         },
+        "latex-workshop.view.pdf.color.light.pageBorderColor": {
+          "scope": "window",
+          "type": "string",
+          "default": "lightgrey",
+          "markdownDescription": "The border color of pages when the OS appearance is light. The string must represent a color in HTML. Reload vscode to make any change in this configuration effective."
+        },
         "latex-workshop.view.pdf.color.dark.pageColorsForeground": {
           "scope": "window",
           "type": "string",
@@ -1585,6 +1591,12 @@
           "type": "string",
           "default": "#ffffff",
           "markdownDescription": "The background color of the viewer when the OS appearance is dark. The string must represent a color in HTML. Reload vscode to make any change in this configuration effective."
+        },
+        "latex-workshop.view.pdf.color.dark.pageBorderColor": {
+          "scope": "window",
+          "type": "string",
+          "default": "lightgrey",
+          "markdownDescription": "The border color of pages when the OS appearance is dark. The string must represent a color in HTML. Reload vscode to make any change in this configuration effective."
         },
         "latex-workshop.synctex.path": {
           "scope": "window",

--- a/src/components/viewer.ts
+++ b/src/components/viewer.ts
@@ -298,12 +298,14 @@ export class Viewer implements IViewer {
                 light: {
                     pageColorsForeground: configuration.get('view.pdf.color.light.pageColorsForeground') || 'CanvasText',
                     pageColorsBackground: configuration.get('view.pdf.color.light.pageColorsBackground') || 'Canvas',
-                    backgroundColor: configuration.get('view.pdf.color.light.backgroundColor', '#ffffff')
+                    backgroundColor: configuration.get('view.pdf.color.light.backgroundColor', '#ffffff'),
+                    pageBorderColor: configuration.get('view.pdf.color.light.pageBorderColor', 'lightgrey')
                 },
                 dark: {
                     pageColorsForeground: configuration.get('view.pdf.color.dark.pageColorsForeground') || 'CanvasText',
                     pageColorsBackground: configuration.get('view.pdf.color.dark.pageColorsBackground') || 'Canvas',
-                    backgroundColor: configuration.get('view.pdf.color.dark.backgroundColor', '#ffffff')
+                    backgroundColor: configuration.get('view.pdf.color.dark.backgroundColor', '#ffffff'),
+                    pageBorderColor: configuration.get('view.pdf.color.dark.pageBorderColor', 'lightgrey')
                 }
             },
             keybindings: {

--- a/types/latex-workshop-protocol-types/index.d.ts
+++ b/types/latex-workshop-protocol-types/index.d.ts
@@ -27,12 +27,14 @@ export type PdfViewerParams = {
         light: {
             pageColorsForeground: string,
             pageColorsBackground: string,
-            backgroundColor: string
+            backgroundColor: string,
+            pageBorderColor: string
         },
         dark: {
             pageColorsForeground: string,
             pageColorsBackground: string,
-            backgroundColor: string
+            backgroundColor: string,
+            pageBorderColor: string
         }
     }
     keybindings: {

--- a/viewer/latexworkshop.ts
+++ b/viewer/latexworkshop.ts
@@ -364,8 +364,10 @@ class LateXWorkshopPdfViewer implements ILatexWorkshopPdfViewer {
         }
         if (this.isPrefersColorSchemeDark()) {
             (document.querySelector('#viewerContainer') as HTMLElement).style.background = params.color.dark.backgroundColor
+            document.querySelectorAll('.pdfViewer.removePageBorders .page').forEach(elm => (elm as HTMLElement).style.boxShadow = `0px 0px 0px 1px ${params.color.dark.pageBorderColor}`)
         } else {
             (document.querySelector('#viewerContainer') as HTMLElement).style.background = params.color.light.backgroundColor
+            document.querySelectorAll('.pdfViewer.removePageBorders .page').forEach(elm => (elm as HTMLElement).style.boxShadow = `0px 0px 0px 1px ${params.color.light.pageBorderColor}`)
         }
 
         if (params.keybindings) {


### PR DESCRIPTION
This PR implements the request in #3487. Two new configuration entries are included:
- `latex-workshop.view.pdf.color.light.pageBorderColor`
- `latex-workshop.view.pdf.color.dark.pageBorderColor`

These two configs will control the `box-shadow` property of page DOMs, where the config changes the last segment of `box-shadow`, i.e., box border color.