### PR TITLE
Update the textmate scope to include `\refcite` to citation command

### DIFF
--- a/syntax/LaTeX.tmLanguage.json
+++ b/syntax/LaTeX.tmLanguage.json
@@ -1677,7 +1677,7 @@
 			"name": "meta.scope.item.latex"
 		},
 		{
-			"begin": "((\\\\)(?:[aA]uto|foot|full|no|short|[tT]ext|[pP]aren|[sS]mart)?[cC]ite(?:al)?(?:p|s|t|author|year(?:par)?|title)?[ANP]*\\*?)((?:(?:\\([^\\)]*\\)){0,2}(?:\\[[^\\]]*\\]){0,2}\\{[\\w:.]*\\})*)(?:([<\\[])[^\\]<>]*([>\\]]))?(?:(\\[)[^\\]]*(\\]))?(\\{)",
+			"begin": "((\\\\)(?:[aA]uto|foot|full|no|ref|short|[tT]ext|[pP]aren|[sS]mart)?[cC]ite(?:al)?(?:p|s|t|author|year(?:par)?|title)?[ANP]*\\*?)((?:(?:\\([^\\)]*\\)){0,2}(?:\\[[^\\]]*\\]){0,2}\\{[\\w:.]*\\})*)(?:([<\\[])[^\\]<>]*([>\\]]))?(?:(\\[)[^\\]]*(\\]))?(\\{)",
 			"captures": {
 				"1": {
 					"name": "keyword.control.cite.latex"


### PR DESCRIPTION
## Motivation
In World Scientific $\LaTeX$ template, there is a citation macro `\refcite{ }`.
For example, please check this [Overleaf template](https://www.overleaf.com/latex/templates/book-template-for-world-scientific-9-dot-00-x-6-dot-00-inches/fcdqkrckjbhb.pdf) 

## Proposed changes
While the cite part still triggers the extension to do auto-completion, the token does not trigger the syntax highlighting because there is no scope on what is inside the parenthesis (see below), this PR adds that (a very simple change).

### Before
![Screenshot from 2022-12-24 08-46-38](https://user-images.githubusercontent.com/4467042/209441292-0129d0f5-cf9b-44e2-982c-5d1ed8a582dc.png)

### After (build locally using `Node.js`)
![Screenshot from 2022-12-24 09-17-36](https://user-images.githubusercontent.com/4467042/209442252-f7ebfaf1-8952-45bf-bad7-eecece17b62f.png)
