### PR TITLE
Revert to use delay to prevent simultaneous auto build by file save or change

### DIFF
--- a/package.json
+++ b/package.json
@@ -1181,7 +1181,7 @@
           "scope": "resource",
           "type": "integer",
           "default": 1000,
-          "markdownDescription": "The minimal time interval between two consecutive auto builds in milliseconds."
+          "markdownDescription": "The minimal time interval in milliseconds for an auto build to trigger after the previous (manual and auto) build. This value is recommended to be greater than ~500 and also `#latex-workshop.latex.watch.interval#` if `#latex-workshop.latex.watch.usePolling#` is `true`."
         },
         "latex-workshop.latex.autoBuild.cleanAndRetry.enabled": {
           "scope": "resource",

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -65,7 +65,7 @@ export class Commander {
             .catch(err => this.extension.logger.addLogMessage(`Error reading data: ${err}.`))
     }
 
-    async build(type: 'manual' | 'auto', skipSelection: boolean = false, rootFile: string | undefined = undefined, languageId: string | undefined = undefined, recipe: string | undefined = undefined) {
+    async build(skipSelection: boolean = false, rootFile: string | undefined = undefined, languageId: string | undefined = undefined, recipe: string | undefined = undefined) {
         this.extension.logger.addLogMessage('BUILD command invoked.')
         if (!vscode.window.activeTextEditor) {
             this.extension.logger.addLogMessage('Cannot start to build because the active editor is undefined.')
@@ -83,7 +83,7 @@ export class Commander {
         }
         if (externalBuildCommand) {
             const pwd = path.dirname(rootFile ? rootFile : vscode.window.activeTextEditor.document.fileName)
-            await this.extension.builder.buildExternal(type, externalBuildCommand, externalBuildArgs, pwd, rootFile)
+            await this.extension.builder.buildExternal(externalBuildCommand, externalBuildArgs, pwd, rootFile)
             return
         }
         if (rootFile === undefined || languageId === undefined) {
@@ -99,7 +99,7 @@ export class Commander {
             }
         }
         this.extension.logger.addLogMessage(`Building root file: ${pickedRootFile}`)
-        await this.extension.builder.build(type, pickedRootFile, languageId, recipe)
+        await this.extension.builder.build(pickedRootFile, languageId, recipe)
     }
 
     async revealOutputDir() {
@@ -125,7 +125,7 @@ export class Commander {
             return
         }
         if (recipe) {
-            return this.build('manual', false, undefined, undefined, recipe)
+            return this.build(false, undefined, undefined, recipe)
         }
         return vscode.window.showQuickPick(recipes.map(candidate => candidate.name), {
             placeHolder: 'Please Select a LaTeX Recipe'
@@ -133,7 +133,7 @@ export class Commander {
             if (!selected) {
                 return
             }
-            return this.build('manual', false, undefined, undefined, selected)
+            return this.build(false, undefined, undefined, selected)
         })
     }
 

--- a/src/components/builder.ts
+++ b/src/components/builder.ts
@@ -13,7 +13,7 @@ export class Builder {
     private prevLangId: string | undefined
     private prevRecipe: Recipe | undefined
     private building: boolean = false
-    private buildOnSaveEvent: vscode.Disposable
+    private saving: boolean = false
     private process: cp.ChildProcessWithoutNullStreams | undefined
 
     private readonly isMiktex: boolean = false
@@ -24,7 +24,6 @@ export class Builder {
     private readonly MAX_PRINT_LINE = '10000'
 
     constructor(private readonly extension: Extension) {
-        this.buildOnSaveEvent = extension.createBuildOnSaveEvent()
         // Check if pdflatex is available, and is MikTeX distro
         try {
             const pdflatexVersion = cp.execSync('pdflatex --version')
@@ -168,20 +167,20 @@ export class Builder {
         return true
     }
 
+    isAutoBuildEnabled() {
+        return !this.saving
+    }
+
     async saveActive() {
-        await this.extension.removeBuildOnSaveEvent(this.buildOnSaveEvent)
-        this.extension.manager.unregisterbuildOnFileChanged()
+        this.saving = true
         await vscode.window.activeTextEditor?.document.save()
-        this.buildOnSaveEvent = this.extension.createBuildOnSaveEvent()
-        this.extension.manager.registerbuildOnFileChanged()
+        setTimeout(() => this.saving = false, 500)
     }
 
     private async saveAll() {
-        await this.extension.removeBuildOnSaveEvent(this.buildOnSaveEvent)
-        this.extension.manager.unregisterbuildOnFileChanged()
+        this.saving = true
         await vscode.workspace.saveAll()
-        this.buildOnSaveEvent = this.extension.createBuildOnSaveEvent()
-        this.extension.manager.registerbuildOnFileChanged()
+        setTimeout(() => this.saving = false, 500)
     }
 
     /**

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -909,20 +909,21 @@ export class Manager implements IManager {
     }
 
     private autoBuild(file: string, bibChanged: boolean ) {
+        if (!this.extension.builder.canAutoBuild()) {
+            this.extension.logger.addLogMessage('Auto Build Run is temporarily disabled for `latex.autoBuild.interval`.')
+            return
+        }
         const configuration = vscode.workspace.getConfiguration('latex-workshop', vscode.Uri.file(file))
         if (!bibChanged && this.localRootFile && configuration.get('latex.rootFile.useSubFile')) {
-            return this.extension.commander.build('auto', true, this.localRootFile, this.rootFileLanguageId)
+            return this.extension.commander.build(true, this.localRootFile, this.rootFileLanguageId)
         } else {
-            return this.extension.commander.build('auto', true, this.rootFile, this.rootFileLanguageId)
+            return this.extension.commander.build(true, this.rootFile, this.rootFileLanguageId)
         }
     }
 
     buildOnFileChanged(file: string, bibChanged: boolean = false) {
         const configuration = vscode.workspace.getConfiguration('latex-workshop', vscode.Uri.file(file))
         if (configuration.get('latex.autoBuild.run') as string !== BuildEvents.onFileChange) {
-            return
-        }
-        if (!this.extension.builder.isAutoBuildEnabled()) {
             return
         }
         this.extension.logger.addLogMessage(`Auto build started detecting the change of a file: ${file}`)
@@ -932,9 +933,6 @@ export class Manager implements IManager {
     buildOnSaveIfEnabled(file: string) {
         const configuration = vscode.workspace.getConfiguration('latex-workshop', vscode.Uri.file(file))
         if (configuration.get('latex.autoBuild.run') as string !== BuildEvents.onSave) {
-            return
-        }
-        if (!this.extension.builder.isAutoBuildEnabled()) {
             return
         }
         this.extension.logger.addLogMessage(`Auto build started on saving file: ${file}`)

--- a/src/main.ts
+++ b/src/main.ts
@@ -62,7 +62,7 @@ function registerLatexWorkshopCommands(extension: Extension, context: vscode.Ext
 
     context.subscriptions.push(
         vscode.commands.registerCommand('latex-workshop.saveWithoutBuilding', () => extension.commander.saveActive()),
-        vscode.commands.registerCommand('latex-workshop.build', () => extension.commander.build('manual')),
+        vscode.commands.registerCommand('latex-workshop.build', () => extension.commander.build()),
         vscode.commands.registerCommand('latex-workshop.recipes', (recipe: string | undefined) => extension.commander.recipes(recipe)),
         vscode.commands.registerCommand('latex-workshop.view', (mode: 'tab' | 'browser' | 'external' | vscode.Uri | undefined) => extension.commander.view(mode)),
         vscode.commands.registerCommand('latex-workshop.refresh-viewer', () => extension.commander.refresh()),

--- a/src/main.ts
+++ b/src/main.ts
@@ -149,7 +149,7 @@ export function deactivate() {
 }
 
 export function activate(context: vscode.ExtensionContext): ReturnType<typeof generateLatexWorkshopApi> {
-    const extension = new Extension(context)
+    const extension = new Extension()
     extensionToDispose = extension
     void vscode.commands.executeCommand('setContext', 'latex-workshop:enabled', true)
 
@@ -163,6 +163,7 @@ export function activate(context: vscode.ExtensionContext): ReturnType<typeof ge
             extension.logger.addLogMessage(`onDidSaveTextDocument triggered: ${e.uri.toString(true)}`)
             extension.manager.updateCachedContent(e)
             extension.linter.lintRootFileIfEnabled()
+            void extension.manager.buildOnSaveIfEnabled(e.fileName)
             extension.counter.countOnSaveIfEnabled(e.fileName)
         }
     }))
@@ -325,8 +326,6 @@ interface IExtension extends
 
 export class Extension implements IExtension {
     readonly extensionRoot: string
-    readonly extensionContext: vscode.ExtensionContext
-
     readonly logger: Logger
     readonly eventBus = new EventBus()
     readonly lwfs: LwFileSystem
@@ -357,9 +356,8 @@ export class Extension implements IExtension {
     readonly mathPreviewPanel: MathPreviewPanel
     readonly duplicateLabels: DuplicateLabels
 
-    constructor(context: vscode.ExtensionContext) {
+    constructor() {
         this.extensionRoot = path.resolve(`${__dirname}/../../`)
-        this.extensionContext = context
         // We must create an instance of Logger first to enable
         // adding log messages during initialization.
         this.logger = new Logger()
@@ -399,27 +397,6 @@ export class Extension implements IExtension {
         this.server.dispose()
         await this.pegParser.dispose()
         await this.mathPreview.dispose()
-    }
-
-    createBuildOnSaveEvent(): vscode.Disposable {
-        const disposable = vscode.workspace.onDidSaveTextDocument( (e: vscode.TextDocument) => {
-            if (this.lwfs.isVirtualUri(e.uri)){
-                return
-            }
-            if (this.manager.hasTexId(e.languageId)) {
-                void this.manager.buildOnSaveIfEnabled(e.fileName)
-            }
-        })
-        this.extensionContext.subscriptions.push(disposable)
-        return disposable
-    }
-
-    async removeBuildOnSaveEvent(disposable: vscode.Disposable) {
-        const index = this.extensionContext.subscriptions.indexOf(disposable)
-        if (index > -1) {
-            this.extensionContext.subscriptions.splice(index, 1)
-        }
-        await disposable.dispose()
     }
 
     private addLogFundamentals() {


### PR DESCRIPTION
This PR should fix #3568 and #3570.

The issue rises as the `onDidSaveTextDocument` emits asynchronously with `saveAll` in the builder, so that the event listener may escape the screening of `saving` variable. Same thing also happened to the `.on('changed')` event of `chokidar`.

In commits d91bd72b5fbfdc3499ab6618459eefb193c07209 and 785b6923c117a9e896399afe12e2a3df70449f03 I tried to temporarily remove both listeners during file-saving. This works for the vscode `onDidSaveTextDocument`, which seems to invoke the event before returning `saveAll`. However, `chokidar` is still not synchronous.

Therefore, this PR uses the old-style delay-after-save to prevent the issue. As long as either events will be triggered within 500ms after the saving function returns, we are good.

I am yet to find a better and more elegant way to handle the issue. I myself don't like hard-coded delays....