### PR TITLE
More structure config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -32,7 +32,7 @@
             "preLaunchTask": "task-watch-all",
             "env": {
                 "LATEXWORKSHOP_CI": "1",
-                "LATEXWORKSHOP_SUITE": ""
+                "LATEXWORKSHOP_SUITE": "06_structure"
             }
         },
         {

--- a/package.json
+++ b/package.json
@@ -1332,6 +1332,12 @@
           "default": true,
           "markdownDescription": "Show the float number in the outline/structure views."
         },
+        "latex-workshop.view.outline.floats.caption.enabled": {
+          "scope": "window",
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Show the float caption in the outline/structure views."
+        },
         "latex-workshop.view.outline.numbers.enabled": {
           "scope": "window",
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -1332,6 +1332,12 @@
           "default": true,
           "markdownDescription": "Show the sectioning numbers in the outline/structure views."
         },
+        "latex-workshop.view.outline.numbers.floats.enabled": {
+          "scope": "window",
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Show the float numbers in the outline/structure views."
+        },
         "latex-workshop.view.autoFocus.enabled": {
           "scope": "window",
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -1326,17 +1326,17 @@
           "default": true,
           "markdownDescription": "Show the floating objects (figures and tables) in the outline/structure views."
         },
+        "latex-workshop.view.outline.floats.number.enabled": {
+          "scope": "window",
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Show the float number in the outline/structure views."
+        },
         "latex-workshop.view.outline.numbers.enabled": {
           "scope": "window",
           "type": "boolean",
           "default": true,
           "markdownDescription": "Show the sectioning numbers in the outline/structure views."
-        },
-        "latex-workshop.view.outline.numbers.floats.enabled": {
-          "scope": "window",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Show the float numbers in the outline/structure views."
         },
         "latex-workshop.view.autoFocus.enabled": {
           "scope": "window",

--- a/src/providers/structure.ts
+++ b/src/providers/structure.ts
@@ -109,7 +109,7 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
 
         // Step 1: Create a flat array of sections.
         let flatStructure = await this.buildLaTeXSectionFromFile(file, subFile, filesBuilt)
-        if (configuration.get('view.outline.numbers.floats.enabled') as boolean) {
+        if (configuration.get('view.outline.floats.number.enabled') as boolean) {
             flatStructure = this.countFloats(flatStructure)
         }
 
@@ -261,10 +261,11 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
             ))
         } else if (latexParser.isEnvironment(node) && this.LaTeXCommands.envs.includes(node.name.replace(/\*$/, ''))) {
             // \begin{figure}...\end{figure}
+            const caption = this.findEnvCaption(node)
             sections.push(new Section(
                 SectionKind.Env,
                 // -> Figure: Caption of figure
-                `${node.name.charAt(0).toUpperCase() + node.name.slice(1)}: ${this.findEnvCaption(node)}`,
+                node.name.charAt(0).toUpperCase() + node.name.slice(1) + (caption ? `: ${caption}` : ''),
                 vscode.TreeItemCollapsibleState.Expanded,
                 -1,
                 node.location.start.line - 1,
@@ -344,11 +345,11 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
      * `table` using their respective syntax.
      *
      * @param node The environment node to be parsed
-     * @returns The caption found, or 'Untitled'.
+     * @returns The caption found, or empty.
      */
     private findEnvCaption(node: latexParser.Environment): string {
         let captionNode: latexParser.Command | undefined
-        let caption: string = 'Untitled'
+        let caption: string = ''
         if (node.name.replace(/\*$/, '') === 'frame') {
             // Frame titles can be specified as either \begin{frame}{Frame Title}
             // or \begin{frame} \frametitle{Frame Title}

--- a/src/providers/structure.ts
+++ b/src/providers/structure.ts
@@ -348,6 +348,10 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
      * @returns The caption found, or empty.
      */
     private findEnvCaption(node: latexParser.Environment): string {
+        const configuration = vscode.workspace.getConfiguration('latex-workshop')
+        if (!configuration.get('view.outline.floats.caption.enabled')) {
+            return ''
+        }
         let captionNode: latexParser.Command | undefined
         let caption: string = ''
         if (node.name.replace(/\*$/, '') === 'frame') {

--- a/test/fixtures/armory/structure_nested.tex
+++ b/test/fixtures/armory/structure_nested.tex
@@ -1,0 +1,18 @@
+\documentclass{article}
+\begin{document}
+\begin{frame}
+\frametitle{Frame Title 1}
+\begin{figure}
+\begin{table}
+\caption{Table Caption}
+\end{table}
+\end{figure}
+\end{frame}
+\begin{frame} {Frame Title 2}
+\begin{figure}
+\caption{Figure Caption}
+\end{figure}
+\end{frame}
+\begin{frame}
+\end{frame}
+\end{document}

--- a/test/suites/04_intellisense.test.ts
+++ b/test/suites/04_intellisense.test.ts
@@ -310,7 +310,7 @@ suite('Intellisense test suite', () => {
         assert.ok(items[0].filterText.includes('hintFake'))
     })
 
-    runTest({only: true, suiteName, fixtureName, testName: 'glossary intellisense'}, async () => {
+    runTest({suiteName, fixtureName, testName: 'glossary intellisense'}, async () => {
         await loadTestFile(fixture, [
             {src: 'intellisense_glossary.tex', dst: 'main.tex'},
             {src: 'intellisense_glossaryentries.tex', dst: 'sub/glossary.tex'}
@@ -333,7 +333,7 @@ suite('Intellisense test suite', () => {
         assert.ok(items.find(item => item.label === 'abbr_x' && item.detail === 'A first abbreviation'))
     })
 
-    runTest({only: true, suiteName, fixtureName, testName: '@-snippet intellisense and configs intellisense.atSuggestion*'}, async () => {
+    runTest({suiteName, fixtureName, testName: '@-snippet intellisense and configs intellisense.atSuggestion*'}, async () => {
         const replaces = {'@+': '\\sum', '@8': '', '@M': '\\sum'}
         await vscode.workspace.getConfiguration('latex-workshop').update('intellisense.atSuggestionJSON.replace', replaces)
         await loadTestFile(fixture, [

--- a/test/suites/06_structure.test.ts
+++ b/test/suites/06_structure.test.ts
@@ -37,6 +37,7 @@ suite('Document structure test suite', () => {
         extension.manager.rootFile = undefined
 
         await vscode.workspace.getConfiguration('latex-workshop').update('view.outline.numbers.enabled', undefined)
+        await vscode.workspace.getConfiguration('latex-workshop').update('view.outline.numbers.floats.enabled', undefined)
         await vscode.workspace.getConfiguration('latex-workshop').update('view.outline.sections', undefined)
         await vscode.workspace.getConfiguration('latex-workshop').update('view.outline.floats.enabled', undefined)
         await vscode.workspace.getConfiguration('latex-workshop').update('view.outline.fastparse.enabled', undefined)
@@ -50,11 +51,9 @@ suite('Document structure test suite', () => {
     runTest({suiteName, fixtureName, testName: 'test structure'}, async () => {
         await loadTestFiles(fixture)
         await openActive(extension, fixture, 'main.tex')
-
         assert.ok(extension)
         const structure = new SectionNodeProvider(extension)
         await structure.update(true)
-
         const sections = structure.ds
         assert.ok(sections)
         assert.strictEqual(sections.length, 6)
@@ -67,37 +66,33 @@ suite('Document structure test suite', () => {
         assert.strictEqual(sections[3].label, '4 4 A long title split over two lines')
         assert.strictEqual(sections[4].label, '* No \\textit{Number} Section')
         assert.strictEqual(sections[5].label, '5 Section pdf Caption')
-        assert.strictEqual(sections[5].children[0].label, 'Figure: Untitled')
-        assert.strictEqual(sections[5].children[1].label, 'Figure: Figure Caption')
-        assert.strictEqual(sections[5].children[2].label, 'Table: Table Caption')
-        assert.strictEqual(sections[5].children[3].label, 'Frame: Frame Title 1')
-        assert.strictEqual(sections[5].children[4].label, 'Frame: Frame Title 2')
-        assert.strictEqual(sections[5].children[5].label, 'Frame: Untitled')
+        assert.strictEqual(sections[5].children[0].label, 'Figure 1: Untitled')
+        assert.strictEqual(sections[5].children[1].label, 'Figure 2: Figure Caption')
+        assert.strictEqual(sections[5].children[2].label, 'Table 1: Table Caption')
+        assert.strictEqual(sections[5].children[3].label, 'Frame 1: Frame Title 1')
+        assert.strictEqual(sections[5].children[4].label, 'Frame 2: Frame Title 2')
+        assert.strictEqual(sections[5].children[5].label, 'Frame 3: Untitled')
     })
 
     runTest({suiteName, fixtureName, testName: 'test view.outline.numbers.enabled'}, async () => {
-        await vscode.workspace.getConfiguration('latex-workshop').update('view.outline.numbers.enabled', false)
         await loadTestFiles(fixture)
         await openActive(extension, fixture, 'main.tex')
-
         assert.ok(extension)
         const structure = new SectionNodeProvider(extension)
+        await vscode.workspace.getConfiguration('latex-workshop').update('view.outline.numbers.enabled', false)
         await structure.update(true)
-
         const sections = structure.ds
         assert.ok(sections)
         assert.strictEqual(sections[1].children[0].label, '2.0.1')
     })
 
     runTest({suiteName, fixtureName, testName: 'test view.outline.sections'}, async () => {
-        await vscode.workspace.getConfiguration('latex-workshop').update('view.outline.sections', ['section', 'altsection', 'subsubsection'])
         await loadTestFiles(fixture)
         await openActive(extension, fixture, 'main.tex')
-
         assert.ok(extension)
         const structure = new SectionNodeProvider(extension)
+        await vscode.workspace.getConfiguration('latex-workshop').update('view.outline.sections', ['section', 'altsection', 'subsubsection'])
         await structure.update(true)
-
         const sections = structure.ds
         assert.ok(sections)
         assert.strictEqual(sections[0].children.length, 2)
@@ -105,31 +100,45 @@ suite('Document structure test suite', () => {
     })
 
     runTest({suiteName, fixtureName, testName: 'test view.outline.floats.enabled'}, async () => {
-        await vscode.workspace.getConfiguration('latex-workshop').update('view.outline.floats.enabled', false)
         await loadTestFiles(fixture)
         await openActive(extension, fixture, 'main.tex')
-
         assert.ok(extension)
         const structure = new SectionNodeProvider(extension)
+        await vscode.workspace.getConfiguration('latex-workshop').update('view.outline.floats.enabled', false)
         await structure.update(true)
-
         const sections = structure.ds
         assert.ok(sections)
         assert.strictEqual(sections[5].children.length, 3)
-        assert.strictEqual(sections[5].children[0].label, 'Frame: Frame Title 1')
-        assert.strictEqual(sections[5].children[1].label, 'Frame: Frame Title 2')
-        assert.strictEqual(sections[5].children[2].label, 'Frame: Untitled')
+        assert.strictEqual(sections[5].children[0].label, 'Frame 1: Frame Title 1')
+        assert.strictEqual(sections[5].children[1].label, 'Frame 2: Frame Title 2')
+        assert.strictEqual(sections[5].children[2].label, 'Frame 3: Untitled')
+    })
+
+    runTest({suiteName, fixtureName, testName: 'test view.outline.numbers.floats.enabled'}, async () => {
+        await loadTestFiles(fixture)
+        await openActive(extension, fixture, 'main.tex')
+        assert.ok(extension)
+        const structure = new SectionNodeProvider(extension)
+        await vscode.workspace.getConfiguration('latex-workshop').update('view.outline.numbers.floats.enabled', false)
+        await structure.update(true)
+        const sections = structure.ds
+        assert.ok(sections)
+        assert.strictEqual(sections[5].children.length, 6)
+        assert.strictEqual(sections[5].children[0].label, 'Figure: Untitled')
+        assert.strictEqual(sections[5].children[1].label, 'Figure: Figure Caption')
+        assert.strictEqual(sections[5].children[2].label, 'Table: Table Caption')
+        assert.strictEqual(sections[5].children[3].label, 'Frame: Frame Title 1')
+        assert.strictEqual(sections[5].children[4].label, 'Frame: Frame Title 2')
+        assert.strictEqual(sections[5].children[5].label, 'Frame: Untitled')
     })
 
     runTest({suiteName, fixtureName, testName: 'test view.outline.fastparse.enabled'}, async () => {
-        await vscode.workspace.getConfiguration('latex-workshop').update('view.outline.fastparse.enabled', true)
         await loadTestFiles(fixture)
         await openActive(extension, fixture, 'main.tex')
-
         assert.ok(extension)
         const structure = new SectionNodeProvider(extension)
+        await vscode.workspace.getConfiguration('latex-workshop').update('view.outline.fastparse.enabled', true)
         await structure.update(true)
-
         const sections = structure.ds
         assert.ok(sections)
         assert.strictEqual(sections.length, 6)
@@ -142,11 +151,11 @@ suite('Document structure test suite', () => {
         assert.strictEqual(sections[3].label, '4 4 A long title split over two lines')
         assert.strictEqual(sections[4].label, '* No \\textit{Number} Section')
         assert.strictEqual(sections[5].label, '5 Section pdf Caption')
-        assert.strictEqual(sections[5].children[0].label, 'Figure: Untitled')
-        assert.strictEqual(sections[5].children[1].label, 'Figure: Figure Caption')
-        assert.strictEqual(sections[5].children[2].label, 'Table: Table Caption')
-        assert.strictEqual(sections[5].children[3].label, 'Frame: Frame Title 1')
-        assert.strictEqual(sections[5].children[4].label, 'Frame: Frame Title 2')
-        assert.strictEqual(sections[5].children[5].label, 'Frame: Untitled')
+        assert.strictEqual(sections[5].children[0].label, 'Figure 1: Untitled')
+        assert.strictEqual(sections[5].children[1].label, 'Figure 2: Figure Caption')
+        assert.strictEqual(sections[5].children[2].label, 'Table 1: Table Caption')
+        assert.strictEqual(sections[5].children[3].label, 'Frame 1: Frame Title 1')
+        assert.strictEqual(sections[5].children[4].label, 'Frame 2: Frame Title 2')
+        assert.strictEqual(sections[5].children[5].label, 'Frame 3: Untitled')
     })
 })

--- a/test/suites/06_structure.test.ts
+++ b/test/suites/06_structure.test.ts
@@ -37,9 +37,9 @@ suite('Document structure test suite', () => {
         extension.manager.rootFile = undefined
 
         await vscode.workspace.getConfiguration('latex-workshop').update('view.outline.numbers.enabled', undefined)
-        await vscode.workspace.getConfiguration('latex-workshop').update('view.outline.numbers.floats.enabled', undefined)
         await vscode.workspace.getConfiguration('latex-workshop').update('view.outline.sections', undefined)
         await vscode.workspace.getConfiguration('latex-workshop').update('view.outline.floats.enabled', undefined)
+        await vscode.workspace.getConfiguration('latex-workshop').update('view.outline.floats.number.enabled', undefined)
         await vscode.workspace.getConfiguration('latex-workshop').update('view.outline.fastparse.enabled', undefined)
 
         if (path.basename(fixture) === 'testground') {
@@ -66,12 +66,12 @@ suite('Document structure test suite', () => {
         assert.strictEqual(sections[3].label, '4 4 A long title split over two lines')
         assert.strictEqual(sections[4].label, '* No \\textit{Number} Section')
         assert.strictEqual(sections[5].label, '5 Section pdf Caption')
-        assert.strictEqual(sections[5].children[0].label, 'Figure 1: Untitled')
+        assert.strictEqual(sections[5].children[0].label, 'Figure 1')
         assert.strictEqual(sections[5].children[1].label, 'Figure 2: Figure Caption')
         assert.strictEqual(sections[5].children[2].label, 'Table 1: Table Caption')
         assert.strictEqual(sections[5].children[3].label, 'Frame 1: Frame Title 1')
         assert.strictEqual(sections[5].children[4].label, 'Frame 2: Frame Title 2')
-        assert.strictEqual(sections[5].children[5].label, 'Frame 3: Untitled')
+        assert.strictEqual(sections[5].children[5].label, 'Frame 3')
     })
 
     runTest({suiteName, fixtureName, testName: 'test view.outline.numbers.enabled'}, async () => {
@@ -111,25 +111,25 @@ suite('Document structure test suite', () => {
         assert.strictEqual(sections[5].children.length, 3)
         assert.strictEqual(sections[5].children[0].label, 'Frame 1: Frame Title 1')
         assert.strictEqual(sections[5].children[1].label, 'Frame 2: Frame Title 2')
-        assert.strictEqual(sections[5].children[2].label, 'Frame 3: Untitled')
+        assert.strictEqual(sections[5].children[2].label, 'Frame 3')
     })
 
-    runTest({suiteName, fixtureName, testName: 'test view.outline.numbers.floats.enabled'}, async () => {
+    runTest({suiteName, fixtureName, testName: 'test view.outline.floats.number.enabled'}, async () => {
         await loadTestFiles(fixture)
         await openActive(extension, fixture, 'main.tex')
         assert.ok(extension)
         const structure = new SectionNodeProvider(extension)
-        await vscode.workspace.getConfiguration('latex-workshop').update('view.outline.numbers.floats.enabled', false)
+        await vscode.workspace.getConfiguration('latex-workshop').update('view.outline.floats.number.enabled', false)
         await structure.update(true)
         const sections = structure.ds
         assert.ok(sections)
         assert.strictEqual(sections[5].children.length, 6)
-        assert.strictEqual(sections[5].children[0].label, 'Figure: Untitled')
+        assert.strictEqual(sections[5].children[0].label, 'Figure')
         assert.strictEqual(sections[5].children[1].label, 'Figure: Figure Caption')
         assert.strictEqual(sections[5].children[2].label, 'Table: Table Caption')
         assert.strictEqual(sections[5].children[3].label, 'Frame: Frame Title 1')
         assert.strictEqual(sections[5].children[4].label, 'Frame: Frame Title 2')
-        assert.strictEqual(sections[5].children[5].label, 'Frame: Untitled')
+        assert.strictEqual(sections[5].children[5].label, 'Frame')
     })
 
     runTest({suiteName, fixtureName, testName: 'test view.outline.fastparse.enabled'}, async () => {
@@ -151,11 +151,11 @@ suite('Document structure test suite', () => {
         assert.strictEqual(sections[3].label, '4 4 A long title split over two lines')
         assert.strictEqual(sections[4].label, '* No \\textit{Number} Section')
         assert.strictEqual(sections[5].label, '5 Section pdf Caption')
-        assert.strictEqual(sections[5].children[0].label, 'Figure 1: Untitled')
+        assert.strictEqual(sections[5].children[0].label, 'Figure 1')
         assert.strictEqual(sections[5].children[1].label, 'Figure 2: Figure Caption')
         assert.strictEqual(sections[5].children[2].label, 'Table 1: Table Caption')
         assert.strictEqual(sections[5].children[3].label, 'Frame 1: Frame Title 1')
         assert.strictEqual(sections[5].children[4].label, 'Frame 2: Frame Title 2')
-        assert.strictEqual(sections[5].children[5].label, 'Frame 3: Untitled')
+        assert.strictEqual(sections[5].children[5].label, 'Frame 3')
     })
 })

--- a/test/suites/06_structure.test.ts
+++ b/test/suites/06_structure.test.ts
@@ -75,6 +75,19 @@ suite('Document structure test suite', () => {
         assert.strictEqual(sections[5].children[5].label, 'Frame 3')
     })
 
+    runTest({suiteName, fixtureName, testName: 'test structure with nested floats'}, async () => {
+        await loadTestFile(fixture, [{src: 'structure_nested.tex', dst: 'main.tex'}])
+        await openActive(extension, fixture, 'main.tex')
+        assert.ok(extension)
+        const structure = new SectionNodeProvider(extension)
+        await structure.update(true)
+        const sections = structure.ds
+        assert.ok(sections)
+        assert.strictEqual(sections.length, 3)
+        assert.strictEqual(sections[0].children.length, 1)
+        assert.strictEqual(sections[0].children[0].children.length, 1)
+    })
+
     runTest({suiteName, fixtureName, testName: 'test view.outline.numbers.enabled'}, async () => {
         await loadTestFiles(fixture)
         await openActive(extension, fixture, 'main.tex')

--- a/test/suites/06_structure.test.ts
+++ b/test/suites/06_structure.test.ts
@@ -40,6 +40,7 @@ suite('Document structure test suite', () => {
         await vscode.workspace.getConfiguration('latex-workshop').update('view.outline.sections', undefined)
         await vscode.workspace.getConfiguration('latex-workshop').update('view.outline.floats.enabled', undefined)
         await vscode.workspace.getConfiguration('latex-workshop').update('view.outline.floats.number.enabled', undefined)
+        await vscode.workspace.getConfiguration('latex-workshop').update('view.outline.floats.caption.enabled', undefined)
         await vscode.workspace.getConfiguration('latex-workshop').update('view.outline.fastparse.enabled', undefined)
 
         if (path.basename(fixture) === 'testground') {
@@ -130,6 +131,24 @@ suite('Document structure test suite', () => {
         assert.strictEqual(sections[5].children[3].label, 'Frame: Frame Title 1')
         assert.strictEqual(sections[5].children[4].label, 'Frame: Frame Title 2')
         assert.strictEqual(sections[5].children[5].label, 'Frame')
+    })
+
+    runTest({suiteName, fixtureName, testName: 'test view.outline.floats.caption.enabled'}, async () => {
+        await loadTestFiles(fixture)
+        await openActive(extension, fixture, 'main.tex')
+        assert.ok(extension)
+        const structure = new SectionNodeProvider(extension)
+        await vscode.workspace.getConfiguration('latex-workshop').update('view.outline.floats.caption.enabled', false)
+        await structure.update(true)
+        const sections = structure.ds
+        assert.ok(sections)
+        assert.strictEqual(sections[5].children.length, 6)
+        assert.strictEqual(sections[5].children[0].label, 'Figure 1')
+        assert.strictEqual(sections[5].children[1].label, 'Figure 2')
+        assert.strictEqual(sections[5].children[2].label, 'Table 1')
+        assert.strictEqual(sections[5].children[3].label, 'Frame 1')
+        assert.strictEqual(sections[5].children[4].label, 'Frame 2')
+        assert.strictEqual(sections[5].children[5].label, 'Frame 3')
     })
 
     runTest({suiteName, fixtureName, testName: 'test view.outline.fastparse.enabled'}, async () => {


### PR DESCRIPTION
This PR provides additional configuration items related to structure/outline. Tweaks are also made:

- `view.outline.floats.number.enabled` can be used to enable/disable float numbering.
- `view.outline.floats.caption.enabled` can be used to enable/disable float captions.
- Now the `Untitled` default caption will not show if a float is not captioned.
- Now floats can also be nested in structure/outline.