### PR TITLE
Patch viewer with Python script

### DIFF
--- a/dev/editviewer.py
+++ b/dev/editviewer.py
@@ -1,0 +1,37 @@
+import os
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument('-w', '--web', help=f'Path to pdf.js distributed web/ folder, end without `/`', type=str)
+parser.add_argument('-v', '--viewer', help=f'Path to extension viewer/ folder, end without `/`', type=str)
+args = parser.parse_args()
+
+with open(args.web + '/viewer.html', 'rt') as fin:
+    with open(args.viewer + '/viewer.html', 'wt') as fout:
+        for line in fin:
+            fout.write(
+                line.replace('''<title>PDF.js viewer</title>''', '''<meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'none'; connect-src 'self' ws://127.0.0.1:*; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:;">\n    <title>PDF.js viewer</title>''')
+                    .replace('''<link rel="stylesheet" href="viewer.css">''', '''<link rel="stylesheet" href="viewer.css">\n    <link rel="stylesheet" href="latexworkshop.css">''')
+                    .replace('''<script src="../build/pdf.js"></script>''', '''<script src="/build/pdf.js" defer></script>''')
+                    .replace('''<script src="viewer.js"></script>''', '''<script src="/out/viewer/latexworkshop.js" type="module"></script>''')
+            )
+
+with open(args.web + '/viewer.js', 'rt') as fin:
+    with open(args.viewer + '/viewer.js', 'wt') as fout:
+        for line in fin:
+            fout.write(
+                line.replace('''this.setTitle(title);''', '''// this.setTitle(title);''')
+                    .replace('''const MATCH_SCROLL_OFFSET_TOP = -50;''', '''const MATCH_SCROLL_OFFSET_TOP = -100;''')
+                    .replace('''this.switchView(view, true);''', '''this.switchView(view, false);''')
+                    .replace('''this.removePageBorders = options.removePageBorders || false;''', '''this.removePageBorders = options.removePageBorders || true;''')
+                    .replace('''localStorage.setItem("pdfjs.history", databaseStr);''', '''// localStorage.setItem("pdfjs.history", databaseStr);''')
+                    .replace('''return localStorage.getItem("pdfjs.history");''', '''return // localStorage.getItem("pdfjs.history");''')
+                    .replace('''localStorage.setItem("pdfjs.preferences", JSON.stringify(prefObj));''', '''// localStorage.setItem("pdfjs.preferences", JSON.stringify(prefObj));''')
+                    .replace('''return JSON.parse(localStorage.getItem("pdfjs.preferences"));''', '''return // JSON.parse(localStorage.getItem("pdfjs.preferences"));''')
+                    .replace('''console.warn('#' + key + ' is undefined.');''', '''// console.warn('#' + key + ' is undefined.');''')
+                    .replace('''(!event.shiftKey || window.chrome || window.opera)) {''', '''(!event.shiftKey || window.chrome || window.opera)) {\n    if (window.parent !== window) {\n      return;\n    }''')
+                    .replace('''console.error(`webviewerloaded: ''', '''// console.error(`webviewerloaded: ''')
+            )
+
+os.system(f'git diff --no-index {args.web}/viewer.html {args.viewer}/viewer.html > {args.viewer}/../dev/viewer/viewer.html.diff')
+os.system(f'git diff --no-index {args.web}/viewer.js {args.viewer}/viewer.js > {args.viewer}/../dev/viewer/viewer.js.diff')

--- a/dev/viewer/viewer.html.diff
+++ b/dev/viewer/viewer.html.diff
@@ -1,19 +1,14 @@
-diff --git a/./pdfjs-3.1.81-dist/web/viewer.html b/viewer/viewer.html
-index 3d12cac9..e9b2230b 100644
---- a/./pdfjs-3.1.81-dist/web/viewer.html
-+++ b/viewer/viewer.html
-@@ -25,15 +25,22 @@ See https://github.com/adobe-type-tools/cmap-resources
+diff --git a/../pdfjs-3.1.81-dist/web/viewer.html b/../viewer/viewer.html
+index 3d12cac9..280fcb80 100644
+--- a/../pdfjs-3.1.81-dist/web/viewer.html
++++ b/../viewer/viewer.html
+@@ -25,15 +25,17 @@ See https://github.com/adobe-type-tools/cmap-resources
      <meta charset="utf-8">
      <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
      <meta name="google" content="notranslate">
 +    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'none'; connect-src 'self' ws://127.0.0.1:*; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:;">
      <title>PDF.js viewer</title>
  
