### PR TITLE
Fixed sleep bug

### DIFF
--- a/viewer/components/connection.ts
+++ b/viewer/components/connection.ts
@@ -27,15 +27,20 @@ export class WebSocketPort implements IConnectionPort {
             sock.addEventListener('open', () => {
                 resolve(sock)
             })
-            sock.addEventListener('error', () => reject(new Error(`Failed to connect to ${server}`)) )
+            sock.addEventListener('error', () => reject(new Error(`Failed to connect to ${server}`)))
         })
         this.startConnectionKeeper()
     }
 
     private startConnectionKeeper() {
         // Send packets every 30 sec to prevent the connection closed by timeout.
-        setInterval(() => {
-            void this.send({type: 'ping'})
+        const id = setInterval(async () => {
+            try {
+                await this.send({type: 'ping'})
+            }
+            catch {
+                clearInterval(id)
+            }
         }, 30000)
     }
 

--- a/viewer/latexworkshop.ts
+++ b/viewer/latexworkshop.ts
@@ -409,23 +409,26 @@ class LateXWorkshopPdfViewer implements ILatexWorkshopPdfViewer {
 
             // Since WebSockets are disconnected when PC resumes from sleep,
             // we have to reconnect. https://github.com/James-Yu/LaTeX-Workshop/pull/1812
-            const reconnect = (i: number) => async () => {
-                console.log('Try to reconnect to LaTeX Workshop.')
-                this.connectionPort = createConnectionPort(this)
+            const reconnect = (tries: number) => async () => {
+                console.log(`Try to reconnect to LaTeX Workshop: (${tries}/10).`)
                 try {
-                    await this.connectionPort.onDidOpen(() => {
+                    this.connectionPort = createConnectionPort(this)
+                    this.connectionPort.onDidOpen(() => {
                         document.title = this.documentTitle
                         this.setupConnectionPort()
-                        console.log('Reconnected: WebScocket to LaTeX Workshop.')
+                        console.log('Reconnected: WebSocket to LaTeX Workshop.')
                     })
                 }
                 catch {
-                    if (i <= 10) {
-                        setTimeout(reconnect(i+1), 1000*(2+(i)))
+                    if (tries <= 10) {
+                        tries++ 
+                        setTimeout(reconnect(tries), 1000 * (tries + 2))
+                    } else {
+                        console.log('Cannot reconnect to LaTeX Workshop.')
                     }
                 }
             }
-            setTimeout(reconnect(2), 3000)
+            setTimeout(reconnect(1), 3000)
         })
     }
 

--- a/viewer/latexworkshop.ts
+++ b/viewer/latexworkshop.ts
@@ -409,13 +409,14 @@ class LateXWorkshopPdfViewer implements ILatexWorkshopPdfViewer {
 
             // Since WebSockets are disconnected when PC resumes from sleep,
             // we have to reconnect. https://github.com/James-Yu/LaTeX-Workshop/pull/1812
-            setTimeout(() => {
+            const id = setInterval(() => {
                 console.log('Try to reconnect to LaTeX Workshop.')
                 this.connectionPort = createConnectionPort(this)
                 this.connectionPort.onDidOpen(() => {
                     document.title = this.documentTitle
                     this.setupConnectionPort()
                     console.log('Reconnected: WebScocket to LaTeX Workshop.')
+                    clearInterval(id)
                 })
             }, 3000)
         })

--- a/viewer/latexworkshop.ts
+++ b/viewer/latexworkshop.ts
@@ -409,7 +409,7 @@ class LateXWorkshopPdfViewer implements ILatexWorkshopPdfViewer {
 
             // Since WebSockets are disconnected when PC resumes from sleep,
             // we have to reconnect. https://github.com/James-Yu/LaTeX-Workshop/pull/1812
-            const reconnect = (tries: number) => async () => {
+            const reconnect = (tries: number) => () => {
                 console.log(`Try to reconnect to LaTeX Workshop: (${tries}/10).`)
                 try {
                     this.connectionPort = createConnectionPort(this)
@@ -421,7 +421,7 @@ class LateXWorkshopPdfViewer implements ILatexWorkshopPdfViewer {
                 }
                 catch {
                     if (tries <= 10) {
-                        tries++ 
+                        tries++
                         setTimeout(reconnect(tries), 1000 * (tries + 2))
                     } else {
                         console.log('Cannot reconnect to LaTeX Workshop.')

--- a/viewer/latexworkshop.ts
+++ b/viewer/latexworkshop.ts
@@ -409,16 +409,23 @@ class LateXWorkshopPdfViewer implements ILatexWorkshopPdfViewer {
 
             // Since WebSockets are disconnected when PC resumes from sleep,
             // we have to reconnect. https://github.com/James-Yu/LaTeX-Workshop/pull/1812
-            const id = setInterval(() => {
+            const reconnect = (i: number) => async () => {
                 console.log('Try to reconnect to LaTeX Workshop.')
                 this.connectionPort = createConnectionPort(this)
-                this.connectionPort.onDidOpen(() => {
-                    document.title = this.documentTitle
-                    this.setupConnectionPort()
-                    console.log('Reconnected: WebScocket to LaTeX Workshop.')
-                    clearInterval(id)
-                })
-            }, 3000)
+                try {
+                    await this.connectionPort.onDidOpen(() => {
+                        document.title = this.documentTitle
+                        this.setupConnectionPort()
+                        console.log('Reconnected: WebScocket to LaTeX Workshop.')
+                    })
+                }
+                catch {
+                    if (i <= 10) {
+                        setTimeout(reconnect(i+1), 1000*(2+(i)))
+                    }
+                }
+            }
+            setTimeout(reconnect(2), 3000)
         })
     }
 


### PR DESCRIPTION
As documented in #3591, #1812 did not solve all the issues with reconnection. I can reproduce consistently on my machine simply by going to sleep and waking. Perhaps we could solve this by extending the timeout instead, but it seems more robust to just repeatedly reconnect until we succeed. This usually occurs within 2-4 attempts for me. Perhaps this has something to do with the time from waking to unlocking the computer.

Additionally, there is a bug in the ping code which causes it to repeatedly produce connection error messages. This was also causing us to leak `WebSocketPort` objects, as the interval was keeping them alive. Clearing the interval should solve that issue as well.