### PR TITLE
Add completion for environment starting with a `+`

### DIFF
--- a/data/packages/tabularray_env.json
+++ b/data/packages/tabularray_env.json
@@ -1,0 +1,128 @@
+{
+  "tblr": {
+    "name": "tblr",
+    "detail": "tblr",
+    "snippet": "",
+    "package": "tabularray"
+  },
+  "tblr{}": {
+    "name": "tblr",
+    "detail": "tblr{options}",
+    "snippet": "{${1:options}}",
+    "package": "tabularray"
+  },
+  "longtblr": {
+    "name": "longtblr",
+    "detail": "longtblr",
+    "snippet": "",
+    "package": "tabularray"
+  },
+  "longtblr{}": {
+    "name": "longtblr",
+    "detail": "longtblr{options}",
+    "snippet": "{${1:options}}",
+    "package": "tabularray"
+  },
+  "talltblr": {
+    "name": "talltblr",
+    "detail": "talltblr",
+    "snippet": "",
+    "package": "tabularray"
+  },
+  "talltblr{}": {
+    "name": "talltblr",
+    "detail": "talltblr{options}",
+    "snippet": "{${1:options}}",
+    "package": "tabularray"
+  },
+  "booktabs": {
+    "name": "booktabs",
+    "detail": "booktabs",
+    "snippet": "",
+    "package": "tabularray"
+  },
+  "booktabs{}": {
+    "name": "booktabs",
+    "detail": "booktabs{options}",
+    "snippet": "{${1:options}}",
+    "package": "tabularray"
+  },
+  "longtabs": {
+    "name": "longtabs",
+    "detail": "longtabs",
+    "snippet": "",
+    "package": "tabularray"
+  },
+  "longtabs{}": {
+    "name": "longtabs",
+    "detail": "longtabs{options}",
+    "snippet": "{${1:options}}",
+    "package": "tabularray"
+  },
+  "talltabs": {
+    "name": "talltabs",
+    "detail": "talltabs",
+    "snippet": "",
+    "package": "tabularray"
+  },
+  "talltabs{}": {
+    "name": "talltabs",
+    "detail": "talltabs{options}",
+    "snippet": "{${1:options}}",
+    "package": "tabularray"
+  },
+  "+array": {
+    "name": "+array",
+    "detail": "+array",
+    "snippet": "",
+    "package": "tabularray"
+  },
+  "+array{}": {
+    "name": "+array",
+    "detail": "+array{options}",
+    "snippet": "{${1:options}}",
+    "package": "tabularray"
+  },
+  "+matrix": {
+    "name": "+matrix",
+    "detail": "+matrix",
+    "snippet": "",
+    "package": "tabularray"
+  },
+  "+bmatrix": {
+    "name": "+bmatrix",
+    "detail": "+bmatrix",
+    "snippet": "",
+    "package": "tabularray"
+  },
+  "+Bmatrix": {
+    "name": "+Bmatrix",
+    "detail": "+Bmatrix",
+    "snippet": "",
+    "package": "tabularray"
+  },
+  "+pmatrix": {
+    "name": "+pmatrix",
+    "detail": "+pmatrix",
+    "snippet": "",
+    "package": "tabularray"
+  },
+  "+vmatrix": {
+    "name": "+vmatrix",
+    "detail": "+vmatrix",
+    "snippet": "",
+    "package": "tabularray"
+  },
+  "+Vmatrix": {
+    "name": "+Vmatrix",
+    "detail": "+Vmatrix",
+    "snippet": "",
+    "package": "tabularray"
+  },
+  "+cases": {
+    "name": "+cases",
+    "detail": "+cases",
+    "snippet": "",
+    "package": "tabularray"
+  }
+}

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -10,7 +10,7 @@ import {InputFileRegExp} from '../utils/inputfilepath'
 
 import type {Extension} from '../main'
 import * as eventbus from './eventbus'
-import type {CmdEnvSuggestion} from '../providers/completer/command'
+import type {CmdEnvSuggestion} from '../providers/completer/commandlib/commandutils'
 import type {CiteSuggestion} from '../providers/completer/citation'
 import type {GlossarySuggestion} from '../providers/completer/glossary'
 import type {ILwCompletionItem} from '../providers/completer/interface'