-+    <!--
-+      Because latexworkshop.css is loaded after viewer.css,
-+      we can override viewer.css by editing latexworkshop.css.
-+      DONT EDIT viewer.css. EDIT latexworkshop.css instead.
-+    -->
      <link rel="stylesheet" href="viewer.css">
 +    <link rel="stylesheet" href="latexworkshop.css">
  

--- a/dev/viewer/viewer.html.diff
+++ b/dev/viewer/viewer.html.diff
@@ -1,8 +1,8 @@
-diff --git a/pdfjs-3.1.81-dist/web/viewer.html b/viewer/viewer.html
-index 3d12cac9..3d4f8158 100644
---- a/pdfjs-3.1.81-dist/web/viewer.html
+diff --git a/./pdfjs-3.1.81-dist/web/viewer.html b/viewer/viewer.html
+index 3d12cac9..e9b2230b 100644
+--- a/./pdfjs-3.1.81-dist/web/viewer.html
 +++ b/viewer/viewer.html
-@@ -25,19 +25,26 @@ See https://github.com/adobe-type-tools/cmap-resources
+@@ -25,15 +25,22 @@ See https://github.com/adobe-type-tools/cmap-resources
      <meta charset="utf-8">
      <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
      <meta name="google" content="notranslate">
@@ -15,99 +15,15 @@ index 3d12cac9..3d4f8158 100644
 +      DONT EDIT viewer.css. EDIT latexworkshop.css instead.
 +    -->
      <link rel="stylesheet" href="viewer.css">
- 
--<!-- This snippet is used in production (included from viewer.html) -->
--<link rel="resource" type="application/l10n" href="locale/locale.properties">
--<script src="../build/pdf.js"></script>
 +    <link rel="stylesheet" href="latexworkshop.css">
  
--  <script src="viewer.js"></script>
- 
-+<!-- This snippet is used in production (included from viewer.html) -->
-+<link rel="resource" type="application/l10n" href="locale/locale.properties">
+ <!-- This snippet is used in production (included from viewer.html) -->
+ <link rel="resource" type="application/l10n" href="locale/locale.properties">
+-<script src="../build/pdf.js"></script>
 +<script src="/build/pdf.js" defer></script>
-+<script src="/out/viewer/latexworkshop.js" type="module"></script>
+ 
+-  <script src="viewer.js"></script>
++  <script src="/out/viewer/latexworkshop.js" type="module"></script>
+ 
    </head>
  
