### PR TITLE
Move the auto-build-disable logic to `builder`

### DIFF
--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -892,16 +892,12 @@ export class Manager implements IManager {
     }
 
     private autoBuild(file: string, bibChanged: boolean ) {
-        if (this.extension.builder.disableBuildAfterSave) {
-            this.extension.logger.addLogMessage('Auto Build Run is temporarily disabled during a second.')
-            return
-        }
         this.extension.logger.addLogMessage(`Auto build started detecting the change of a file: ${file}`)
         const configuration = vscode.workspace.getConfiguration('latex-workshop', vscode.Uri.file(file))
         if (!bibChanged && this.localRootFile && configuration.get('latex.rootFile.useSubFile')) {
-            return this.extension.commander.build(true, this.localRootFile, this.rootFileLanguageId)
+            return this.extension.commander.build('auto', true, this.localRootFile, this.rootFileLanguageId)
         } else {
-            return this.extension.commander.build(true, this.rootFile, this.rootFileLanguageId)
+            return this.extension.commander.build('auto', true, this.rootFile, this.rootFileLanguageId)
         }
     }
 
@@ -916,10 +912,6 @@ export class Manager implements IManager {
     buildOnSaveIfEnabled(file: string) {
         const configuration = vscode.workspace.getConfiguration('latex-workshop', vscode.Uri.file(file))
         if (configuration.get('latex.autoBuild.run') as string !== BuildEvents.onSave) {
-            return
-        }
-        if (this.extension.builder.disableBuildAfterSave) {
-            this.extension.logger.addLogMessage('Auto Build Run is temporarily disabled during a second.')
             return
         }
         this.extension.logger.addLogMessage(`Auto build started on saving file: ${file}`)

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -22,8 +22,7 @@ export interface BuilderLocator {
 }
 
 export interface IBuilder {
-    readonly tmpDir: string,
-    readonly disableBuildAfterSave: boolean
+    readonly tmpDir: string
 }
 
 export interface LoggerLocator {

--- a/src/main.ts
+++ b/src/main.ts
@@ -61,8 +61,8 @@ function selectDocumentsWithId(ids: string[]): vscode.DocumentSelector {
 function registerLatexWorkshopCommands(extension: Extension, context: vscode.ExtensionContext) {
 
     context.subscriptions.push(
-        vscode.commands.registerCommand('latex-workshop.saveWithoutBuilding', () => extension.commander.saveWithoutBuilding()),
-        vscode.commands.registerCommand('latex-workshop.build', () => extension.commander.build()),
+        vscode.commands.registerCommand('latex-workshop.saveWithoutBuilding', () => extension.commander.saveActive()),
+        vscode.commands.registerCommand('latex-workshop.build', () => extension.commander.build('manual')),
         vscode.commands.registerCommand('latex-workshop.recipes', (recipe: string | undefined) => extension.commander.recipes(recipe)),
         vscode.commands.registerCommand('latex-workshop.view', (mode: 'tab' | 'browser' | 'external' | vscode.Uri | undefined) => extension.commander.view(mode)),
         vscode.commands.registerCommand('latex-workshop.refresh-viewer', () => extension.commander.refresh()),


### PR DESCRIPTION
In the previous implementation, the disable of auto-build after a previous one was defined by a public variable `disableBuildAfterSave`, which was controlled by logics in `manager` and `commander`. Quite in-elegant.

This PR refactor the feature by replacing the public variable with a private one, i.e., `saving`. If `true`, auto-build will be disabled (manual build not affected). This new variable is controlled in the new `saveActive` function and the previous `saveAll`. The pause after auto-build, defined by `latex.autoBuild.interval`, is now determined in a new function `canBuild`, which reads the last auto-build timestamp to confirm whether the current auto-build should trigger.

To facilitate the above logic, `build` and `buildExternal` functions accepts a new parameter `type: 'manual' | 'auto'`, which defines whether the building is manually triggered (by BUILD command) or auto-build triggered (by `onSave` or file changes).