--- a/src/providers/completer/command.ts
+++ b/src/providers/completer/command.ts
@@ -5,7 +5,7 @@ import {latexParser} from 'latex-utensils'
 import {Environment, EnvSnippetType} from './environment'
 import type {IProvider, ILwCompletionItem, ICommand} from './interface'
 import {CommandFinder, isTriggerSuggestNeeded, resolveCmdEnvFile} from './commandlib/commandfinder'
-import {CmdEnvSuggestion, splitSignatureString} from './commandlib/commandutils'
+import {CmdEnvSuggestion, splitSignatureString, filterNonLetterSuggestions} from './commandlib/commandutils'
 import {CommandSignatureDuplicationDetector, CommandNameDuplicationDetector} from './commandlib/commandfinder'
 import {SurroundCommand} from './commandlib/surround'
 import type {CompleterLocator, ExtensionRootLocator, LoggerLocator, ManagerLocator} from '../../interfaces'
@@ -88,7 +88,8 @@ export class Command implements IProvider, ICommand {
                 return exactSuggestion
             }
         }
-        return suggestions
+        // Commands starting with a non letter character are not filtered properly because of wordPattern definition.
+       return filterNonLetterSuggestions(suggestions, result[1], args.position)
     }
 
     private provide(languageId: string, document?: vscode.TextDocument, position?: vscode.Position): ILwCompletionItem[] {

--- a/src/providers/completer/command.ts
+++ b/src/providers/completer/command.ts
@@ -5,6 +5,7 @@ import {latexParser} from 'latex-utensils'
 import {Environment, EnvSnippetType} from './environment'
 import type {IProvider, ILwCompletionItem, ICommand} from './interface'
 import {CommandFinder, isTriggerSuggestNeeded, resolveCmdEnvFile} from './commandlib/commandfinder'
+import {CmdEnvSuggestion, splitSignatureString} from './commandlib/commandutils'
 import {CommandSignatureDuplicationDetector, CommandNameDuplicationDetector} from './commandlib/commandfinder'
 import {SurroundCommand} from './commandlib/surround'
 import type {CompleterLocator, ExtensionRootLocator, LoggerLocator, ManagerLocator} from '../../interfaces'
@@ -28,57 +29,6 @@ export interface CmdSignature {
 
 function isCmdItemEntry(obj: any): obj is CmdItemEntry {
     return (typeof obj.command === 'string') && (typeof obj.snippet === 'string')
-}
-
-/**
- * Return {name, args} from a signature string `name` + `args`
- */
-export function splitSignatureString(signature: string): CmdSignature {
-    const i = signature.search(/[[{]/)
-    if (i > -1) {
-        return {
-            name: signature.substring(0, i),
-            args: signature.substring(i, undefined)
-        }
-    } else {
-        return {
-            name: signature,
-            args: ''
-        }
-    }
-}
-
-export class CmdEnvSuggestion extends vscode.CompletionItem implements ILwCompletionItem {
-    label: string
-    package: string
-    signature: CmdSignature
-
-    constructor(label: string, pkg: string, signature: CmdSignature, kind: vscode.CompletionItemKind) {
-        super(label, kind)
-        this.label = label
-        this.package = pkg
-        this.signature = signature
-    }
-
-    /**
-     * Return the signature, ie the name + {} for mandatory arguments + [] for optional arguments.
-     * The leading backward slash is not part of the signature
-     */
-    signatureAsString(): string {
-        return this.signature.name + this.signature.args
-    }
-
-    /**
-     * Return the name without the arguments
-     * The leading backward slash is not part of the signature
-     */
-    name(): string {
-        return this.signature.name
-    }
-
-    hasOptionalArgs(): boolean {
-        return this.signature.args.includes('[')
-    }
 }
 
 interface IExtension extends

--- a/src/providers/completer/commandlib/commandfinder.ts
+++ b/src/providers/completer/commandlib/commandfinder.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode'
 import * as fs from 'fs'
 import {latexParser} from 'latex-utensils'
-import {CmdEnvSuggestion} from '../command'
+import {CmdEnvSuggestion} from './commandutils'
 import type {ILwCompletionItem} from '../interface'
 import type {CompleterLocator, ManagerLocator} from '../../../interfaces'
 

--- a/src/providers/completer/commandlib/commandutils.ts
+++ b/src/providers/completer/commandlib/commandutils.ts
@@ -57,3 +57,15 @@ export class CmdEnvSuggestion extends vscode.CompletionItem implements ILwComple
     }
 }
 
+export function filterNonLetterSuggestions(suggestions: ILwCompletionItem[], typedText: string, pos: vscode.Position): ILwCompletionItem[] {
+    if (typedText.match(/[^a-zA-Z]/)) {
+        const exactSuggestion = suggestions.filter(entry => entry.label.startsWith(typedText))
+        if (exactSuggestion.length > 0) {
+            return exactSuggestion.map(item => {
+                item.range = new vscode.Range(pos.translate(undefined, -typedText.length), pos)
+                return item
+            })
+        }
+    }
+    return suggestions
+}

--- a/src/providers/completer/commandlib/commandutils.ts
+++ b/src/providers/completer/commandlib/commandutils.ts
@@ -1,0 +1,59 @@
+import * as vscode from 'vscode'
+import type {ILwCompletionItem} from '../interface'
+
+export interface CmdSignature {
+    readonly name: string, // name without leading `\`
+    readonly args: string // {} for mandatory args and [] for optional args
+}
+
+/**
+ * Return {name, args} from a signature string `name` + `args`
+ */
+ export function splitSignatureString(signature: string): CmdSignature {
+    const i = signature.search(/[[{]/)
+    if (i > -1) {
+        return {
+            name: signature.substring(0, i),
+            args: signature.substring(i, undefined)
+        }
+    } else {
+        return {
+            name: signature,
+            args: ''
+        }
+    }
+}
+
+export class CmdEnvSuggestion extends vscode.CompletionItem implements ILwCompletionItem {
+    label: string
+    package: string
+    signature: CmdSignature
+
+    constructor(label: string, pkg: string, signature: CmdSignature, kind: vscode.CompletionItemKind) {
+        super(label, kind)
+        this.label = label
+        this.package = pkg
+        this.signature = signature
+    }
+
+    /**
+     * Return the signature, ie the name + {} for mandatory arguments + [] for optional arguments.
+     * The leading backward slash is not part of the signature
+     */
+    signatureAsString(): string {
+        return this.signature.name + this.signature.args
+    }
+
+    /**
+     * Return the name without the arguments
+     * The leading backward slash is not part of the signature
+     */
+    name(): string {
+        return this.signature.name
+    }
+
+    hasOptionalArgs(): boolean {
+        return this.signature.args.includes('[')
+    }
+}
+

--- a/src/providers/completer/environment.ts
+++ b/src/providers/completer/environment.ts
@@ -4,7 +4,7 @@ import {latexParser} from 'latex-utensils'
 
 import type {IProvider} from './interface'
 import {resolveCmdEnvFile, CommandSignatureDuplicationDetector} from './commandlib/commandfinder'
-import {CmdEnvSuggestion, splitSignatureString} from './command'
+import {CmdEnvSuggestion, splitSignatureString} from './commandlib/commandutils'
 import type {CompleterLocator, ExtensionRootLocator, LoggerLocator, ManagerLocator} from '../../interfaces'
 
 type DataEnvsJsonType = typeof import('../../../data/environments.json')

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -166,7 +166,7 @@ export class Completer implements vscode.CompletionItemProvider, CommandLocator 
                 provider = this.environment
                 break
             case 'command':
-                reg = args.document.languageId === 'latex-expl3' ? /\\([a-zA-Z_@]*(?::[a-zA-Z]*)?)$/ : /\\([a-zA-Z]*|(?:left|[Bb]ig{1,2}l)?[({[]?)$/
+                reg = args.document.languageId === 'latex-expl3' ? /\\([a-zA-Z_@]*(?::[a-zA-Z]*)?)$/ : /\\(\+?[a-zA-Z]*|(?:left|[Bb]ig{1,2}l)?[({[]?)$/
                 provider = this.command
                 break
             case 'package':


### PR DESCRIPTION
Close #3537 (auto-completion for `tabularray` environments)

This  PR introduces a `tabularray_env.json` file and implements the following changes
- Allow auto-completion of commands starting with `+`
- Manual filtering of suggestions for commands and environments starting with a non letter character.