--  <body tabindex="1">
-+  <body tabindex="1" class="loadingInProgress">
-     <div id="outerContainer">
- 
-       <div id="sidebarContainer">
-@@ -79,7 +86,7 @@ See https://github.com/adobe-type-tools/cmap-resources
-           <div id="layersView" class="hidden">
-           </div>
-         </div>
--        <div id="sidebarResizer"></div>
-+        <div id="sidebarResizer" class="hidden"></div>
-       </div>  <!-- sidebarContainer -->
- 
-       <div id="mainContainer">
-@@ -230,6 +237,14 @@ See https://github.com/adobe-type-tools/cmap-resources
-               </button>
-             </div>
- 
-+            <div class="horizontalToolbarSeparator spreadModeButtons"></div>
-+
-+            <button id="synctexOffButton" class="secondaryToolbarButton" title="Disable forward SyncTeX" tabindex="70">
-+              <input id="synctexOff" type="checkbox"><span>Stop SyncTeX</span>
-+            </button>
-+            <button id="autoReloadOffButton" class="secondaryToolbarButton" title="Disable auto reload" tabindex="71">
-+               <input id="autoReloadOff" type="checkbox"><span>Auto Reload</span>
-+            </button>
-             <div class="horizontalToolbarSeparator"></div>
- 
-             <button id="documentProperties" class="secondaryToolbarButton" title="Document Properties…" tabindex="69" data-l10n-id="document_properties" aria-controls="documentPropertiesDialog">
-@@ -238,13 +253,20 @@ See https://github.com/adobe-type-tools/cmap-resources
-           </div>
-         </div>  <!-- secondaryToolbar -->
- 
--        <div class="toolbar">
-+        <div class="toolbar hide">
-           <div id="toolbarContainer">
-             <div id="toolbarViewer">
-               <div id="toolbarViewerLeft">
-                 <button id="sidebarToggle" class="toolbarButton" title="Toggle Sidebar" tabindex="11" data-l10n-id="toggle_sidebar" aria-expanded="false" aria-controls="sidebarContainer">
-                   <span data-l10n-id="toggle_sidebar_label">Toggle Sidebar</span>
-                 </button>
-+                <!-- History back button, useful in the embedded viewer -->
-+                <button class="toolbarButton findPrevious" title="Back" id="historyBack">
-+                  <span>Back</span>
-+                </button>
-+                <button class="toolbarButton findNext" title="Forward" id="historyForward">
-+                  <span>Forward</span>
-+                </button>
-                 <div class="toolbarButtonSpacer"></div>
-                 <button id="viewFind" class="toolbarButton" title="Find in Document" tabindex="12" data-l10n-id="findbar" aria-expanded="false" aria-controls="findbar">
-                   <span data-l10n-id="findbar_label">Find</span>
-@@ -316,6 +338,15 @@ See https://github.com/adobe-type-tools/cmap-resources
-                     <option title="" value="2" data-l10n-id="page_scale_percent" data-l10n-args='{ "scale": 200 }'>200%</option>
-                     <option title="" value="3" data-l10n-id="page_scale_percent" data-l10n-args='{ "scale": 300 }'>300%</option>
-                     <option title="" value="4" data-l10n-id="page_scale_percent" data-l10n-args='{ "scale": 400 }'>400%</option>
-+                    <option id="trimOption" title="" disabled="disabled" hidden="true"> Trimming </option>
-+                  </select>
-+                </span>
-+                <span id="trimSelectContainer" class="dropdownToolbarButton">
-+                  <select id="trimSelect" title="Trim" tabindex="23" >
-+                    <option title="" value="0.0" selected="selected" >No page trimming</option>
-+                    <option title="" value="0.05" >Trim 5% at margin</option>
-+                    <option title="" value="0.10" >Trim 10% at margin</option>
-+                    <option title="" value="0.15" >Trim 15% at margin</option>
-                   </select>
-                 </span>
-               </div>
-@@ -331,6 +362,7 @@ See https://github.com/adobe-type-tools/cmap-resources
- 
-         <div id="viewerContainer" tabindex="0">
-           <div id="viewer" class="pdfViewer"></div>
-+          <div id="synctex-indicator"></div>
-         </div>
-       </div> <!-- mainContainer -->
- 
-@@ -430,4 +462,4 @@ See https://github.com/adobe-type-tools/cmap-resources
- 
-     <input type="file" id="fileInput" class="hidden">
-   </body>
--</html>
-+</html>
-\ No newline at end of file

--- a/dev/viewer/viewer.js.diff
+++ b/dev/viewer/viewer.js.diff
@@ -1,7 +1,7 @@
-diff --git a/pdfjs-3.1.81-dist/web/viewer.js b/viewer/viewer.js
+diff --git a/../pdfjs-3.1.81-dist/web/viewer.js b/../viewer/viewer.js
 index 7cc55739..ddd7e29d 100644
