### PR TITLE
Add output directory for pdflatex

### DIFF
--- a/package.json
+++ b/package.json
@@ -917,7 +917,7 @@
                 "-synctex=1",
                 "-interaction=nonstopmode",
                 "-file-line-error",
-				        "-output-directory=%OUTDIR%",
+		"-output-directory=%OUTDIR%",
                 "%DOC%"
               ],
               "env": {}

--- a/package.json
+++ b/package.json
@@ -917,6 +917,7 @@
                 "-synctex=1",
                 "-interaction=nonstopmode",
                 "-file-line-error",
+				        "-output-directory=%OUTDIR%",
                 "%DOC%"
               ],
               "env": {}


### PR DESCRIPTION
Make sure that `pdflatex` auxiliary files end up in the `out` dir.