### PR TITLE
Make all config items effective without reloading vscode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -32,7 +32,7 @@
             "preLaunchTask": "task-watch-all",
             "env": {
                 "LATEXWORKSHOP_CI": "1",
-                "LATEXWORKSHOP_SUITE": "06_structure"
+                "LATEXWORKSHOP_SUITE": ""
             }
         },
         {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -32,7 +32,7 @@
             "preLaunchTask": "task-watch-all",
             "env": {
                 "LATEXWORKSHOP_CI": "1",
-                "LATEXWORKSHOP_SUITE": ""
+                "LATEXWORKSHOP_SUITE": "04_intellisense"
             }
         },
         {

--- a/package.json
+++ b/package.json
@@ -1102,25 +1102,25 @@
           "scope": "window",
           "type": "boolean",
           "default": false,
-          "markdownDescription": "When set to true, polling is used to watch changes on files. When TeX files are placed on network drives or OneDrive, this option should be turned on. Setting this option to true might lead to high CPU utilization. Reload vscode to make any change in this configuration effective."
+          "markdownDescription": "When set to true, polling is used to watch changes on files. When TeX files are placed on network drives or OneDrive, this option should be turned on. Setting this option to true might lead to high CPU utilization."
         },
         "latex-workshop.latex.watch.interval": {
           "scope": "window",
           "type": "number",
           "default": 300,
-          "markdownDescription": "Interval of polling, in milliseconds. Reload vscode to make any change in this configuration effective."
+          "markdownDescription": "Interval of polling, in milliseconds."
         },
         "latex-workshop.latex.watch.delay": {
           "scope": "window",
           "type": "number",
           "default": 250,
-          "markdownDescription": "Delay before starting builds, in milliseconds. Reload vscode to make any change in this configuration effective."
+          "markdownDescription": "Delay before starting builds, in milliseconds."
         },
-        "latex-workshop.latex.pdfWatch.delay": {
+        "latex-workshop.latex.watch.pdf.delay": {
           "scope": "window",
           "type": "number",
           "default": 250,
-          "markdownDescription": "Delay before reloading a PDF file after last change, in milliseconds. Reload vscode to make any change in this configuration effective."
+          "markdownDescription": "Delay before reloading a PDF file after last change, in milliseconds."
         },
         "latex-workshop.latex.watch.files.ignore": {
           "scope": "window",

--- a/package.json
+++ b/package.json
@@ -2273,7 +2273,7 @@
           "scope": "window",
           "type": "boolean",
           "default": true,
-          "markdownDescription": "Many snippets use text hints of the form `${\\d:some_tex}` for their argument. You may prefer to hide instead by setting this configuration to `false`. Reload vscode to make any change in this configuration effective."
+          "markdownDescription": "Many snippets use text hints of the form `${\\d:some_tex}` for their argument. You may prefer to hide instead by setting this configuration to `false`."
         },
         "latex-workshop.intellisense.citation.backend": {
           "scope": "resource",

--- a/package.json
+++ b/package.json
@@ -2316,7 +2316,7 @@
             "type": "string"
           },
           "default": {},
-          "markdownDescription": "Dictionary of `\"command name\": \"command action\"` to replace the default snippets in `data/commands.json`. Remove the leading `\\` of the command name. See `data/commands.json` for the list of command names. An empty action removes the snippet. E.g. `{ \"[\": \"[ ${1} \\\\]\", \"figure\": \"\" }`. Reload vscode to make any change in this configuration effective."
+          "markdownDescription": "Dictionary of `\"command name\": \"command action\"` to replace the default snippets in `data/commands.json`. Remove the leading `\\` of the command name. See `data/commands.json` for the list of command names. An empty action removes the snippet. E.g. `{ \"[\": \"[ ${1} \\\\]\", \"figure\": \"\" }`."
         },
         "latex-workshop.texdoc.path": {
           "scope": "window",

--- a/package.json
+++ b/package.json
@@ -1416,7 +1416,7 @@
             "ctrl-click",
             "double-click"
           ],