---- a/pdfjs-3.1.81-dist/web/viewer.js
-+++ b/viewer/viewer.js
+--- a/../pdfjs-3.1.81-dist/web/viewer.js
++++ b/../viewer/viewer.js
 @@ -1764,7 +1764,7 @@ const PDFViewerApplication = {
          title = url;
        }

--- a/src/components/server.ts
+++ b/src/components/server.ts
@@ -182,83 +182,83 @@ export class Server {
                 response.end()
             }
             return
-        } else if (request.url === '/config.json') {
+        }
+        if (request.url === '/config.json') {
             const params = this.extension.viewer.viewerParams()
             const content = JSON.stringify(params)
             this.sendOkResponse(response, Buffer.from(content), 'application/json')
             return
-        } else {
-            let root: string
-            if (request.url.startsWith('/build/') || request.url.startsWith('/cmaps/') || request.url.startsWith('/standard_fonts/')) {
-                root = path.resolve(`${this.extension.extensionRoot}/node_modules/pdfjs-dist`)
-            } else if (request.url.startsWith('/out/viewer/') || request.url.startsWith('/viewer/')) {
-                // For requests to /out/viewer/*.js and requests to /viewer/*.ts.
-                // The latter is for debugging with sourcemap.
-                root = path.resolve(this.extension.extensionRoot)
-            } else {
-                root = path.resolve(`${this.extension.extensionRoot}/viewer`)
-            }
-            //
-            // Prevent directory traversal attack.
-            // - https://en.wikipedia.org/wiki/Directory_traversal_attack
-            //
-            const reqFileName = path.posix.resolve('/', request.url.split('?')[0])
-            const fileName = path.resolve(root, '.' + reqFileName)
-            let contentType: string
-            switch (path.extname(fileName)) {
-                case '.html': {
-                    contentType = 'text/html'
-                    break
-                }
-                case '.js': {
-                    contentType = 'text/javascript'
-                    break
-                }
-                case '.css': {
-                    contentType = 'text/css'
-                    break
-                }
-                case '.json': {
-                    contentType = 'application/json'
-                    break
-                }
-                case '.png': {
-                    contentType = 'image/png'
-                    break
-                }
-                case '.jpg': {
-                    contentType = 'image/jpg'
-                    break
-                }
-                case '.gif': {
-                    contentType = 'image/gif'
-                    break
-                }
-                case '.svg': {
-                    contentType = 'image/svg+xml'
-                    break
-                }
-                case '.ico': {
-                    contentType = 'image/x-icon'
-                    break
-                }
-                default: {
-                    contentType = 'application/octet-stream'
-                    break
-                }
-            }
-            fs.readFile(fileName, (err, content) => {
-                if (err) {
-                    if (err.code === 'ENOENT') {
-                        response.writeHead(404)
-                    } else {
-                        response.writeHead(500)
-                    }
-                    response.end()
-                } else {
-                    this.sendOkResponse(response, content, contentType)
-                }
-            })
         }
+        let root: string
+        if (request.url.startsWith('/build/') || request.url.startsWith('/cmaps/') || request.url.startsWith('/standard_fonts/')) {
+            root = path.resolve(`${this.extension.extensionRoot}/node_modules/pdfjs-dist`)
+        } else if (request.url.startsWith('/out/viewer/') || request.url.startsWith('/viewer/')) {
+            // For requests to /out/viewer/*.js and requests to /viewer/*.ts.
+            // The latter is for debugging with sourcemap.
+            root = path.resolve(this.extension.extensionRoot)
+        } else {
+            root = path.resolve(`${this.extension.extensionRoot}/viewer`)
+        }
+        //
+        // Prevent directory traversal attack.
+        // - https://en.wikipedia.org/wiki/Directory_traversal_attack
+        //
+        const reqFileName = path.posix.resolve('/', request.url.split('?')[0])
+        const fileName = path.resolve(root, '.' + reqFileName)
+        let contentType: string
+        switch (path.extname(fileName)) {
+            case '.html': {
+                contentType = 'text/html'
+                break
+            }
+            case '.js': {
+                contentType = 'text/javascript'
+                break
+            }
+            case '.css': {
+                contentType = 'text/css'
+                break
+            }
+            case '.json': {
+                contentType = 'application/json'
+                break
+            }
+            case '.png': {
+                contentType = 'image/png'
+                break
+            }
+            case '.jpg': {
+                contentType = 'image/jpg'
+                break
+            }
+            case '.gif': {
+                contentType = 'image/gif'
+                break
+            }
+            case '.svg': {
+                contentType = 'image/svg+xml'
+                break
+            }
+            case '.ico': {
+                contentType = 'image/x-icon'
+                break
+            }
+            default: {
+                contentType = 'application/octet-stream'
+                break
+            }
+        }
+        fs.readFile(fileName, (err, content) => {
+            if (err) {
+                if (err.code === 'ENOENT') {
+                    response.writeHead(404)
+                } else {
+                    response.writeHead(500)
+                }
+                response.end()
+            } else {
+                this.sendOkResponse(response, content, contentType)
+            }
+        })
     }
 }

