### PR TITLE
Use `ctrl+shift+m` instead of `cmd+m` for macos keybindings

### DIFF
--- a/package.json
+++ b/package.json
@@ -650,43 +650,43 @@
       },
       {
         "key": "ctrl+m ctrl+b",
-        "mac": "cmd+m cmd+b",
+        "mac": "ctrl+shift+m cmd+b",
         "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$/",
         "command": "latex-workshop.shortcut.mathbf"
       },
       {
         "key": "ctrl+m ctrl+i",
-        "mac": "cmd+m cmd+i",
+        "mac": "ctrl+shift+m cmd+i",
         "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$/",
         "command": "latex-workshop.shortcut.mathit"
       },
       {
         "key": "ctrl+m ctrl+r",
-        "mac": "cmd+m cmd+r",
+        "mac": "ctrl+shift+m cmd+r",
         "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$/",
         "command": "latex-workshop.shortcut.mathrm"
       },
       {
         "key": "ctrl+m ctrl+t",
-        "mac": "cmd+m cmd+t",
+        "mac": "ctrl+shift+m cmd+t",
         "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$/",
         "command": "latex-workshop.shortcut.mathtt"
       },
       {
         "key": "ctrl+m ctrl+s",
-        "mac": "cmd+m cmd+s",
+        "mac": "ctrl+shift+m cmd+s",
         "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$/",
         "command": "latex-workshop.shortcut.mathsf"
       },
       {
         "key": "ctrl+m ctrl+shift+b",
-        "mac": "cmd+m cmd+shift+b",
+        "mac": "ctrl+shift+m cmd+shift+b",
         "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$/",
         "command": "latex-workshop.shortcut.mathbb"
       },
       {
         "key": "ctrl+m ctrl+c",
-        "mac": "cmd+m cmd+c",
+        "mac": "ctrl+shift+m cmd+c",
         "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$/",
         "command": "latex-workshop.shortcut.mathcal"
       },
@@ -699,7 +699,7 @@
       {
         "command": "editor.action.toggleTabFocusMode",
         "key": "ctrl+l ctrl+m",
-        "mac": "cmd+l cmd+m",
+        "mac": "cmd+l ctrl+shift+m",
         "when": "textInputFocus && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$/"
       },
       {


### PR DESCRIPTION
See #3535 for discussion. This PR should close #3535.