-          "markdownDescription": "Which keybinding to use for the internal viewer for reverse synctex. `ctrl`/`cmd` + click (default) or double click. You must reload VSCode or the PDF viewer to make any change in this configuration effective."
+          "markdownDescription": "Which keybinding to use for the internal viewer for reverse synctex. `ctrl`/`cmd` + click (default) or double click. Reload the viewer to make any change in this configuration effective."
         },
         "latex-workshop.viewer.pdf.internal.keyboardEvent": {
           "scope": "window",
@@ -1566,49 +1566,49 @@
           "scope": "window",
           "type": "string",
           "default": "",
-          "markdownDescription": "The foreground color of the document when the OS appearance is light. The string must represent a color in HTML. Reload vscode to make any change in this configuration effective."
+          "markdownDescription": "The foreground color of the document when the OS appearance is light. The string must represent a color in HTML. Reload the viewer to make any change in this configuration effective."
         },
         "latex-workshop.view.pdf.color.light.pageColorsBackground": {
           "scope": "window",
           "type": "string",
           "default": "",
-          "markdownDescription": "The background color of the document when the OS appearance is light. The string must represent a color in HTML. Reload vscode to make any change in this configuration effective."
+          "markdownDescription": "The background color of the document when the OS appearance is light. The string must represent a color in HTML. Reload the viewer to make any change in this configuration effective."
         },
         "latex-workshop.view.pdf.color.light.backgroundColor": {
           "scope": "window",
           "type": "string",
           "default": "#ffffff",
-          "markdownDescription": "The background color of the viewer when the OS appearance is light. The string must represent a color in HTML. Reload vscode to make any change in this configuration effective."
+          "markdownDescription": "The background color of the viewer when the OS appearance is light. The string must represent a color in HTML. Reload the viewer to make any change in this configuration effective."
         },
         "latex-workshop.view.pdf.color.light.pageBorderColor": {
           "scope": "window",
           "type": "string",
           "default": "lightgrey",
-          "markdownDescription": "The border color of pages when the OS appearance is light. The string must represent a color in HTML. Reload vscode to make any change in this configuration effective."
+          "markdownDescription": "The border color of pages when the OS appearance is light. The string must represent a color in HTML. Reload the viewer to make any change in this configuration effective."
         },
         "latex-workshop.view.pdf.color.dark.pageColorsForeground": {
           "scope": "window",
           "type": "string",
           "default": "",
-          "markdownDescription": "The foreground color of the document when the OS appearance is dark. The string must represent a color in HTML. Reload vscode to make any change in this configuration effective."
+          "markdownDescription": "The foreground color of the document when the OS appearance is dark. The string must represent a color in HTML. Reload the viewer to make any change in this configuration effective."
         },
         "latex-workshop.view.pdf.color.dark.pageColorsBackground": {
           "scope": "window",
           "type": "string",
           "default": "",
-          "markdownDescription": "The background color of the document when the OS appearance is dark. The string must represent a color in HTML. Reload vscode to make any change in this configuration effective."
+          "markdownDescription": "The background color of the document when the OS appearance is dark. The string must represent a color in HTML. Reload the viewer to make any change in this configuration effective."
         },
         "latex-workshop.view.pdf.color.dark.backgroundColor": {
           "scope": "window",
           "type": "string",
           "default": "#ffffff",
-          "markdownDescription": "The background color of the viewer when the OS appearance is dark. The string must represent a color in HTML. Reload vscode to make any change in this configuration effective."
+          "markdownDescription": "The background color of the viewer when the OS appearance is dark. The string must represent a color in HTML. Reload the viewer to make any change in this configuration effective."
         },
         "latex-workshop.view.pdf.color.dark.pageBorderColor": {
           "scope": "window",
           "type": "string",
           "default": "lightgrey",
-          "markdownDescription": "The border color of pages when the OS appearance is dark. The string must represent a color in HTML. Reload vscode to make any change in this configuration effective."
+          "markdownDescription": "The border color of pages when the OS appearance is dark. The string must represent a color in HTML. Reload the viewer to make any change in this configuration effective."
         },
         "latex-workshop.synctex.path": {
           "scope": "window",
@@ -1908,7 +1908,7 @@
           "default": [
             "{"
           ],
-          "markdownDescription": "Additional trigger characters for intellisense of LaTeX documents. Reload vscode to make any change in this configuration effective."
+          "markdownDescription": "Additional trigger characters for intellisense of LaTeX documents."
         },
         "latex-workshop.intellisense.snippets.trigger.latex": {
           "scope": "window",

--- a/src/components/managerlib/bibwatcher.ts
+++ b/src/components/managerlib/bibwatcher.ts
@@ -37,6 +37,10 @@ export class BibWatcher {
         return bibWatcher
     }
 
+    updateWatcherOptions() {
+        this.extension.manager.updateWatcherOptions(this.bibWatcher)
+    }
+
     private async onWatchedBibChanged(file: string) {
         this.extension.logger.addLogMessage(`Bib file watcher - file changed: ${file}`)
         await this.extension.completer.citation.parseBibFile(file)

--- a/src/components/managerlib/pdfwatcher.ts
+++ b/src/components/managerlib/pdfwatcher.ts
@@ -28,7 +28,7 @@ export class PdfWatcher {
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         const usePolling = configuration.get('latex.watch.usePolling') as boolean
         const interval = configuration.get('latex.watch.interval') as number
-        const pdfDelay = configuration.get('latex.watch.pdfDelay') as number
+        const pdfDelay = configuration.get('latex.watch.pdf.delay') as number
         const pdfWatcherOptions = {
             useFsEvents: false,
             usePolling,
@@ -42,6 +42,10 @@ export class PdfWatcher {
         pdfWatcher.on('change', (file: string) => this.onWatchedPdfChanged(file))
         pdfWatcher.on('unlink', (file: string) => this.onWatchedPdfDeleted(file))
         return pdfWatcher
+    }
+
+    updateWatcherOptions() {
+        this.extension.manager.updateWatcherOptions(this.pdfWatcher, true)
     }
 
     private isWatchedVirtualUri(pdfFile: vscode.Uri): boolean {

--- a/src/main.ts
+++ b/src/main.ts
@@ -146,7 +146,7 @@ export function deactivate() {
 }
 
 export function activate(context: vscode.ExtensionContext): ReturnType<typeof generateLatexWorkshopApi> {
-    const extension = new Extension()
+    const extension = new Extension(context)
     extensionToDispose = extension
     void vscode.commands.executeCommand('setContext', 'latex-workshop:enabled', true)
 
@@ -344,6 +344,7 @@ function registerProviders(extension: Extension, context: vscode.ExtensionContex
 
 export class Extension {
     readonly extensionRoot: string
+    readonly context: vscode.ExtensionContext
     readonly logger: Logger
     readonly eventBus = new EventBus()
     readonly lwfs: LwFileSystem
@@ -374,8 +375,9 @@ export class Extension {
     readonly mathPreviewPanel: MathPreviewPanel
     readonly duplicateLabels: DuplicateLabels
 
-    constructor() {
+    constructor(context: vscode.ExtensionContext) {
         this.extensionRoot = path.resolve(`${__dirname}/../../`)
+        this.context = context
         // We must create an instance of Logger first to enable
         // adding log messages during initialization.
         this.logger = new Logger()

--- a/src/providers/completer/argument.ts
+++ b/src/providers/completer/argument.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode'
 
 import type { Extension } from '../../main'
 import type { IProvider } from '../completion'
-import { CmdEnvSuggestion } from './completerutils'
+import { CmdEnvSuggestion, filterArgumentHint } from './completerutils'
 import { EnvSnippetType } from './environment'
 
 export class Argument implements IProvider {
@@ -52,11 +52,15 @@ export class Argument implements IProvider {
                 break
             }
         }
-        return candidate?.keyvals?.map(option => {
+        const suggestions = candidate?.keyvals?.map(option => {
             const item = new vscode.CompletionItem(option, vscode.CompletionItemKind.Constant)
             item.insertText = new vscode.SnippetString(option)
             return item
         }) || []
+
+        filterArgumentHint(suggestions)
+
+        return suggestions
     }
 
     private providePackageOptions(args: {document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken, context: vscode.CompletionContext}): vscode.CompletionItem[] {
@@ -67,12 +71,16 @@ export class Argument implements IProvider {
             return []
         }
         this.extension.completer.loadPackageData(match[1])
-        return this.extension.completer.package.getPackageOptions(match[1])
+        const suggestions = this.extension.completer.package.getPackageOptions(match[1])
             .map(option => {
                 const item = new vscode.CompletionItem(option, vscode.CompletionItemKind.Constant)
                 item.insertText = new vscode.SnippetString(option)
                 return item
             })
+
+        filterArgumentHint(suggestions)
+
+        return suggestions
     }
 
     private provideClassOptions(args: {document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken, context: vscode.CompletionContext}): vscode.CompletionItem[] {
@@ -84,12 +92,16 @@ export class Argument implements IProvider {
         }
         const isDefaultClass = ['article', 'report', 'book'].includes(match[1])
         this.extension.completer.loadPackageData(isDefaultClass ? 'latex-document' : `class-${match[1]}`)
-        return this.extension.completer.package.getPackageOptions(isDefaultClass ? 'latex-document' : `class-${match[1]}`)
+        const suggestions = this.extension.completer.package.getPackageOptions(isDefaultClass ? 'latex-document' : `class-${match[1]}`)
             .map(option => {
                 const item = new vscode.CompletionItem(option, vscode.CompletionItemKind.Constant)
                 item.insertText = new vscode.SnippetString(option)
                 return item
             })
+
+        filterArgumentHint(suggestions)
+
+        return suggestions
     }
 
     private getArgumentIndex(argstr: string) {

--- a/src/providers/completer/atsuggestion.ts
+++ b/src/providers/completer/atsuggestion.ts
@@ -26,11 +26,11 @@ export class AtSuggestion implements IProvider {
 
         const allSuggestions: {[key: string]: AtSuggestionItemEntry} = JSON.parse(fs.readFileSync(`${this.extension.extensionRoot}/data/at-suggestions.json`).toString()) as DataAtSuggestionJsonType
         this.initialize(allSuggestions)
-        vscode.workspace.onDidChangeConfiguration((e: vscode.ConfigurationChangeEvent) => {
+        this.extension.context.subscriptions.push(vscode.workspace.onDidChangeConfiguration((e: vscode.ConfigurationChangeEvent) => {
             if (e.affectsConfiguration('latex-workshop.intellisense.atSuggestionJSON.replace')) {
                 this.initialize(allSuggestions)
             }
-        })
+        }))
     }
 
     private initialize(suggestions: {[key: string]: AtSuggestionItemEntry}) {

--- a/src/providers/completer/command.ts
+++ b/src/providers/completer/command.ts
@@ -5,7 +5,7 @@ import {latexParser} from 'latex-utensils'
 import type { Extension } from '../../main'
 import type { IProvider, ICompletionItem } from '../completion'
 import {CommandFinder, isTriggerSuggestNeeded} from './commandlib/commandfinder'
-import {CmdEnvSuggestion, splitSignatureString, filterNonLetterSuggestions} from './completerutils'
+import {CmdEnvSuggestion, splitSignatureString, filterNonLetterSuggestions, filterArgumentHint} from './completerutils'
 import {CommandSignatureDuplicationDetector, CommandNameDuplicationDetector} from './commandlib/commandfinder'
 import {SurroundCommand} from './commandlib/surround'
 
@@ -154,6 +154,8 @@ export class Command implements IProvider {
             }
         })
 
+        filterArgumentHint(suggestions)
+
         return suggestions
     }
 
@@ -201,7 +203,6 @@ export class Command implements IProvider {
 
     private entryCmdToCompletion(itemKey: string, item: CmdType): CmdEnvSuggestion {
         item.command = item.command || itemKey
-        const configuration = vscode.workspace.getConfiguration('latex-workshop')
         const backslash = item.command.startsWith(' ') ? '' : '\\'
         const suggestion = new CmdEnvSuggestion(
             item.label || `${backslash}${item.command}`,
@@ -212,9 +213,6 @@ export class Command implements IProvider {
             vscode.CompletionItemKind.Function)
 
         if (item.snippet) {
-            if (!configuration.get('intellisense.argumentHint.enabled')) {
-                item.snippet = item.snippet.replace(/\$\{(\d+):[^$}]*\}/g, '$${$1}')
-            }
             // Wrap the selected text when there is a single placeholder
             if (! (item.snippet.match(/\$\{?2/) || (item.snippet.match(/\$\{?0/) && item.snippet.match(/\$\{?1/)))) {
                 item.snippet = item.snippet.replace(/\$1|\$\{1\}/, '$${1:$${TM_SELECTED_TEXT}}').replace(/\$\{1:([^$}]+)\}/, '$${1:$${TM_SELECTED_TEXT:$1}}')

--- a/src/providers/completer/completerutils.ts
+++ b/src/providers/completer/completerutils.ts
@@ -84,3 +84,18 @@ export function computeFilteringRange(document: vscode.TextDocument, position: v
     }
     return undefined
 }
+
+export function filterArgumentHint(suggestions: vscode.CompletionItem[]) {
+    if (!vscode.workspace.getConfiguration('latex-workshop').get('intellisense.argumentHint.enabled')) {
+        suggestions.forEach(item => {
+            if (!item.insertText) {
+                return
+            }
+            if (typeof item.insertText === 'string') {
+                item.insertText = item.insertText.replace(/\$\{(\d+):[^$}]*\}/g, '$${$1}')
+            } else {
+                item.insertText = new vscode.SnippetString(item.insertText.value.replace(/\$\{(\d+):[^$}]*\}/g, '$${$1}'))
+            }
+        })
+    }
+}

--- a/src/providers/completer/environment.ts
+++ b/src/providers/completer/environment.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode'
+import * as fs from 'fs'
 import {latexParser} from 'latex-utensils'
 
 import type { Extension } from '../../main'
@@ -6,6 +7,8 @@ import type { ICompletionItem } from '../completion'
 import type { IProvider } from '../completion'
 import {CommandSignatureDuplicationDetector} from './commandlib/commandfinder'
 import {CmdEnvSuggestion, splitSignatureString, filterNonLetterSuggestions, filterArgumentHint} from './completerutils'
+
+type DataEnvsJsonType = typeof import('../../../data/environments.json')
 
 export type EnvType = {
     name: string, // Name of the environment, what comes inside \begin{...}
@@ -37,7 +40,9 @@ export class Environment implements IProvider {
         this.extension = extension
     }
 
-    initialize(envs: {[key: string]: EnvType}) {
+    initialize() {
+        const defaultEnvs = fs.readFileSync(`${this.extension.extensionRoot}/data/environments.json`, {encoding: 'utf8'})
+        const envs: { [key: string]: EnvType } = JSON.parse(defaultEnvs) as DataEnvsJsonType
         this.defaultEnvsAsCommand = []
         this.defaultEnvsForBegin = []
         this.defaultEnvsAsName = []
@@ -46,6 +51,8 @@ export class Environment implements IProvider {
            this.defaultEnvsForBegin.push(this.entryEnvToCompletion(key, envs[key], EnvSnippetType.ForBegin))
            this.defaultEnvsAsName.push(this.entryEnvToCompletion(key, envs[key], EnvSnippetType.AsName))
         })
+
+        return this
     }
 
     /**

--- a/src/providers/completer/environment.ts
+++ b/src/providers/completer/environment.ts
@@ -5,7 +5,7 @@ import type { Extension } from '../../main'
 import type { ICompletionItem } from '../completion'
 import type { IProvider } from '../completion'
 import {CommandSignatureDuplicationDetector} from './commandlib/commandfinder'
-import {CmdEnvSuggestion, splitSignatureString, filterNonLetterSuggestions} from './completerutils'
+import {CmdEnvSuggestion, splitSignatureString, filterNonLetterSuggestions, filterArgumentHint} from './completerutils'
 
 export type EnvType = {
     name: string, // Name of the environment, what comes inside \begin{...}
@@ -134,6 +134,8 @@ export class Environment implements IProvider {
                 })
             }
         })
+
+        filterArgumentHint(suggestions)
 
         return suggestions
     }

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -6,7 +6,7 @@ import {Citation} from './completer/citation'
 import {DocumentClass} from './completer/documentclass'
 import {Command} from './completer/command'
 import type {CmdType} from './completer/command'
-import {Environment, EnvSnippetType} from './completer/environment'
+import {Environment} from './completer/environment'
 import type {EnvType} from './completer/environment'
 import { Argument } from './completer/argument'
 import {AtSuggestion} from './completer/atsuggestion'
@@ -17,11 +17,6 @@ import {Glossary} from './completer/glossary'
 import type {ReferenceDocType} from './completer/reference'
 import {escapeRegExp} from '../utils/utils'
 import {resolvePkgFile} from './completer/commandlib/commandfinder'
-
-type DataEnvsJsonType = typeof import('../../data/environments.json')
-type DataCmdsJsonType = typeof import('../../data/commands.json')
-type DataTeXJsonType = typeof import('../../data/packages/tex.json')
-
 
 export type PkgType = {includes: string[], cmds: {[key: string]: CmdType}, envs: {[key: string]: EnvType}, options: string[]}
 
@@ -115,24 +110,9 @@ export class Completer implements vscode.CompletionItemProvider {
     }
 
     private loadDefaultItems() {
-        const defaultEnvs = fs.readFileSync(`${this.extension.extensionRoot}/data/environments.json`, {encoding: 'utf8'})
-        const defaultCommands = fs.readFileSync(`${this.extension.extensionRoot}/data/commands.json`, {encoding: 'utf8'})
-        const defaultLaTeXMathSymbols = fs.readFileSync(`${this.extension.extensionRoot}/data/packages/tex.json`, {encoding: 'utf8'})
-        const env: { [key: string]: EnvType } = JSON.parse(defaultEnvs) as DataEnvsJsonType
-        const cmds = JSON.parse(defaultCommands) as DataCmdsJsonType
-        const maths: { [key: string]: CmdType } = (JSON.parse(defaultLaTeXMathSymbols) as DataTeXJsonType).cmds
-        for (const key of Object.keys(maths)) {
-            if (key.match(/\{.*?\}/)) {
-                const ent = maths[key]
-                const newKey = key.replace(/\{.*?\}/, '')
-                delete maths[key]
-                maths[newKey] = ent
-            }
-        }
-        Object.assign(maths, cmds)
         // Make sure to initialize environment first
-        this.environment.initialize(env)
-        this.command.initialize(maths, this.environment.getDefaultEnvs(EnvSnippetType.AsCommand))
+        const environment = this.environment.initialize()
+        this.command.initialize(environment)
     }
 
     provideCompletionItems(

--- a/test/suites/04_intellisense.test.ts
+++ b/test/suites/04_intellisense.test.ts
@@ -46,6 +46,7 @@ suite('Intellisense test suite', () => {
         await vscode.workspace.getConfiguration('latex-workshop').update('intellisense.citation.label', undefined)
         await vscode.workspace.getConfiguration('latex-workshop').update('intellisense.citation.format', undefined)
         await vscode.workspace.getConfiguration('latex-workshop').update('intellisense.label.keyval', undefined)
+        await vscode.workspace.getConfiguration('latex-workshop').update('intellisense.argumentHint.enabled', undefined)
 
         if (path.basename(fixture) === 'testground') {
             rimraf(fixture + '/{*,.vscode/*}', (e) => {if (e) {console.error(e)}})
@@ -146,6 +147,7 @@ suite('Intellisense test suite', () => {
             {src: 'intellisense_sub.tex', dst: 'sub/s.tex'}
         ])
         let result = await openActive(extension, fixture, 'main.tex')
+        await extension.manager.updateCompleter(path.resolve(fixture, 'main.tex'), result.doc.getText())
         let items = getIntellisense(result.doc, new vscode.Position(0, 1), extension)
         assert.ok(items)
         assert.ok(items.length > 0)
@@ -161,6 +163,7 @@ suite('Intellisense test suite', () => {
             {src: 'intellisense_glossaryentries.tex', dst: 'sub/glossary.tex'}
         ])
         result = await openActive(extension, fixture, 'main.tex')
+        await extension.manager.updateCompleter(path.resolve(fixture, 'main.tex'), result.doc.getText())
         items = getIntellisense(result.doc, new vscode.Position(0, 1), extension)
         assert.ok(items)
         assert.ok(items.length > 0)
@@ -168,6 +171,39 @@ suite('Intellisense test suite', () => {
         labels = items.map(item => item.label.toString())
         assert.ok(!labels.includes('\\includefrom{}{}'))
         assert.ok(labels.includes('\\gls{}'))
+    })
+
+    runTest({suiteName, fixtureName, testName: 'command intellisense with config `intellisense.argumentHint.enabled`'}, async () => {
+        await vscode.workspace.getConfiguration('latex-workshop').update('intellisense.argumentHint.enabled', true)
+        await loadTestFile(fixture, [
+            {src: 'intellisense_base.tex', dst: 'main.tex'},
+            {src: 'intellisense_sub.tex', dst: 'sub/s.tex'}
+        ])
+        const result = await openActive(extension, fixture, 'main.tex')
+        await extension.manager.updateCompleter(path.resolve(fixture, 'main.tex'), result.doc.getText())
+        let items = getIntellisense(result.doc, new vscode.Position(0, 1), extension)
+        assert.ok(items)
+        assert.ok(items.length > 0)
+
+        let labels = items.map(item => item.label.toString())
+        assert.ok(labels.includes('\\includefrom{}{}'))
+        let snippet = items.filter(item => item.label === '\\includefrom{}{}')[0].insertText
+        assert.ok(snippet)
+        assert.ok(typeof snippet !== 'string')
+        assert.ok(snippet.value.includes('${1:'))
+
+        await vscode.workspace.getConfiguration('latex-workshop').update('intellisense.argumentHint.enabled', false)
+        await extension.manager.updateCompleter(path.resolve(fixture, 'main.tex'), result.doc.getText())
+        items = getIntellisense(result.doc, new vscode.Position(0, 1), extension)
+        assert.ok(items)
+        assert.ok(items.length > 0)
+
+        labels = items.map(item => item.label.toString())
+        assert.ok(labels.includes('\\includefrom{}{}'))
+        snippet = items.filter(item => item.label === '\\includefrom{}{}')[0].insertText
+        assert.ok(snippet)
+        assert.ok(typeof snippet !== 'string')
+        assert.ok(!snippet.value.includes('${1:'))
     })
 
     runTest({suiteName, fixtureName, testName: 'reference intellisense and config intellisense.label.keyval'}, async () => {


### PR DESCRIPTION
This PR makes the following config items independent of vscode reload to take effect:

- `intellisense.triggers.latex`
- `intellisense.argumentHint.enabled`
- `intellisense.commandsJSON.replace`
- `latex.watch.usePolling`
- `latex.watch.interval`
- `latex.watch.delay`
- `latex.watch.pdf.delay`

This PR also resolves an issue where the original `latex.pdfWatch.delay` config does not work due to a typo in 897dd1813c6f1f7ef653315adaf0ff9eb909f556