--- a/viewer/components/htmleditor.ts
+++ b/viewer/components/htmleditor.ts
@@ -1,0 +1,67 @@
+export function editHTML() {
+    document.getElementById('sidebarResizer')?.classList.add('hidden')
+    document.getElementsByClassName('toolbar')[0]?.classList.add('hide')
+
+    const template = document.createElement('template')
+    template.innerHTML =
+`<button id="synctexOffButton" class="secondaryToolbarButton" title="Disable forward SyncTeX" tabindex="70">
+    <input id="synctexOff" type="checkbox"><span>Stop SyncTeX</span>
+</button>
+<button id="autoReloadOffButton" class="secondaryToolbarButton" title="Disable auto reload" tabindex="71">
+    <input id="autoReloadOff" type="checkbox"><span>Auto Reload</span>
+</button>
+<div class="horizontalToolbarSeparator"></div>`
+    let anchor: HTMLElement | Element | null | undefined = document.getElementById('documentProperties')
+    if (anchor) {
+        for (const node of template.content.childNodes) {
+            anchor.parentNode?.insertBefore(node, anchor)
+        }
+    }
+
+    template.innerHTML =
+`<!-- History back button, useful in the embedded viewer -->
+<button class="toolbarButton findPrevious" title="Back" id="historyBack">
+  <span>Back</span>
+</button>
+<button class="toolbarButton findNext" title="Forward" id="historyForward">
+  <span>Forward</span>
+</button>`
+    anchor = document.getElementById('sidebarToggle')?.nextElementSibling
+    if (anchor) {
+        for (const node of template.content.childNodes) {
+            anchor.parentNode?.insertBefore(node, anchor)
+        }
+    }
+
+    template.innerHTML = '<option id="trimOption" title="" disabled="disabled" hidden="true"> Trimming </option>'
+    anchor = document.getElementById('scaleSelect')
+    if (anchor) {
+        for (const node of template.content.childNodes) {
+            anchor.appendChild(node)
+        }
+    }
+
+    template.innerHTML =
+`<span id="trimSelectContainer" class="dropdownToolbarButton">
+<select id="trimSelect" title="Trim" tabindex="23" >
+  <option title="" value="0.0" selected="selected" >No page trimming</option>
+  <option title="" value="0.05" >Trim 5% at margin</option>
+  <option title="" value="0.10" >Trim 10% at margin</option>
+  <option title="" value="0.15" >Trim 15% at margin</option>
+</select>
+</span>`
+    anchor = document.getElementById('scaleSelectContainer')
+    if (anchor) {
+        for (const node of template.content.childNodes) {
+            anchor.parentNode?.appendChild(node)
+        }
+    }
+
+    template.innerHTML = '<div id="synctex-indicator"></div>'
+    anchor = document.getElementById('viewerContainer')
+    if (anchor) {
+        for (const node of template.content.childNodes) {
+            anchor.appendChild(node)
+        }
+    }
+}

--- a/viewer/components/pagetrimmer.ts
+++ b/viewer/components/pagetrimmer.ts
@@ -14,60 +14,60 @@ function getTrimScale() {
     return 1.0/(1 - 2*Number(trimValue))
 }
 
-
-(document.getElementById('trimSelect') as HTMLElement).addEventListener('change', () => {
-    const trimScale = getTrimScale()
-    const trimSelect = document.getElementById('trimSelect') as HTMLSelectElement
-    const scaleSelect = document.getElementById('scaleSelect') as HTMLSelectElement
-    const ev = new Event('change')
-    if (trimSelect.selectedIndex <= 0) {
-        for ( const opt of scaleSelect.options ) {
-            opt.disabled = false
-        }
-        (document.getElementById('trimOption') as HTMLOptionElement).disabled = true;
-        (document.getElementById('trimOption') as HTMLOptionElement).hidden = true
-        if (originalUserSelectIndex !== undefined) {
-            /**
-             * If the original scale is custom, selectedIndex === 4,
-             * we use page-width, selectedIndex === 3.
-             * There is no way to set the custom scale.
-             */
-            if (originalUserSelectIndex === 4) {
-                scaleSelect.selectedIndex = 3
-            } else {
-                scaleSelect.selectedIndex = originalUserSelectIndex
+export function registerPageTrimmer() {
+    (document.getElementById('trimSelect') as HTMLElement).addEventListener('change', () => {
+        const trimScale = getTrimScale()
+        const trimSelect = document.getElementById('trimSelect') as HTMLSelectElement
+        const scaleSelect = document.getElementById('scaleSelect') as HTMLSelectElement
+        const ev = new Event('change')
+        if (trimSelect.selectedIndex <= 0) {
+            for ( const opt of scaleSelect.options ) {
+                opt.disabled = false
             }
-        }
-        scaleSelect.dispatchEvent(ev)
-        currentUserSelectScale = undefined
-        originalUserSelectIndex = undefined
-        const viewer = document.getElementById('viewer') as HTMLElement
-        for ( const page of viewer.getElementsByClassName('page') ) {
-            for ( const layer of page.getElementsByClassName('annotationLayer') ) {
-                for ( const secionOfAnnotation of layer.getElementsByTagName('section') ) {
-                    if (secionOfAnnotation.dataset.originalLeft !== undefined) {
-                        secionOfAnnotation.style.left = secionOfAnnotation.dataset.originalLeft
+            (document.getElementById('trimOption') as HTMLOptionElement).disabled = true;
+            (document.getElementById('trimOption') as HTMLOptionElement).hidden = true
+            if (originalUserSelectIndex !== undefined) {
+                /**
+                 * If the original scale is custom, selectedIndex === 4,
+                 * we use page-width, selectedIndex === 3.
+                 * There is no way to set the custom scale.
+                 */
+                if (originalUserSelectIndex === 4) {
+                    scaleSelect.selectedIndex = 3
+                } else {
+                    scaleSelect.selectedIndex = originalUserSelectIndex
+                }
+            }
+            scaleSelect.dispatchEvent(ev)
+            currentUserSelectScale = undefined
+            originalUserSelectIndex = undefined
+            const viewer = document.getElementById('viewer') as HTMLElement
+            for ( const page of viewer.getElementsByClassName('page') ) {
+                for ( const layer of page.getElementsByClassName('annotationLayer') ) {
+                    for ( const secionOfAnnotation of layer.getElementsByTagName('section') ) {
+                        if (secionOfAnnotation.dataset.originalLeft !== undefined) {
+                            secionOfAnnotation.style.left = secionOfAnnotation.dataset.originalLeft
+                        }
                     }
                 }
             }
+            return
         }
-        return
-    }
-    for ( const opt of scaleSelect.options ) {
-        opt.disabled = true
-    }
-    if (currentUserSelectScale === undefined) {
-        currentUserSelectScale = PDFViewerApplication.pdfViewer._currentScale
-    }
-    if (originalUserSelectIndex === undefined) {
-        originalUserSelectIndex = scaleSelect.selectedIndex
-    }
-    const opt = document.getElementById('trimOption') as HTMLOptionElement
-    opt.value = (currentUserSelectScale * trimScale).toString()
-    opt.selected = true
-    scaleSelect.dispatchEvent(ev)
-})
-
+        for ( const opt of scaleSelect.options ) {
+            opt.disabled = true
+        }
+        if (currentUserSelectScale === undefined) {
+            currentUserSelectScale = PDFViewerApplication.pdfViewer._currentScale
+        }
+        if (originalUserSelectIndex === undefined) {
+            originalUserSelectIndex = scaleSelect.selectedIndex
+        }
+        const opt = document.getElementById('trimOption') as HTMLOptionElement
+        opt.value = (currentUserSelectScale * trimScale).toString()
+        opt.selected = true
+        scaleSelect.dispatchEvent(ev)
+    })
+}
 
 function trimPage(page: HTMLElement) {
     const trimScale = getTrimScale()

--- a/viewer/latexworkshop.ts
+++ b/viewer/latexworkshop.ts
@@ -1,6 +1,7 @@
 import {IConnectionPort, createConnectionPort} from './components/connection.js'
+import {editHTML} from './components/htmleditor.js'
 import {SyncTex} from './components/synctex.js'
-import {PageTrimmer} from './components/pagetrimmer.js'
+import {PageTrimmer, registerPageTrimmer} from './components/pagetrimmer.js'
 import * as utils from './components/utils.js'
 import {ExternalPromise} from './components/externalpromise.js'
 import {ViewerHistory} from './components/viewerhistory.js'
@@ -50,6 +51,8 @@ class LateXWorkshopPdfViewer implements ILatexWorkshopPdfViewer {
         document.title = this.documentTitle
         this.pdfFileUri = pack.pdfFileUri
 
+        editHTML()
+
         this.viewerHistory = new ViewerHistory(this)
         this.connectionPort = createConnectionPort(this)
         this.synctex = new SyncTex(this)
@@ -72,6 +75,8 @@ class LateXWorkshopPdfViewer implements ILatexWorkshopPdfViewer {
         this.startRebroadcastingKeyboardEvent()
         this.startSendingState()
         void this.startReceivingPanelManagerResponse()
+
+        registerPageTrimmer()
 
         this.pdfPagesLoaded = new Promise((resolve) => {
             this.onPagesLoaded(() => resolve(), {once: true})

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -28,11 +28,6 @@ See https://github.com/adobe-type-tools/cmap-resources
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'none'; connect-src 'self' ws://127.0.0.1:*; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:;">
     <title>PDF.js viewer</title>
 
-    <!--
-      Because latexworkshop.css is loaded after viewer.css,
-      we can override viewer.css by editing latexworkshop.css.
-      DONT EDIT viewer.css. EDIT latexworkshop.css instead.
-    -->
     <link rel="stylesheet" href="viewer.css">
     <link rel="stylesheet" href="latexworkshop.css">
 

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -34,17 +34,17 @@ See https://github.com/adobe-type-tools/cmap-resources
       DONT EDIT viewer.css. EDIT latexworkshop.css instead.
     -->
     <link rel="stylesheet" href="viewer.css">
-
     <link rel="stylesheet" href="latexworkshop.css">
-
 
 <!-- This snippet is used in production (included from viewer.html) -->
 <link rel="resource" type="application/l10n" href="locale/locale.properties">
 <script src="/build/pdf.js" defer></script>
-<script src="/out/viewer/latexworkshop.js" type="module"></script>
+
+  <script src="/out/viewer/latexworkshop.js" type="module"></script>
+
   </head>
 
-  <body tabindex="1" class="loadingInProgress">
+  <body tabindex="1">
     <div id="outerContainer">
 
       <div id="sidebarContainer">
@@ -86,7 +86,7 @@ See https://github.com/adobe-type-tools/cmap-resources
           <div id="layersView" class="hidden">
           </div>
         </div>
-        <div id="sidebarResizer" class="hidden"></div>
+        <div id="sidebarResizer"></div>
       </div>  <!-- sidebarContainer -->
 
       <div id="mainContainer">
@@ -237,14 +237,6 @@ See https://github.com/adobe-type-tools/cmap-resources
               </button>
             </div>
 
-            <div class="horizontalToolbarSeparator spreadModeButtons"></div>
-
-            <button id="synctexOffButton" class="secondaryToolbarButton" title="Disable forward SyncTeX" tabindex="70">
-              <input id="synctexOff" type="checkbox"><span>Stop SyncTeX</span>
-            </button>
-            <button id="autoReloadOffButton" class="secondaryToolbarButton" title="Disable auto reload" tabindex="71">
-               <input id="autoReloadOff" type="checkbox"><span>Auto Reload</span>
-            </button>
             <div class="horizontalToolbarSeparator"></div>
 
             <button id="documentProperties" class="secondaryToolbarButton" title="Document Properties…" tabindex="69" data-l10n-id="document_properties" aria-controls="documentPropertiesDialog">
@@ -253,19 +245,12 @@ See https://github.com/adobe-type-tools/cmap-resources
           </div>
         </div>  <!-- secondaryToolbar -->
 
-        <div class="toolbar hide">
+        <div class="toolbar">
           <div id="toolbarContainer">
             <div id="toolbarViewer">
               <div id="toolbarViewerLeft">
                 <button id="sidebarToggle" class="toolbarButton" title="Toggle Sidebar" tabindex="11" data-l10n-id="toggle_sidebar" aria-expanded="false" aria-controls="sidebarContainer">
                   <span data-l10n-id="toggle_sidebar_label">Toggle Sidebar</span>
-                </button>
-                <!-- History back button, useful in the embedded viewer -->
-                <button class="toolbarButton findPrevious" title="Back" id="historyBack">
-                  <span>Back</span>
-                </button>
-                <button class="toolbarButton findNext" title="Forward" id="historyForward">
-                  <span>Forward</span>
                 </button>
                 <div class="toolbarButtonSpacer"></div>
                 <button id="viewFind" class="toolbarButton" title="Find in Document" tabindex="12" data-l10n-id="findbar" aria-expanded="false" aria-controls="findbar">
@@ -338,15 +323,6 @@ See https://github.com/adobe-type-tools/cmap-resources
                     <option title="" value="2" data-l10n-id="page_scale_percent" data-l10n-args='{ "scale": 200 }'>200%</option>
                     <option title="" value="3" data-l10n-id="page_scale_percent" data-l10n-args='{ "scale": 300 }'>300%</option>
                     <option title="" value="4" data-l10n-id="page_scale_percent" data-l10n-args='{ "scale": 400 }'>400%</option>
-                    <option id="trimOption" title="" disabled="disabled" hidden="true"> Trimming </option>
-                  </select>
-                </span>
-                <span id="trimSelectContainer" class="dropdownToolbarButton">
-                  <select id="trimSelect" title="Trim" tabindex="23" >
-                    <option title="" value="0.0" selected="selected" >No page trimming</option>
-                    <option title="" value="0.05" >Trim 5% at margin</option>
-                    <option title="" value="0.10" >Trim 10% at margin</option>
-                    <option title="" value="0.15" >Trim 15% at margin</option>
                   </select>
                 </span>
               </div>
@@ -362,7 +338,6 @@ See https://github.com/adobe-type-tools/cmap-resources
 
         <div id="viewerContainer" tabindex="0">
           <div id="viewer" class="pdfViewer"></div>
-          <div id="synctex-indicator"></div>
         </div>
       </div> <!-- mainContainer -->
 


### PR DESCRIPTION
This PR does two things:

- Most of the edits in `viewer.html` is moved to a `htmleditor.ts` script, which dynamically add the new DOMs on load before any other actions/bindings.
- The remaining edits in `viewer.html` and all in `viewer.js` is patched by a Python script `dev/editviewer.py`, which uses string replacements.

With this patch, updating pdf.js can be a bit easier than before.