### PR TITLE
Concise logger messages

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -8,7 +8,7 @@ Where LaTeX Workshop differs from other extensions of VS Code is in treating the
 
 ## Application Log
 
-When something goes wrong, we always add to log messages what went wrong with `Extension.logger.addLogMessage()`. It is much beneficial for debugging.
+When something goes wrong, we always add to log messages what went wrong with `Logger.log()`. It is much beneficial for debugging.
 
 ## VS Code filesystem and virtual workspaces
 

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -5,7 +5,11 @@ import * as path from 'path'
 import type {Extension} from './main'
 import {TeXDoc} from './components/texdoc'
 import {getSurroundingCommandRange} from './utils/utils'
-import * as logger from './components/logger'
+
+import { getLogger } from './components/logger'
+
+const logger = getLogger('Commander')
+
 type SnippetsLatexJsonType = typeof import('../snippets/latex.json')
 
 async function quickPickRootFile(rootFile: string, localRootFile: string): Promise<string | undefined> {
@@ -59,19 +63,19 @@ export class Commander {
                 Object.keys(snipObj).forEach(key => {
                     this.snippets.set(key, new vscode.SnippetString(snipObj[key]['body']))
                 })
-                logger.log('[Commander] Snippet data loaded.')
+                logger.log('Snippet data loaded.')
             })
-            .catch(err => logger.log(`[Commander] Error reading data: ${err}.`))
+            .catch(err => logger.log(`Error reading data: ${err}.`))
     }
 
     async build(skipSelection: boolean = false, rootFile: string | undefined = undefined, languageId: string | undefined = undefined, recipe: string | undefined = undefined) {
-        logger.log('[Commander] BUILD command invoked.')
+        logger.log('BUILD command invoked.')
         if (!vscode.window.activeTextEditor) {
-            logger.log('[Commander] Cannot start to build because the active editor is undefined.')
+            logger.log('Cannot start to build because the active editor is undefined.')
             return
         }
-        logger.log(`[Commander] The document of the active editor: ${vscode.window.activeTextEditor.document.uri.toString(true)}`)
-        logger.log(`[Commander] The languageId of the document: ${vscode.window.activeTextEditor.document.languageId}`)
+        logger.log(`The document of the active editor: ${vscode.window.activeTextEditor.document.uri.toString(true)}`)
+        logger.log(`The languageId of the document: ${vscode.window.activeTextEditor.document.languageId}`)
         const workspace = rootFile ? vscode.Uri.file(rootFile) : vscode.window.activeTextEditor.document.uri
         const configuration = vscode.workspace.getConfiguration('latex-workshop', workspace)
         const externalBuildCommand = configuration.get('latex.external.build.command') as string
@@ -86,7 +90,7 @@ export class Commander {
             return
         }
         if (rootFile === undefined || languageId === undefined) {
-            logger.log('[Commander] Cannot find LaTeX root file. See https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#the-root-file')
+            logger.log('Cannot find LaTeX root file. See https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#the-root-file')
             return
         }
         let pickedRootFile: string | undefined = rootFile
@@ -97,7 +101,7 @@ export class Commander {
                 return
             }
         }
-        logger.log(`[Commander] Building root file: ${pickedRootFile}`)
+        logger.log(`Building root file: ${pickedRootFile}`)
         await this.extension.builder.build(pickedRootFile, languageId, recipe)
     }
 
@@ -107,17 +111,17 @@ export class Commander {
             const workspaceFolder = vscode.workspace.workspaceFolders?.[0]
             const rootDir = this.extension.manager.rootDir || workspaceFolder?.uri.fsPath
             if (rootDir === undefined) {
-                logger.log(`[Commander] Cannot reveal ${vscode.Uri.file(outDir)}: no root dir can be identified.`)
+                logger.log(`Cannot reveal ${vscode.Uri.file(outDir)}: no root dir can be identified.`)
                 return
             }
             outDir = path.resolve(rootDir, outDir)
         }
-        logger.log(`[Commander] Reveal ${vscode.Uri.file(outDir)}`)
+        logger.log(`Reveal ${vscode.Uri.file(outDir)}`)
         await vscode.commands.executeCommand('revealFileInOS', vscode.Uri.file(outDir))
     }
 
     recipes(recipe?: string) {
-        logger.log('[Commander] RECIPES command invoked.')
+        logger.log('RECIPES command invoked.')
         const configuration = vscode.workspace.getConfiguration('latex-workshop', this.extension.manager.getWorkspaceFolderRootDir())
         const recipes = configuration.get('latex.recipes') as {name: string}[]
         if (!recipes) {
@@ -138,21 +142,21 @@ export class Commander {
 
     async view(mode?: 'tab' | 'browser' | 'external' | vscode.Uri) {
         if (mode) {
-            logger.log(`[Commander] VIEW command invoked with mode: ${mode}.`)
+            logger.log(`VIEW command invoked with mode: ${mode}.`)
         } else {
-            logger.log('[Commander] VIEW command invoked.')
+            logger.log('VIEW command invoked.')
         }
         if (!vscode.window.activeTextEditor) {
-            logger.log('[Commander] Cannot find active TextEditor.')
+            logger.log('Cannot find active TextEditor.')
             return
         }
         if (!this.extension.manager.hasTexId(vscode.window.activeTextEditor.document.languageId)) {
-            logger.log('[Commander] Active document is not a TeX file.')
+            logger.log('Active document is not a TeX file.')
             return
         }
         const rootFile = await this.extension.manager.findRoot()
         if (rootFile === undefined) {
-            logger.log('[Commander] Cannot find LaTeX root PDF to view.')
+            logger.log('Cannot find LaTeX root PDF to view.')
             return
         }
         let pickedRootFile: string | undefined = rootFile
@@ -178,17 +182,17 @@ export class Commander {
     }
 
     refresh() {
-        logger.log('[Commander] REFRESH command invoked.')
+        logger.log('REFRESH command invoked.')
         this.extension.viewer.refreshExistingViewer()
     }
 
     kill() {
-        logger.log('[Commander] KILL command invoked.')
+        logger.log('KILL command invoked.')
         this.extension.builder.kill()
     }
 
     pdf(uri: vscode.Uri | undefined) {
-        logger.log('[Commander] PDF command invoked.')
+        logger.log('PDF command invoked.')
         if (uri === undefined || !uri.fsPath.endsWith('.pdf')) {
             return
         }
@@ -196,9 +200,9 @@ export class Commander {
     }
 
     synctex() {
-        logger.log('[Commander] SYNCTEX command invoked.')
+        logger.log('SYNCTEX command invoked.')
         if (!vscode.window.activeTextEditor || !this.extension.manager.hasTexId(vscode.window.activeTextEditor.document.languageId)) {
-            logger.log('[Commander] Cannot start SyncTeX. The active editor is undefined, or the document is not a TeX document.')
+            logger.log('Cannot start SyncTeX. The active editor is undefined, or the document is not a TeX document.')
             return
         }
         const configuration = vscode.workspace.getConfiguration('latex-workshop', this.extension.manager.getWorkspaceFolderRootDir())
@@ -212,19 +216,19 @@ export class Commander {
     }
 
     synctexonref(line: number, filePath: string) {
-        logger.log('[Commander] SYNCTEX command invoked on a reference.')
+        logger.log('SYNCTEX command invoked on a reference.')
         if (!vscode.window.activeTextEditor || !this.extension.manager.hasTexId(vscode.window.activeTextEditor.document.languageId)) {
-            logger.log('[Commander] Cannot start SyncTeX. The active editor is undefined, or the document is not a TeX document.')
+            logger.log('Cannot start SyncTeX. The active editor is undefined, or the document is not a TeX document.')
             return
         }
         this.extension.locator.syncTeXOnRef({line, filePath})
     }
 
     async clean(): Promise<void> {
-        logger.log('[Commander] CLEAN command invoked.')
+        logger.log('CLEAN command invoked.')
         const rootFile = await this.extension.manager.findRoot()
         if (rootFile === undefined) {
-            logger.log('[Commander] Cannot find LaTeX root file to clean.')
+            logger.log('Cannot find LaTeX root file to clean.')
             return
         }
         let pickedRootFile: string | undefined = rootFile
@@ -239,7 +243,7 @@ export class Commander {
     }
 
     addTexRoot() {
-        logger.log('[Commander] ADDTEXROOT command invoked.')
+        logger.log('ADDTEXROOT command invoked.')
         if (!vscode.window.activeTextEditor || !this.extension.manager.hasTexId(vscode.window.activeTextEditor.document.languageId)) {
             return
         }
@@ -247,18 +251,18 @@ export class Commander {
     }
 
     citation() {
-        logger.log('[Commander] CITATION command invoked.')
+        logger.log('CITATION command invoked.')
         this.extension.completer.citation.browser()
     }
 
     wordcount() {
-        logger.log('[Commander] WORDCOUNT command invoked.')
+        logger.log('WORDCOUNT command invoked.')
         if (!vscode.window.activeTextEditor || !this.extension.manager.hasTexId(vscode.window.activeTextEditor.document.languageId) ||
             this.extension.manager.rootFile === vscode.window.activeTextEditor.document.fileName) {
             if (this.extension.manager.rootFile) {
                 this.extension.counter.count(this.extension.manager.rootFile)
             } else {
-                logger.log('[Commander] WORDCOUNT: No rootFile defined.')
+                logger.log('WORDCOUNT: No rootFile defined.')
             }
         } else {
             this.extension.counter.count(vscode.window.activeTextEditor.document.fileName, false)
@@ -266,7 +270,7 @@ export class Commander {
     }
 
     showLog(compiler?: string) {
-        logger.log(`[Commander] SHOWLOG command invoked: ${compiler || 'default'}`)
+        logger.log(`SHOWLOG command invoked: ${compiler || 'default'}`)
         if (compiler) {
             logger.showCompilerLog()
         } else {
@@ -275,7 +279,7 @@ export class Commander {
     }
 
     gotoSection(filePath: string, lineNumber: number) {
-        logger.log(`[Commander] GOTOSECTION command invoked. Target ${filePath}, line ${lineNumber}`)
+        logger.log(`GOTOSECTION command invoked. Target ${filePath}, line ${lineNumber}`)
         const activeEditor = vscode.window.activeTextEditor
 
         void vscode.workspace.openTextDocument(filePath).then((doc) => {
@@ -291,7 +295,7 @@ export class Commander {
     }
 
     navigateToEnvPair() {
-        logger.log('[Commander] JumpToEnvPair command invoked.')
+        logger.log('JumpToEnvPair command invoked.')
         if (!vscode.window.activeTextEditor || !this.extension.manager.hasTexId(vscode.window.activeTextEditor.document.languageId)) {
             return
         }
@@ -299,7 +303,7 @@ export class Commander {
     }
 
     selectEnvContent() {
-        logger.log('[Commander] SelectEnv command invoked.')
+        logger.log('SelectEnv command invoked.')
         if (!vscode.window.activeTextEditor || !this.extension.manager.hasTexId(vscode.window.activeTextEditor.document.languageId)) {
             return
         }
@@ -307,7 +311,7 @@ export class Commander {
     }
 
     selectEnvName() {
-        logger.log('[Commander] SelectEnvName command invoked.')
+        logger.log('SelectEnvName command invoked.')
         if (!vscode.window.activeTextEditor || !this.extension.manager.hasTexId(vscode.window.activeTextEditor.document.languageId)) {
             return
         }
@@ -315,7 +319,7 @@ export class Commander {
     }
 
     multiCursorEnvName() {
-        logger.log('[Commander] MutliCursorEnvName command invoked.')
+        logger.log('MutliCursorEnvName command invoked.')
         if (!vscode.window.activeTextEditor || !this.extension.manager.hasTexId(vscode.window.activeTextEditor.document.languageId)) {
             return
         }
@@ -323,7 +327,7 @@ export class Commander {
     }
 
     toggleEquationEnv() {
-        logger.log('[Commander] toggleEquationEnv command invoked.')
+        logger.log('toggleEquationEnv command invoked.')
         if (!vscode.window.activeTextEditor || !this.extension.manager.hasTexId(vscode.window.activeTextEditor.document.languageId)) {
             return
         }
@@ -331,7 +335,7 @@ export class Commander {
     }
 
     closeEnv() {
-        logger.log('[Commander] CloseEnv command invoked.')
+        logger.log('CloseEnv command invoked.')
         if (!vscode.window.activeTextEditor || !this.extension.manager.hasTexId(vscode.window.activeTextEditor.document.languageId)) {
             return
         }
@@ -339,7 +343,7 @@ export class Commander {
     }
 
     actions() {
-        logger.log('[Commander] ACTIONS command invoked.')
+        logger.log('ACTIONS command invoked.')
         return vscode.commands.executeCommand('workbench.view.extension.latex-workshop-activitybar').then(() => vscode.commands.executeCommand('workbench.action.focusActiveEditorGroup'))
     }
 
@@ -468,7 +472,7 @@ export class Commander {
                 })
             })
         } else {
-            logger.log('[Commander] toggleSelectedKeyword: cannot handle mixed edit and snippet actions')
+            logger.log('toggleSelectedKeyword: cannot handle mixed edit and snippet actions')
         }
     }
 

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -59,19 +59,19 @@ export class Commander {
                 Object.keys(snipObj).forEach(key => {
                     this.snippets.set(key, new vscode.SnippetString(snipObj[key]['body']))
                 })
-                logger.log('Snippet data loaded.')
+                logger.log('[Commander] Snippet data loaded.')
             })
-            .catch(err => logger.log(`Error reading data: ${err}.`))
+            .catch(err => logger.log(`[Commander] Error reading data: ${err}.`))
     }
 
     async build(skipSelection: boolean = false, rootFile: string | undefined = undefined, languageId: string | undefined = undefined, recipe: string | undefined = undefined) {
-        logger.log('BUILD command invoked.')
+        logger.log('[Commander] BUILD command invoked.')
         if (!vscode.window.activeTextEditor) {
-            logger.log('Cannot start to build because the active editor is undefined.')
+            logger.log('[Commander] Cannot start to build because the active editor is undefined.')
             return
         }
-        logger.log(`The document of the active editor: ${vscode.window.activeTextEditor.document.uri.toString(true)}`)
-        logger.log(`The languageId of the document: ${vscode.window.activeTextEditor.document.languageId}`)
+        logger.log(`[Commander] The document of the active editor: ${vscode.window.activeTextEditor.document.uri.toString(true)}`)
+        logger.log(`[Commander] The languageId of the document: ${vscode.window.activeTextEditor.document.languageId}`)
         const workspace = rootFile ? vscode.Uri.file(rootFile) : vscode.window.activeTextEditor.document.uri
         const configuration = vscode.workspace.getConfiguration('latex-workshop', workspace)
         const externalBuildCommand = configuration.get('latex.external.build.command') as string
@@ -86,7 +86,7 @@ export class Commander {
             return
         }
         if (rootFile === undefined || languageId === undefined) {
-            logger.log('Cannot find LaTeX root file. See https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#the-root-file')
+            logger.log('[Commander] Cannot find LaTeX root file. See https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#the-root-file')
             return
         }
         let pickedRootFile: string | undefined = rootFile
@@ -97,7 +97,7 @@ export class Commander {
                 return
             }
         }
-        logger.log(`Building root file: ${pickedRootFile}`)
+        logger.log(`[Commander] Building root file: ${pickedRootFile}`)
         await this.extension.builder.build(pickedRootFile, languageId, recipe)
     }
 
@@ -107,17 +107,17 @@ export class Commander {
             const workspaceFolder = vscode.workspace.workspaceFolders?.[0]
             const rootDir = this.extension.manager.rootDir || workspaceFolder?.uri.fsPath
             if (rootDir === undefined) {
-                logger.log(`Cannot reveal ${vscode.Uri.file(outDir)}: no root dir can be identified.`)
+                logger.log(`[Commander] Cannot reveal ${vscode.Uri.file(outDir)}: no root dir can be identified.`)
                 return
             }
             outDir = path.resolve(rootDir, outDir)
         }
-        logger.log(`Reveal ${vscode.Uri.file(outDir)}`)
+        logger.log(`[Commander] Reveal ${vscode.Uri.file(outDir)}`)
         await vscode.commands.executeCommand('revealFileInOS', vscode.Uri.file(outDir))
     }
 
     recipes(recipe?: string) {
-        logger.log('RECIPES command invoked.')
+        logger.log('[Commander] RECIPES command invoked.')
         const configuration = vscode.workspace.getConfiguration('latex-workshop', this.extension.manager.getWorkspaceFolderRootDir())
         const recipes = configuration.get('latex.recipes') as {name: string}[]
         if (!recipes) {
@@ -138,21 +138,21 @@ export class Commander {
 
     async view(mode?: 'tab' | 'browser' | 'external' | vscode.Uri) {
         if (mode) {
-            logger.log(`VIEW command invoked with mode: ${mode}.`)
+            logger.log(`[Commander] VIEW command invoked with mode: ${mode}.`)
         } else {
-            logger.log('VIEW command invoked.')
+            logger.log('[Commander] VIEW command invoked.')
         }
         if (!vscode.window.activeTextEditor) {
-            logger.log('Cannot find active TextEditor.')
+            logger.log('[Commander] Cannot find active TextEditor.')
             return
         }
         if (!this.extension.manager.hasTexId(vscode.window.activeTextEditor.document.languageId)) {
-            logger.log('Active document is not a TeX file.')
+            logger.log('[Commander] Active document is not a TeX file.')
             return
         }
         const rootFile = await this.extension.manager.findRoot()
         if (rootFile === undefined) {
-            logger.log('Cannot find LaTeX root PDF to view.')
+            logger.log('[Commander] Cannot find LaTeX root PDF to view.')
             return
         }
         let pickedRootFile: string | undefined = rootFile
@@ -178,17 +178,17 @@ export class Commander {
     }
 
     refresh() {
-        logger.log('REFRESH command invoked.')
+        logger.log('[Commander] REFRESH command invoked.')
         this.extension.viewer.refreshExistingViewer()
     }
 
     kill() {
-        logger.log('KILL command invoked.')
+        logger.log('[Commander] KILL command invoked.')
         this.extension.builder.kill()
     }
 
     pdf(uri: vscode.Uri | undefined) {
-        logger.log('PDF command invoked.')
+        logger.log('[Commander] PDF command invoked.')
         if (uri === undefined || !uri.fsPath.endsWith('.pdf')) {
             return
         }
@@ -196,9 +196,9 @@ export class Commander {
     }
 
     synctex() {
-        logger.log('SYNCTEX command invoked.')
+        logger.log('[Commander] SYNCTEX command invoked.')
         if (!vscode.window.activeTextEditor || !this.extension.manager.hasTexId(vscode.window.activeTextEditor.document.languageId)) {
-            logger.log('Cannot start SyncTeX. The active editor is undefined, or the document is not a TeX document.')
+            logger.log('[Commander] Cannot start SyncTeX. The active editor is undefined, or the document is not a TeX document.')
             return
         }
         const configuration = vscode.workspace.getConfiguration('latex-workshop', this.extension.manager.getWorkspaceFolderRootDir())
@@ -212,19 +212,19 @@ export class Commander {
     }
 
     synctexonref(line: number, filePath: string) {
-        logger.log('SYNCTEX command invoked on a reference.')
+        logger.log('[Commander] SYNCTEX command invoked on a reference.')
         if (!vscode.window.activeTextEditor || !this.extension.manager.hasTexId(vscode.window.activeTextEditor.document.languageId)) {
-            logger.log('Cannot start SyncTeX. The active editor is undefined, or the document is not a TeX document.')
+            logger.log('[Commander] Cannot start SyncTeX. The active editor is undefined, or the document is not a TeX document.')
             return
         }
         this.extension.locator.syncTeXOnRef({line, filePath})
     }
 
     async clean(): Promise<void> {
-        logger.log('CLEAN command invoked.')
+        logger.log('[Commander] CLEAN command invoked.')
         const rootFile = await this.extension.manager.findRoot()
         if (rootFile === undefined) {
-            logger.log('Cannot find LaTeX root file to clean.')
+            logger.log('[Commander] Cannot find LaTeX root file to clean.')
             return
         }
         let pickedRootFile: string | undefined = rootFile
@@ -239,7 +239,7 @@ export class Commander {
     }
 
     addTexRoot() {
-        logger.log('ADDTEXROOT command invoked.')
+        logger.log('[Commander] ADDTEXROOT command invoked.')
         if (!vscode.window.activeTextEditor || !this.extension.manager.hasTexId(vscode.window.activeTextEditor.document.languageId)) {
             return
         }
@@ -247,18 +247,18 @@ export class Commander {
     }
 
     citation() {
-        logger.log('CITATION command invoked.')
+        logger.log('[Commander] CITATION command invoked.')
         this.extension.completer.citation.browser()
     }
 
     wordcount() {
-        logger.log('WORDCOUNT command invoked.')
+        logger.log('[Commander] WORDCOUNT command invoked.')
         if (!vscode.window.activeTextEditor || !this.extension.manager.hasTexId(vscode.window.activeTextEditor.document.languageId) ||
             this.extension.manager.rootFile === vscode.window.activeTextEditor.document.fileName) {
             if (this.extension.manager.rootFile) {
                 this.extension.counter.count(this.extension.manager.rootFile)
             } else {
-                logger.log('WORDCOUNT: No rootFile defined.')
+                logger.log('[Commander] WORDCOUNT: No rootFile defined.')
             }
         } else {
             this.extension.counter.count(vscode.window.activeTextEditor.document.fileName, false)
@@ -266,7 +266,7 @@ export class Commander {
     }
 
     showLog(compiler?: string) {
-        logger.log(`SHOWLOG command invoked: ${compiler || 'default'}`)
+        logger.log(`[Commander] SHOWLOG command invoked: ${compiler || 'default'}`)
         if (compiler) {
             logger.showCompilerLog()
         } else {
@@ -275,7 +275,7 @@ export class Commander {
     }
 
     gotoSection(filePath: string, lineNumber: number) {
-        logger.log(`GOTOSECTION command invoked. Target ${filePath}, line ${lineNumber}`)
+        logger.log(`[Commander] GOTOSECTION command invoked. Target ${filePath}, line ${lineNumber}`)
         const activeEditor = vscode.window.activeTextEditor
 
         void vscode.workspace.openTextDocument(filePath).then((doc) => {
@@ -291,7 +291,7 @@ export class Commander {
     }
 
     navigateToEnvPair() {
-        logger.log('JumpToEnvPair command invoked.')
+        logger.log('[Commander] JumpToEnvPair command invoked.')
         if (!vscode.window.activeTextEditor || !this.extension.manager.hasTexId(vscode.window.activeTextEditor.document.languageId)) {
             return
         }
@@ -299,7 +299,7 @@ export class Commander {
     }
 
     selectEnvContent() {
-        logger.log('SelectEnv command invoked.')
+        logger.log('[Commander] SelectEnv command invoked.')
         if (!vscode.window.activeTextEditor || !this.extension.manager.hasTexId(vscode.window.activeTextEditor.document.languageId)) {
             return
         }
@@ -307,7 +307,7 @@ export class Commander {
     }
 
     selectEnvName() {
-        logger.log('SelectEnvName command invoked.')
+        logger.log('[Commander] SelectEnvName command invoked.')
         if (!vscode.window.activeTextEditor || !this.extension.manager.hasTexId(vscode.window.activeTextEditor.document.languageId)) {
             return
         }
@@ -315,7 +315,7 @@ export class Commander {
     }
 
     multiCursorEnvName() {
-        logger.log('MutliCursorEnvName command invoked.')
+        logger.log('[Commander] MutliCursorEnvName command invoked.')
         if (!vscode.window.activeTextEditor || !this.extension.manager.hasTexId(vscode.window.activeTextEditor.document.languageId)) {
             return
         }
@@ -323,7 +323,7 @@ export class Commander {
     }
 
     toggleEquationEnv() {
-        logger.log('toggleEquationEnv command invoked.')
+        logger.log('[Commander] toggleEquationEnv command invoked.')
         if (!vscode.window.activeTextEditor || !this.extension.manager.hasTexId(vscode.window.activeTextEditor.document.languageId)) {
             return
         }
@@ -331,7 +331,7 @@ export class Commander {
     }
 
     closeEnv() {
-        logger.log('CloseEnv command invoked.')
+        logger.log('[Commander] CloseEnv command invoked.')
         if (!vscode.window.activeTextEditor || !this.extension.manager.hasTexId(vscode.window.activeTextEditor.document.languageId)) {
             return
         }
@@ -339,7 +339,7 @@ export class Commander {
     }
 
     actions() {
-        logger.log('ACTIONS command invoked.')
+        logger.log('[Commander] ACTIONS command invoked.')
         return vscode.commands.executeCommand('workbench.view.extension.latex-workshop-activitybar').then(() => vscode.commands.executeCommand('workbench.action.focusActiveEditorGroup'))
     }
 
@@ -468,7 +468,7 @@ export class Commander {
                 })
             })
         } else {
-            logger.log('toggleSelectedKeyword: cannot handle mixed edit and snippet actions')
+            logger.log('[Commander] toggleSelectedKeyword: cannot handle mixed edit and snippet actions')
         }
     }
 

--- a/src/components/builder.ts
+++ b/src/components/builder.ts
@@ -7,6 +7,7 @@ import * as cs from 'cross-spawn'
 import type { Extension } from '../main'
 import { replaceArgumentPlaceholders } from '../utils/utils'
 import { BuildDone } from './eventbus'
+import { Logger } from './logger'
 
 const enum BuildEvents {
     never = 'never',
@@ -34,10 +35,10 @@ export class Builder {
             const pdflatexVersion = cp.execSync('pdflatex --version')
             if (pdflatexVersion.toString().match(/MiKTeX/)) {
                 this.isMiktex = true
-                this.extension.logger.addLogMessage('pdflatex is provided by MiKTeX')
+                Logger.log('pdflatex is provided by MiKTeX')
             }
         } catch (e) {
-            this.extension.logger.addLogMessage('Cannot run pdflatex to determine if we are using MiKTeX')
+            Logger.log('Cannot run pdflatex to determine if we are using MiKTeX')
         }
     }
 
@@ -51,12 +52,12 @@ export class Builder {
      */
     kill() {
         if (this.process === undefined) {
-            this.extension.logger.addLogMessage('LaTeX build process to kill is not found.')
+            Logger.log('LaTeX build process to kill is not found.')
             return
         }
         const pid = this.process.pid
         try {
-            this.extension.logger.addLogMessage(`Kill child processes of the current process. PPID: ${pid}`)
+            Logger.log(`Kill child processes of the current process. PPID: ${pid}`)
             if (process.platform === 'linux' || process.platform === 'darwin') {
                 cp.execSync(`pkill -P ${pid}`, { timeout: 1000 })
             } else if (process.platform === 'win32') {
@@ -64,12 +65,12 @@ export class Builder {
             }
         } catch (e) {
             if (e instanceof Error) {
-                this.extension.logger.addLogMessage(`Error when killing child processes of the current process. ${e.message}`)
+                Logger.log(`Error when killing child processes of the current process. ${e.message}`)
             }
         } finally {
             this.stepQueue.clear()
             this.process.kill()
-            this.extension.logger.addLogMessage(`Kill the current process. PID: ${pid}`)
+            Logger.log(`Kill the current process. PID: ${pid}`)
         }
     }
 
@@ -78,7 +79,7 @@ export class Builder {
         if (configuration.get('latex.autoBuild.run') as string !== BuildEvents.onFileChange) {
             return
         }
-        this.extension.logger.addLogMessage(`Auto build started detecting the change of a file: ${file}`)
+        Logger.log(`Auto build started detecting the change of a file: ${file}`)
         return this.invokeBuild(file, bibChanged)
     }
 
@@ -87,13 +88,13 @@ export class Builder {
         if (configuration.get('latex.autoBuild.run') as string !== BuildEvents.onSave) {
             return
         }
-        this.extension.logger.addLogMessage(`Auto build started on saving file: ${file}`)
+        Logger.log(`Auto build started on saving file: ${file}`)
         return this.invokeBuild(file, false)
     }
 
     private invokeBuild(file: string, bibChanged: boolean ) {
         if (!this.extension.builder.canAutoBuild()) {
-            this.extension.logger.addLogMessage('Auto Build Run is temporarily disabled for `latex.autoBuild.interval`.')
+            Logger.log('Auto Build Run is temporarily disabled for `latex.autoBuild.interval`.')
             return
         }
         const configuration = vscode.workspace.getConfiguration('latex-workshop', vscode.Uri.file(file))
@@ -119,7 +120,7 @@ export class Builder {
      */
     async buildExternal(command: string, args: string[], pwd: string, rootFile?: string) {
         if (this.building) {
-            void this.extension.logger.showErrorMessageWithCompilerLogButton('Please wait for the current build to finish.')
+            void Logger.showErrorMessageWithCompilerLogButton('Please wait for the current build to finish.')
             return
         }
 
@@ -156,7 +157,7 @@ export class Builder {
      * builder tries to determine on its own, in {@link createBuildTools}.
      */
     async build(rootFile: string, langId: string, recipeName?: string) {
-        this.extension.logger.addLogMessage(`Build root file ${rootFile}`)
+        Logger.log(`Build root file ${rootFile}`)
 
         this.lastBuild = Date.now()
 
@@ -171,7 +172,7 @@ export class Builder {
         const tools = this.createBuildTools(rootFile, langId, recipeName)
 
         if (tools === undefined) {
-            this.extension.logger.addLogMessage('Invalid toolchain.')
+            Logger.log('Invalid toolchain.')
             return
         }
         const timestamp = Date.now()
@@ -242,12 +243,12 @@ export class Builder {
     private spawnProcess(step: Step, cwd?: string): ProcessEnv {
         const configuration = vscode.workspace.getConfiguration('latex-workshop', step.rootFile ? vscode.Uri.file(step.rootFile) : undefined)
         if (step.index === 0 || configuration.get('latex.build.clearLog.everyRecipeStep.enabled') as boolean) {
-            this.extension.logger.clearCompilerMessage()
+            Logger.clearCompilerMessage()
         }
-        this.extension.logger.displayStatus('sync~spin', 'statusBar.foreground', undefined, undefined, ' ' + this.stepQueue.getStepString(step))
-        this.extension.logger.logCommand(`Recipe step ${step.index + 1}`, step.command, step.args)
-        this.extension.logger.addLogMessage(`Recipe step env: ${JSON.stringify(step.env)}`)
-        this.extension.logger.addLogMessage(`Recipe step root file: ${step.rootFile}`)
+        Logger.displayStatus('sync~spin', 'statusBar.foreground', undefined, undefined, ' ' + this.stepQueue.getStepString(step))
+        Logger.logCommand(`Recipe step ${step.index + 1}`, step.command, step.args)
+        Logger.log(`Recipe step env: ${JSON.stringify(step.env)}`)
+        Logger.log(`Recipe step root file: ${step.rootFile}`)
 
         const env = Object.create(null) as ProcessEnv
         Object.keys(process.env).forEach(key => env[key] = process.env[key])
@@ -260,7 +261,7 @@ export class Builder {
         if (!step.isExternal &&
             (step.name.startsWith(this.TEX_MAGIC_PROGRAM_NAME) ||
              step.name.startsWith(this.BIB_MAGIC_PROGRAM_NAME))) {
-            this.extension.logger.addLogMessage(`cwd: ${path.dirname(step.rootFile)}`)
+            Logger.log(`cwd: ${path.dirname(step.rootFile)}`)
 
             const args = step.args
             if (args && !step.name.endsWith(this.MAGIC_PROGRAM_ARGS_SUFFIX)) {
@@ -278,14 +279,14 @@ export class Builder {
             } else {
                 cwd = path.dirname(step.rootFile)
             }
-            this.extension.logger.addLogMessage(`cwd: ${cwd}`)
+            Logger.log(`cwd: ${cwd}`)
             this.process = cs.spawn(step.command, step.args, {cwd, env})
         } else {
-            this.extension.logger.logCommand('Build using external command', step.command, step.args)
-            this.extension.logger.addLogMessage(`cwd: ${step.cwd}`)
+            Logger.logCommand('Build using external command', step.command, step.args)
+            Logger.log(`cwd: ${step.cwd}`)
             this.process = cs.spawn(step.command, step.args, {cwd: step.cwd})
         }
-        this.extension.logger.addLogMessage(`LaTeX build process spawned. PID: ${this.process.pid}.`)
+        Logger.log(`LaTeX build process spawned. PID: ${this.process.pid}.`)
         return env
     }
 
@@ -317,13 +318,13 @@ export class Builder {
         let stdout = ''
         this.process.stdout.on('data', (msg: Buffer | string) => {
             stdout += msg
-            this.extension.logger.addCompilerMessage(msg.toString())
+            Logger.addCompilerMessage(msg.toString())
         })
 
         let stderr = ''
         this.process.stderr.on('data', (msg: Buffer | string) => {
             stderr += msg
-            this.extension.logger.addCompilerMessage(msg.toString())
+            Logger.addCompilerMessage(msg.toString())
         })
 
         const result: boolean = await new Promise(resolve => {
@@ -332,12 +333,12 @@ export class Builder {
                 return
             }
             this.process.on('error', err => {
-                this.extension.logger.addLogMessage(`LaTeX fatal error: ${err.message}, ${stderr}. PID: ${this.process?.pid}.`)
-                this.extension.logger.addLogMessage(`Does the executable exist? $PATH: ${env['PATH']}`)
-                this.extension.logger.addLogMessage(`Does the executable exist? $Path: ${env['Path']}`)
-                this.extension.logger.addLogMessage(`The environment variable $SHELL: ${process.env.SHELL}`)
-                this.extension.logger.displayStatus('x', 'errorForeground', undefined, 'error')
-                void this.extension.logger.showErrorMessageWithExtensionLogButton(`Recipe terminated with fatal error: ${err.message}.`)
+                Logger.log(`LaTeX fatal error: ${err.message}, ${stderr}. PID: ${this.process?.pid}.`)
+                Logger.log(`Does the executable exist? $PATH: ${env['PATH']}`)
+                Logger.log(`Does the executable exist? $Path: ${env['Path']}`)
+                Logger.log(`The environment variable $SHELL: ${process.env.SHELL}`)
+                Logger.displayStatus('x', 'errorForeground', undefined, 'error')
+                void Logger.showErrorMessageWithExtensionLogButton(`Recipe terminated with fatal error: ${err.message}.`)
                 this.process = undefined
                 this.stepQueue.clear()
                 resolve(false)
@@ -346,13 +347,13 @@ export class Builder {
             this.process.on('exit', async (code, signal) => {
                 this.extension.compilerLogParser.parse(stdout, step.rootFile)
                 if (!step.isExternal && code === 0) {
-                    this.extension.logger.addLogMessage(`A step in recipe finished. PID: ${this.process?.pid}.`)
+                    Logger.log(`A step in recipe finished. PID: ${this.process?.pid}.`)
                     this.process = undefined
                     resolve(true)
                     return
                 } else if (code === 0) {
-                    this.extension.logger.addLogMessage(`Successfully built. PID: ${this.process?.pid}`)
-                    this.extension.logger.displayStatus('check', 'statusBar.foreground', 'Build succeeded.')
+                    Logger.log(`Successfully built. PID: ${this.process?.pid}`)
+                    Logger.displayStatus('check', 'statusBar.foreground', 'Build succeeded.')
                     if (step.rootFile === undefined) {
                         this.extension.viewer.refreshExistingViewer()
                     }
@@ -362,38 +363,38 @@ export class Builder {
                 }
 
                 if (!step.isExternal) {
-                    this.extension.logger.addLogMessage(`Recipe returns with error: ${code}/${signal}. PID: ${this.process?.pid}. message: ${stderr}.`)
-                    this.extension.logger.addLogMessage(`Does the executable exist? $PATH: ${env['PATH']}`)
-                    this.extension.logger.addLogMessage(`Does the executable exist? $Path: ${env['Path']}`)
-                    this.extension.logger.addLogMessage(`The environment variable $SHELL: ${process.env.SHELL}`)
+                    Logger.log(`Recipe returns with error: ${code}/${signal}. PID: ${this.process?.pid}. message: ${stderr}.`)
+                    Logger.log(`Does the executable exist? $PATH: ${env['PATH']}`)
+                    Logger.log(`Does the executable exist? $Path: ${env['Path']}`)
+                    Logger.log(`The environment variable $SHELL: ${process.env.SHELL}`)
                 }
 
                 const configuration = vscode.workspace.getConfiguration('latex-workshop', step.rootFile ? vscode.Uri.file(step.rootFile) : undefined)
                 if (!step.isExternal && signal !== 'SIGTERM' && !step.isRetry && configuration.get('latex.autoBuild.cleanAndRetry.enabled')) {
                     // Recipe, not terminated by user, is not retry and should retry
                     step.isRetry = true
-                    this.extension.logger.displayStatus('x', 'errorForeground', 'Recipe terminated with error. Retry building the project.', 'warning')
-                    this.extension.logger.addLogMessage('Cleaning auxiliary files and retrying build after toolchain error.')
+                    Logger.displayStatus('x', 'errorForeground', 'Recipe terminated with error. Retry building the project.', 'warning')
+                    Logger.log('Cleaning auxiliary files and retrying build after toolchain error.')
 
                     this.stepQueue.prepend(step)
                     await this.extension.cleaner.clean(step.rootFile)
                 } else if (!step.isExternal && signal !== 'SIGTERM') {
                     // Recipe, not terminated by user, is retry or should not retry
-                    this.extension.logger.displayStatus('x', 'errorForeground')
+                    Logger.displayStatus('x', 'errorForeground')
                     if (['onFailed', 'onBuilt'].includes(configuration.get('latex.autoClean.run') as string)) {
                         await this.extension.cleaner.clean(step.rootFile)
                     }
-                    void this.extension.logger.showErrorMessageWithCompilerLogButton('Recipe terminated with error.')
+                    void Logger.showErrorMessageWithCompilerLogButton('Recipe terminated with error.')
                     this.stepQueue.clear()
                 } else if (step.isExternal) {
                     // External command
-                    this.extension.logger.addLogMessage(`Build returns with error: ${code}/${signal}. PID: ${this.process?.pid}.`)
-                    this.extension.logger.displayStatus('x', 'errorForeground', undefined, 'warning')
-                    void this.extension.logger.showErrorMessageWithCompilerLogButton('Build terminated with error.')
+                    Logger.log(`Build returns with error: ${code}/${signal}. PID: ${this.process?.pid}.`)
+                    Logger.displayStatus('x', 'errorForeground', undefined, 'warning')
+                    void Logger.showErrorMessageWithCompilerLogButton('Build terminated with error.')
                     this.stepQueue.clear()
                 } else {
                     // Terminated by user
-                    this.extension.logger.displayStatus('x', 'errorForeground')
+                    Logger.displayStatus('x', 'errorForeground')
                     this.stepQueue.clear()
                 }
                 this.process = undefined
@@ -416,8 +417,8 @@ export class Builder {
             // This only happens when the step is an external command.
             return
         }
-        this.extension.logger.addLogMessage(`Successfully built ${step.rootFile}.`)
-        this.extension.logger.displayStatus('check', 'statusBar.foreground', 'Recipe succeeded.')
+        Logger.log(`Successfully built ${step.rootFile}.`)
+        Logger.displayStatus('check', 'statusBar.foreground', 'Recipe succeeded.')
         this.extension.eventBus.fire(BuildDone)
         if (this.extension.compilerLogParser.isLaTeXmkSkipped) {
             return
@@ -429,11 +430,11 @@ export class Builder {
         // If the PDF viewer is internal, we call SyncTeX in src/components/viewer.ts.
         if (configuration.get('view.pdf.viewer') === 'external' && configuration.get('synctex.afterBuild.enabled')) {
             const pdfFile = this.extension.manager.tex2pdf(step.rootFile)
-            this.extension.logger.addLogMessage('SyncTex after build invoked.')
+            Logger.log('SyncTex after build invoked.')
             this.extension.locator.syncTeX(undefined, undefined, pdfFile)
         }
         if (configuration.get('latex.autoClean.run') as string === 'onBuilt') {
-            this.extension.logger.addLogMessage('Auto Clean invoked.')
+            Logger.log('Auto Clean invoked.')
             await this.extension.cleaner.clean(step.rootFile)
         }
     }
@@ -454,7 +455,7 @@ export class Builder {
             if (recipe === undefined) {
                 return undefined
             }
-            this.extension.logger.addLogMessage(`Preparing to run recipe: ${recipe.name}`)
+            Logger.log(`Preparing to run recipe: ${recipe.name}`)
             this.prevRecipe = recipe
             this.prevLangId = langId
             const tools = configuration.get('latex.tools') as Tool[]
@@ -462,8 +463,8 @@ export class Builder {
                 if (typeof tool === 'string') {
                     const candidates = tools.filter(candidate => candidate.name === tool)
                     if (candidates.length < 1) {
-                        this.extension.logger.addLogMessage(`Skipping undefined tool: ${tool} in ${recipe.name}`)
-                        void this.extension.logger.showErrorMessage(`Skipping undefined tool "${tool}" in recipe "${recipe.name}."`)
+                        Logger.log(`Skipping undefined tool: ${tool} in ${recipe.name}`)
+                        void Logger.showErrorMessage(`Skipping undefined tool "${tool}" in recipe "${recipe.name}."`)
                     } else {
                         buildTools.push(candidates[0])
                     }
@@ -496,7 +497,7 @@ export class Builder {
             if (docker) {
                 switch (tool.command) {
                     case 'latexmk':
-                        this.extension.logger.addLogMessage('Use Docker to invoke the command.')
+                        Logger.log('Use Docker to invoke the command.')
                         if (process.platform === 'win32') {
                             tool.command = path.resolve(this.extension.extensionRoot, './scripts/latexmk.bat')
                         } else {
@@ -505,7 +506,7 @@ export class Builder {
                         }
                         break
                     default:
-                        this.extension.logger.addLogMessage(`Will not use Docker to invoke the command: ${tool.command}`)
+                        Logger.log(`Will not use Docker to invoke the command: ${tool.command}`)
                         break
                 }
             }
@@ -545,8 +546,8 @@ export class Builder {
         const defaultRecipeName = configuration.get('latex.recipe.default') as string
 
         if (recipes.length < 1) {
-            this.extension.logger.addLogMessage('No recipes defined.')
-            void this.extension.logger.showErrorMessage('No recipes defined.')
+            Logger.log('No recipes defined.')
+            void Logger.showErrorMessage('No recipes defined.')
             return undefined
         }
         if (this.prevLangId !== langId) {
@@ -560,8 +561,8 @@ export class Builder {
         if (recipeName) {
             const candidates = recipes.filter(candidate => candidate.name === recipeName)
             if (candidates.length < 1) {
-                this.extension.logger.addLogMessage(`Failed to resolve build recipe: ${recipeName}`)
-                void this.extension.logger.showErrorMessage(`Failed to resolve build recipe: ${recipeName}`)
+                Logger.log(`Failed to resolve build recipe: ${recipeName}`)
+                void Logger.showErrorMessage(`Failed to resolve build recipe: ${recipeName}`)
             }
             recipe = candidates[0]
         }
@@ -580,8 +581,8 @@ export class Builder {
                 candidates = recipes.filter(candidate => candidate.name.toLowerCase().match('pnw|pweave'))
             }
              if (candidates.length < 1) {
-                 this.extension.logger.addLogMessage(`Failed to resolve build recipe: ${recipeName}`)
-                 void this.extension.logger.showErrorMessage(`Failed to resolve build recipe: ${recipeName}`)
+                 Logger.log(`Failed to resolve build recipe: ${recipeName}`)
+                 void Logger.showErrorMessage(`Failed to resolve build recipe: ${recipeName}`)
              }
              recipe = candidates[0]
         }
@@ -623,11 +624,11 @@ export class Builder {
                 name: this.TEX_MAGIC_PROGRAM_NAME,
                 command: tex[1]
             }
-            this.extension.logger.addLogMessage(`Found TeX program by magic comment: ${texCommand.command}`)
+            Logger.log(`Found TeX program by magic comment: ${texCommand.command}`)
             const res = content.match(regexTexOptions)
             if (res) {
                 texCommand.args = [res[1]]
-                this.extension.logger.addLogMessage(`Found TeX options by magic comment: ${texCommand.args}`)
+                Logger.log(`Found TeX options by magic comment: ${texCommand.args}`)
             }
         }
 
@@ -636,11 +637,11 @@ export class Builder {
                 name: this.BIB_MAGIC_PROGRAM_NAME,
                 command: bib[1]
             }
-            this.extension.logger.addLogMessage(`Found BIB program by magic comment: ${bibCommand.command}`)
+            Logger.log(`Found BIB program by magic comment: ${bibCommand.command}`)
             const res = content.match(regexBibOptions)
             if (res) {
                 bibCommand.args = [res[1]]
-                this.extension.logger.addLogMessage(`Found BIB options by magic comment: ${bibCommand.args}`)
+                Logger.log(`Found BIB options by magic comment: ${bibCommand.args}`)
             }
         }
 
@@ -659,7 +660,7 @@ export class Builder {
         if (!path.isAbsolute(outDir)) {
             outDir = path.resolve(rootDir, outDir)
         }
-        this.extension.logger.addLogMessage(`outDir: ${outDir}`)
+        Logger.log(`outDir: ${outDir}`)
         try {
             this.extension.cacher.getIncludedTeX(rootFile).forEach(file => {
                 const relativePath = path.dirname(file.replace(rootDir, '.'))
@@ -671,8 +672,8 @@ export class Builder {
                 }
             })
         } catch (e) {
-            this.extension.logger.addLogMessage('Unexpected Error: please see the console log of the Developer Tools of VS Code.')
-            this.extension.logger.displayStatus('x', 'errorForeground')
+            Logger.log('Unexpected Error: please see the console log of the Developer Tools of VS Code.')
+            Logger.displayStatus('x', 'errorForeground')
             throw(e)
         }
     }

--- a/src/components/builder.ts
+++ b/src/components/builder.ts
@@ -7,7 +7,10 @@ import * as cs from 'cross-spawn'
 import type { Extension } from '../main'
 import { replaceArgumentPlaceholders } from '../utils/utils'
 import { BuildDone } from './eventbus'
-import * as logger from './logger'
+
+import { getLogger } from './logger'
+
+const logger = getLogger('Builder')
 
 const enum BuildEvents {
     never = 'never',
@@ -35,10 +38,10 @@ export class Builder {
             const pdflatexVersion = cp.execSync('pdflatex --version')
             if (pdflatexVersion.toString().match(/MiKTeX/)) {
                 this.isMiktex = true
-                logger.log('[Builder] pdflatex is provided by MiKTeX.')
+                logger.log('pdflatex is provided by MiKTeX.')
             }
         } catch (e) {
-            logger.log('[Builder] Cannot run pdflatex to determine if we are using MiKTeX.')
+            logger.log('Cannot run pdflatex to determine if we are using MiKTeX.')
         }
     }
 
@@ -52,23 +55,23 @@ export class Builder {
      */
     kill() {
         if (this.process === undefined) {
-            logger.log('[Builder] LaTeX build process to kill is not found.')
+            logger.log('LaTeX build process to kill is not found.')
             return
         }
         const pid = this.process.pid
         try {
-            logger.log(`[Builder] Kill child processes of the current process with PID ${pid}.`)
+            logger.log(`Kill child processes of the current process with PID ${pid}.`)
             if (process.platform === 'linux' || process.platform === 'darwin') {
                 cp.execSync(`pkill -P ${pid}`, { timeout: 1000 })
             } else if (process.platform === 'win32') {
                 cp.execSync(`taskkill /F /T /PID ${pid}`, { timeout: 1000 })
             }
         } catch (e) {
-            logger.logError('[Builder] Failed killing child processes of the current process.', e)
+            logger.logError('Failed killing child processes of the current process.', e)
         } finally {
             this.stepQueue.clear()
             this.process.kill()
-            logger.log(`[Builder] Killed the current process with PID ${pid}`)
+            logger.log(`Killed the current process with PID ${pid}`)
         }
     }
 
@@ -77,7 +80,7 @@ export class Builder {
         if (configuration.get('latex.autoBuild.run') as string !== BuildEvents.onFileChange) {
             return
         }
-        logger.log(`[Builder] Auto build started detecting the change of a file: ${file} .`)
+        logger.log(`Auto build started detecting the change of a file: ${file} .`)
         return this.invokeBuild(file, bibChanged)
     }
 
@@ -86,13 +89,13 @@ export class Builder {
         if (configuration.get('latex.autoBuild.run') as string !== BuildEvents.onSave) {
             return
         }
-        logger.log(`[Builder] Auto build started on saving file: ${file} .`)
+        logger.log(`Auto build started on saving file: ${file} .`)
         return this.invokeBuild(file, false)
     }
 
     private invokeBuild(file: string, bibChanged: boolean ) {
         if (!this.extension.builder.canAutoBuild()) {
-            logger.log('[Builder] Autobuild temporarily disabled.')
+            logger.log('Autobuild temporarily disabled.')
             return
         }
         const configuration = vscode.workspace.getConfiguration('latex-workshop', vscode.Uri.file(file))
@@ -155,7 +158,7 @@ export class Builder {
      * builder tries to determine on its own, in {@link createBuildTools}.
      */
     async build(rootFile: string, langId: string, recipeName?: string) {
-        logger.log(`[Builder] Build root file ${rootFile}`)
+        logger.log(`Build root file ${rootFile}`)
 
         this.lastBuild = Date.now()
 
@@ -170,7 +173,7 @@ export class Builder {
         const tools = this.createBuildTools(rootFile, langId, recipeName)
 
         if (tools === undefined) {
-            logger.log('[Builder] Invalid toolchain.')
+            logger.log('Invalid toolchain.')
             return
         }
         const timestamp = Date.now()
@@ -244,9 +247,9 @@ export class Builder {
             logger.clearCompilerMessage()
         }
         logger.refreshStatus('sync~spin', 'statusBar.foreground', undefined, undefined, ' ' + this.stepQueue.getStepString(step))
-        logger.logCommand(`[Builder] Recipe step ${step.index + 1}`, step.command, step.args)
-        logger.log(`[Builder] env: ${JSON.stringify(step.env)}`)
-        logger.log(`[Builder] root: ${step.rootFile}`)
+        logger.logCommand(`Recipe step ${step.index + 1}`, step.command, step.args)
+        logger.log(`env: ${JSON.stringify(step.env)}`)
+        logger.log(`root: ${step.rootFile}`)
 
         const env = Object.create(null) as ProcessEnv
         Object.keys(process.env).forEach(key => env[key] = process.env[key])
@@ -259,7 +262,7 @@ export class Builder {
         if (!step.isExternal &&
             (step.name.startsWith(this.TEX_MAGIC_PROGRAM_NAME) ||
              step.name.startsWith(this.BIB_MAGIC_PROGRAM_NAME))) {
-            logger.log(`[Builder] cwd: ${path.dirname(step.rootFile)}`)
+            logger.log(`cwd: ${path.dirname(step.rootFile)}`)
 
             const args = step.args
             if (args && !step.name.endsWith(this.MAGIC_PROGRAM_ARGS_SUFFIX)) {
@@ -277,13 +280,13 @@ export class Builder {
             } else {
                 cwd = path.dirname(step.rootFile)
             }
-            logger.log(`[Builder] cwd: ${cwd}`)
+            logger.log(`cwd: ${cwd}`)
             this.process = cs.spawn(step.command, step.args, {cwd, env})
         } else {
-            logger.log(`[Builder] cwd: ${step.cwd}`)
+            logger.log(`cwd: ${step.cwd}`)
             this.process = cs.spawn(step.command, step.args, {cwd: step.cwd})
         }
-        logger.log(`[Builder] LaTeX build process spawned with PID ${this.process.pid}.`)
+        logger.log(`LaTeX build process spawned with PID ${this.process.pid}.`)
         return env
     }
 
@@ -315,13 +318,13 @@ export class Builder {
         let stdout = ''
         this.process.stdout.on('data', (msg: Buffer | string) => {
             stdout += msg
-            logger.addCompilerMessage(msg.toString())
+            logger.logCompiler(msg.toString())
         })
 
         let stderr = ''
         this.process.stderr.on('data', (msg: Buffer | string) => {
             stderr += msg
-            logger.addCompilerMessage(msg.toString())
+            logger.logCompiler(msg.toString())
         })
 
         const result: boolean = await new Promise(resolve => {
@@ -330,9 +333,9 @@ export class Builder {
                 return
             }
             this.process.on('error', err => {
-                logger.logError(`[Builder] LaTeX fatal error on PID ${this.process?.pid}.`, err)
-                logger.log(`[Builder] Does the executable exist? $PATH: ${env['PATH']}, $Path: ${env['Path']}, $SHELL: ${process.env.SHELL}`)
-                logger.log(`[STDERR] ${stderr}`)
+                logger.logError(`LaTeX fatal error on PID ${this.process?.pid}.`, err)
+                logger.log(`Does the executable exist? $PATH: ${env['PATH']}, $Path: ${env['Path']}, $SHELL: ${process.env.SHELL}`)
+                logger.log(`${stderr}`)
                 logger.refreshStatus('x', 'errorForeground', undefined, 'error')
                 void logger.showErrorMessageWithExtensionLogButton(`Recipe terminated with fatal error: ${err.message}.`)
                 this.process = undefined
@@ -343,12 +346,12 @@ export class Builder {
             this.process.on('exit', async (code, signal) => {
                 this.extension.compilerLogParser.parse(stdout, step.rootFile)
                 if (!step.isExternal && code === 0) {
-                    logger.log(`[Builder] Finished a step in recipe with PID ${this.process?.pid}.`)
+                    logger.log(`Finished a step in recipe with PID ${this.process?.pid}.`)
                     this.process = undefined
                     resolve(true)
                     return
                 } else if (code === 0) {
-                    logger.log(`[Builder] Successfully built document with PID ${this.process?.pid}.`)
+                    logger.log(`Successfully built document with PID ${this.process?.pid}.`)
                     logger.refreshStatus('check', 'statusBar.foreground', 'Build succeeded.')
                     if (step.rootFile === undefined) {
                         this.extension.viewer.refreshExistingViewer()
@@ -359,9 +362,9 @@ export class Builder {
                 }
 
                 if (!step.isExternal) {
-                    logger.log(`[Builder] Recipe returns with error code ${code}/${signal} on PID ${this.process?.pid}.`)
-                    logger.log(`[Builder] Does the executable exist? $PATH: ${env['PATH']}, $Path: ${env['Path']}, $SHELL: ${process.env.SHELL}`)
-                    logger.log(`[STDERR] ${stderr}`)
+                    logger.log(`Recipe returns with error code ${code}/${signal} on PID ${this.process?.pid}.`)
+                    logger.log(`Does the executable exist? $PATH: ${env['PATH']}, $Path: ${env['Path']}, $SHELL: ${process.env.SHELL}`)
+                    logger.log(`${stderr}`)
                 }
 
                 const configuration = vscode.workspace.getConfiguration('latex-workshop', step.rootFile ? vscode.Uri.file(step.rootFile) : undefined)
@@ -369,7 +372,7 @@ export class Builder {
                     // Recipe, not terminated by user, is not retry and should retry
                     step.isRetry = true
                     logger.refreshStatus('x', 'errorForeground', 'Recipe terminated with error. Retry building the project.', 'warning')
-                    logger.log('[Builder] Cleaning auxiliary files and retrying build after toolchain error.')
+                    logger.log('Cleaning auxiliary files and retrying build after toolchain error.')
 
                     this.stepQueue.prepend(step)
                     await this.extension.cleaner.clean(step.rootFile)
@@ -383,7 +386,7 @@ export class Builder {
                     this.stepQueue.clear()
                 } else if (step.isExternal) {
                     // External command
-                    logger.log(`[Builder] Build returns with error: ${code}/${signal} on PID ${this.process?.pid}.`)
+                    logger.log(`Build returns with error: ${code}/${signal} on PID ${this.process?.pid}.`)
                     logger.refreshStatus('x', 'errorForeground', undefined, 'warning')
                     void logger.showErrorMessageWithCompilerLogButton('Build terminated with error.')
                     this.stepQueue.clear()
@@ -412,7 +415,7 @@ export class Builder {
             // This only happens when the step is an external command.
             return
         }
-        logger.log(`[Builder] Successfully built ${step.rootFile} .`)
+        logger.log(`Successfully built ${step.rootFile} .`)
         logger.refreshStatus('check', 'statusBar.foreground', 'Recipe succeeded.')
         this.extension.eventBus.fire(BuildDone)
         if (this.extension.compilerLogParser.isLaTeXmkSkipped) {
@@ -425,11 +428,11 @@ export class Builder {
         // If the PDF viewer is internal, we call SyncTeX in src/components/viewer.ts.
         if (configuration.get('view.pdf.viewer') === 'external' && configuration.get('synctex.afterBuild.enabled')) {
             const pdfFile = this.extension.manager.tex2pdf(step.rootFile)
-            logger.log('[Builder] SyncTex after build invoked.')
+            logger.log('SyncTex after build invoked.')
             this.extension.locator.syncTeX(undefined, undefined, pdfFile)
         }
         if (configuration.get('latex.autoClean.run') as string === 'onBuilt') {
-            logger.log('[Builder] Auto Clean invoked.')
+            logger.log('Auto Clean invoked.')
             await this.extension.cleaner.clean(step.rootFile)
         }
     }
@@ -450,7 +453,7 @@ export class Builder {
             if (recipe === undefined) {
                 return undefined
             }
-            logger.log(`[Builder] Preparing to run recipe: ${recipe.name}.`)
+            logger.log(`Preparing to run recipe: ${recipe.name}.`)
             this.prevRecipe = recipe
             this.prevLangId = langId
             const tools = configuration.get('latex.tools') as Tool[]
@@ -458,7 +461,7 @@ export class Builder {
                 if (typeof tool === 'string') {
                     const candidates = tools.filter(candidate => candidate.name === tool)
                     if (candidates.length < 1) {
-                        logger.log(`[Builder] Skipping undefined tool ${tool} in recipe ${recipe.name}.`)
+                        logger.log(`Skipping undefined tool ${tool} in recipe ${recipe.name}.`)
                         void logger.showErrorMessage(`Skipping undefined tool "${tool}" in recipe "${recipe.name}."`)
                     } else {
                         buildTools.push(candidates[0])
@@ -492,7 +495,7 @@ export class Builder {
             if (docker) {
                 switch (tool.command) {
                     case 'latexmk':
-                        logger.log('[Builder] Use Docker to invoke the command.')
+                        logger.log('Use Docker to invoke the command.')
                         if (process.platform === 'win32') {
                             tool.command = path.resolve(this.extension.extensionRoot, './scripts/latexmk.bat')
                         } else {
@@ -501,7 +504,7 @@ export class Builder {
                         }
                         break
                     default:
-                        logger.log(`[Builder] Do not use Docker to invoke the command: ${tool.command}.`)
+                        logger.log(`Do not use Docker to invoke the command: ${tool.command}.`)
                         break
                 }
             }
@@ -541,7 +544,7 @@ export class Builder {
         const defaultRecipeName = configuration.get('latex.recipe.default') as string
 
         if (recipes.length < 1) {
-            logger.log('[Builder] No recipes defined.')
+            logger.log('No recipes defined.')
             void logger.showErrorMessage('[Builder] No recipes defined.')
             return undefined
         }
@@ -556,7 +559,7 @@ export class Builder {
         if (recipeName) {
             const candidates = recipes.filter(candidate => candidate.name === recipeName)
             if (candidates.length < 1) {
-                logger.log(`[Builder] Failed to resolve build recipe: ${recipeName}.`)
+                logger.log(`Failed to resolve build recipe: ${recipeName}.`)
                 void logger.showErrorMessage(`[Builder] Failed to resolve build recipe: ${recipeName}.`)
             }
             recipe = candidates[0]
@@ -576,7 +579,7 @@ export class Builder {
                 candidates = recipes.filter(candidate => candidate.name.toLowerCase().match('pnw|pweave'))
             }
              if (candidates.length < 1) {
-                 logger.log(`[Builder] Failed to resolve build recipe: ${recipeName}.`)
+                 logger.log(`Failed to resolve build recipe: ${recipeName}.`)
                  void logger.showErrorMessage(`Failed to resolve build recipe: ${recipeName}.`)
              }
              recipe = candidates[0]
@@ -619,11 +622,11 @@ export class Builder {
                 name: this.TEX_MAGIC_PROGRAM_NAME,
                 command: tex[1]
             }
-            logger.log(`[Builder] Found TeX program by magic comment: ${texCommand.command}.`)
+            logger.log(`Found TeX program by magic comment: ${texCommand.command}.`)
             const res = content.match(regexTexOptions)
             if (res) {
                 texCommand.args = [res[1]]
-                logger.log(`[Builder] Found TeX options by magic comment: ${texCommand.args}.`)
+                logger.log(`Found TeX options by magic comment: ${texCommand.args}.`)
             }
         }
 
@@ -632,11 +635,11 @@ export class Builder {
                 name: this.BIB_MAGIC_PROGRAM_NAME,
                 command: bib[1]
             }
-            logger.log(`[Builder] Found BIB program by magic comment: ${bibCommand.command}.`)
+            logger.log(`Found BIB program by magic comment: ${bibCommand.command}.`)
             const res = content.match(regexBibOptions)
             if (res) {
                 bibCommand.args = [res[1]]
-                logger.log(`[Builder] Found BIB options by magic comment: ${bibCommand.args}.`)
+                logger.log(`Found BIB options by magic comment: ${bibCommand.args}.`)
             }
         }
 
@@ -655,7 +658,7 @@ export class Builder {
         if (!path.isAbsolute(outDir)) {
             outDir = path.resolve(rootDir, outDir)
         }
-        logger.log(`[Builder] outDir: ${outDir} .`)
+        logger.log(`outDir: ${outDir} .`)
         try {
             this.extension.cacher.getIncludedTeX(rootFile).forEach(file => {
                 const relativePath = path.dirname(file.replace(rootDir, '.'))
@@ -667,7 +670,7 @@ export class Builder {
                 }
             })
         } catch (e) {
-            logger.log('[Builder] Unexpected Error: please see the console log of the Developer Tools of VS Code.')
+            logger.log('Unexpected Error: please see the console log of the Developer Tools of VS Code.')
             logger.refreshStatus('x', 'errorForeground')
             throw(e)
         }

--- a/src/components/cacher.ts
+++ b/src/components/cacher.ts
@@ -132,6 +132,7 @@ export class Cacher {
         this.updateChildren(filePath, rootPath, contentTrimmed)
         await this.updateElements(filePath, content, contentTrimmed)
         await this.updateBibfiles(filePath, contentTrimmed)
+        logger.log(`Cached ${filePath} .`)
         this.extension.eventBus.fire(eventbus.FileParsed, filePath)
     }
 
@@ -271,8 +272,10 @@ export class Cacher {
             if (path.extname(outputFile) === '.aux' && fs.existsSync(outputFile)) {
                 logger.log(`Found .aux ${filePath} from .fls ${flsPath} , parsing.`)
                 await this.parseAuxFile(outputFile, path.dirname(outputFile).replace(outDir, rootDir))
+                logger.log(`Parsed .aux ${filePath} .`)
             }
         }
+        logger.log(`Parsed .fls ${flsPath} .`)
     }
 
     private async parseAuxFile(filePath: string, srcDir: string) {

--- a/src/components/cacherlib/bibwatcher.ts
+++ b/src/components/cacherlib/bibwatcher.ts
@@ -2,7 +2,9 @@ import * as vscode from 'vscode'
 import * as chokidar from 'chokidar'
 
 import type {Extension} from '../../main'
-import * as logger from '../logger'
+import { getLogger } from '../logger'
+
+const logger = getLogger('Cacher', 'Bib')
 
 export class BibWatcher {
     private bibWatcher: chokidar.FSWatcher
@@ -47,28 +49,28 @@ export class BibWatcher {
     private onWatchedBibChanged(filePath: string) {
         void this.extension.completer.citation.parseBibFile(filePath)
         void this.extension.builder.buildOnFileChanged(filePath, true)
-        logger.log(`[Cacher][Bib] Changed ${filePath} .`)
+        logger.log(`File changed ${filePath} .`)
     }
 
     private onWatchedBibDeleted(filePath: string) {
         this.bibWatcher.unwatch(filePath)
         this.bibsWatched.delete(filePath)
         this.extension.completer.citation.removeEntriesInFile(filePath)
-        logger.log(`[Cacher][PDF] Unlinked ${filePath} .`)
+        logger.log(`File unlinked ${filePath} .`)
     }
 
     async watchBibFile(filePath: string) {
         if (!this.bibsWatched.has(filePath)) {
             this.bibWatcher.add(filePath)
             this.bibsWatched.add(filePath)
-            logger.log(`[Cacher][PDF] Watched ${filePath} .`)
+            logger.log(`File watched ${filePath} .`)
             await this.extension.completer.citation.parseBibFile(filePath)
         }
     }
 
     logWatchedFiles() {
-        logger.log(`[Cacher][PDF][getWatched()] ${JSON.stringify(this.bibWatcher.getWatched())}`)
-        logger.log(`[Cacher][PDF][bibsWatched()] ${JSON.stringify(Array.from(this.bibsWatched))}`)
+        logger.log(`getWatched() => ${JSON.stringify(this.bibWatcher.getWatched())}`)
+        logger.log(`bibsWatched() => ${JSON.stringify(Array.from(this.bibsWatched))}`)
     }
 
 }

--- a/src/components/cacherlib/bibwatcher.ts
+++ b/src/components/cacherlib/bibwatcher.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode'
 import * as chokidar from 'chokidar'
 
 import type {Extension} from '../../main'
-import { Logger } from '../logger'
+import * as logger from '../logger'
 
 export class BibWatcher {
     private bibWatcher: chokidar.FSWatcher
@@ -44,31 +44,31 @@ export class BibWatcher {
         }
     }
 
-    private async onWatchedBibChanged(file: string) {
-        Logger.log(`Bib file watcher - file changed: ${file}`)
-        await this.extension.completer.citation.parseBibFile(file)
-        await this.extension.builder.buildOnFileChanged(file, true)
+    private onWatchedBibChanged(filePath: string) {
+        void this.extension.completer.citation.parseBibFile(filePath)
+        void this.extension.builder.buildOnFileChanged(filePath, true)
+        logger.log(`[Cacher][Bib] Changed ${filePath} .`)
     }
 
-    private onWatchedBibDeleted(file: string) {
-        Logger.log(`Bib file watcher - file deleted: ${file}`)
-        this.bibWatcher.unwatch(file)
-        this.bibsWatched.delete(file)
-        this.extension.completer.citation.removeEntriesInFile(file)
+    private onWatchedBibDeleted(filePath: string) {
+        this.bibWatcher.unwatch(filePath)
+        this.bibsWatched.delete(filePath)
+        this.extension.completer.citation.removeEntriesInFile(filePath)
+        logger.log(`[Cacher][PDF] Unlinked ${filePath} .`)
     }
 
-    async watchBibFile(bibPath: string) {
-        if (!this.bibsWatched.has(bibPath)) {
-            Logger.log(`Added to bib file watcher: ${bibPath}`)
-            this.bibWatcher.add(bibPath)
-            this.bibsWatched.add(bibPath)
-            await this.extension.completer.citation.parseBibFile(bibPath)
+    async watchBibFile(filePath: string) {
+        if (!this.bibsWatched.has(filePath)) {
+            this.bibWatcher.add(filePath)
+            this.bibsWatched.add(filePath)
+            logger.log(`[Cacher][PDF] Watched ${filePath} .`)
+            await this.extension.completer.citation.parseBibFile(filePath)
         }
     }
 
     logWatchedFiles() {
-        Logger.log(`BibWatcher.bibWatcher.getWatched: ${JSON.stringify(this.bibWatcher.getWatched())}`)
-        Logger.log(`BibWatcher.bibsWatched: ${JSON.stringify(Array.from(this.bibsWatched))}`)
+        logger.log(`[Cacher][PDF][getWatched()] ${JSON.stringify(this.bibWatcher.getWatched())}`)
+        logger.log(`[Cacher][PDF][bibsWatched()] ${JSON.stringify(Array.from(this.bibsWatched))}`)
     }
 
 }

--- a/src/components/cacherlib/bibwatcher.ts
+++ b/src/components/cacherlib/bibwatcher.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode'
 import * as chokidar from 'chokidar'
 
 import type {Extension} from '../../main'
+import { Logger } from '../logger'
 
 export class BibWatcher {
     private bibWatcher: chokidar.FSWatcher
@@ -44,13 +45,13 @@ export class BibWatcher {
     }
 
     private async onWatchedBibChanged(file: string) {
-        this.extension.logger.addLogMessage(`Bib file watcher - file changed: ${file}`)
+        Logger.log(`Bib file watcher - file changed: ${file}`)
         await this.extension.completer.citation.parseBibFile(file)
         await this.extension.builder.buildOnFileChanged(file, true)
     }
 
     private onWatchedBibDeleted(file: string) {
-        this.extension.logger.addLogMessage(`Bib file watcher - file deleted: ${file}`)
+        Logger.log(`Bib file watcher - file deleted: ${file}`)
         this.bibWatcher.unwatch(file)
         this.bibsWatched.delete(file)
         this.extension.completer.citation.removeEntriesInFile(file)
@@ -58,7 +59,7 @@ export class BibWatcher {
 
     async watchBibFile(bibPath: string) {
         if (!this.bibsWatched.has(bibPath)) {
-            this.extension.logger.addLogMessage(`Added to bib file watcher: ${bibPath}`)
+            Logger.log(`Added to bib file watcher: ${bibPath}`)
             this.bibWatcher.add(bibPath)
             this.bibsWatched.add(bibPath)
             await this.extension.completer.citation.parseBibFile(bibPath)
@@ -66,8 +67,8 @@ export class BibWatcher {
     }
 
     logWatchedFiles() {
-        this.extension.logger.addLogMessage(`BibWatcher.bibWatcher.getWatched: ${JSON.stringify(this.bibWatcher.getWatched())}`)
-        this.extension.logger.addLogMessage(`BibWatcher.bibsWatched: ${JSON.stringify(Array.from(this.bibsWatched))}`)
+        Logger.log(`BibWatcher.bibWatcher.getWatched: ${JSON.stringify(this.bibWatcher.getWatched())}`)
+        Logger.log(`BibWatcher.bibsWatched: ${JSON.stringify(Array.from(this.bibsWatched))}`)
     }
 
 }

--- a/src/components/cacherlib/pathutils.ts
+++ b/src/components/cacherlib/pathutils.ts
@@ -5,7 +5,7 @@ import * as fs from 'fs'
 
 import type { Extension } from '../../main'
 import * as utils from '../../utils/utils'
-import { Logger } from '../logger'
+import * as logger from '../logger'
 
 export class PathUtils {
     private readonly extension: Extension
@@ -33,16 +33,15 @@ export class PathUtils {
         const baseName = path.parse(texFile).name
         const flsFile = path.resolve(rootDir, path.join(outDir, baseName + '.fls'))
         if (!fs.existsSync(flsFile)) {
-            Logger.log(`Cannot find fls file: ${flsFile}`)
+            logger.log(`[Cacher][Path] Non-existent .fls for ${texFile} .`)
             return undefined
         }
-        Logger.log(`Fls file found: ${flsFile}`)
         return flsFile
     }
 
     private kpsewhichBibPath(bib: string): string | undefined {
         const kpsewhich = vscode.workspace.getConfiguration('latex-workshop').get('kpsewhich.path') as string
-        Logger.log(`Calling ${kpsewhich} to resolve file: ${bib}`)
+        logger.log(`[Cacher][Path] Calling ${kpsewhich} to resolve ${bib} .`)
         try {
             const kpsewhichReturn = cs.sync(kpsewhich, ['-format=.bib', bib])
             if (kpsewhichReturn.status === 0) {
@@ -50,12 +49,11 @@ export class PathUtils {
                 if (bibPath === '') {
                     return undefined
                 } else {
-                    Logger.log(`Found .bib file using kpsewhich: ${bibPath}`)
                     return bibPath
                 }
             }
         } catch(e) {
-            Logger.log(`Cannot run kpsewhich to resolve .bib file: ${bib}`)
+            logger.logError(`[Cacher][Path] Calling ${kpsewhich} on ${bib} failed.`, e)
         }
         return undefined
     }
@@ -74,14 +72,13 @@ export class PathUtils {
         const bibPath = utils.resolveFile(searchDirs, bib, '.bib')
 
         if (!bibPath) {
-            Logger.log(`Cannot find .bib file: ${bib}`)
             if (configuration.get('kpsewhich.enabled')) {
                 return this.kpsewhichBibPath(bib)
             } else {
+                logger.log(`[Cacher][Path] Cannot resolve ${bib} .`)
                 return undefined
             }
         }
-        Logger.log(`Found .bib file: ${bibPath}`)
         return bibPath
     }
 

--- a/src/components/cacherlib/pathutils.ts
+++ b/src/components/cacherlib/pathutils.ts
@@ -5,7 +5,9 @@ import * as fs from 'fs'
 
 import type { Extension } from '../../main'
 import * as utils from '../../utils/utils'
-import * as logger from '../logger'
+import { getLogger } from '../logger'
+
+const logger = getLogger('Cacher', 'Path')
 
 export class PathUtils {
     private readonly extension: Extension
@@ -33,7 +35,7 @@ export class PathUtils {
         const baseName = path.parse(texFile).name
         const flsFile = path.resolve(rootDir, path.join(outDir, baseName + '.fls'))
         if (!fs.existsSync(flsFile)) {
-            logger.log(`[Cacher][Path] Non-existent .fls for ${texFile} .`)
+            logger.log(`Non-existent .fls for ${texFile} .`)
             return undefined
         }
         return flsFile
@@ -41,7 +43,7 @@ export class PathUtils {
 
     private kpsewhichBibPath(bib: string): string | undefined {
         const kpsewhich = vscode.workspace.getConfiguration('latex-workshop').get('kpsewhich.path') as string
-        logger.log(`[Cacher][Path] Calling ${kpsewhich} to resolve ${bib} .`)
+        logger.log(`Calling ${kpsewhich} to resolve ${bib} .`)
         try {
             const kpsewhichReturn = cs.sync(kpsewhich, ['-format=.bib', bib])
             if (kpsewhichReturn.status === 0) {
@@ -53,7 +55,7 @@ export class PathUtils {
                 }
             }
         } catch(e) {
-            logger.logError(`[Cacher][Path] Calling ${kpsewhich} on ${bib} failed.`, e)
+            logger.logError(`Calling ${kpsewhich} on ${bib} failed.`, e)
         }
         return undefined
     }
@@ -75,7 +77,7 @@ export class PathUtils {
             if (configuration.get('kpsewhich.enabled')) {
                 return this.kpsewhichBibPath(bib)
             } else {
-                logger.log(`[Cacher][Path] Cannot resolve ${bib} .`)
+                logger.log(`Cannot resolve ${bib} .`)
                 return undefined
             }
         }

--- a/src/components/cacherlib/pathutils.ts
+++ b/src/components/cacherlib/pathutils.ts
@@ -5,6 +5,7 @@ import * as fs from 'fs'
 
 import type { Extension } from '../../main'
 import * as utils from '../../utils/utils'
+import { Logger } from '../logger'
 
 export class PathUtils {
     private readonly extension: Extension
@@ -32,16 +33,16 @@ export class PathUtils {
         const baseName = path.parse(texFile).name
         const flsFile = path.resolve(rootDir, path.join(outDir, baseName + '.fls'))
         if (!fs.existsSync(flsFile)) {
-            this.extension.logger.addLogMessage(`Cannot find fls file: ${flsFile}`)
+            Logger.log(`Cannot find fls file: ${flsFile}`)
             return undefined
         }
-        this.extension.logger.addLogMessage(`Fls file found: ${flsFile}`)
+        Logger.log(`Fls file found: ${flsFile}`)
         return flsFile
     }
 
     private kpsewhichBibPath(bib: string): string | undefined {
         const kpsewhich = vscode.workspace.getConfiguration('latex-workshop').get('kpsewhich.path') as string
-        this.extension.logger.addLogMessage(`Calling ${kpsewhich} to resolve file: ${bib}`)
+        Logger.log(`Calling ${kpsewhich} to resolve file: ${bib}`)
         try {
             const kpsewhichReturn = cs.sync(kpsewhich, ['-format=.bib', bib])
             if (kpsewhichReturn.status === 0) {
@@ -49,12 +50,12 @@ export class PathUtils {
                 if (bibPath === '') {
                     return undefined
                 } else {
-                    this.extension.logger.addLogMessage(`Found .bib file using kpsewhich: ${bibPath}`)
+                    Logger.log(`Found .bib file using kpsewhich: ${bibPath}`)
                     return bibPath
                 }
             }
         } catch(e) {
-            this.extension.logger.addLogMessage(`Cannot run kpsewhich to resolve .bib file: ${bib}`)
+            Logger.log(`Cannot run kpsewhich to resolve .bib file: ${bib}`)
         }
         return undefined
     }
@@ -73,14 +74,14 @@ export class PathUtils {
         const bibPath = utils.resolveFile(searchDirs, bib, '.bib')
 
         if (!bibPath) {
-            this.extension.logger.addLogMessage(`Cannot find .bib file: ${bib}`)
+            Logger.log(`Cannot find .bib file: ${bib}`)
             if (configuration.get('kpsewhich.enabled')) {
                 return this.kpsewhichBibPath(bib)
             } else {
                 return undefined
             }
         }
-        this.extension.logger.addLogMessage(`Found .bib file: ${bibPath}`)
+        Logger.log(`Found .bib file: ${bibPath}`)
         return bibPath
     }
 

--- a/src/components/cacherlib/pdfwatcher.ts
+++ b/src/components/cacherlib/pdfwatcher.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode'
 import * as chokidar from 'chokidar'
 
 import type {Extension} from '../../main'
+import { Logger } from '../logger'
 
 export class PdfWatcher {
     private readonly watchedPdfLocalPaths = new Set<string>()
@@ -80,12 +81,12 @@ export class PdfWatcher {
         if (this.isIgnored(file)) {
             return
         }
-        this.extension.logger.addLogMessage(`PDF file watcher - file changed: ${file}`)
+        Logger.log(`PDF file watcher - file changed: ${file}`)
         this.extension.viewer.refreshExistingViewer(undefined, file)
     }
 
     private onWatchedPdfDeleted(file: string) {
-        this.extension.logger.addLogMessage(`PDF file watcher - file deleted: ${file}`)
+        Logger.log(`PDF file watcher - file deleted: ${file}`)
         this.pdfWatcher.unwatch(file)
         this.watchedPdfLocalPaths.delete(file)
     }
@@ -95,7 +96,7 @@ export class PdfWatcher {
         if (isLocal) {
             const pdfFilePath = pdfFileUri.fsPath
             if (!this.watchedPdfLocalPaths.has(pdfFilePath)) {
-                this.extension.logger.addLogMessage(`Added to PDF file watcher: ${pdfFileUri.toString(true)}`)
+                Logger.log(`Added to PDF file watcher: ${pdfFileUri.toString(true)}`)
                 this.pdfWatcher.add(pdfFilePath)
                 this.watchedPdfLocalPaths.add(pdfFilePath)
             }
@@ -120,10 +121,10 @@ export class PdfWatcher {
     }
 
     logWatchedFiles() {
-        this.extension.logger.addLogMessage(`PdfWatcher.pdfWatcher.getWatched: ${JSON.stringify(this.pdfWatcher.getWatched())}`)
-        this.extension.logger.addLogMessage(`PdfWatcher.pdfsWatched: ${JSON.stringify(Array.from(this.watchedPdfLocalPaths))}`)
-        this.extension.logger.addLogMessage(`PdfWatcher.watchedPdfVirtualUris: ${JSON.stringify(Array.from(this.watchedPdfVirtualUris))}`)
-        this.extension.logger.addLogMessage(`PdfWatcher.ignoredPdfUris: ${JSON.stringify(Array.from(this.ignoredPdfUris))}`)
+        Logger.log(`PdfWatcher.pdfWatcher.getWatched: ${JSON.stringify(this.pdfWatcher.getWatched())}`)
+        Logger.log(`PdfWatcher.pdfsWatched: ${JSON.stringify(Array.from(this.watchedPdfLocalPaths))}`)
+        Logger.log(`PdfWatcher.watchedPdfVirtualUris: ${JSON.stringify(Array.from(this.watchedPdfVirtualUris))}`)
+        Logger.log(`PdfWatcher.ignoredPdfUris: ${JSON.stringify(Array.from(this.ignoredPdfUris))}`)
     }
 
 }

--- a/src/components/cacherlib/pdfwatcher.ts
+++ b/src/components/cacherlib/pdfwatcher.ts
@@ -2,7 +2,9 @@ import * as vscode from 'vscode'
 import * as chokidar from 'chokidar'
 
 import type {Extension} from '../../main'
-import * as logger from '../logger'
+import { getLogger } from '../logger'
+
+const logger = getLogger('Cacher', 'PDF')
 
 export class PdfWatcher {
     private readonly watchedPdfLocalPaths = new Set<string>()
@@ -82,13 +84,13 @@ export class PdfWatcher {
             return
         }
         this.extension.viewer.refreshExistingViewer(undefined, filePath)
-        logger.log(`[Cacher][PDF] Changed ${filePath} .`)
+        logger.log(`Changed ${filePath} .`)
     }
 
     private onWatchedPdfDeleted(filePath: string) {
         this.pdfWatcher.unwatch(filePath)
         this.watchedPdfLocalPaths.delete(filePath)
-        logger.log(`[Cacher][PDF] Unlinked ${filePath} .`)
+        logger.log(`Unlinked ${filePath} .`)
     }
 
     watchPdfFile(fileUri: vscode.Uri) {
@@ -98,11 +100,11 @@ export class PdfWatcher {
             if (!this.watchedPdfLocalPaths.has(pdfFilePath)) {
                 this.pdfWatcher.add(pdfFilePath)
                 this.watchedPdfLocalPaths.add(pdfFilePath)
-                logger.log(`[Cacher][PDF] Watched ${fileUri.toString(true)} .`)
+                logger.log(`Watched ${fileUri.toString(true)} .`)
             }
         } else {
             this.watchedPdfVirtualUris.add(this.toKey(fileUri))
-            logger.log(`[Cacher][PDF] Watched ${this.toKey(fileUri)} .`)
+            logger.log(`Watched ${this.toKey(fileUri)} .`)
         }
     }
 
@@ -122,10 +124,10 @@ export class PdfWatcher {
     }
 
     logWatchedFiles() {
-        logger.log(`[Cacher][PDF][getWatched()] ${JSON.stringify(this.pdfWatcher.getWatched())}`)
-        logger.log(`[Cacher][PDF][pdfsWatched()] ${JSON.stringify(Array.from(this.watchedPdfLocalPaths))}`)
-        logger.log(`[Cacher][PDF][watchedPdfVirtualUris()] ${JSON.stringify(Array.from(this.watchedPdfVirtualUris))}`)
-        logger.log(`[Cacher][PDF][ignoredPdfUris()] ${JSON.stringify(Array.from(this.ignoredPdfUris))}`)
+        logger.log(`${JSON.stringify(this.pdfWatcher.getWatched())}`)
+        logger.log(`${JSON.stringify(Array.from(this.watchedPdfLocalPaths))}`)
+        logger.log(`${JSON.stringify(Array.from(this.watchedPdfVirtualUris))}`)
+        logger.log(`${JSON.stringify(Array.from(this.ignoredPdfUris))}`)
     }
 
 }

--- a/src/components/cacherlib/texwatcher.ts
+++ b/src/components/cacherlib/texwatcher.ts
@@ -5,7 +5,9 @@ import { Extension } from '../../main'
 import * as eventbus from '../eventbus'
 import { Cacher } from '../cacher'
 import { canContext, isExcluded } from './cacherutils'
-import * as logger from '../logger'
+import { getLogger } from '../logger'
+
+const logger = getLogger('Cacher', 'Watcher')
 
 export class Watcher {
     watcher: chokidar.FSWatcher
@@ -50,11 +52,11 @@ export class Watcher {
         await this.watcher.close()
         this.watched.clear()
         this.initializeWatcher()
-        logger.log('[Cacher][Watcher] Reset.')
+        logger.log('Reset.')
     }
 
     private onAdd(filePath: string) {
-        logger.log(`[Cacher][Watcher] Watched ${filePath} .`)
+        logger.log(`Watched ${filePath} .`)
         this.extension.eventBus.fire(eventbus.FileWatched, filePath)
     }
 
@@ -63,7 +65,7 @@ export class Watcher {
             void this.cacher.refreshContext(filePath)
         }
         void this.extension.builder.buildOnFileChanged(filePath)
-        logger.log(`[Cacher][Watcher] Changed ${filePath} .`)
+        logger.log(`Changed ${filePath} .`)
         this.extension.eventBus.fire(eventbus.FileChanged, filePath)
     }
 
@@ -72,11 +74,11 @@ export class Watcher {
         this.watched.delete(filePath)
         this.cacher.remove(filePath)
         if (filePath === this.extension.manager.rootFile) {
-            logger.log(`[Cacher][Watcher] Root unlinked ${filePath} .`)
+            logger.log(`Root unlinked ${filePath} .`)
             this.extension.manager.rootFile = undefined
             void this.extension.manager.findRoot()
         } else {
-            logger.log(`[Cacher][Watcher] Unlinked ${filePath} .`)
+            logger.log(`Unlinked ${filePath} .`)
         }
         this.extension.eventBus.fire(eventbus.FileRemoved, filePath)
     }
@@ -91,7 +93,7 @@ export class Watcher {
                     this.watcher = chokidar.watch([], options)
                     this.watched.forEach(filePath => this.watcher.add(filePath))
                     this.initializeWatcher()
-                    logger.log(`[Cacher][Watcher] Option ${JSON.stringify(options)}.`)
+                    logger.log(`Option ${JSON.stringify(options)}.`)
             }
             if (e.affectsConfiguration('latex-workshop.latex.watch.files.ignore')) {
                 this.watched.forEach(filePath => {
@@ -101,7 +103,7 @@ export class Watcher {
                     this.watcher.unwatch(filePath)
                     this.watched.delete(filePath)
                     this.cacher.remove(filePath)
-                    logger.log(`[Cacher][Watcher] Ignored ${filePath} .`)
+                    logger.log(`Ignored ${filePath} .`)
                     void this.extension.manager.findRoot()
                 })
             }

--- a/src/components/cacherlib/texwatcher.ts
+++ b/src/components/cacherlib/texwatcher.ts
@@ -5,6 +5,7 @@ import { Extension } from '../../main'
 import * as eventbus from '../eventbus'
 import { Cacher } from '../cacher'
 import { canContext, isExcluded } from './cacherutils'
+import { Logger } from '../logger'
 
 export class Watcher {
     watcher: chokidar.FSWatcher
@@ -52,7 +53,7 @@ export class Watcher {
     }
 
     private onAdd(filePath: string) {
-        this.extension.logger.addLogMessage(`[Cacher][Watcher] Watched ${filePath}.`)
+        Logger.log(`[Cacher][Watcher] Watched ${filePath}.`)
         this.extension.eventBus.fire(eventbus.FileWatched, filePath)
     }
 
@@ -61,7 +62,7 @@ export class Watcher {
             void this.cacher.refreshContext(filePath)
         }
         void this.extension.builder.buildOnFileChanged(filePath)
-        this.extension.logger.addLogMessage(`[Cacher][Watcher] Changed ${filePath}.`)
+        Logger.log(`[Cacher][Watcher] Changed ${filePath}.`)
         this.extension.eventBus.fire(eventbus.FileChanged, filePath)
     }
 
@@ -70,11 +71,11 @@ export class Watcher {
         this.watched.delete(filePath)
         this.cacher.remove(filePath)
         if (filePath === this.extension.manager.rootFile) {
-            this.extension.logger.addLogMessage(`[Cacher][Watcher] Root deleted ${filePath}.`)
+            Logger.log(`[Cacher][Watcher] Root deleted ${filePath}.`)
             this.extension.manager.rootFile = undefined
             void this.extension.manager.findRoot()
         } else {
-            this.extension.logger.addLogMessage(`[Cacher][Watcher] Deleted ${filePath}.`)
+            Logger.log(`[Cacher][Watcher] Deleted ${filePath}.`)
         }
         this.extension.eventBus.fire(eventbus.FileRemoved, filePath)
     }
@@ -97,7 +98,7 @@ export class Watcher {
                     this.watcher.unwatch(filePath)
                     this.watched.delete(filePath)
                     this.cacher.remove(filePath)
-                    this.extension.logger.addLogMessage(`[Cacher][Watcher] Ignored ${filePath}.`)
+                    Logger.log(`[Cacher][Watcher] Ignored ${filePath}.`)
                     void this.extension.manager.findRoot()
                 })
             }

--- a/src/components/cleaner.ts
+++ b/src/components/cleaner.ts
@@ -45,7 +45,7 @@ export class Cleaner {
             }
             rootFile = this.extension.manager.rootFile
             if (!rootFile) {
-                logger.log('Cannot determine the root file to be cleaned.')
+                logger.log('[Cleaner] Cannot determine the root file to be cleaned.')
                 return
             }
         }
@@ -57,7 +57,7 @@ export class Cleaner {
             case 'cleanCommand':
                 return this.cleanCommand(rootFile)
             default:
-                logger.log(`Unknown cleaning method: ${cleanMethod}`)
+                logger.log(`[Cleaner] Unknown cleaning method ${cleanMethod} .`)
                 return
         }
     }
@@ -108,10 +108,10 @@ export class Cleaner {
         if (configuration.get('latex.clean.subfolder.enabled') as boolean) {
             globs = globs.map(globType => './**/' + globType)
         }
-        logger.log(`Clean glob matched files: ${JSON.stringify({globs, outdir})}`)
+        logger.log(`[Cleaner] Clean glob matched files ${JSON.stringify({globs, outdir})} .`)
 
         const { fileOrFolderGlobs, folderGlobsExplicit, folderGlobsWithGlobstar } = Cleaner.splitGlobs(globs)
-        logger.log(`Ignore folder glob patterns with globstar: ${folderGlobsWithGlobstar}`)
+        logger.log(`[Cleaner] Ignore folder glob patterns with globstar: ${folderGlobsWithGlobstar} .`)
 
         const explicitFolders: string[] = globAll(folderGlobsExplicit, outdir)
         const explicitFoldersSet: Set<string> = new Set(explicitFolders)
@@ -123,14 +123,14 @@ export class Cleaner {
                 const stats: fs.Stats = fs.statSync(realPath)
                 if (stats.isFile()) {
                     await fs.promises.unlink(realPath)
-                    logger.log(`Cleaning file: ${realPath}`)
+                    logger.log(`[Cleaner] Cleaning file ${realPath} .`)
                 } else if (stats.isDirectory()) {
-                    logger.log(`Not removing folder that is not explicitly specified: ${realPath}`)
+                    logger.log(`[Cleaner] Not removing folder that is not explicitly specified ${realPath} .`)
                 } else {
-                    logger.log(`Not removing non-file: ${realPath}`)
+                    logger.log(`[Cleaner] Not removing non-file ${realPath} .`)
                 }
             } catch (err) {
-                logger.logError(`[Cleaner] Failed cleaning path ${realPath}`, err)
+                logger.logError(`[Cleaner] Failed cleaning path ${realPath} .`, err)
             }
         }
 
@@ -139,12 +139,12 @@ export class Cleaner {
             try {
                 if (fs.readdirSync(folderRealPath).length === 0) {
                     await fs.promises.rmdir(folderRealPath)
-                    logger.log(`Removing empty folder: ${folderRealPath}`)
+                    logger.log(`[Cleaner] Removing empty folder: ${folderRealPath} .`)
                 } else {
-                    logger.log(`Not removing non-empty folder: ${folderRealPath}`)
+                    logger.log(`[Cleaner] Not removing non-empty folder: ${folderRealPath} .`)
                 }
             } catch (err) {
-                logger.logError(`[Cleaner] Failed cleaning folder ${folderRealPath}`, err)
+                logger.logError(`[Cleaner] Failed cleaning folder ${folderRealPath} .`, err)
             }
         }
     }
@@ -159,7 +159,7 @@ export class Cleaner {
                 .replace(/%TEX%/g, rootFile)
             })
         }
-        logger.logCommand('Clean temporary files command', command, args)
+        logger.logCommand('[Cleaner] Clean temporary files command', command, args)
         return new Promise((resolve, _reject) => {
             const proc = cs.spawn(command, args, {cwd: path.dirname(rootFile), detached: true})
             let stderr = ''
@@ -172,8 +172,7 @@ export class Cleaner {
             })
             proc.on('exit', exitCode => {
                 if (exitCode !== 0) {
-                    logger.log(`The clean command failed with exit code ${exitCode}`)
-                    logger.log(`Clean command stderr: ${stderr}`)
+                    logger.logError('[Cleaner] The clean command failed.', exitCode, stderr)
                 }
                 resolve()
             })

--- a/src/components/configuration.ts
+++ b/src/components/configuration.ts
@@ -1,7 +1,10 @@
 import * as vscode from 'vscode'
 import * as path from 'path'
 import { readFileSync } from 'fs'
-import * as logger from './logger'
+
+import { getLogger } from './logger'
+
+const logger = getLogger('Config')
 
 export class Configuration {
     constructor() {
@@ -32,11 +35,11 @@ export class Configuration {
     private logConfiguration() {
         const workspaceFolders = vscode.workspace.workspaceFolders || [undefined]
         for (const workspace of workspaceFolders) {
-            logger.log(`[Config] Configuration for workspace: ${workspace?.uri.toString(true)} .`)
+            logger.log(`Configuration for workspace: ${workspace?.uri.toString(true)} .`)
             const configuration = vscode.workspace.getConfiguration(undefined, workspace)
             for(const config of this.configurationsToLog) {
                 const value = configuration.get(config)
-                logger.log(`[Config] ${config}: ${JSON.stringify(value, null, ' ')} .`)
+                logger.log(`${config}: ${JSON.stringify(value, null, ' ')} .`)
             }
         }
     }
@@ -48,7 +51,7 @@ export class Configuration {
                 if (ev.affectsConfiguration(config, workspace)) {
                     const configuration = vscode.workspace.getConfiguration(undefined, workspace)
                     const value = configuration.get(config)
-                    logger.log(`[Config] Configuration changed to { ${config}: ${JSON.stringify(value)} } at ${workspace?.uri.toString(true)} .`)
+                    logger.log(`Configuration changed to { ${config}: ${JSON.stringify(value)} } at ${workspace?.uri.toString(true)} .`)
                 }
             }
         }
@@ -67,7 +70,7 @@ export class Configuration {
                 const configValue = configuration.get(config)
                 if (JSON.stringify(defaultValue) !== JSON.stringify(configValue)) {
                     const fullConfig = `latex-workshop.${config}`
-                    logger.log(`[Config] Deprecated config ${config} with default value ${JSON.stringify(defaultValue)} is set to ${JSON.stringify(configValue)} at ${workspace?.uri.toString(true)} .`)
+                    logger.log(`Deprecated config ${config} with default value ${JSON.stringify(defaultValue)} is set to ${JSON.stringify(configValue)} at ${workspace?.uri.toString(true)} .`)
                     void vscode.window.showWarningMessage(`Config "${fullConfig}" is deprecated. ${packageDef.contributes.configuration.properties[fullConfig].deprecationMessage}`)
                 }
             })

--- a/src/components/configuration.ts
+++ b/src/components/configuration.ts
@@ -32,11 +32,11 @@ export class Configuration {
     private logConfiguration() {
         const workspaceFolders = vscode.workspace.workspaceFolders || [undefined]
         for (const workspace of workspaceFolders) {
-            logger.log(`Configuration for workspace: ${workspace?.uri.toString(true)}`)
+            logger.log(`[Config] Configuration for workspace: ${workspace?.uri.toString(true)} .`)
             const configuration = vscode.workspace.getConfiguration(undefined, workspace)
             for(const config of this.configurationsToLog) {
                 const value = configuration.get(config)
-                logger.log(`${config}: ${JSON.stringify(value, null, ' ')}`)
+                logger.log(`[Config] ${config}: ${JSON.stringify(value, null, ' ')} .`)
             }
         }
     }
@@ -48,7 +48,7 @@ export class Configuration {
                 if (ev.affectsConfiguration(config, workspace)) {
                     const configuration = vscode.workspace.getConfiguration(undefined, workspace)
                     const value = configuration.get(config)
-                    logger.log(`Configuration changed to { ${config}: ${JSON.stringify(value)} } at ${workspace?.uri.toString(true)}`)
+                    logger.log(`[Config] Configuration changed to { ${config}: ${JSON.stringify(value)} } at ${workspace?.uri.toString(true)} .`)
                 }
             }
         }
@@ -67,7 +67,7 @@ export class Configuration {
                 const configValue = configuration.get(config)
                 if (JSON.stringify(defaultValue) !== JSON.stringify(configValue)) {
                     const fullConfig = `latex-workshop.${config}`
-                    logger.log(`Deprecated config ${config} with default value ${JSON.stringify(defaultValue)} is set to ${JSON.stringify(configValue)} at ${workspace?.uri.toString(true)} .`)
+                    logger.log(`[Config] Deprecated config ${config} with default value ${JSON.stringify(defaultValue)} is set to ${JSON.stringify(configValue)} at ${workspace?.uri.toString(true)} .`)
                     void vscode.window.showWarningMessage(`Config "${fullConfig}" is deprecated. ${packageDef.contributes.configuration.properties[fullConfig].deprecationMessage}`)
                 }
             })

--- a/src/components/configuration.ts
+++ b/src/components/configuration.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode'
 import * as path from 'path'
 import { readFileSync } from 'fs'
-import { Logger } from './logger'
+import * as logger from './logger'
 
 export class Configuration {
     constructor() {
@@ -32,11 +32,11 @@ export class Configuration {
     private logConfiguration() {
         const workspaceFolders = vscode.workspace.workspaceFolders || [undefined]
         for (const workspace of workspaceFolders) {
-            Logger.log(`Configuration for workspace: ${workspace?.uri.toString(true)}`)
+            logger.log(`Configuration for workspace: ${workspace?.uri.toString(true)}`)
             const configuration = vscode.workspace.getConfiguration(undefined, workspace)
             for(const config of this.configurationsToLog) {
                 const value = configuration.get(config)
-                Logger.log(`${config}: ${JSON.stringify(value, null, ' ')}`)
+                logger.log(`${config}: ${JSON.stringify(value, null, ' ')}`)
             }
         }
     }
@@ -48,7 +48,7 @@ export class Configuration {
                 if (ev.affectsConfiguration(config, workspace)) {
                     const configuration = vscode.workspace.getConfiguration(undefined, workspace)
                     const value = configuration.get(config)
-                    Logger.log(`Configuration changed to { ${config}: ${JSON.stringify(value)} } at ${workspace?.uri.toString(true)}`)
+                    logger.log(`Configuration changed to { ${config}: ${JSON.stringify(value)} } at ${workspace?.uri.toString(true)}`)
                 }
             }
         }
@@ -67,7 +67,7 @@ export class Configuration {
                 const configValue = configuration.get(config)
                 if (JSON.stringify(defaultValue) !== JSON.stringify(configValue)) {
                     const fullConfig = `latex-workshop.${config}`
-                    Logger.log(`Deprecated config ${config} with default value ${JSON.stringify(defaultValue)} is set to ${JSON.stringify(configValue)} at ${workspace?.uri.toString(true)}.`)
+                    logger.log(`Deprecated config ${config} with default value ${JSON.stringify(defaultValue)} is set to ${JSON.stringify(configValue)} at ${workspace?.uri.toString(true)} .`)
                     void vscode.window.showWarningMessage(`Config "${fullConfig}" is deprecated. ${packageDef.contributes.configuration.properties[fullConfig].deprecationMessage}`)
                 }
             })

--- a/src/components/configuration.ts
+++ b/src/components/configuration.ts
@@ -1,13 +1,10 @@
 import * as vscode from 'vscode'
 import * as path from 'path'
 import { readFileSync } from 'fs'
-import type {Extension} from '../main'
+import { Logger } from './logger'
 
 export class Configuration {
-    private readonly extension: Extension
-
-    constructor(extension: Extension) {
-        this.extension = extension
+    constructor() {
         this.logConfiguration()
         this.checkDeprecatedConfiguration()
         vscode.workspace.onDidChangeConfiguration((ev) => {
@@ -35,11 +32,11 @@ export class Configuration {
     private logConfiguration() {
         const workspaceFolders = vscode.workspace.workspaceFolders || [undefined]
         for (const workspace of workspaceFolders) {
-            this.extension.logger.addLogMessage(`Configuration for workspace: ${workspace?.uri.toString(true)}`)
+            Logger.log(`Configuration for workspace: ${workspace?.uri.toString(true)}`)
             const configuration = vscode.workspace.getConfiguration(undefined, workspace)
             for(const config of this.configurationsToLog) {
                 const value = configuration.get(config)
-                this.extension.logger.addLogMessage(`${config}: ${JSON.stringify(value, null, ' ')}`)
+                Logger.log(`${config}: ${JSON.stringify(value, null, ' ')}`)
             }
         }
     }
@@ -51,7 +48,7 @@ export class Configuration {
                 if (ev.affectsConfiguration(config, workspace)) {
                     const configuration = vscode.workspace.getConfiguration(undefined, workspace)
                     const value = configuration.get(config)
-                    this.extension.logger.addLogMessage(`Configuration changed to { ${config}: ${JSON.stringify(value)} } at ${workspace?.uri.toString(true)}`)
+                    Logger.log(`Configuration changed to { ${config}: ${JSON.stringify(value)} } at ${workspace?.uri.toString(true)}`)
                 }
             }
         }
@@ -70,7 +67,7 @@ export class Configuration {
                 const configValue = configuration.get(config)
                 if (JSON.stringify(defaultValue) !== JSON.stringify(configValue)) {
                     const fullConfig = `latex-workshop.${config}`
-                    this.extension.logger.addLogMessage(`Deprecated config ${config} with default value ${JSON.stringify(defaultValue)} is set to ${JSON.stringify(configValue)} at ${workspace?.uri.toString(true)}.`)
+                    Logger.log(`Deprecated config ${config} with default value ${JSON.stringify(defaultValue)} is set to ${JSON.stringify(configValue)} at ${workspace?.uri.toString(true)}.`)
                     void vscode.window.showWarningMessage(`Config "${fullConfig}" is deprecated. ${packageDef.contributes.configuration.properties[fullConfig].deprecationMessage}`)
                 }
             })

--- a/src/components/counter.ts
+++ b/src/components/counter.ts
@@ -4,7 +4,10 @@ import * as path from 'path'
 import * as cs from 'cross-spawn'
 
 import type {Extension} from '../main'
-import * as logger from './logger'
+
+import { getLogger } from './logger'
+
+const logger = getLogger('Counter')
 
 export class Counter {
     private readonly extension: Extension
@@ -81,10 +84,10 @@ export class Counter {
             return
         }
         if (this.disableCountAfterSave) {
-            logger.log('[Counter] Auto texcount is temporarily disabled during a second.')
+            logger.log('Auto texcount is temporarily disabled during a second.')
             return
         }
-        logger.log(`[Counter] Auto texcount started on saving file ${file} .`)
+        logger.log(`Auto texcount started on saving file ${file} .`)
         this.disableCountAfterSave = true
         setTimeout(() => this.disableCountAfterSave = false, this.autoRunInterval)
         void this.runTeXCount(file).then(() => {
@@ -102,7 +105,7 @@ export class Counter {
     runTeXCount(file: string, merge: boolean = true): Promise<boolean> {
         let command = this.commandPath
         if (this.useDocker) {
-            logger.log('[Counter] Use Docker to invoke the command.')
+            logger.log('Use Docker to invoke the command.')
             if (process.platform === 'win32') {
                 command = path.resolve(this.extension.extensionRoot, './scripts/texcount.bat')
             } else {
@@ -115,7 +118,7 @@ export class Counter {
             args.push('-merge')
         }
         args.push(path.basename(file))
-        logger.logCommand('[Counter] Count words using command.', command, args)
+        logger.logCommand('Count words using command.', command, args)
         const proc = cs.spawn(command, args, {cwd: path.dirname(file)})
         proc.stdout.setEncoding('utf8')
         proc.stderr.setEncoding('utf8')
@@ -131,14 +134,14 @@ export class Counter {
         })
 
         proc.on('error', err => {
-            logger.logError('[Counter] Cannot count words.', err, stderr)
+            logger.logError('Cannot count words.', err, stderr)
             void logger.showErrorMessage('TeXCount failed. Please refer to LaTeX Workshop Output for details.')
         })
 
         return new Promise( resolve => {
             proc.on('exit', exitCode => {
                 if (exitCode !== 0) {
-                    logger.logError('[Counter] Cannot count words', exitCode, stderr)
+                    logger.logError('Cannot count words', exitCode, stderr)
                     void logger.showErrorMessage('TeXCount failed. Please refer to LaTeX Workshop Output for details.')
                 } else {
                     const words = /Words in text: ([0-9]*)/g.exec(stdout)

--- a/src/components/counter.ts
+++ b/src/components/counter.ts
@@ -4,7 +4,7 @@ import * as path from 'path'
 import * as cs from 'cross-spawn'
 
 import type {Extension} from '../main'
-import { Logger } from './logger'
+import * as logger from './logger'
 
 export class Counter {
     private readonly extension: Extension
@@ -81,10 +81,10 @@ export class Counter {
             return
         }
         if (this.disableCountAfterSave) {
-            Logger.log('Auto texcount is temporarily disabled during a second.')
+            logger.log('Auto texcount is temporarily disabled during a second.')
             return
         }
-        Logger.log(`Auto texcount started on saving file: ${file}`)
+        logger.log(`Auto texcount started on saving file: ${file}`)
         this.disableCountAfterSave = true
         setTimeout(() => this.disableCountAfterSave = false, this.autoRunInterval)
         void this.runTeXCount(file).then(() => {
@@ -102,7 +102,7 @@ export class Counter {
     runTeXCount(file: string, merge: boolean = true): Promise<boolean> {
         let command = this.commandPath
         if (this.useDocker) {
-            Logger.log('Use Docker to invoke the command.')
+            logger.log('Use Docker to invoke the command.')
             if (process.platform === 'win32') {
                 command = path.resolve(this.extension.extensionRoot, './scripts/texcount.bat')
             } else {
@@ -115,7 +115,7 @@ export class Counter {
             args.push('-merge')
         }
         args.push(path.basename(file))
-        Logger.logCommand('Count words using command', command, args)
+        logger.logCommand('Count words using command', command, args)
         const proc = cs.spawn(command, args, {cwd: path.dirname(file)})
         proc.stdout.setEncoding('utf8')
         proc.stderr.setEncoding('utf8')
@@ -131,15 +131,15 @@ export class Counter {
         })
 
         proc.on('error', err => {
-            Logger.log(`Cannot count words: ${err.message}, ${stderr}`)
-            void Logger.showErrorMessage('TeXCount failed. Please refer to LaTeX Workshop Output for details.')
+            logger.log(`Cannot count words: ${err.message}, ${stderr}`)
+            void logger.showErrorMessage('TeXCount failed. Please refer to LaTeX Workshop Output for details.')
         })
 
         return new Promise( resolve => {
             proc.on('exit', exitCode => {
                 if (exitCode !== 0) {
-                    Logger.log(`Cannot count words, code: ${exitCode}, ${stderr}`)
-                    void Logger.showErrorMessage('TeXCount failed. Please refer to LaTeX Workshop Output for details.')
+                    logger.log(`Cannot count words, code: ${exitCode}, ${stderr}`)
+                    void logger.showErrorMessage('TeXCount failed. Please refer to LaTeX Workshop Output for details.')
                 } else {
                     const words = /Words in text: ([0-9]*)/g.exec(stdout)
                     const floats = /Number of floats\/tables\/figures: ([0-9]*)/g.exec(stdout)

--- a/src/components/counter.ts
+++ b/src/components/counter.ts
@@ -81,10 +81,10 @@ export class Counter {
             return
         }
         if (this.disableCountAfterSave) {
-            logger.log('Auto texcount is temporarily disabled during a second.')
+            logger.log('[Counter] Auto texcount is temporarily disabled during a second.')
             return
         }
-        logger.log(`Auto texcount started on saving file: ${file}`)
+        logger.log(`[Counter] Auto texcount started on saving file ${file} .`)
         this.disableCountAfterSave = true
         setTimeout(() => this.disableCountAfterSave = false, this.autoRunInterval)
         void this.runTeXCount(file).then(() => {
@@ -102,7 +102,7 @@ export class Counter {
     runTeXCount(file: string, merge: boolean = true): Promise<boolean> {
         let command = this.commandPath
         if (this.useDocker) {
-            logger.log('Use Docker to invoke the command.')
+            logger.log('[Counter] Use Docker to invoke the command.')
             if (process.platform === 'win32') {
                 command = path.resolve(this.extension.extensionRoot, './scripts/texcount.bat')
             } else {
@@ -115,7 +115,7 @@ export class Counter {
             args.push('-merge')
         }
         args.push(path.basename(file))
-        logger.logCommand('Count words using command', command, args)
+        logger.logCommand('[Counter] Count words using command.', command, args)
         const proc = cs.spawn(command, args, {cwd: path.dirname(file)})
         proc.stdout.setEncoding('utf8')
         proc.stderr.setEncoding('utf8')
@@ -131,14 +131,14 @@ export class Counter {
         })
 
         proc.on('error', err => {
-            logger.log(`Cannot count words: ${err.message}, ${stderr}`)
+            logger.logError('[Counter] Cannot count words.', err, stderr)
             void logger.showErrorMessage('TeXCount failed. Please refer to LaTeX Workshop Output for details.')
         })
 
         return new Promise( resolve => {
             proc.on('exit', exitCode => {
                 if (exitCode !== 0) {
-                    logger.log(`Cannot count words, code: ${exitCode}, ${stderr}`)
+                    logger.logError('[Counter] Cannot count words', exitCode, stderr)
                     void logger.showErrorMessage('TeXCount failed. Please refer to LaTeX Workshop Output for details.')
                 } else {
                     const words = /Words in text: ([0-9]*)/g.exec(stdout)

--- a/src/components/duplicatelabels.ts
+++ b/src/components/duplicatelabels.ts
@@ -2,7 +2,10 @@ import * as vscode from 'vscode'
 import * as path from 'path'
 
 import type {Extension} from '../main'
-import * as logger from './logger'
+
+import { getLogger } from './logger'
+
+const logger = getLogger('DupLabel')
 
 
 export class DuplicateLabels {
@@ -15,7 +18,7 @@ export class DuplicateLabels {
      */
     private computeDuplicates(file: string): string[] {
         if (!this.extension.cacher.get(file)) {
-            logger.log(`[DupLabel] Cannot check for duplicate labels in a file not in manager: ${file} .`)
+            logger.log(`Cannot check for duplicate labels in a file not in manager: ${file} .`)
             return []
         }
         const labelsCount = new Map<string, number>()
@@ -50,7 +53,7 @@ export class DuplicateLabels {
         if (!configuration.get('check.duplicatedLabels.enabled')) {
             return
         }
-        logger.log(`[DupLabel] Checking for duplicate labels: ${file} .`)
+        logger.log(`Checking for duplicate labels: ${file} .`)
         const duplicates = this.computeDuplicates(file)
         this.showDiagnostics(duplicates)
     }

--- a/src/components/duplicatelabels.ts
+++ b/src/components/duplicatelabels.ts
@@ -15,7 +15,7 @@ export class DuplicateLabels {
      */
     private computeDuplicates(file: string): string[] {
         if (!this.extension.cacher.get(file)) {
-            logger.log(`Cannot check for duplicate labels in a file not in manager: ${file} .`)
+            logger.log(`[DupLabel] Cannot check for duplicate labels in a file not in manager: ${file} .`)
             return []
         }
         const labelsCount = new Map<string, number>()
@@ -50,7 +50,7 @@ export class DuplicateLabels {
         if (!configuration.get('check.duplicatedLabels.enabled')) {
             return
         }
-        logger.log(`Checking for duplicate labels: ${file} .`)
+        logger.log(`[DupLabel] Checking for duplicate labels: ${file} .`)
         const duplicates = this.computeDuplicates(file)
         this.showDiagnostics(duplicates)
     }

--- a/src/components/duplicatelabels.ts
+++ b/src/components/duplicatelabels.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode'
 import * as path from 'path'
 
 import type {Extension} from '../main'
-import { Logger } from './logger'
+import * as logger from './logger'
 
 
 export class DuplicateLabels {
@@ -15,7 +15,7 @@ export class DuplicateLabels {
      */
     private computeDuplicates(file: string): string[] {
         if (!this.extension.cacher.get(file)) {
-            Logger.log(`Cannot check for duplicate labels in a file not in manager: ${file}.`)
+            logger.log(`Cannot check for duplicate labels in a file not in manager: ${file} .`)
             return []
         }
         const labelsCount = new Map<string, number>()
@@ -50,7 +50,7 @@ export class DuplicateLabels {
         if (!configuration.get('check.duplicatedLabels.enabled')) {
             return
         }
-        Logger.log(`Checking for duplicate labels: ${file}.`)
+        logger.log(`Checking for duplicate labels: ${file} .`)
         const duplicates = this.computeDuplicates(file)
         this.showDiagnostics(duplicates)
     }

--- a/src/components/duplicatelabels.ts
+++ b/src/components/duplicatelabels.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode'
 import * as path from 'path'
 
 import type {Extension} from '../main'
+import { Logger } from './logger'
 
 
 export class DuplicateLabels {
@@ -14,7 +15,7 @@ export class DuplicateLabels {
      */
     private computeDuplicates(file: string): string[] {
         if (!this.extension.cacher.get(file)) {
-            this.extension.logger.addLogMessage(`Cannot check for duplicate labels in a file not in manager: ${file}.`)
+            Logger.log(`Cannot check for duplicate labels in a file not in manager: ${file}.`)
             return []
         }
         const labelsCount = new Map<string, number>()
@@ -49,7 +50,7 @@ export class DuplicateLabels {
         if (!configuration.get('check.duplicatedLabels.enabled')) {
             return
         }
-        this.extension.logger.addLogMessage(`Checking for duplicate labels: ${file}.`)
+        Logger.log(`Checking for duplicate labels: ${file}.`)
         const duplicates = this.computeDuplicates(file)
         this.showDiagnostics(duplicates)
     }

--- a/src/components/envpair.ts
+++ b/src/components/envpair.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode'
 import * as utils from '../utils/utils'
-import type { Extension } from '../main'
+import { Logger } from './logger'
 
 
 function regexpAllMatches(str: string, reg: RegExp) {
@@ -20,13 +20,11 @@ interface MatchEnv {
 }
 
 export class EnvPair {
-    private readonly extension: Extension
     private readonly beginLength = '\\begin'.length
     private readonly endLength = '\\end'.length
     private readonly delimiters = Object.create(null) as { [key: string]: {end: string, splitCharacter: string} }
 
-    constructor(extension: Extension) {
-        this.extension = extension
+    constructor() {
         this.delimiters['begin'] = {end: 'end', splitCharacter: '}'}
         this.delimiters['['] = {end: ']', splitCharacter: '['}
         this.delimiters['('] = {end: ')', splitCharacter: '('}
@@ -97,7 +95,7 @@ export class EnvPair {
                 line = line.slice(startCol, pos.character)
                 break
             default:
-                this.extension.logger.addLogMessage('Direction error in locateMatchingPair')
+                Logger.log('Direction error in locateMatchingPair')
                 return null
         }
         const begins = Object.keys(this.delimiters)
@@ -256,7 +254,7 @@ export class EnvPair {
                         editor.selection = new vscode.Selection(startingPos, startingPos)
                         break
                     default:
-                        this.extension.logger.addLogMessage('Error - while selecting environment name')
+                        Logger.log('Error - while selecting environment name')
                 }
             }
         })

--- a/src/components/envpair.ts
+++ b/src/components/envpair.ts
@@ -1,7 +1,9 @@
 import * as vscode from 'vscode'
 import * as utils from '../utils/utils'
-import * as logger from './logger'
 
+import { getLogger } from './logger'
+
+const logger = getLogger('EnvPair')
 
 function regexpAllMatches(str: string, reg: RegExp) {
     const res: RegExpExecArray[] = []
@@ -95,7 +97,7 @@ export class EnvPair {
                 line = line.slice(startCol, pos.character)
                 break
             default:
-                logger.log('[EnvPair] Direction error in locateMatchingPair')
+                logger.log('Direction error in locateMatchingPair')
                 return null
         }
         const begins = Object.keys(this.delimiters)
@@ -254,7 +256,7 @@ export class EnvPair {
                         editor.selection = new vscode.Selection(startingPos, startingPos)
                         break
                     default:
-                        logger.log('[EnvPair] Error while selecting environment name')
+                        logger.log('Error while selecting environment name')
                 }
             }
         })

--- a/src/components/envpair.ts
+++ b/src/components/envpair.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode'
 import * as utils from '../utils/utils'
-import { Logger } from './logger'
+import * as logger from './logger'
 
 
 function regexpAllMatches(str: string, reg: RegExp) {
@@ -95,7 +95,7 @@ export class EnvPair {
                 line = line.slice(startCol, pos.character)
                 break
             default:
-                Logger.log('Direction error in locateMatchingPair')
+                logger.log('Direction error in locateMatchingPair')
                 return null
         }
         const begins = Object.keys(this.delimiters)
@@ -254,7 +254,7 @@ export class EnvPair {
                         editor.selection = new vscode.Selection(startingPos, startingPos)
                         break
                     default:
-                        Logger.log('Error - while selecting environment name')
+                        logger.log('Error - while selecting environment name')
                 }
             }
         })

--- a/src/components/envpair.ts
+++ b/src/components/envpair.ts
@@ -95,7 +95,7 @@ export class EnvPair {
                 line = line.slice(startCol, pos.character)
                 break
             default:
-                logger.log('Direction error in locateMatchingPair')
+                logger.log('[EnvPair] Direction error in locateMatchingPair')
                 return null
         }
         const begins = Object.keys(this.delimiters)
@@ -254,7 +254,7 @@ export class EnvPair {
                         editor.selection = new vscode.Selection(startingPos, startingPos)
                         break
                     default:
-                        logger.log('Error - while selecting environment name')
+                        logger.log('[EnvPair] Error while selecting environment name')
                 }
             }
         })

--- a/src/components/linter.ts
+++ b/src/components/linter.ts
@@ -1,11 +1,13 @@
 import * as vscode from 'vscode'
 
 import type { Extension } from '../main'
+import * as logger from './logger'
 import { ChkTeX } from './linterlib/chktex'
 import { LaCheck } from './linterlib/lacheck'
 export interface ILinter {
+    getName(): string,
     readonly linterDiagnostics: vscode.DiagnosticCollection,
-    lintRootFile(): void,
+    lintRootFile(rootPath: string): void,
     lintFile(document: vscode.TextDocument): void,
     parseLog(log: string, filePath?: string): void
 }
@@ -52,7 +54,14 @@ export class Linter {
 
     lintRootFileIfEnabled() {
         const linters = this.getLinters(this.extension.manager.getWorkspaceFolderRootDir())
-        linters.forEach(linter => linter.lintRootFile())
+        linters.forEach(linter => {
+            if (this.extension.manager.rootFile === undefined) {
+                logger.log(`[Linter][${linter.getName()}] No root file found.`)
+                return
+            }
+            logger.log(`[Linter][${linter.getName()}] Linting root ${this.extension.manager.rootFile} .`)
+            linter.lintRootFile(this.extension.manager.rootFile)
+        })
     }
 
     lintActiveFileIfEnabledAfterInterval(document: vscode.TextDocument) {
@@ -64,7 +73,10 @@ export class Linter {
             if (this.linterTimeout) {
                 clearTimeout(this.linterTimeout)
             }
-            this.linterTimeout = setTimeout(() => linters.forEach(linter => linter.lintFile(document)), interval)
+            this.linterTimeout = setTimeout(() => linters.forEach(linter => {
+                logger.log(`[Linter][${linter.getName()}] Linting ${document.fileName} .`)
+                linter.lintFile(document)
+            }), interval)
         }
     }
 }

--- a/src/components/linter.ts
+++ b/src/components/linter.ts
@@ -1,9 +1,13 @@
 import * as vscode from 'vscode'
 
 import type { Extension } from '../main'
-import * as logger from './logger'
 import { ChkTeX } from './linterlib/chktex'
 import { LaCheck } from './linterlib/lacheck'
+
+import { getLogger } from './logger'
+
+const logger = getLogger('Linter')
+
 export interface ILinter {
     getName(): string,
     readonly linterDiagnostics: vscode.DiagnosticCollection,
@@ -56,10 +60,10 @@ export class Linter {
         const linters = this.getLinters(this.extension.manager.getWorkspaceFolderRootDir())
         linters.forEach(linter => {
             if (this.extension.manager.rootFile === undefined) {
-                logger.log(`[Linter][${linter.getName()}] No root file found.`)
+                logger.log(`No root file found for ${linter.getName()}.`)
                 return
             }
-            logger.log(`[Linter][${linter.getName()}] Linting root ${this.extension.manager.rootFile} .`)
+            logger.log(`${linter.getName()} lints root ${this.extension.manager.rootFile} .`)
             linter.lintRootFile(this.extension.manager.rootFile)
         })
     }
@@ -74,7 +78,7 @@ export class Linter {
                 clearTimeout(this.linterTimeout)
             }
             this.linterTimeout = setTimeout(() => linters.forEach(linter => {
-                logger.log(`[Linter][${linter.getName()}] Linting ${document.fileName} .`)
+                logger.log(`${linter.getName()} lints ${document.fileName} .`)
                 linter.lintFile(document)
             }), interval)
         }

--- a/src/components/linterlib/chktex.ts
+++ b/src/components/linterlib/chktex.ts
@@ -7,37 +7,34 @@ import type { Extension } from '../../main'
 import type { ILinter } from '../linter'
 import { LinterUtil } from './linterutil'
 import { convertFilenameEncoding } from '../../utils/convertfilename'
-import { Logger } from '../logger'
+import * as logger from '../logger'
 
 export class ChkTeX implements ILinter {
-    readonly #linterName = 'ChkTeX'
-    readonly linterDiagnostics: vscode.DiagnosticCollection = vscode.languages.createDiagnosticCollection(this.#linterName)
+    readonly linterName = 'ChkTeX'
+    readonly linterDiagnostics: vscode.DiagnosticCollection = vscode.languages.createDiagnosticCollection(this.linterName)
     readonly #linterUtil: LinterUtil
 
     constructor(private readonly extension: Extension) {
         this.#linterUtil = new LinterUtil()
     }
 
-    async lintRootFile() {
-        Logger.log('Linter for root file started.')
-        if (this.extension.manager.rootFile === undefined) {
-            Logger.log('No root file found for linting.')
-            return
-        }
-        const filePath = this.extension.manager.rootFile
-        const requiredArgs = ['-f%f:%l:%c:%d:%k:%n:%m\n', filePath]
+    getName() {
+        return this.linterName
+    }
 
-        const stdout = await this.chktexWrapper('root', vscode.Uri.file(filePath), filePath, requiredArgs, undefined)
+    async lintRootFile(rootPath: string) {
+        const requiredArgs = ['-f%f:%l:%c:%d:%k:%n:%m\n', rootPath]
+
+        const stdout = await this.chktexWrapper('root', vscode.Uri.file(rootPath), rootPath, requiredArgs, undefined)
         if (stdout === undefined) { // It's possible to have empty string as output
             return
         }
 
-        const tabSize = this.getChktexrcTabSize(filePath)
+        const tabSize = this.getChktexrcTabSize(rootPath)
         this.parseLog(stdout, undefined, tabSize)
     }
 
     async lintFile(document: vscode.TextDocument) {
-        Logger.log('Linter for active file started.')
         const filePath = document.fileName
         const content = document.getText()
         const requiredArgs = ['-I0', '-f%f:%l:%c:%d:%k:%n:%m\n']
@@ -151,7 +148,7 @@ export class ChkTeX implements ILinter {
             }
         }
         if (!filePath) {
-            Logger.log('The .chktexrc file not found.')
+            logger.log(`[Linter][${this.linterName}] No .chktexrc file is found to determine TabSize.`)
             return
         }
         const rcFile = fs.readFileSync(filePath).toString()
@@ -159,10 +156,10 @@ export class ChkTeX implements ILinter {
         const match = reg.exec(rcFile)
         if (match) {
             const ret = Number(match[1])
-            Logger.log(`TabSize and .chktexrc: ${ret}, ${filePath}`)
+            logger.log(`[Linter][${this.linterName}] TabSize ${ret} defined in .chktexrc ${filePath} .`)
             return ret
         }
-        Logger.log(`TabSize not found in the .chktexrc file: ${filePath}`)
+        logger.log(`[Linter][${this.linterName}] No TabSize is found in .chktexrc ${filePath} .`)
         return
     }
 
@@ -190,7 +187,7 @@ export class ChkTeX implements ILinter {
             })
             match = re.exec(log)
         }
-        Logger.log(`Linter log parsed with ${linterLog.length} messages.`)
+        logger.log(`[Linter][${this.linterName}] Logged ${linterLog.length} messages.`)
         if (singleFileOriginalPath === undefined) {
             // A full lint of the project has taken place - clear all previous results.
             this.linterDiagnostics.clear()
@@ -209,7 +206,7 @@ export class ChkTeX implements ILinter {
         }
         const filePath = convertFilenameEncoding(filePathArg)
         if (!filePath){
-            Logger.log(`Stop converting chktex's column numbers. File not found: ${filePathArg}`)
+            logger.log(`[Linter][${this.linterName}] Column number not converted on non-existent ${filePathArg} .`)
             return column
         }
         const lineString = fs.readFileSync(filePath).toString().split('\n')[line-1]
@@ -221,7 +218,7 @@ export class ChkTeX implements ILinter {
             tabSize = tabSizeArg
         }
         if (lineString === undefined) {
-            Logger.log(`Stop converting chktex's column numbers. Invalid line number: ${line}`)
+            logger.log(`[Linter][${this.linterName}] Column number not converted by invalid line ${line} of ${filePathArg}.`)
             return column
         }
         return this.convertColumn(column, lineString, tabSize)
@@ -260,7 +257,7 @@ export class ChkTeX implements ILinter {
             )
             const diag = new vscode.Diagnostic(range, item.text, DIAGNOSTIC_SEVERITY[item.type])
             diag.code = item.code
-            diag.source = this.#linterName
+            diag.source = this.linterName
             if (diagsCollection[item.file] === undefined) {
                 diagsCollection[item.file] = []
             }

--- a/src/components/linterlib/chktex.ts
+++ b/src/components/linterlib/chktex.ts
@@ -7,7 +7,9 @@ import type { Extension } from '../../main'
 import type { ILinter } from '../linter'
 import { LinterUtil } from './linterutil'
 import { convertFilenameEncoding } from '../../utils/convertfilename'
-import * as logger from '../logger'
+import { getLogger } from '../logger'
+
+const logger = getLogger('Linter', 'ChkTeX')
 
 export class ChkTeX implements ILinter {
     readonly linterName = 'ChkTeX'
@@ -148,7 +150,7 @@ export class ChkTeX implements ILinter {
             }
         }
         if (!filePath) {
-            logger.log(`[Linter][${this.linterName}] No .chktexrc file is found to determine TabSize.`)
+            logger.log(`No .chktexrc file is found to determine TabSize.`)
             return
         }
         const rcFile = fs.readFileSync(filePath).toString()
@@ -156,10 +158,10 @@ export class ChkTeX implements ILinter {
         const match = reg.exec(rcFile)
         if (match) {
             const ret = Number(match[1])
-            logger.log(`[Linter][${this.linterName}] TabSize ${ret} defined in .chktexrc ${filePath} .`)
+            logger.log(`TabSize ${ret} defined in .chktexrc ${filePath} .`)
             return ret
         }
-        logger.log(`[Linter][${this.linterName}] No TabSize is found in .chktexrc ${filePath} .`)
+        logger.log(`No TabSize is found in .chktexrc ${filePath} .`)
         return
     }
 
@@ -187,7 +189,7 @@ export class ChkTeX implements ILinter {
             })
             match = re.exec(log)
         }
-        logger.log(`[Linter][${this.linterName}] Logged ${linterLog.length} messages.`)
+        logger.log(`Logged ${linterLog.length} messages.`)
         if (singleFileOriginalPath === undefined) {
             // A full lint of the project has taken place - clear all previous results.
             this.linterDiagnostics.clear()
@@ -206,7 +208,7 @@ export class ChkTeX implements ILinter {
         }
         const filePath = convertFilenameEncoding(filePathArg)
         if (!filePath){
-            logger.log(`[Linter][${this.linterName}] Column number not converted on non-existent ${filePathArg} .`)
+            logger.log(`Column number not converted on non-existent ${filePathArg} .`)
             return column
         }
         const lineString = fs.readFileSync(filePath).toString().split('\n')[line-1]
@@ -218,7 +220,7 @@ export class ChkTeX implements ILinter {
             tabSize = tabSizeArg
         }
         if (lineString === undefined) {
-            logger.log(`[Linter][${this.linterName}] Column number not converted by invalid line ${line} of ${filePathArg}.`)
+            logger.log(`Column number not converted by invalid line ${line} of ${filePathArg}.`)
             return column
         }
         return this.convertColumn(column, lineString, tabSize)

--- a/src/components/linterlib/chktex.ts
+++ b/src/components/linterlib/chktex.ts
@@ -150,7 +150,7 @@ export class ChkTeX implements ILinter {
             }
         }
         if (!filePath) {
-            logger.log(`No .chktexrc file is found to determine TabSize.`)
+            logger.log('No .chktexrc file is found to determine TabSize.')
             return
         }
         const rcFile = fs.readFileSync(filePath).toString()

--- a/src/components/linterlib/lacheck.ts
+++ b/src/components/linterlib/lacheck.ts
@@ -6,6 +6,7 @@ import type { Extension } from '../../main'
 import type { ILinter } from '../linter'
 import { LinterUtil } from './linterutil'
 import { convertFilenameEncoding } from '../../utils/convertfilename'
+import { Logger } from '../logger'
 
 export class LaCheck implements ILinter {
     readonly #linterName = 'LaCheck'
@@ -13,13 +14,13 @@ export class LaCheck implements ILinter {
     readonly #linterUtil: LinterUtil
 
     constructor(private readonly extension: Extension) {
-        this.#linterUtil = new LinterUtil(extension)
+        this.#linterUtil = new LinterUtil()
     }
 
     async lintRootFile() {
-        this.extension.logger.addLogMessage('Linter for root file started.')
+        Logger.log('Linter for root file started.')
         if (this.extension.manager.rootFile === undefined) {
-            this.extension.logger.addLogMessage('No root file found for linting.')
+            Logger.log('No root file found for linting.')
             return
         }
         const filePath = this.extension.manager.rootFile
@@ -33,7 +34,7 @@ export class LaCheck implements ILinter {
     }
 
     async lintFile(document: vscode.TextDocument) {
-        this.extension.logger.addLogMessage('Linter for active file started.')
+        Logger.log('Linter for active file started.')
         const filePath = document.fileName
         const content = document.getText()
 
@@ -99,7 +100,7 @@ export class LaCheck implements ILinter {
                 })
             }
         }
-        this.extension.logger.addLogMessage(`Linter log parsed with ${linterLog.length} messages.`)
+        Logger.log(`Linter log parsed with ${linterLog.length} messages.`)
         this.linterDiagnostics.clear()
         this.showLinterDiagnostics(linterLog)
     }

--- a/src/components/linterlib/lacheck.ts
+++ b/src/components/linterlib/lacheck.ts
@@ -6,7 +6,9 @@ import type { Extension } from '../../main'
 import type { ILinter } from '../linter'
 import { LinterUtil } from './linterutil'
 import { convertFilenameEncoding } from '../../utils/convertfilename'
-import * as logger from '../logger'
+import { getLogger } from '../logger'
+
+const logger = getLogger('Linter', 'LaCheck')
 
 export class LaCheck implements ILinter {
     readonly linterName = 'LaCheck'
@@ -96,7 +98,7 @@ export class LaCheck implements ILinter {
                 })
             }
         }
-        logger.log(`[Linter][${this.linterName}] Logged ${linterLog.length} messages.`)
+        logger.log(`Logged ${linterLog.length} messages.`)
         this.linterDiagnostics.clear()
         this.showLinterDiagnostics(linterLog)
     }

--- a/src/components/linterlib/linterutil.ts
+++ b/src/components/linterlib/linterutil.ts
@@ -1,16 +1,13 @@
 import {ChildProcessWithoutNullStreams, spawn} from 'child_process'
 import {EOL} from 'os'
 
-import type { Extension } from '../../main'
+import { Logger } from '../logger'
 
 export class LinterUtil {
     readonly #currentProcesses = Object.create(null) as { [linterId: string]: ChildProcessWithoutNullStreams }
 
-    constructor(private readonly extension: Extension) {
-    }
-
     processWrapper(linterId: string, command: string, args: string[], options: {cwd: string}, stdin?: string): Promise<string> {
-        this.extension.logger.logCommand(`Linter for ${linterId} command`, command, args)
+        Logger.logCommand(`Linter for ${linterId} command`, command, args)
         return new Promise((resolve, reject) => {
             if (this.#currentProcesses[linterId]) {
                 this.#currentProcesses[linterId].kill()
@@ -32,7 +29,7 @@ export class LinterUtil {
             })
 
             proc.on('error', err => {
-                this.extension.logger.addLogMessage(`Linter for ${linterId} failed to spawn command, encountering error: ${err.message}`)
+                Logger.log(`Linter for ${linterId} failed to spawn command, encountering error: ${err.message}`)
                 return reject(err)
             })
 
@@ -44,11 +41,11 @@ export class LinterUtil {
                     } else {
                         msg = '\n' + stderr
                     }
-                    this.extension.logger.addLogMessage(`Linter for ${linterId} failed with exit code ${exitCode} and error:${msg}`)
+                    Logger.log(`Linter for ${linterId} failed with exit code ${exitCode} and error:${msg}`)
                     return reject({ exitCode, stdout, stderr})
                 } else {
                     const [s, ms] = process.hrtime(startTime)
-                    this.extension.logger.addLogMessage(`Linter for ${linterId} successfully finished in ${s}s ${Math.round(ms / 1000000)}ms`)
+                    Logger.log(`Linter for ${linterId} successfully finished in ${s}s ${Math.round(ms / 1000000)}ms`)
                     return resolve(stdout)
                 }
             })

--- a/src/components/linterlib/linterutil.ts
+++ b/src/components/linterlib/linterutil.ts
@@ -1,13 +1,15 @@
 import {ChildProcessWithoutNullStreams, spawn} from 'child_process'
 import {EOL} from 'os'
 
-import * as logger from '../logger'
+import { getLogger } from '../logger'
+
+const logger = getLogger('Linter')
 
 export class LinterUtil {
     readonly #currentProcesses = Object.create(null) as { [linterId: string]: ChildProcessWithoutNullStreams }
 
     processWrapper(linterId: string, command: string, args: string[], options: {cwd: string}, stdin?: string): Promise<string> {
-        logger.logCommand(`[Linter] Linter for ${linterId} command`, command, args)
+        logger.logCommand(`Linter for ${linterId} command`, command, args)
         return new Promise((resolve, reject) => {
             if (this.#currentProcesses[linterId]) {
                 this.#currentProcesses[linterId].kill()
@@ -29,7 +31,7 @@ export class LinterUtil {
             })
 
             proc.on('error', err => {
-                logger.log(`[Linter] Linter for ${linterId} failed to spawn command, encountering error: ${err.message}`)
+                logger.log(`Linter for ${linterId} failed to spawn command, encountering error: ${err.message}`)
                 return reject(err)
             })
 
@@ -41,11 +43,11 @@ export class LinterUtil {
                     } else {
                         msg = '\n' + stderr
                     }
-                    logger.log(`[Linter] Linter for ${linterId} failed with exit code ${exitCode} and error:${msg}`)
+                    logger.log(`Linter for ${linterId} failed with exit code ${exitCode} and error:${msg}`)
                     return reject({ exitCode, stdout, stderr})
                 } else {
                     const [s, ms] = process.hrtime(startTime)
-                    logger.log(`[Linter] Linter for ${linterId} successfully finished in ${s}s ${Math.round(ms / 1000000)}ms`)
+                    logger.log(`Linter for ${linterId} successfully finished in ${s}s ${Math.round(ms / 1000000)}ms`)
                     return resolve(stdout)
                 }
             })

--- a/src/components/linterlib/linterutil.ts
+++ b/src/components/linterlib/linterutil.ts
@@ -7,7 +7,7 @@ export class LinterUtil {
     readonly #currentProcesses = Object.create(null) as { [linterId: string]: ChildProcessWithoutNullStreams }
 
     processWrapper(linterId: string, command: string, args: string[], options: {cwd: string}, stdin?: string): Promise<string> {
-        logger.logCommand(`Linter for ${linterId} command`, command, args)
+        logger.logCommand(`[Linter] Linter for ${linterId} command`, command, args)
         return new Promise((resolve, reject) => {
             if (this.#currentProcesses[linterId]) {
                 this.#currentProcesses[linterId].kill()
@@ -29,7 +29,7 @@ export class LinterUtil {
             })
 
             proc.on('error', err => {
-                logger.log(`Linter for ${linterId} failed to spawn command, encountering error: ${err.message}`)
+                logger.log(`[Linter] Linter for ${linterId} failed to spawn command, encountering error: ${err.message}`)
                 return reject(err)
             })
 
@@ -41,11 +41,11 @@ export class LinterUtil {
                     } else {
                         msg = '\n' + stderr
                     }
-                    logger.log(`Linter for ${linterId} failed with exit code ${exitCode} and error:${msg}`)
+                    logger.log(`[Linter] Linter for ${linterId} failed with exit code ${exitCode} and error:${msg}`)
                     return reject({ exitCode, stdout, stderr})
                 } else {
                     const [s, ms] = process.hrtime(startTime)
-                    logger.log(`Linter for ${linterId} successfully finished in ${s}s ${Math.round(ms / 1000000)}ms`)
+                    logger.log(`[Linter] Linter for ${linterId} successfully finished in ${s}s ${Math.round(ms / 1000000)}ms`)
                     return resolve(stdout)
                 }
             })

--- a/src/components/linterlib/linterutil.ts
+++ b/src/components/linterlib/linterutil.ts
@@ -1,13 +1,13 @@
 import {ChildProcessWithoutNullStreams, spawn} from 'child_process'
 import {EOL} from 'os'
 
-import { Logger } from '../logger'
+import * as logger from '../logger'
 
 export class LinterUtil {
     readonly #currentProcesses = Object.create(null) as { [linterId: string]: ChildProcessWithoutNullStreams }
 
     processWrapper(linterId: string, command: string, args: string[], options: {cwd: string}, stdin?: string): Promise<string> {
-        Logger.logCommand(`Linter for ${linterId} command`, command, args)
+        logger.logCommand(`Linter for ${linterId} command`, command, args)
         return new Promise((resolve, reject) => {
             if (this.#currentProcesses[linterId]) {
                 this.#currentProcesses[linterId].kill()
@@ -29,7 +29,7 @@ export class LinterUtil {
             })
 
             proc.on('error', err => {
-                Logger.log(`Linter for ${linterId} failed to spawn command, encountering error: ${err.message}`)
+                logger.log(`Linter for ${linterId} failed to spawn command, encountering error: ${err.message}`)
                 return reject(err)
             })
 
@@ -41,11 +41,11 @@ export class LinterUtil {
                     } else {
                         msg = '\n' + stderr
                     }
-                    Logger.log(`Linter for ${linterId} failed with exit code ${exitCode} and error:${msg}`)
+                    logger.log(`Linter for ${linterId} failed with exit code ${exitCode} and error:${msg}`)
                     return reject({ exitCode, stdout, stderr})
                 } else {
                     const [s, ms] = process.hrtime(startTime)
-                    Logger.log(`Linter for ${linterId} successfully finished in ${s}s ${Math.round(ms / 1000000)}ms`)
+                    logger.log(`Linter for ${linterId} successfully finished in ${s}s ${Math.round(ms / 1000000)}ms`)
                     return resolve(stdout)
                 }
             })

--- a/src/components/locator.ts
+++ b/src/components/locator.ts
@@ -207,7 +207,7 @@ export class Locator {
         return new Promise( (resolve) => {
             proc.on('exit', exitCode => {
                 if (exitCode !== 0) {
-                    logger.logError(`[SyncTeX][${logTag}] Forward SyncTeX failed.`, {code: exitCode}, stderr)
+                    logger.logError(`[SyncTeX][${logTag}] Forward SyncTeX failed.`, exitCode, stderr)
                 } else {
                     resolve(this.parseSyncTeXForward(stdout))
                 }
@@ -234,7 +234,7 @@ export class Locator {
 
         let command = configuration.get('synctex.path') as string
         if (docker) {
-            logger.log('Use Docker to invoke the command.')
+            logger.log('[SyncTeX][Docker] Use Docker to invoke the command.')
             if (process.platform === 'win32') {
                 command = path.resolve(this.extension.extensionRoot, './scripts/synctex.bat')
             } else {
@@ -267,7 +267,7 @@ export class Locator {
         return new Promise( (resolve) => {
             proc.on('exit', exitCode => {
                 if (exitCode !== 0) {
-                    logger.logError(`[SyncTeX][${logTag}] Backward SyncTeX failed.`, {code: exitCode}, stderr)
+                    logger.logError(`[SyncTeX][${logTag}] Backward SyncTeX failed.`, exitCode, stderr)
                 } else {
                     const record = this.parseSyncTeXBackward(stdout)
                     resolve(record)

--- a/src/components/locatorlib/synctex.ts
+++ b/src/components/locatorlib/synctex.ts
@@ -7,8 +7,10 @@ import type { SyncTeXRecordForward, SyncTeXRecordBackward } from '../locator'
 import { PdfSyncObject, parseSyncTex, Block, SyncTexJsError } from '../../lib/synctexjs'
 import {iconvLiteSupportedEncodings} from '../../utils/convertfilename'
 import {isSameRealPath} from '../../utils/pathnormalize'
-import * as logger from '../logger'
 
+import { getLogger } from '../logger'
+
+const logger = getLogger('SyncTeX')
 
 class Rectangle {
     readonly top: number
@@ -91,7 +93,7 @@ export class SyncTexJs {
             const s = fs.readFileSync(synctexFile, {encoding: 'binary'})
             return parseSyncTex(s)
         } catch (e: unknown) {
-            logger.logError(`[SyncTeX] Failed parsing .synctex ${synctexFile} , using .synctex.gz.`, e)
+            logger.logError(`Failed parsing .synctex ${synctexFile} , using .synctex.gz.`, e)
         }
 
         try {
@@ -100,7 +102,7 @@ export class SyncTexJs {
             const s = b.toString('binary')
             return parseSyncTex(s)
         } catch (e: unknown) {
-            logger.logError(`[SyncTeX] Failed parsing .synctex.gz ${synctexFileGz} .`, e)
+            logger.logError(`Failed parsing .synctex.gz ${synctexFileGz} .`, e)
         }
 
         throw new SyncTexJsError('SyncTeX failed.')

--- a/src/components/locatorlib/synctex.ts
+++ b/src/components/locatorlib/synctex.ts
@@ -3,11 +3,11 @@ import * as iconv from 'iconv-lite'
 import * as path from 'path'
 import * as zlib from 'zlib'
 
-import type { Extension } from '../../main'
 import type { SyncTeXRecordForward, SyncTeXRecordBackward } from '../locator'
 import { PdfSyncObject, parseSyncTex, Block, SyncTexJsError } from '../../lib/synctexjs'
 import {iconvLiteSupportedEncodings} from '../../utils/convertfilename'
 import {isSameRealPath} from '../../utils/pathnormalize'
+import { Logger } from '../logger'
 
 
 class Rectangle {
@@ -73,12 +73,6 @@ class Rectangle {
 }
 
 export class SyncTexJs {
-    private readonly extension: Extension
-
-    constructor(extension: Extension) {
-        this.extension = extension
-    }
-
     parseSyncTexForPdf(pdfFile: string): PdfSyncObject {
         const filename = path.basename(pdfFile, path.extname(pdfFile))
         const dir = path.dirname(pdfFile)
@@ -90,9 +84,9 @@ export class SyncTexJs {
             return parseSyncTex(s)
         } catch (e: unknown) {
             if (fs.existsSync(synctexFile)) {
-                this.extension.logger.addLogMessage(`[SyncTexJs] parseSyncTex failed with: ${synctexFile}`)
+                Logger.log(`[SyncTexJs] parseSyncTex failed with: ${synctexFile}`)
                 if (e instanceof Error) {
-                    this.extension.logger.logError(e)
+                    Logger.logError(e)
                 }
             }
         }
@@ -104,15 +98,15 @@ export class SyncTexJs {
             return parseSyncTex(s)
         } catch (e: unknown) {
             if (fs.existsSync(synctexFileGz)) {
-                this.extension.logger.addLogMessage(`[SyncTexJs] parseSyncTex failed with: ${synctexFileGz}`)
+                Logger.log(`[SyncTexJs] parseSyncTex failed with: ${synctexFileGz}`)
                 if (e instanceof Error) {
-                    this.extension.logger.logError(e)
+                    Logger.logError(e)
                 }
             }
         }
 
         if (!fs.existsSync(synctexFile) && !fs.existsSync(synctexFileGz)) {
-            this.extension.logger.addLogMessage(`[SyncTexJs] .synctex and .synctex.gz file not found: ${JSON.stringify({synctexFile, synctexFileGz})}`)
+            Logger.log(`[SyncTexJs] .synctex and .synctex.gz file not found: ${JSON.stringify({synctexFile, synctexFileGz})}`)
         }
 
         throw new SyncTexJsError(`parseSyncTexForPdf failed with: ${pdfFile}`)
@@ -141,7 +135,7 @@ export class SyncTexJs {
     }
 
     syncTexJsForward(line: number, filePath: string, pdfFile: string): SyncTeXRecordForward {
-        this.extension.logger.addLogMessage(`[SyncTexJs] Execute syncTexJsForward: ${JSON.stringify({pdfFile, filePath, line})}`)
+        Logger.log(`[SyncTexJs] Execute syncTexJsForward: ${JSON.stringify({pdfFile, filePath, line})}`)
         const pdfSyncObject = this.parseSyncTexForPdf(pdfFile)
         const inputFilePath = this.findInputFilePathForward(filePath, pdfSyncObject)
         if (inputFilePath === undefined) {
@@ -185,7 +179,7 @@ export class SyncTexJs {
     }
 
     syncTexJsBackward(page: number, x: number, y: number, pdfPath: string): SyncTeXRecordBackward {
-        this.extension.logger.addLogMessage(`[SyncTexJs] Execute syncTexJsBackward: ${JSON.stringify({pdfPath, page, x, y})}`)
+        Logger.log(`[SyncTexJs] Execute syncTexJsBackward: ${JSON.stringify({pdfPath, page, x, y})}`)
         const pdfSyncObject = this.parseSyncTexForPdf(pdfPath)
         const y0 = y - pdfSyncObject.offset.y
         const x0 = x - pdfSyncObject.offset.x

--- a/src/components/logger.ts
+++ b/src/components/logger.ts
@@ -1,65 +1,73 @@
 import * as vscode from 'vscode'
 
 export class Logger {
-    private readonly logPanel: vscode.OutputChannel
-    private readonly compilerLogPanel: vscode.OutputChannel
-    readonly status: vscode.StatusBarItem
+    static readonly LOG_PANEL = vscode.window.createOutputChannel('LaTeX Workshop')
+    static readonly COMPILER_PANEL = vscode.window.createOutputChannel('LaTeX Compiler')
+    static readonly status = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, -10000)
 
     constructor() {
-        this.logPanel = vscode.window.createOutputChannel('LaTeX Workshop')
-        this.compilerLogPanel = vscode.window.createOutputChannel('LaTeX Compiler')
-        this.compilerLogPanel.append('Ready')
-        this.status = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, -10000)
-        this.status.command = 'latex-workshop.actions'
-        this.status.show()
-        this.displayStatus('check', 'statusBar.foreground')
+        Logger.COMPILER_PANEL.append('Ready')
     }
 
-    addLogMessage(message: string) {
+    static initializeStatusBarItem() {
+        Logger.status.command = 'latex-workshop.actions'
+        Logger.status.show()
+        Logger.displayStatus('check', 'statusBar.foreground')
+    }
+
+    static log(message: string) {
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         if (configuration.get('message.log.show')) {
-            this.logPanel.append(`[${new Date().toLocaleTimeString('en-US', { hour12: false })}] ${message}\n`)
+            Logger.LOG_PANEL.append(`[${new Date().toLocaleTimeString('en-US', { hour12: false })}] ${message}\n`)
         }
     }
 
-    logCommand(message: string, command: string, args: string[] = []) {
-        this.addLogMessage(message + ': ' + command)
-        this.addLogMessage(message + ' args: ' + JSON.stringify(args))
+    static logCommand(message: string, command: string, args: string[] = []) {
+        Logger.log(message + ': ' + command)
+        Logger.log(message + ' args: ' + JSON.stringify(args))
     }
 
-    addCompilerMessage(message: string) {
-        this.compilerLogPanel.append(message)
+    static addCompilerMessage(message: string) {
+        Logger.COMPILER_PANEL.append(message)
     }
 
-    logError(e: Error) {
-        this.addLogMessage(e.message)
+    static logError(e: Error) {
+        Logger.log(e.message)
         if (e.stack) {
-            this.addLogMessage(e.stack)
+            Logger.log(e.stack)
         }
     }
 
-    logOnRejected(e: unknown) {
+    static logOnRejected(e: unknown) {
         if (e instanceof Error) {
             this.logError(e)
         } else {
-            this.addLogMessage(String(e))
+            Logger.log(String(e))
         }
     }
 
-    clearCompilerMessage() {
-        this.compilerLogPanel.clear()
+    static clearCompilerMessage() {
+        Logger.COMPILER_PANEL.clear()
     }
 
-    displayStatus(
+    static showLog() {
+        Logger.LOG_PANEL.show()
+    }
+
+    static showCompilerLog() {
+        Logger.COMPILER_PANEL.show()
+    }
+
+    static displayStatus(
         icon: string,
         color: string,
         message: string | undefined = undefined,
         severity: 'info' | 'warning' | 'error' = 'info',
         build: string = ''
     ) {
-        this.status.text = `$(${icon})${build}`
-        this.status.tooltip = message
-        this.status.color = new vscode.ThemeColor(color)
+        Logger.status.text = `$(${icon})${build}`
+        Logger.status.tooltip = message
+        Logger.status.color = new vscode.ThemeColor(color)
         if (message === undefined) {
             return
         }
@@ -84,7 +92,7 @@ export class Logger {
         }
     }
 
-    showErrorMessage(message: string, ...args: string[]): Thenable<string | undefined> | undefined {
+    static showErrorMessage(message: string, ...args: string[]): Thenable<string | undefined> | undefined {
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         if (configuration.get('message.error.show')) {
             return vscode.window.showErrorMessage(message, ...args)
@@ -93,13 +101,13 @@ export class Logger {
         }
     }
 
-    showErrorMessageWithCompilerLogButton(message: string) {
-        const res = this.showErrorMessage(message, 'Open compiler log')
+    static showErrorMessageWithCompilerLogButton(message: string) {
+        const res = Logger.showErrorMessage(message, 'Open compiler log')
         if (res) {
             return res.then(option => {
                 switch (option) {
                     case 'Open compiler log': {
-                        this.showCompilerLog()
+                        Logger.showCompilerLog()
                         break
                     }
                     default: {
@@ -111,13 +119,13 @@ export class Logger {
         return
     }
 
-    showErrorMessageWithExtensionLogButton(message: string) {
-        const res = this.showErrorMessage(message, 'Open LaTeX Workshop log')
+    static showErrorMessageWithExtensionLogButton(message: string) {
+        const res = Logger.showErrorMessage(message, 'Open LaTeX Workshop log')
         if (res) {
             return res.then(option => {
                 switch (option) {
                     case 'Open LaTeX Workshop log': {
-                        this.showLog()
+                        Logger.showLog()
                         break
                     }
                     default: {
@@ -127,13 +135,5 @@ export class Logger {
             })
         }
         return
-    }
-
-    showLog() {
-        this.logPanel.show()
-    }
-
-    showCompilerLog() {
-        this.compilerLogPanel.show()
     }
 }

--- a/src/components/logger.ts
+++ b/src/components/logger.ts
@@ -1,139 +1,137 @@
 import * as vscode from 'vscode'
 
-export class Logger {
-    static readonly LOG_PANEL = vscode.window.createOutputChannel('LaTeX Workshop')
-    static readonly COMPILER_PANEL = vscode.window.createOutputChannel('LaTeX Compiler')
-    static readonly status = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, -10000)
+const LOG_PANEL = vscode.window.createOutputChannel('LaTeX Workshop')
+const COMPILER_PANEL = vscode.window.createOutputChannel('LaTeX Compiler')
+const STATUS_ITEM = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, -10000)
 
-    constructor() {
-        Logger.COMPILER_PANEL.append('Ready')
+COMPILER_PANEL.append('Ready')
+
+export function initializeStatusBarItem() {
+    STATUS_ITEM.command = 'latex-workshop.actions'
+    STATUS_ITEM.show()
+    refreshStatus('check', 'statusBar.foreground')
+}
+
+export function log(message: string) {
+    const configuration = vscode.workspace.getConfiguration('latex-workshop')
+    if (configuration.get('message.log.show')) {
+        LOG_PANEL.appendLine(`[${new Date().toLocaleTimeString('en-US', { hour12: false })}] ${message}`)
     }
+}
 
-    static initializeStatusBarItem() {
-        Logger.status.command = 'latex-workshop.actions'
-        Logger.status.show()
-        Logger.displayStatus('check', 'statusBar.foreground')
-    }
+export function logCommand(message: string, command: string, args: string[] = []) {
+    log(`${message} The command is ${command}:${JSON.stringify(args)}.`)
+}
 
-    static log(message: string) {
-        const configuration = vscode.workspace.getConfiguration('latex-workshop')
-        if (configuration.get('message.log.show')) {
-            Logger.LOG_PANEL.append(`[${new Date().toLocaleTimeString('en-US', { hour12: false })}] ${message}\n`)
+export function addCompilerMessage(message: string) {
+    COMPILER_PANEL.append(message)
+}
+
+export function logError(message: string, error: unknown, stderr?: string) {
+    if (error instanceof Error) {
+        log(`${message} ${error.name}: ${error.message}`)
+        if (error.stack) {
+            log(error.stack)
         }
+    } else {
+        log(`${message} Context: ${String(error)}.`)
     }
-
-    static logCommand(message: string, command: string, args: string[] = []) {
-        Logger.log(message + ': ' + command)
-        Logger.log(message + ' args: ' + JSON.stringify(args))
+    if (stderr) {
+        log(`STDERR: ${stderr}`)
     }
+}
 
-    static addCompilerMessage(message: string) {
-        Logger.COMPILER_PANEL.append(message)
-    }
+export function clearCompilerMessage() {
+    COMPILER_PANEL.clear()
+}
 
-    static logError(e: Error) {
-        Logger.log(e.message)
-        if (e.stack) {
-            Logger.log(e.stack)
-        }
-    }
+export function showLog() {
+    LOG_PANEL.show()
+}
 
-    static logOnRejected(e: unknown) {
-        if (e instanceof Error) {
-            this.logError(e)
-        } else {
-            Logger.log(String(e))
-        }
-    }
+export function showCompilerLog() {
+    COMPILER_PANEL.show()
+}
 
-    static clearCompilerMessage() {
-        Logger.COMPILER_PANEL.clear()
-    }
+export function showStatus() {
+    STATUS_ITEM.show()
+}
 
-    static showLog() {
-        Logger.LOG_PANEL.show()
-    }
-
-    static showCompilerLog() {
-        Logger.COMPILER_PANEL.show()
-    }
-
-    static displayStatus(
-        icon: string,
-        color: string,
-        message: string | undefined = undefined,
-        severity: 'info' | 'warning' | 'error' = 'info',
-        build: string = ''
-    ) {
-        Logger.status.text = `$(${icon})${build}`
-        Logger.status.tooltip = message
-        Logger.status.color = new vscode.ThemeColor(color)
-        if (message === undefined) {
-            return
-        }
-        const configuration = vscode.workspace.getConfiguration('latex-workshop')
-        switch (severity) {
-            case 'info':
-                if (configuration.get('message.information.show')) {
-                    void vscode.window.showInformationMessage(message)
-                }
-                break
-            case 'warning':
-                if (configuration.get('message.warning.show')) {
-                    void vscode.window.showWarningMessage(message)
-                }
-                break
-            case 'error':
-            default:
-                if (configuration.get('message.error.show')) {
-                    void vscode.window.showErrorMessage(message)
-                }
-                break
-        }
-    }
-
-    static showErrorMessage(message: string, ...args: string[]): Thenable<string | undefined> | undefined {
-        const configuration = vscode.workspace.getConfiguration('latex-workshop')
-        if (configuration.get('message.error.show')) {
-            return vscode.window.showErrorMessage(message, ...args)
-        } else {
-            return undefined
-        }
-    }
-
-    static showErrorMessageWithCompilerLogButton(message: string) {
-        const res = Logger.showErrorMessage(message, 'Open compiler log')
-        if (res) {
-            return res.then(option => {
-                switch (option) {
-                    case 'Open compiler log': {
-                        Logger.showCompilerLog()
-                        break
-                    }
-                    default: {
-                        break
-                    }
-                }
-            })
-        }
+export function refreshStatus(
+    icon: string,
+    color: string,
+    message: string | undefined = undefined,
+    severity: 'info' | 'warning' | 'error' = 'info',
+    build: string = ''
+) {
+    STATUS_ITEM.text = `$(${icon})${build}`
+    STATUS_ITEM.tooltip = message
+    STATUS_ITEM.color = new vscode.ThemeColor(color)
+    if (message === undefined) {
         return
     }
-
-    static showErrorMessageWithExtensionLogButton(message: string) {
-        const res = Logger.showErrorMessage(message, 'Open LaTeX Workshop log')
-        if (res) {
-            return res.then(option => {
-                switch (option) {
-                    case 'Open LaTeX Workshop log': {
-                        Logger.showLog()
-                        break
-                    }
-                    default: {
-                        break
-                    }
-                }
-            })
-        }
-        return
+    const configuration = vscode.workspace.getConfiguration('latex-workshop')
+    switch (severity) {
+        case 'info':
+            if (configuration.get('message.information.show')) {
+                void vscode.window.showInformationMessage(message)
+            }
+            break
+        case 'warning':
+            if (configuration.get('message.warning.show')) {
+                void vscode.window.showWarningMessage(message)
+            }
+            break
+        case 'error':
+        default:
+            if (configuration.get('message.error.show')) {
+                void vscode.window.showErrorMessage(message)
+            }
+            break
     }
+}
+
+export function showErrorMessage(message: string, ...args: string[]): Thenable<string | undefined> | undefined {
+    const configuration = vscode.workspace.getConfiguration('latex-workshop')
+    if (configuration.get('message.error.show')) {
+        return vscode.window.showErrorMessage(message, ...args)
+    } else {
+        return undefined
+    }
+}
+
+export function showErrorMessageWithCompilerLogButton(message: string) {
+    const res = showErrorMessage(message, 'Open compiler log')
+    if (res) {
+        return res.then(option => {
+            switch (option) {
+                case 'Open compiler log': {
+                    showCompilerLog()
+                    break
+                }
+                default: {
+                    break
+                }
+            }
+        })
+    }
+    return
+}
+
+export function showErrorMessageWithExtensionLogButton(message: string) {
+    const res = showErrorMessage(message, 'Open LaTeX Workshop log')
+    if (res) {
+        return res.then(option => {
+            switch (option) {
+                case 'Open LaTeX Workshop log': {
+                    showLog()
+                    break
+                }
+                default: {
+                    break
+                }
+            }
+        })
+    }
+    return
 }

--- a/src/components/logger.ts
+++ b/src/components/logger.ts
@@ -33,11 +33,13 @@ export function logError(message: string, error: unknown, stderr?: string) {
         if (error.stack) {
             log(error.stack)
         }
+    } else if (error instanceof Number) {
+        log(`${message} Exit code ${error}`)
     } else {
         log(`${message} Context: ${String(error)}.`)
     }
     if (stderr) {
-        log(`STDERR: ${stderr}`)
+        log(`[STDERR] ${stderr}`)
     }
 }
 

--- a/src/components/lwfs.ts
+++ b/src/components/lwfs.ts
@@ -1,15 +1,8 @@
 import * as vscode from 'vscode'
 import * as fs from 'fs'
-
-import type { Extension } from '../main'
+import { Logger } from './logger'
 
 export class LwFileSystem {
-    private readonly extension: Extension
-
-    constructor(extension: Extension) {
-        this.extension = extension
-    }
-
     isLocalUri(uri: vscode.Uri): boolean {
         return uri.scheme === 'file'
     }
@@ -51,7 +44,7 @@ export class LwFileSystem {
             return ret
         } catch (err) {
             if (err instanceof Error) {
-                this.extension.logger.logError(err)
+                Logger.logError(err)
             }
             return undefined
         }

--- a/src/components/lwfs.ts
+++ b/src/components/lwfs.ts
@@ -1,6 +1,5 @@
 import * as vscode from 'vscode'
 import * as fs from 'fs'
-import { Logger } from './logger'
 
 export class LwFileSystem {
     isLocalUri(uri: vscode.Uri): boolean {
@@ -43,9 +42,6 @@ export class LwFileSystem {
             const ret = fs.readFileSync(filepath).toString()
             return ret
         } catch (err) {
-            if (err instanceof Error) {
-                Logger.logError(err)
-            }
             return undefined
         }
     }

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -9,7 +9,7 @@ import type {Extension} from '../main'
 import * as eventbus from './eventbus'
 
 import {FinderUtils} from './managerlib/finderutils'
-import { Logger } from './logger'
+import * as logger from './logger'
 
 type RootFileType = {
     type: 'filePath',
@@ -97,7 +97,7 @@ export class Manager {
                 if (ret.uri.scheme === 'file') {
                     return ret.uri.fsPath
                 } else {
-                    Logger.log(`The file cannot be used as the root file: ${ret.uri.toString(true)}`)
+                    logger.log(`The file cannot be used as the root file: ${ret.uri.toString(true)}`)
                     return
                 }
             }
@@ -240,7 +240,7 @@ export class Manager {
      */
     async findRoot(): Promise<string | undefined> {
         const wsfolders = vscode.workspace.workspaceFolders?.map(e => e.uri.toString(true))
-        Logger.log(`Current workspace folders: ${JSON.stringify(wsfolders)}`)
+        logger.log(`Current workspace folders: ${JSON.stringify(wsfolders)}`)
         this.localRootFile = undefined
         const findMethods = [
             () => this.finderUtils.findRootFromMagic(),
@@ -254,11 +254,11 @@ export class Manager {
                 continue
             }
             if (this.rootFile !== rootFile) {
-                Logger.log(`Root file changed: from ${this.rootFile} to ${rootFile}`)
-                Logger.log('Start to find all dependencies.')
+                logger.log(`Root file changed: from ${this.rootFile} to ${rootFile}`)
+                logger.log('Start to find all dependencies.')
                 this.rootFile = rootFile
                 this.rootFileLanguageId = this.inferLanguageId(rootFile)
-                Logger.log(`Root file languageId: ${this.rootFileLanguageId}`)
+                logger.log(`Root file languageId: ${this.rootFileLanguageId}`)
                 // We also clean the completions from the old project
                 this.extension.completer.input.reset()
                 this.extension.duplicateLabels.reset()
@@ -272,7 +272,7 @@ export class Manager {
                 await this.extension.cacher.loadFlsFile(this.rootFile)
                 this.extension.eventBus.fire(eventbus.RootFileChanged, rootFile)
             } else {
-                Logger.log(`Keep using the same root file: ${this.rootFile}`)
+                logger.log(`Keep using the same root file: ${this.rootFile}`)
             }
             this.extension.eventBus.fire(eventbus.RootFileSearched)
             return rootFile
@@ -286,7 +286,7 @@ export class Manager {
             return undefined
         }
         if (this.extension.lwfs.isVirtualUri(vscode.window.activeTextEditor.document.uri)) {
-            Logger.log(`The active document cannot be used as the root file: ${vscode.window.activeTextEditor.document.uri.toString(true)}`)
+            logger.log(`The active document cannot be used as the root file: ${vscode.window.activeTextEditor.document.uri.toString(true)}`)
             return undefined
         }
         if (this.extension.cacher.getIncludedTeX().includes(vscode.window.activeTextEditor.document.fileName)) {
@@ -300,7 +300,7 @@ export class Manager {
             return undefined
         }
         if (this.extension.lwfs.isVirtualUri(vscode.window.activeTextEditor.document.uri)) {
-            Logger.log(`The active document cannot be used as the root file: ${vscode.window.activeTextEditor.document.uri.toString(true)}`)
+            logger.log(`The active document cannot be used as the root file: ${vscode.window.activeTextEditor.document.uri.toString(true)}`)
             return undefined
         }
         const regex = /\\begin{document}/m
@@ -313,7 +313,7 @@ export class Manager {
                this.localRootFile = file
                return rootSubFile
             } else {
-                Logger.log(`Found root file from active editor: ${file}`)
+                logger.log(`Found root file from active editor: ${file}`)
                 return file
             }
         }
@@ -323,7 +323,7 @@ export class Manager {
     private async findRootInWorkspace(): Promise<string | undefined> {
         const regex = /\\begin{document}/m
         const currentWorkspaceDirUri = this.findWorkspace()
-        Logger.log(`Current workspaceRootDir: ${currentWorkspaceDirUri ? currentWorkspaceDirUri.toString(true) : ''}`)
+        logger.log(`Current workspaceRootDir: ${currentWorkspaceDirUri ? currentWorkspaceDirUri.toString(true) : ''}`)
 
         if (!currentWorkspaceDirUri) {
             return undefined
@@ -339,12 +339,12 @@ export class Manager {
             const candidates: string[] = []
             for (const file of files) {
                 if (this.extension.lwfs.isVirtualUri(file)) {
-                    Logger.log(`Skip the file: ${file.toString(true)}`)
+                    logger.log(`Skip the file: ${file.toString(true)}`)
                     continue
                 }
                 const flsChildren = this.extension.cacher.getTeXChildrenFromFls(file.fsPath)
                 if (vscode.window.activeTextEditor && flsChildren.includes(vscode.window.activeTextEditor.document.fileName)) {
-                    Logger.log(`Found root file from '.fls': ${file.fsPath}`)
+                    logger.log(`Found root file from '.fls': ${file.fsPath}`)
                     return file.fsPath
                 }
                 const content = utils.stripCommentsAndVerbatim(fs.readFileSync(file.fsPath).toString())
@@ -353,7 +353,7 @@ export class Manager {
                     // Can be a root
                     const children = await this.extension.cacher.getTeXChildren(file.fsPath, file.fsPath, [])
                     if (vscode.window.activeTextEditor && children.includes(vscode.window.activeTextEditor.document.fileName)) {
-                        Logger.log(`Found root file from parent: ${file.fsPath}`)
+                        logger.log(`Found root file from parent: ${file.fsPath}`)
                         return file.fsPath
                     }
                     // Not including the active file, yet can still be a root candidate
@@ -361,7 +361,7 @@ export class Manager {
                 }
             }
             if (candidates.length > 0) {
-                Logger.log(`Found files that might be root, choose the first one: ${candidates}`)
+                logger.log(`Found files that might be root, choose the first one: ${candidates}`)
                 return candidates[0]
             }
         } catch (e) {}
@@ -372,7 +372,7 @@ export class Manager {
         const setEnvVar = () => {
             const configuration = vscode.workspace.getConfiguration('latex-workshop')
             const dockerImageName: string = configuration.get('docker.image.latex', '')
-            Logger.log(`Set $LATEXWORKSHOP_DOCKER_LATEX: ${JSON.stringify(dockerImageName)}`)
+            logger.log(`Set $LATEXWORKSHOP_DOCKER_LATEX: ${JSON.stringify(dockerImageName)}`)
             process.env['LATEXWORKSHOP_DOCKER_LATEX'] = dockerImageName
         }
         setEnvVar()

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -97,7 +97,7 @@ export class Manager {
                 if (ret.uri.scheme === 'file') {
                     return ret.uri.fsPath
                 } else {
-                    logger.log(`The file cannot be used as the root file: ${ret.uri.toString(true)}`)
+                    logger.log(`[Manager] The file cannot be used as the root file: ${ret.uri.toString(true)}`)
                     return
                 }
             }
@@ -240,7 +240,7 @@ export class Manager {
      */
     async findRoot(): Promise<string | undefined> {
         const wsfolders = vscode.workspace.workspaceFolders?.map(e => e.uri.toString(true))
-        logger.log(`Current workspace folders: ${JSON.stringify(wsfolders)}`)
+        logger.log(`[Manager] Current workspace folders: ${JSON.stringify(wsfolders)}`)
         this.localRootFile = undefined
         const findMethods = [
             () => this.finderUtils.findRootFromMagic(),
@@ -254,11 +254,11 @@ export class Manager {
                 continue
             }
             if (this.rootFile !== rootFile) {
-                logger.log(`Root file changed: from ${this.rootFile} to ${rootFile}`)
-                logger.log('Start to find all dependencies.')
+                logger.log(`[Manager] Root file changed: from ${this.rootFile} to ${rootFile}`)
+                logger.log('[Manager] Start to find all dependencies.')
                 this.rootFile = rootFile
                 this.rootFileLanguageId = this.inferLanguageId(rootFile)
-                logger.log(`Root file languageId: ${this.rootFileLanguageId}`)
+                logger.log(`[Manager] Root file languageId: ${this.rootFileLanguageId}`)
                 // We also clean the completions from the old project
                 this.extension.completer.input.reset()
                 this.extension.duplicateLabels.reset()
@@ -272,7 +272,7 @@ export class Manager {
                 await this.extension.cacher.loadFlsFile(this.rootFile)
                 this.extension.eventBus.fire(eventbus.RootFileChanged, rootFile)
             } else {
-                logger.log(`Keep using the same root file: ${this.rootFile}`)
+                logger.log(`[Manager] Keep using the same root file: ${this.rootFile}`)
             }
             this.extension.eventBus.fire(eventbus.RootFileSearched)
             return rootFile
@@ -286,7 +286,7 @@ export class Manager {
             return undefined
         }
         if (this.extension.lwfs.isVirtualUri(vscode.window.activeTextEditor.document.uri)) {
-            logger.log(`The active document cannot be used as the root file: ${vscode.window.activeTextEditor.document.uri.toString(true)}`)
+            logger.log(`[Manager] The active document cannot be used as the root file: ${vscode.window.activeTextEditor.document.uri.toString(true)}`)
             return undefined
         }
         if (this.extension.cacher.getIncludedTeX().includes(vscode.window.activeTextEditor.document.fileName)) {
@@ -300,7 +300,7 @@ export class Manager {
             return undefined
         }
         if (this.extension.lwfs.isVirtualUri(vscode.window.activeTextEditor.document.uri)) {
-            logger.log(`The active document cannot be used as the root file: ${vscode.window.activeTextEditor.document.uri.toString(true)}`)
+            logger.log(`[Manager] The active document cannot be used as the root file: ${vscode.window.activeTextEditor.document.uri.toString(true)}`)
             return undefined
         }
         const regex = /\\begin{document}/m
@@ -313,7 +313,7 @@ export class Manager {
                this.localRootFile = file
                return rootSubFile
             } else {
-                logger.log(`Found root file from active editor: ${file}`)
+                logger.log(`[Manager] Found root file from active editor: ${file}`)
                 return file
             }
         }
@@ -323,7 +323,7 @@ export class Manager {
     private async findRootInWorkspace(): Promise<string | undefined> {
         const regex = /\\begin{document}/m
         const currentWorkspaceDirUri = this.findWorkspace()
-        logger.log(`Current workspaceRootDir: ${currentWorkspaceDirUri ? currentWorkspaceDirUri.toString(true) : ''}`)
+        logger.log(`[Manager] Current workspaceRootDir: ${currentWorkspaceDirUri ? currentWorkspaceDirUri.toString(true) : ''}`)
 
         if (!currentWorkspaceDirUri) {
             return undefined
@@ -339,12 +339,12 @@ export class Manager {
             const candidates: string[] = []
             for (const file of files) {
                 if (this.extension.lwfs.isVirtualUri(file)) {
-                    logger.log(`Skip the file: ${file.toString(true)}`)
+                    logger.log(`[Manager] Skip the file: ${file.toString(true)}`)
                     continue
                 }
                 const flsChildren = this.extension.cacher.getTeXChildrenFromFls(file.fsPath)
                 if (vscode.window.activeTextEditor && flsChildren.includes(vscode.window.activeTextEditor.document.fileName)) {
-                    logger.log(`Found root file from '.fls': ${file.fsPath}`)
+                    logger.log(`[Manager] Found root file from '.fls': ${file.fsPath}`)
                     return file.fsPath
                 }
                 const content = utils.stripCommentsAndVerbatim(fs.readFileSync(file.fsPath).toString())
@@ -353,7 +353,7 @@ export class Manager {
                     // Can be a root
                     const children = await this.extension.cacher.getTeXChildren(file.fsPath, file.fsPath, [])
                     if (vscode.window.activeTextEditor && children.includes(vscode.window.activeTextEditor.document.fileName)) {
-                        logger.log(`Found root file from parent: ${file.fsPath}`)
+                        logger.log(`[Manager] Found root file from parent: ${file.fsPath}`)
                         return file.fsPath
                     }
                     // Not including the active file, yet can still be a root candidate
@@ -361,7 +361,7 @@ export class Manager {
                 }
             }
             if (candidates.length > 0) {
-                logger.log(`Found files that might be root, choose the first one: ${candidates}`)
+                logger.log(`[Manager] Found files that might be root, choose the first one: ${candidates}`)
                 return candidates[0]
             }
         } catch (e) {}
@@ -372,7 +372,7 @@ export class Manager {
         const setEnvVar = () => {
             const configuration = vscode.workspace.getConfiguration('latex-workshop')
             const dockerImageName: string = configuration.get('docker.image.latex', '')
-            logger.log(`Set $LATEXWORKSHOP_DOCKER_LATEX: ${JSON.stringify(dockerImageName)}`)
+            logger.log(`[Manager] Set $LATEXWORKSHOP_DOCKER_LATEX: ${JSON.stringify(dockerImageName)}`)
             process.env['LATEXWORKSHOP_DOCKER_LATEX'] = dockerImageName
         }
         setEnvVar()

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -9,6 +9,7 @@ import type {Extension} from '../main'
 import * as eventbus from './eventbus'
 
 import {FinderUtils} from './managerlib/finderutils'
+import { Logger } from './logger'
 
 type RootFileType = {
     type: 'filePath',
@@ -96,7 +97,7 @@ export class Manager {
                 if (ret.uri.scheme === 'file') {
                     return ret.uri.fsPath
                 } else {
-                    this.extension.logger.addLogMessage(`The file cannot be used as the root file: ${ret.uri.toString(true)}`)
+                    Logger.log(`The file cannot be used as the root file: ${ret.uri.toString(true)}`)
                     return
                 }
             }
@@ -239,7 +240,7 @@ export class Manager {
      */
     async findRoot(): Promise<string | undefined> {
         const wsfolders = vscode.workspace.workspaceFolders?.map(e => e.uri.toString(true))
-        this.extension.logger.addLogMessage(`Current workspace folders: ${JSON.stringify(wsfolders)}`)
+        Logger.log(`Current workspace folders: ${JSON.stringify(wsfolders)}`)
         this.localRootFile = undefined
         const findMethods = [
             () => this.finderUtils.findRootFromMagic(),
@@ -253,11 +254,11 @@ export class Manager {
                 continue
             }
             if (this.rootFile !== rootFile) {
-                this.extension.logger.addLogMessage(`Root file changed: from ${this.rootFile} to ${rootFile}`)
-                this.extension.logger.addLogMessage('Start to find all dependencies.')
+                Logger.log(`Root file changed: from ${this.rootFile} to ${rootFile}`)
+                Logger.log('Start to find all dependencies.')
                 this.rootFile = rootFile
                 this.rootFileLanguageId = this.inferLanguageId(rootFile)
-                this.extension.logger.addLogMessage(`Root file languageId: ${this.rootFileLanguageId}`)
+                Logger.log(`Root file languageId: ${this.rootFileLanguageId}`)
                 // We also clean the completions from the old project
                 this.extension.completer.input.reset()
                 this.extension.duplicateLabels.reset()
@@ -271,7 +272,7 @@ export class Manager {
                 await this.extension.cacher.loadFlsFile(this.rootFile)
                 this.extension.eventBus.fire(eventbus.RootFileChanged, rootFile)
             } else {
-                this.extension.logger.addLogMessage(`Keep using the same root file: ${this.rootFile}`)
+                Logger.log(`Keep using the same root file: ${this.rootFile}`)
             }
             this.extension.eventBus.fire(eventbus.RootFileSearched)
             return rootFile
@@ -285,7 +286,7 @@ export class Manager {
             return undefined
         }
         if (this.extension.lwfs.isVirtualUri(vscode.window.activeTextEditor.document.uri)) {
-            this.extension.logger.addLogMessage(`The active document cannot be used as the root file: ${vscode.window.activeTextEditor.document.uri.toString(true)}`)
+            Logger.log(`The active document cannot be used as the root file: ${vscode.window.activeTextEditor.document.uri.toString(true)}`)
             return undefined
         }
         if (this.extension.cacher.getIncludedTeX().includes(vscode.window.activeTextEditor.document.fileName)) {
@@ -299,7 +300,7 @@ export class Manager {
             return undefined
         }
         if (this.extension.lwfs.isVirtualUri(vscode.window.activeTextEditor.document.uri)) {
-            this.extension.logger.addLogMessage(`The active document cannot be used as the root file: ${vscode.window.activeTextEditor.document.uri.toString(true)}`)
+            Logger.log(`The active document cannot be used as the root file: ${vscode.window.activeTextEditor.document.uri.toString(true)}`)
             return undefined
         }
         const regex = /\\begin{document}/m
@@ -312,7 +313,7 @@ export class Manager {
                this.localRootFile = file
                return rootSubFile
             } else {
-                this.extension.logger.addLogMessage(`Found root file from active editor: ${file}`)
+                Logger.log(`Found root file from active editor: ${file}`)
                 return file
             }
         }
@@ -322,7 +323,7 @@ export class Manager {
     private async findRootInWorkspace(): Promise<string | undefined> {
         const regex = /\\begin{document}/m
         const currentWorkspaceDirUri = this.findWorkspace()
-        this.extension.logger.addLogMessage(`Current workspaceRootDir: ${currentWorkspaceDirUri ? currentWorkspaceDirUri.toString(true) : ''}`)
+        Logger.log(`Current workspaceRootDir: ${currentWorkspaceDirUri ? currentWorkspaceDirUri.toString(true) : ''}`)
 
         if (!currentWorkspaceDirUri) {
             return undefined
@@ -338,12 +339,12 @@ export class Manager {
             const candidates: string[] = []
             for (const file of files) {
                 if (this.extension.lwfs.isVirtualUri(file)) {
-                    this.extension.logger.addLogMessage(`Skip the file: ${file.toString(true)}`)
+                    Logger.log(`Skip the file: ${file.toString(true)}`)
                     continue
                 }
                 const flsChildren = this.extension.cacher.getTeXChildrenFromFls(file.fsPath)
                 if (vscode.window.activeTextEditor && flsChildren.includes(vscode.window.activeTextEditor.document.fileName)) {
-                    this.extension.logger.addLogMessage(`Found root file from '.fls': ${file.fsPath}`)
+                    Logger.log(`Found root file from '.fls': ${file.fsPath}`)
                     return file.fsPath
                 }
                 const content = utils.stripCommentsAndVerbatim(fs.readFileSync(file.fsPath).toString())
@@ -352,7 +353,7 @@ export class Manager {
                     // Can be a root
                     const children = await this.extension.cacher.getTeXChildren(file.fsPath, file.fsPath, [])
                     if (vscode.window.activeTextEditor && children.includes(vscode.window.activeTextEditor.document.fileName)) {
-                        this.extension.logger.addLogMessage(`Found root file from parent: ${file.fsPath}`)
+                        Logger.log(`Found root file from parent: ${file.fsPath}`)
                         return file.fsPath
                     }
                     // Not including the active file, yet can still be a root candidate
@@ -360,7 +361,7 @@ export class Manager {
                 }
             }
             if (candidates.length > 0) {
-                this.extension.logger.addLogMessage(`Found files that might be root, choose the first one: ${candidates}`)
+                Logger.log(`Found files that might be root, choose the first one: ${candidates}`)
                 return candidates[0]
             }
         } catch (e) {}
@@ -371,7 +372,7 @@ export class Manager {
         const setEnvVar = () => {
             const configuration = vscode.workspace.getConfiguration('latex-workshop')
             const dockerImageName: string = configuration.get('docker.image.latex', '')
-            this.extension.logger.addLogMessage(`Set $LATEXWORKSHOP_DOCKER_LATEX: ${JSON.stringify(dockerImageName)}`)
+            Logger.log(`Set $LATEXWORKSHOP_DOCKER_LATEX: ${JSON.stringify(dockerImageName)}`)
             process.env['LATEXWORKSHOP_DOCKER_LATEX'] = dockerImageName
         }
         setEnvVar()

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -9,7 +9,10 @@ import type {Extension} from '../main'
 import * as eventbus from './eventbus'
 
 import {FinderUtils} from './managerlib/finderutils'
-import * as logger from './logger'
+
+import { getLogger } from './logger'
+
+const logger = getLogger('Manager')
 
 type RootFileType = {
     type: 'filePath',
@@ -97,7 +100,7 @@ export class Manager {
                 if (ret.uri.scheme === 'file') {
                     return ret.uri.fsPath
                 } else {
-                    logger.log(`[Manager] The file cannot be used as the root file: ${ret.uri.toString(true)}`)
+                    logger.log(`The file cannot be used as the root file: ${ret.uri.toString(true)}`)
                     return
                 }
             }
@@ -240,7 +243,7 @@ export class Manager {
      */
     async findRoot(): Promise<string | undefined> {
         const wsfolders = vscode.workspace.workspaceFolders?.map(e => e.uri.toString(true))
-        logger.log(`[Manager] Current workspace folders: ${JSON.stringify(wsfolders)}`)
+        logger.log(`Current workspace folders: ${JSON.stringify(wsfolders)}`)
         this.localRootFile = undefined
         const findMethods = [
             () => this.finderUtils.findRootFromMagic(),
@@ -254,11 +257,11 @@ export class Manager {
                 continue
             }
             if (this.rootFile !== rootFile) {
-                logger.log(`[Manager] Root file changed: from ${this.rootFile} to ${rootFile}`)
-                logger.log('[Manager] Start to find all dependencies.')
+                logger.log(`Root file changed: from ${this.rootFile} to ${rootFile}`)
+                logger.log('Start to find all dependencies.')
                 this.rootFile = rootFile
                 this.rootFileLanguageId = this.inferLanguageId(rootFile)
-                logger.log(`[Manager] Root file languageId: ${this.rootFileLanguageId}`)
+                logger.log(`Root file languageId: ${this.rootFileLanguageId}`)
                 // We also clean the completions from the old project
                 this.extension.completer.input.reset()
                 this.extension.duplicateLabels.reset()
@@ -272,7 +275,7 @@ export class Manager {
                 await this.extension.cacher.loadFlsFile(this.rootFile)
                 this.extension.eventBus.fire(eventbus.RootFileChanged, rootFile)
             } else {
-                logger.log(`[Manager] Keep using the same root file: ${this.rootFile}`)
+                logger.log(`Keep using the same root file: ${this.rootFile}`)
             }
             this.extension.eventBus.fire(eventbus.RootFileSearched)
             return rootFile
@@ -286,7 +289,7 @@ export class Manager {
             return undefined
         }
         if (this.extension.lwfs.isVirtualUri(vscode.window.activeTextEditor.document.uri)) {
-            logger.log(`[Manager] The active document cannot be used as the root file: ${vscode.window.activeTextEditor.document.uri.toString(true)}`)
+            logger.log(`The active document cannot be used as the root file: ${vscode.window.activeTextEditor.document.uri.toString(true)}`)
             return undefined
         }
         if (this.extension.cacher.getIncludedTeX().includes(vscode.window.activeTextEditor.document.fileName)) {
@@ -300,7 +303,7 @@ export class Manager {
             return undefined
         }
         if (this.extension.lwfs.isVirtualUri(vscode.window.activeTextEditor.document.uri)) {
-            logger.log(`[Manager] The active document cannot be used as the root file: ${vscode.window.activeTextEditor.document.uri.toString(true)}`)
+            logger.log(`The active document cannot be used as the root file: ${vscode.window.activeTextEditor.document.uri.toString(true)}`)
             return undefined
         }
         const regex = /\\begin{document}/m
@@ -313,7 +316,7 @@ export class Manager {
                this.localRootFile = file
                return rootSubFile
             } else {
-                logger.log(`[Manager] Found root file from active editor: ${file}`)
+                logger.log(`Found root file from active editor: ${file}`)
                 return file
             }
         }
@@ -323,7 +326,7 @@ export class Manager {
     private async findRootInWorkspace(): Promise<string | undefined> {
         const regex = /\\begin{document}/m
         const currentWorkspaceDirUri = this.findWorkspace()
-        logger.log(`[Manager] Current workspaceRootDir: ${currentWorkspaceDirUri ? currentWorkspaceDirUri.toString(true) : ''}`)
+        logger.log(`Current workspaceRootDir: ${currentWorkspaceDirUri ? currentWorkspaceDirUri.toString(true) : ''}`)
 
         if (!currentWorkspaceDirUri) {
             return undefined
@@ -339,12 +342,12 @@ export class Manager {
             const candidates: string[] = []
             for (const file of files) {
                 if (this.extension.lwfs.isVirtualUri(file)) {
-                    logger.log(`[Manager] Skip the file: ${file.toString(true)}`)
+                    logger.log(`Skip the file: ${file.toString(true)}`)
                     continue
                 }
                 const flsChildren = this.extension.cacher.getTeXChildrenFromFls(file.fsPath)
                 if (vscode.window.activeTextEditor && flsChildren.includes(vscode.window.activeTextEditor.document.fileName)) {
-                    logger.log(`[Manager] Found root file from '.fls': ${file.fsPath}`)
+                    logger.log(`Found root file from '.fls': ${file.fsPath}`)
                     return file.fsPath
                 }
                 const content = utils.stripCommentsAndVerbatim(fs.readFileSync(file.fsPath).toString())
@@ -353,7 +356,7 @@ export class Manager {
                     // Can be a root
                     const children = await this.extension.cacher.getTeXChildren(file.fsPath, file.fsPath, [])
                     if (vscode.window.activeTextEditor && children.includes(vscode.window.activeTextEditor.document.fileName)) {
-                        logger.log(`[Manager] Found root file from parent: ${file.fsPath}`)
+                        logger.log(`Found root file from parent: ${file.fsPath}`)
                         return file.fsPath
                     }
                     // Not including the active file, yet can still be a root candidate
@@ -361,7 +364,7 @@ export class Manager {
                 }
             }
             if (candidates.length > 0) {
-                logger.log(`[Manager] Found files that might be root, choose the first one: ${candidates}`)
+                logger.log(`Found files that might be root, choose the first one: ${candidates}`)
                 return candidates[0]
             }
         } catch (e) {}
@@ -372,7 +375,7 @@ export class Manager {
         const setEnvVar = () => {
             const configuration = vscode.workspace.getConfiguration('latex-workshop')
             const dockerImageName: string = configuration.get('docker.image.latex', '')
-            logger.log(`[Manager] Set $LATEXWORKSHOP_DOCKER_LATEX: ${JSON.stringify(dockerImageName)}`)
+            logger.log(`Set $LATEXWORKSHOP_DOCKER_LATEX: ${JSON.stringify(dockerImageName)}`)
             process.env['LATEXWORKSHOP_DOCKER_LATEX'] = dockerImageName
         }
         setEnvVar()

--- a/src/components/managerlib/finderutils.ts
+++ b/src/components/managerlib/finderutils.ts
@@ -3,6 +3,7 @@ import * as path from 'path'
 
 import type { Extension } from '../../main'
 import * as utils from '../../utils/utils'
+import { Logger } from '../logger'
 
 export class FinderUtils {
     private readonly extension: Extension
@@ -25,27 +26,27 @@ export class FinderUtils {
             content = this.extension.lwfs.readFileSyncGracefully(file)
             if (content === undefined) {
                 const msg = `Not found root file specified in the magic comment: ${file}`
-                this.extension.logger.addLogMessage(msg)
+                Logger.log(msg)
                 throw new Error(msg)
             }
             fileStack.push(file)
-            this.extension.logger.addLogMessage(`Found root file by magic comment: ${file}`)
+            Logger.log(`Found root file by magic comment: ${file}`)
 
             result = content.match(regex)
             while (result) {
                 file = path.resolve(path.dirname(file), result[1])
                 if (fileStack.includes(file)) {
-                    this.extension.logger.addLogMessage(`Looped root file by magic comment found: ${file}, stop here.`)
+                    Logger.log(`Looped root file by magic comment found: ${file}, stop here.`)
                     return file
                 } else {
                     fileStack.push(file)
-                    this.extension.logger.addLogMessage(`Recursively found root file by magic comment: ${file}`)
+                    Logger.log(`Recursively found root file by magic comment: ${file}`)
                 }
 
                 content = this.extension.lwfs.readFileSyncGracefully(file)
                 if (content === undefined) {
                     const msg = `Not found root file specified in the magic comment: ${file}`
-                    this.extension.logger.addLogMessage(msg)
+                    Logger.log(msg)
                     throw new Error(msg)
 
                 }
@@ -65,9 +66,9 @@ export class FinderUtils {
         if (result) {
             const file = utils.resolveFile([path.dirname(vscode.window.activeTextEditor.document.fileName)], result[1])
             if (file) {
-                this.extension.logger.addLogMessage(`Found root file of this subfile from active editor: ${file}`)
+                Logger.log(`Found root file of this subfile from active editor: ${file}`)
             } else {
-                this.extension.logger.addLogMessage(`Cannot find root file of this subfile from active editor: ${result[1]}`)
+                Logger.log(`Cannot find root file of this subfile from active editor: ${result[1]}`)
             }
             return file
         }

--- a/src/components/managerlib/finderutils.ts
+++ b/src/components/managerlib/finderutils.ts
@@ -3,7 +3,7 @@ import * as path from 'path'
 
 import type { Extension } from '../../main'
 import * as utils from '../../utils/utils'
-import { Logger } from '../logger'
+import * as logger from '../logger'
 
 export class FinderUtils {
     private readonly extension: Extension
@@ -25,33 +25,31 @@ export class FinderUtils {
             let file = path.resolve(path.dirname(vscode.window.activeTextEditor.document.fileName), result[1])
             content = this.extension.lwfs.readFileSyncGracefully(file)
             if (content === undefined) {
-                const msg = `Not found root file specified in the magic comment: ${file}`
-                Logger.log(msg)
-                throw new Error(msg)
+                logger.log(`[Manager][Magic] Non-existent magic root ${file} .`)
+                return undefined
             }
             fileStack.push(file)
-            Logger.log(`Found root file by magic comment: ${file}`)
+            logger.log(`[Manager][Magic] Found magic root ${file} from active.`)
 
             result = content.match(regex)
             while (result) {
                 file = path.resolve(path.dirname(file), result[1])
                 if (fileStack.includes(file)) {
-                    Logger.log(`Looped root file by magic comment found: ${file}, stop here.`)
+                    logger.log(`[Manager][Magic] Found looped magic root ${file} .`)
                     return file
                 } else {
                     fileStack.push(file)
-                    Logger.log(`Recursively found root file by magic comment: ${file}`)
+                    logger.log(`[Manager][Magic] Found magic root ${file}`)
                 }
 
                 content = this.extension.lwfs.readFileSyncGracefully(file)
                 if (content === undefined) {
-                    const msg = `Not found root file specified in the magic comment: ${file}`
-                    Logger.log(msg)
-                    throw new Error(msg)
-
+                    logger.log(`[Manager][Magic] Non-existent magic root ${file} .`)
+                    return undefined
                 }
                 result = content.match(regex)
             }
+            logger.log(`[Manager][Magic] Finalized magic root ${file} .`)
             return file
         }
         return undefined
@@ -66,9 +64,7 @@ export class FinderUtils {
         if (result) {
             const file = utils.resolveFile([path.dirname(vscode.window.activeTextEditor.document.fileName)], result[1])
             if (file) {
-                Logger.log(`Found root file of this subfile from active editor: ${file}`)
-            } else {
-                Logger.log(`Cannot find root file of this subfile from active editor: ${result[1]}`)
+                logger.log(`[Manager][Subfile] Found subfile root ${file} from active.`)
             }
             return file
         }

--- a/src/components/managerlib/finderutils.ts
+++ b/src/components/managerlib/finderutils.ts
@@ -3,7 +3,10 @@ import * as path from 'path'
 
 import type { Extension } from '../../main'
 import * as utils from '../../utils/utils'
-import * as logger from '../logger'
+
+import { getLogger } from '../logger'
+
+const logger = getLogger('Manager', 'Finder')
 
 export class FinderUtils {
     private readonly extension: Extension
@@ -25,31 +28,31 @@ export class FinderUtils {
             let file = path.resolve(path.dirname(vscode.window.activeTextEditor.document.fileName), result[1])
             content = this.extension.lwfs.readFileSyncGracefully(file)
             if (content === undefined) {
-                logger.log(`[Manager][Magic] Non-existent magic root ${file} .`)
+                logger.log(`Non-existent magic root ${file} .`)
                 return undefined
             }
             fileStack.push(file)
-            logger.log(`[Manager][Magic] Found magic root ${file} from active.`)
+            logger.log(`Found magic root ${file} from active.`)
 
             result = content.match(regex)
             while (result) {
                 file = path.resolve(path.dirname(file), result[1])
                 if (fileStack.includes(file)) {
-                    logger.log(`[Manager][Magic] Found looped magic root ${file} .`)
+                    logger.log(`Found looped magic root ${file} .`)
                     return file
                 } else {
                     fileStack.push(file)
-                    logger.log(`[Manager][Magic] Found magic root ${file}`)
+                    logger.log(`Found magic root ${file}`)
                 }
 
                 content = this.extension.lwfs.readFileSyncGracefully(file)
                 if (content === undefined) {
-                    logger.log(`[Manager][Magic] Non-existent magic root ${file} .`)
+                    logger.log(`Non-existent magic root ${file} .`)
                     return undefined
                 }
                 result = content.match(regex)
             }
-            logger.log(`[Manager][Magic] Finalized magic root ${file} .`)
+            logger.log(`Finalized magic root ${file} .`)
             return file
         }
         return undefined
@@ -64,7 +67,7 @@ export class FinderUtils {
         if (result) {
             const file = utils.resolveFile([path.dirname(vscode.window.activeTextEditor.document.fileName)], result[1])
             if (file) {
-                logger.log(`[Manager][Subfile] Found subfile root ${file} from active.`)
+                logger.log(`Found subfile root ${file} from active.`)
             }
             return file
         }

--- a/src/components/mathpreviewpanel.ts
+++ b/src/components/mathpreviewpanel.ts
@@ -3,7 +3,7 @@ import * as path from 'path'
 import type {TexMathEnv} from '../providers/preview/mathpreview'
 import {openWebviewPanel} from '../utils/webview'
 import type {Extension} from '../main'
-import { Logger } from './logger'
+import * as logger from './logger'
 
 
 type UpdateEvent = {
@@ -33,7 +33,7 @@ export class MathPreviewPanelSerializer implements vscode.WebviewPanelSerializer
             localResourceRoots: [resourcesFolder(this.extension.extensionRoot)]
         }
         panel.webview.html = this.extension.mathPreviewPanel.getHtml(panel.webview)
-        Logger.log('Math preview panel: restored')
+        logger.log('Math preview panel: restored')
         return Promise.resolve()
     }
 
@@ -92,7 +92,7 @@ export class MathPreviewPanel {
         if (activeDocument) {
             await openWebviewPanel(panel, editorGroup, activeDocument)
         }
-        Logger.log('Math preview panel: opened')
+        logger.log('Math preview panel: opened')
     }
 
     initializePanel(panel: vscode.WebviewPanel) {
@@ -109,7 +109,7 @@ export class MathPreviewPanel {
             disposable.dispose()
             this.clearCache()
             this.panel = undefined
-            Logger.log('Math preview panel: disposed')
+            logger.log('Math preview panel: disposed')
         })
         panel.onDidChangeViewState((ev) => {
             if (ev.webviewPanel.visible) {
@@ -117,7 +117,7 @@ export class MathPreviewPanel {
             }
         })
         panel.webview.onDidReceiveMessage(() => {
-            Logger.log('Math preview panel: initialized')
+            logger.log('Math preview panel: initialized')
             void this.update()
         })
     }
@@ -126,7 +126,7 @@ export class MathPreviewPanel {
         this.panel?.dispose()
         this.panel = undefined
         this.clearCache()
-        Logger.log('Math preview panel: closed')
+        logger.log('Math preview panel: closed')
     }
 
     toggle() {

--- a/src/components/mathpreviewpanel.ts
+++ b/src/components/mathpreviewpanel.ts
@@ -3,8 +3,10 @@ import * as path from 'path'
 import type {TexMathEnv} from '../providers/preview/mathpreview'
 import {openWebviewPanel} from '../utils/webview'
 import type {Extension} from '../main'
-import * as logger from './logger'
 
+import { getLogger } from './logger'
+
+const logger = getLogger('Preview', 'Math')
 
 type UpdateEvent = {
     type: 'edit',
@@ -33,7 +35,7 @@ export class MathPreviewPanelSerializer implements vscode.WebviewPanelSerializer
             localResourceRoots: [resourcesFolder(this.extension.extensionRoot)]
         }
         panel.webview.html = this.extension.mathPreviewPanel.getHtml(panel.webview)
-        logger.log('[Preview][Math] Math preview panel: restored')
+        logger.log('Math preview panel: restored')
         return Promise.resolve()
     }
 
@@ -92,7 +94,7 @@ export class MathPreviewPanel {
         if (activeDocument) {
             await openWebviewPanel(panel, editorGroup, activeDocument)
         }
-        logger.log('[Preview][Math] Math preview panel: opened')
+        logger.log('Math preview panel: opened')
     }
 
     initializePanel(panel: vscode.WebviewPanel) {
@@ -109,7 +111,7 @@ export class MathPreviewPanel {
             disposable.dispose()
             this.clearCache()
             this.panel = undefined
-            logger.log('[Preview][Math] Math preview panel: disposed')
+            logger.log('Math preview panel: disposed')
         })
         panel.onDidChangeViewState((ev) => {
             if (ev.webviewPanel.visible) {
@@ -117,7 +119,7 @@ export class MathPreviewPanel {
             }
         })
         panel.webview.onDidReceiveMessage(() => {
-            logger.log('[Preview][Math] Math preview panel: initialized')
+            logger.log('Math preview panel: initialized')
             void this.update()
         })
     }
@@ -126,7 +128,7 @@ export class MathPreviewPanel {
         this.panel?.dispose()
         this.panel = undefined
         this.clearCache()
-        logger.log('[Preview][Math] Math preview panel: closed')
+        logger.log('Math preview panel: closed')
     }
 
     toggle() {

--- a/src/components/mathpreviewpanel.ts
+++ b/src/components/mathpreviewpanel.ts
@@ -3,6 +3,7 @@ import * as path from 'path'
 import type {TexMathEnv} from '../providers/preview/mathpreview'
 import {openWebviewPanel} from '../utils/webview'
 import type {Extension} from '../main'
+import { Logger } from './logger'
 
 
 type UpdateEvent = {
@@ -32,7 +33,7 @@ export class MathPreviewPanelSerializer implements vscode.WebviewPanelSerializer
             localResourceRoots: [resourcesFolder(this.extension.extensionRoot)]
         }
         panel.webview.html = this.extension.mathPreviewPanel.getHtml(panel.webview)
-        this.extension.logger.addLogMessage('Math preview panel: restored')
+        Logger.log('Math preview panel: restored')
         return Promise.resolve()
     }
 
@@ -91,7 +92,7 @@ export class MathPreviewPanel {
         if (activeDocument) {
             await openWebviewPanel(panel, editorGroup, activeDocument)
         }
-        this.extension.logger.addLogMessage('Math preview panel: opened')
+        Logger.log('Math preview panel: opened')
     }
 
     initializePanel(panel: vscode.WebviewPanel) {
@@ -108,7 +109,7 @@ export class MathPreviewPanel {
             disposable.dispose()
             this.clearCache()
             this.panel = undefined
-            this.extension.logger.addLogMessage('Math preview panel: disposed')
+            Logger.log('Math preview panel: disposed')
         })
         panel.onDidChangeViewState((ev) => {
             if (ev.webviewPanel.visible) {
@@ -116,7 +117,7 @@ export class MathPreviewPanel {
             }
         })
         panel.webview.onDidReceiveMessage(() => {
-            this.extension.logger.addLogMessage('Math preview panel: initialized')
+            Logger.log('Math preview panel: initialized')
             void this.update()
         })
     }
@@ -125,7 +126,7 @@ export class MathPreviewPanel {
         this.panel?.dispose()
         this.panel = undefined
         this.clearCache()
-        this.extension.logger.addLogMessage('Math preview panel: closed')
+        Logger.log('Math preview panel: closed')
     }
 
     toggle() {

--- a/src/components/mathpreviewpanel.ts
+++ b/src/components/mathpreviewpanel.ts
@@ -33,7 +33,7 @@ export class MathPreviewPanelSerializer implements vscode.WebviewPanelSerializer
             localResourceRoots: [resourcesFolder(this.extension.extensionRoot)]
         }
         panel.webview.html = this.extension.mathPreviewPanel.getHtml(panel.webview)
-        logger.log('Math preview panel: restored')
+        logger.log('[Preview][Math] Math preview panel: restored')
         return Promise.resolve()
     }
 
@@ -92,7 +92,7 @@ export class MathPreviewPanel {
         if (activeDocument) {
             await openWebviewPanel(panel, editorGroup, activeDocument)
         }
-        logger.log('Math preview panel: opened')
+        logger.log('[Preview][Math] Math preview panel: opened')
     }
 
     initializePanel(panel: vscode.WebviewPanel) {
@@ -109,7 +109,7 @@ export class MathPreviewPanel {
             disposable.dispose()
             this.clearCache()
             this.panel = undefined
-            logger.log('Math preview panel: disposed')
+            logger.log('[Preview][Math] Math preview panel: disposed')
         })
         panel.onDidChangeViewState((ev) => {
             if (ev.webviewPanel.visible) {
@@ -117,7 +117,7 @@ export class MathPreviewPanel {
             }
         })
         panel.webview.onDidReceiveMessage(() => {
-            logger.log('Math preview panel: initialized')
+            logger.log('[Preview][Math] Math preview panel: initialized')
             void this.update()
         })
     }
@@ -126,7 +126,7 @@ export class MathPreviewPanel {
         this.panel?.dispose()
         this.panel = undefined
         this.clearCache()
-        logger.log('Math preview panel: closed')
+        logger.log('[Preview][Math] Math preview panel: closed')
     }
 
     toggle() {

--- a/src/components/parser/biblogparser.ts
+++ b/src/components/parser/biblogparser.ts
@@ -1,7 +1,10 @@
 import * as vscode from 'vscode'
 import type { Extension } from '../../main'
-import * as logger from '../logger'
 import type { LogEntry } from './compilerlog'
+
+import { getLogger } from '../logger'
+
+const logger = getLogger('Parser', 'BibLog')
 
 const multiLineWarning = /^Warning--(.+)\n--line (\d+) of file (.+)$/gm
 const singleLineWarning = /^Warning--(.+) in ([^\s]+)\s*$/gm
@@ -24,7 +27,7 @@ export class BibLogParser {
             rootFile = this.extension.manager.rootFile
         }
         if (rootFile === undefined) {
-            logger.log('[Parser][BibLog] How can you reach this point?')
+            logger.log('How can you reach this point?')
             return
         }
 
@@ -33,7 +36,7 @@ export class BibLogParser {
         try {
             excludeRegexp = (configuration.get('message.bibtexlog.exclude') as string[]).map(regexp => RegExp(regexp))
         } catch (e) {
-            logger.logError('[Parser][BibLog] Invalid message.bibtexlog.exclude config.', e)
+            logger.logError('Invalid message.bibtexlog.exclude config.', e)
             return
         }
         this.buildLog = []
@@ -65,7 +68,7 @@ export class BibLogParser {
             this.pushLog('error', filename, result[1], 1, excludeRegexp)
         }
 
-        logger.log(`[Parser][BibLog] Logged ${this.buildLog.length} messages.`)
+        logger.log(`Logged ${this.buildLog.length} messages.`)
         this.extension.compilerLogParser.showCompilerDiagnostics(this.compilerDiagnostics, this.buildLog, 'BibTeX')
     }
 
@@ -89,7 +92,7 @@ export class BibLogParser {
                 return tex
             }
         }
-        logger.log(`[Parser][BibLog] Cannot resolve file ${filename} .`)
+        logger.log(`Cannot resolve file ${filename} .`)
         return filename
     }
 
@@ -103,7 +106,7 @@ export class BibLogParser {
                 return bib
             }
         }
-        logger.log(`[Parser][BibLog] Cannot resolve file ${filename} .`)
+        logger.log(`Cannot resolve file ${filename} .`)
         return filename
     }
 
@@ -114,7 +117,7 @@ export class BibLogParser {
             const line = entry.position.line + 1
             return {file, line}
         } else {
-            logger.log(`[Parser][BibLog] Cannot find key ${key}`)
+            logger.log(`Cannot find key ${key}`)
             return undefined
         }
     }

--- a/src/components/parser/biblogparser.ts
+++ b/src/components/parser/biblogparser.ts
@@ -24,7 +24,7 @@ export class BibLogParser {
             rootFile = this.extension.manager.rootFile
         }
         if (rootFile === undefined) {
-            logger.log('How can you reach this point?')
+            logger.log('[Parser][BibLog] How can you reach this point?')
             return
         }
 
@@ -33,9 +33,7 @@ export class BibLogParser {
         try {
             excludeRegexp = (configuration.get('message.bibtexlog.exclude') as string[]).map(regexp => RegExp(regexp))
         } catch (e) {
-            if (e instanceof Error) {
-                logger.log(`latex-workshop.message.bibtexlog.exclude is invalid: ${e.message}`)
-            }
+            logger.logError('[Parser][BibLog] Invalid message.bibtexlog.exclude config.', e)
             return
         }
         this.buildLog = []
@@ -67,7 +65,7 @@ export class BibLogParser {
             this.pushLog('error', filename, result[1], 1, excludeRegexp)
         }
 
-        logger.log(`BibTeX log parsed with ${this.buildLog.length} messages.`)
+        logger.log(`[Parser][BibLog] Logged ${this.buildLog.length} messages.`)
         this.extension.compilerLogParser.showCompilerDiagnostics(this.compilerDiagnostics, this.buildLog, 'BibTeX')
     }
 
@@ -91,7 +89,7 @@ export class BibLogParser {
                 return tex
             }
         }
-        logger.log(`Cannot resolve file while parsing BibTeX log: ${filename}`)
+        logger.log(`[Parser][BibLog] Cannot resolve file ${filename} .`)
         return filename
     }
 
@@ -105,7 +103,7 @@ export class BibLogParser {
                 return bib
             }
         }
-        logger.log(`Cannot resolve file while parsing BibTeX log: ${filename}`)
+        logger.log(`[Parser][BibLog] Cannot resolve file ${filename} .`)
         return filename
     }
 
@@ -116,7 +114,7 @@ export class BibLogParser {
             const line = entry.position.line + 1
             return {file, line}
         } else {
-            logger.log(`Cannot find key when parsing BibTeX log: ${key}`)
+            logger.log(`[Parser][BibLog] Cannot find key ${key}`)
             return undefined
         }
     }

--- a/src/components/parser/biblogparser.ts
+++ b/src/components/parser/biblogparser.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode'
 import type { Extension } from '../../main'
+import { Logger } from '../logger'
 import type { LogEntry } from './compilerlog'
 
 const multiLineWarning = /^Warning--(.+)\n--line (\d+) of file (.+)$/gm
@@ -23,7 +24,7 @@ export class BibLogParser {
             rootFile = this.extension.manager.rootFile
         }
         if (rootFile === undefined) {
-            this.extension.logger.addLogMessage('How can you reach this point?')
+            Logger.log('How can you reach this point?')
             return
         }
 
@@ -33,7 +34,7 @@ export class BibLogParser {
             excludeRegexp = (configuration.get('message.bibtexlog.exclude') as string[]).map(regexp => RegExp(regexp))
         } catch (e) {
             if (e instanceof Error) {
-                this.extension.logger.addLogMessage(`latex-workshop.message.bibtexlog.exclude is invalid: ${e.message}`)
+                Logger.log(`latex-workshop.message.bibtexlog.exclude is invalid: ${e.message}`)
             }
             return
         }
@@ -66,7 +67,7 @@ export class BibLogParser {
             this.pushLog('error', filename, result[1], 1, excludeRegexp)
         }
 
-        this.extension.logger.addLogMessage(`BibTeX log parsed with ${this.buildLog.length} messages.`)
+        Logger.log(`BibTeX log parsed with ${this.buildLog.length} messages.`)
         this.extension.compilerLogParser.showCompilerDiagnostics(this.compilerDiagnostics, this.buildLog, 'BibTeX')
     }
 
@@ -90,7 +91,7 @@ export class BibLogParser {
                 return tex
             }
         }
-        this.extension.logger.addLogMessage(`Cannot resolve file while parsing BibTeX log: ${filename}`)
+        Logger.log(`Cannot resolve file while parsing BibTeX log: ${filename}`)
         return filename
     }
 
@@ -104,7 +105,7 @@ export class BibLogParser {
                 return bib
             }
         }
-        this.extension.logger.addLogMessage(`Cannot resolve file while parsing BibTeX log: ${filename}`)
+        Logger.log(`Cannot resolve file while parsing BibTeX log: ${filename}`)
         return filename
     }
 
@@ -115,7 +116,7 @@ export class BibLogParser {
             const line = entry.position.line + 1
             return {file, line}
         } else {
-            this.extension.logger.addLogMessage(`Cannot find key when parsing BibTeX log: ${key}`)
+            Logger.log(`Cannot find key when parsing BibTeX log: ${key}`)
             return undefined
         }
     }

--- a/src/components/parser/biblogparser.ts
+++ b/src/components/parser/biblogparser.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode'
 import type { Extension } from '../../main'
-import { Logger } from '../logger'
+import * as logger from '../logger'
 import type { LogEntry } from './compilerlog'
 
 const multiLineWarning = /^Warning--(.+)\n--line (\d+) of file (.+)$/gm
@@ -24,7 +24,7 @@ export class BibLogParser {
             rootFile = this.extension.manager.rootFile
         }
         if (rootFile === undefined) {
-            Logger.log('How can you reach this point?')
+            logger.log('How can you reach this point?')
             return
         }
 
@@ -34,7 +34,7 @@ export class BibLogParser {
             excludeRegexp = (configuration.get('message.bibtexlog.exclude') as string[]).map(regexp => RegExp(regexp))
         } catch (e) {
             if (e instanceof Error) {
-                Logger.log(`latex-workshop.message.bibtexlog.exclude is invalid: ${e.message}`)
+                logger.log(`latex-workshop.message.bibtexlog.exclude is invalid: ${e.message}`)
             }
             return
         }
@@ -67,7 +67,7 @@ export class BibLogParser {
             this.pushLog('error', filename, result[1], 1, excludeRegexp)
         }
 
-        Logger.log(`BibTeX log parsed with ${this.buildLog.length} messages.`)
+        logger.log(`BibTeX log parsed with ${this.buildLog.length} messages.`)
         this.extension.compilerLogParser.showCompilerDiagnostics(this.compilerDiagnostics, this.buildLog, 'BibTeX')
     }
 
@@ -91,7 +91,7 @@ export class BibLogParser {
                 return tex
             }
         }
-        Logger.log(`Cannot resolve file while parsing BibTeX log: ${filename}`)
+        logger.log(`Cannot resolve file while parsing BibTeX log: ${filename}`)
         return filename
     }
 
@@ -105,7 +105,7 @@ export class BibLogParser {
                 return bib
             }
         }
-        Logger.log(`Cannot resolve file while parsing BibTeX log: ${filename}`)
+        logger.log(`Cannot resolve file while parsing BibTeX log: ${filename}`)
         return filename
     }
 
@@ -116,7 +116,7 @@ export class BibLogParser {
             const line = entry.position.line + 1
             return {file, line}
         } else {
-            Logger.log(`Cannot find key when parsing BibTeX log: ${key}`)
+            logger.log(`Cannot find key when parsing BibTeX log: ${key}`)
             return undefined
         }
     }

--- a/src/components/parser/latexlog.ts
+++ b/src/components/parser/latexlog.ts
@@ -52,7 +52,7 @@ export class LatexLogParser {
             rootFile = this.extension.manager.rootFile
         }
         if (rootFile === undefined) {
-            logger.log('How can you reach this point?')
+            logger.log('[Parser][TeXLog] How can you reach this point?')
             return
         }
 
@@ -68,7 +68,7 @@ export class LatexLogParser {
         if (state.currentResult.type !== '' && !state.currentResult.text.match(bibEmpty)) {
             this.buildLog.push(state.currentResult)
         }
-        logger.log(`LaTeX log parsed with ${this.buildLog.length} messages.`)
+        logger.log(`[Parser][TeXLog] Logged ${this.buildLog.length} messages.`)
         this.extension.compilerLogParser.showCompilerDiagnostics(this.compilerDiagnostics, this.buildLog, 'LaTeX')
     }
 
@@ -78,9 +78,7 @@ export class LatexLogParser {
         try {
             excludeRegexp = (configuration.get('message.latexlog.exclude') as string[]).map(regexp => RegExp(regexp))
         } catch (e) {
-            if (e instanceof Error) {
-                logger.log(`latex-workshop.message.latexlog.exclude is invalid: ${e.message}`)
-            }
+            logger.logError('[Parser][BibLog] Invalid message.latexlog.exclude config.', e)
             return
         }
         // Compose the current file

--- a/src/components/parser/latexlog.ts
+++ b/src/components/parser/latexlog.ts
@@ -3,7 +3,7 @@ import * as path from 'path'
 
 import type { Extension } from '../../main'
 import type { LogEntry } from './compilerlog'
-import { Logger } from '../logger'
+import * as logger from '../logger'
 
 const latexError = /^(?:(.*):(\d+):|!)(?: (.+) Error:)? (.+?)$/
 const latexBox = /^((?:Over|Under)full \\[vh]box \([^)]*\)) in paragraph at lines (\d+)--(\d+)$/
@@ -52,7 +52,7 @@ export class LatexLogParser {
             rootFile = this.extension.manager.rootFile
         }
         if (rootFile === undefined) {
-            Logger.log('How can you reach this point?')
+            logger.log('How can you reach this point?')
             return
         }
 
@@ -68,7 +68,7 @@ export class LatexLogParser {
         if (state.currentResult.type !== '' && !state.currentResult.text.match(bibEmpty)) {
             this.buildLog.push(state.currentResult)
         }
-        Logger.log(`LaTeX log parsed with ${this.buildLog.length} messages.`)
+        logger.log(`LaTeX log parsed with ${this.buildLog.length} messages.`)
         this.extension.compilerLogParser.showCompilerDiagnostics(this.compilerDiagnostics, this.buildLog, 'LaTeX')
     }
 
@@ -79,7 +79,7 @@ export class LatexLogParser {
             excludeRegexp = (configuration.get('message.latexlog.exclude') as string[]).map(regexp => RegExp(regexp))
         } catch (e) {
             if (e instanceof Error) {
-                Logger.log(`latex-workshop.message.latexlog.exclude is invalid: ${e.message}`)
+                logger.log(`latex-workshop.message.latexlog.exclude is invalid: ${e.message}`)
             }
             return
         }

--- a/src/components/parser/latexlog.ts
+++ b/src/components/parser/latexlog.ts
@@ -3,7 +3,10 @@ import * as path from 'path'
 
 import type { Extension } from '../../main'
 import type { LogEntry } from './compilerlog'
-import * as logger from '../logger'
+
+import { getLogger } from '../logger'
+
+const logger = getLogger('Parser', 'TexLog')
 
 const latexError = /^(?:(.*):(\d+):|!)(?: (.+) Error:)? (.+?)$/
 const latexBox = /^((?:Over|Under)full \\[vh]box \([^)]*\)) in paragraph at lines (\d+)--(\d+)$/
@@ -52,7 +55,7 @@ export class LatexLogParser {
             rootFile = this.extension.manager.rootFile
         }
         if (rootFile === undefined) {
-            logger.log('[Parser][TeXLog] How can you reach this point?')
+            logger.log('How can you reach this point?')
             return
         }
 
@@ -68,7 +71,7 @@ export class LatexLogParser {
         if (state.currentResult.type !== '' && !state.currentResult.text.match(bibEmpty)) {
             this.buildLog.push(state.currentResult)
         }
-        logger.log(`[Parser][TeXLog] Logged ${this.buildLog.length} messages.`)
+        logger.log(`Logged ${this.buildLog.length} messages.`)
         this.extension.compilerLogParser.showCompilerDiagnostics(this.compilerDiagnostics, this.buildLog, 'LaTeX')
     }
 
@@ -78,7 +81,7 @@ export class LatexLogParser {
         try {
             excludeRegexp = (configuration.get('message.latexlog.exclude') as string[]).map(regexp => RegExp(regexp))
         } catch (e) {
-            logger.logError('[Parser][BibLog] Invalid message.latexlog.exclude config.', e)
+            logger.logError('Invalid message.latexlog.exclude config.', e)
             return
         }
         // Compose the current file

--- a/src/components/parser/latexlog.ts
+++ b/src/components/parser/latexlog.ts
@@ -3,6 +3,7 @@ import * as path from 'path'
 
 import type { Extension } from '../../main'
 import type { LogEntry } from './compilerlog'
+import { Logger } from '../logger'
 
 const latexError = /^(?:(.*):(\d+):|!)(?: (.+) Error:)? (.+?)$/
 const latexBox = /^((?:Over|Under)full \\[vh]box \([^)]*\)) in paragraph at lines (\d+)--(\d+)$/
@@ -51,7 +52,7 @@ export class LatexLogParser {
             rootFile = this.extension.manager.rootFile
         }
         if (rootFile === undefined) {
-            this.extension.logger.addLogMessage('How can you reach this point?')
+            Logger.log('How can you reach this point?')
             return
         }
 
@@ -67,7 +68,7 @@ export class LatexLogParser {
         if (state.currentResult.type !== '' && !state.currentResult.text.match(bibEmpty)) {
             this.buildLog.push(state.currentResult)
         }
-        this.extension.logger.addLogMessage(`LaTeX log parsed with ${this.buildLog.length} messages.`)
+        Logger.log(`LaTeX log parsed with ${this.buildLog.length} messages.`)
         this.extension.compilerLogParser.showCompilerDiagnostics(this.compilerDiagnostics, this.buildLog, 'LaTeX')
     }
 
@@ -78,7 +79,7 @@ export class LatexLogParser {
             excludeRegexp = (configuration.get('message.latexlog.exclude') as string[]).map(regexp => RegExp(regexp))
         } catch (e) {
             if (e instanceof Error) {
-                this.extension.logger.addLogMessage(`latex-workshop.message.latexlog.exclude is invalid: ${e.message}`)
+                Logger.log(`latex-workshop.message.latexlog.exclude is invalid: ${e.message}`)
             }
             return
         }

--- a/src/components/section.ts
+++ b/src/components/section.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode'
 
-import type { Extension } from '../main'
 import { stripCommentsAndVerbatim } from '../utils/utils'
+import { Logger } from './logger'
 
 interface MatchSection {
     level: string,
@@ -9,13 +9,11 @@ interface MatchSection {
 }
 
 export class Section {
-    private readonly extension: Extension
     private readonly levels: string[] = ['part', 'chapter', 'section', 'subsection', 'subsubsection', 'paragraph', 'subparagraph']
     private readonly upperLevels = Object.create(null) as {[key: string]: string}
     private readonly lowerLevels = Object.create(null) as {[key: string]: string}
 
-    constructor(extension: Extension) {
-        this.extension = extension
+    constructor() {
         for (let i = 0; i < this.levels.length; i++) {
             const current = this.levels[i]
             const upper = this.levels[Math.max(i - 1, 0)]
@@ -31,7 +29,7 @@ export class Section {
      * @param change 'promote' or 'demote'
      */
     shiftSectioningLevel(change: 'promote' | 'demote') {
-        this.extension.logger.addLogMessage(`Calling shiftSectioningLevel with parameter: ${change}`)
+        Logger.log(`Calling shiftSectioningLevel with parameter: ${change}`)
         if (change !== 'promote' && change !== 'demote') {
             throw TypeError(
             `Invalid value of function parameter 'change' (=${change})`
@@ -161,7 +159,7 @@ export class Section {
     }
 
     selectSection() {
-        this.extension.logger.addLogMessage('Calling selectSection.')
+        Logger.log('Calling selectSection.')
 
         const editor = vscode.window.activeTextEditor
         if (editor === undefined) {
@@ -169,7 +167,7 @@ export class Section {
         }
         const beginLevel = this.searchLevelUp(this.levels, editor.selection.anchor, editor.document)
         if (!beginLevel) {
-            this.extension.logger.addLogMessage('Cannot find any section command above current line.')
+            Logger.log('Cannot find any section command above current line.')
             return
         }
         const levelIndex = this.levels.indexOf(beginLevel.level)

--- a/src/components/section.ts
+++ b/src/components/section.ts
@@ -1,7 +1,10 @@
 import * as vscode from 'vscode'
 
 import { stripCommentsAndVerbatim } from '../utils/utils'
-import * as logger from './logger'
+
+import { getLogger } from './logger'
+
+const logger = getLogger('Section')
 
 interface MatchSection {
     level: string,
@@ -29,7 +32,7 @@ export class Section {
      * @param change 'promote' or 'demote'
      */
     shiftSectioningLevel(change: 'promote' | 'demote') {
-        logger.log(`[Section] Calling shiftSectioningLevel with parameter: ${change}`)
+        logger.log(`Calling shiftSectioningLevel with parameter: ${change}`)
         if (change !== 'promote' && change !== 'demote') {
             throw TypeError(
             `Invalid value of function parameter 'change' (=${change})`
@@ -159,7 +162,7 @@ export class Section {
     }
 
     selectSection() {
-        logger.log('[Section] Calling selectSection.')
+        logger.log('Calling selectSection.')
 
         const editor = vscode.window.activeTextEditor
         if (editor === undefined) {
@@ -167,7 +170,7 @@ export class Section {
         }
         const beginLevel = this.searchLevelUp(this.levels, editor.selection.anchor, editor.document)
         if (!beginLevel) {
-            logger.log('[Section] Cannot find any section command above current line.')
+            logger.log('Cannot find any section command above current line.')
             return
         }
         const levelIndex = this.levels.indexOf(beginLevel.level)

--- a/src/components/section.ts
+++ b/src/components/section.ts
@@ -29,7 +29,7 @@ export class Section {
      * @param change 'promote' or 'demote'
      */
     shiftSectioningLevel(change: 'promote' | 'demote') {
-        logger.log(`Calling shiftSectioningLevel with parameter: ${change}`)
+        logger.log(`[Section] Calling shiftSectioningLevel with parameter: ${change}`)
         if (change !== 'promote' && change !== 'demote') {
             throw TypeError(
             `Invalid value of function parameter 'change' (=${change})`
@@ -159,7 +159,7 @@ export class Section {
     }
 
     selectSection() {
-        logger.log('Calling selectSection.')
+        logger.log('[Section] Calling selectSection.')
 
         const editor = vscode.window.activeTextEditor
         if (editor === undefined) {
@@ -167,7 +167,7 @@ export class Section {
         }
         const beginLevel = this.searchLevelUp(this.levels, editor.selection.anchor, editor.document)
         if (!beginLevel) {
-            logger.log('Cannot find any section command above current line.')
+            logger.log('[Section] Cannot find any section command above current line.')
             return
         }
         const levelIndex = this.levels.indexOf(beginLevel.level)

--- a/src/components/section.ts
+++ b/src/components/section.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode'
 
 import { stripCommentsAndVerbatim } from '../utils/utils'
-import { Logger } from './logger'
+import * as logger from './logger'
 
 interface MatchSection {
     level: string,
@@ -29,7 +29,7 @@ export class Section {
      * @param change 'promote' or 'demote'
      */
     shiftSectioningLevel(change: 'promote' | 'demote') {
-        Logger.log(`Calling shiftSectioningLevel with parameter: ${change}`)
+        logger.log(`Calling shiftSectioningLevel with parameter: ${change}`)
         if (change !== 'promote' && change !== 'demote') {
             throw TypeError(
             `Invalid value of function parameter 'change' (=${change})`
@@ -159,7 +159,7 @@ export class Section {
     }
 
     selectSection() {
-        Logger.log('Calling selectSection.')
+        logger.log('Calling selectSection.')
 
         const editor = vscode.window.activeTextEditor
         if (editor === undefined) {
@@ -167,7 +167,7 @@ export class Section {
         }
         const beginLevel = this.searchLevelUp(this.levels, editor.selection.anchor, editor.document)
         if (!beginLevel) {
-            Logger.log('Cannot find any section command above current line.')
+            logger.log('Cannot find any section command above current line.')
             return
         }
         const levelIndex = this.levels.indexOf(beginLevel.level)

--- a/src/components/server.ts
+++ b/src/components/server.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode'
 import type {Extension} from '../main'
 import {PdfFilePathEncoder} from './serverlib/encodepath'
 import {EventEmitter} from 'events'
-import { Logger } from './logger'
+import * as logger from './logger'
 
 class WsServer extends ws.Server {
     private readonly validOrigin: string
@@ -26,8 +26,8 @@ class WsServer extends ws.Server {
     shouldHandle(req: http.IncomingMessage): boolean {
         const reqOrigin = req.headers['origin']
         if (reqOrigin !== undefined && reqOrigin !== this.validOrigin) {
-            Logger.log(`[Server] Origin in WebSocket upgrade request is invalid: ${JSON.stringify(req.headers)}`)
-            Logger.log(`[Server] Valid origin: ${this.validOrigin}`)
+            logger.log(`[Server] Origin in WebSocket upgrade request is invalid: ${JSON.stringify(req.headers)}`)
+            logger.log(`[Server] Valid origin: ${this.validOrigin}`)
             return false
         } else {
             return true
@@ -55,7 +55,7 @@ export class Server {
         this.pdfFilePathEncoder = new PdfFilePathEncoder(extension)
         this.httpServer = http.createServer((request, response) => this.handler(request, response))
         this.initializeHttpServer()
-        Logger.log('[Server] Creating LaTeX Workshop http and websocket server.')
+        logger.log('[Server] Creating LaTeX Workshop http and websocket server.')
     }
 
     dispose() {
@@ -65,7 +65,7 @@ export class Server {
     get port(): number {
         const portNum = this.address?.port
         if (portNum === undefined) {
-            Logger.log('Server port number is undefined.')
+            logger.log('Server port number is undefined.')
             throw new Error('Server port number is undefined.')
         }
         return portNum
@@ -86,17 +86,17 @@ export class Server {
             const address = this.httpServer.address()
             if (address && typeof address !== 'string') {
                 this.address = address
-                Logger.log(`[Server] Server successfully started: ${JSON.stringify(address)}`)
+                logger.log(`[Server] Server successfully started: ${JSON.stringify(address)}`)
                 this.validOriginUri = await this.obtainValidOrigin(address.port)
-                Logger.log(`[Server] valdOrigin is ${this.validOrigin}`)
+                logger.log(`[Server] valdOrigin is ${this.validOrigin}`)
                 this.initializeWsServer()
                 this.eventEmitter.emit(ServerStartedEvent)
             } else {
-                Logger.log(`[Server] Server failed to start. Address is invalid: ${JSON.stringify(address)}`)
+                logger.log(`[Server] Server failed to start. Address is invalid: ${JSON.stringify(address)}`)
             }
         })
         this.httpServer.on('error', (err) => {
-            Logger.log(`[Server] Error creating LaTeX Workshop http server: ${JSON.stringify(err)}.`)
+            logger.log(`[Server] Error creating LaTeX Workshop http server: ${JSON.stringify(err)} .`)
         })
     }
 
@@ -110,7 +110,7 @@ export class Server {
         const wsServer = new WsServer(this.httpServer, this.validOrigin)
         wsServer.on('connection', (websocket) => {
             websocket.on('message', (msg: string) => this.extension.viewer.handler(websocket, msg))
-            websocket.on('error', (err) => Logger.log(`[Server] Error on WebSocket connection. ${JSON.stringify(err)}`))
+            websocket.on('error', (err) => logger.log(`[Server] Error on WebSocket connection. ${JSON.stringify(err)}`))
         })
     }
 
@@ -123,8 +123,8 @@ export class Server {
     private checkHttpOrigin(req: http.IncomingMessage, response: http.ServerResponse): boolean {
         const reqOrigin = req.headers['origin']
         if (reqOrigin !== undefined && reqOrigin !== this.validOrigin) {
-            Logger.log(`[Server] Origin in http request is invalid: ${JSON.stringify(req.headers)}`)
-            Logger.log(`[Server] Valid origin: ${this.validOrigin}`)
+            logger.log(`[Server] Origin in http request is invalid: ${JSON.stringify(req.headers)}`)
+            logger.log(`[Server] Valid origin: ${this.validOrigin}`)
             response.writeHead(403)
             response.end()
             return false
@@ -165,18 +165,15 @@ export class Server {
             const s = request.url.replace('/', '')
             const fileUri = this.pdfFilePathEncoder.decodePathWithPrefix(s)
             if (this.extension.viewer.getClientSet(fileUri) === undefined) {
-                Logger.log(`Invalid PDF request: ${fileUri.toString(true)}`)
+                logger.log(`Invalid PDF request: ${fileUri.toString(true)}`)
                 return
             }
             try {
                 const buf: Buffer = await this.extension.lwfs.readFileAsBuffer(fileUri)
                 this.sendOkResponse(response, buf, 'application/pdf')
-                Logger.log(`Preview PDF file: ${fileUri.toString(true)}`)
+                logger.log(`Preview PDF file: ${fileUri.toString(true)}`)
             } catch (e) {
-                Logger.log(`Error reading PDF file: ${fileUri.toString(true)}`)
-                if (e instanceof Error) {
-                    Logger.logError(e)
-                }
+                logger.logError(`[Server] Error reading PDF ${fileUri.toString(true)}`, e)
                 response.writeHead(404)
                 response.end()
             }

--- a/src/components/server.ts
+++ b/src/components/server.ts
@@ -8,14 +8,13 @@ import * as vscode from 'vscode'
 import type {Extension} from '../main'
 import {PdfFilePathEncoder} from './serverlib/encodepath'
 import {EventEmitter} from 'events'
+import { Logger } from './logger'
 
 class WsServer extends ws.Server {
-    private readonly extension: Extension
     private readonly validOrigin: string
 
-    constructor(server: http.Server, extension: Extension, validOrigin: string) {
+    constructor(server: http.Server, validOrigin: string) {
         super({server})
-        this.extension = extension
         this.validOrigin = validOrigin
     }
 
@@ -27,8 +26,8 @@ class WsServer extends ws.Server {
     shouldHandle(req: http.IncomingMessage): boolean {
         const reqOrigin = req.headers['origin']
         if (reqOrigin !== undefined && reqOrigin !== this.validOrigin) {
-            this.extension.logger.addLogMessage(`[Server] Origin in WebSocket upgrade request is invalid: ${JSON.stringify(req.headers)}`)
-            this.extension.logger.addLogMessage(`[Server] Valid origin: ${this.validOrigin}`)
+            Logger.log(`[Server] Origin in WebSocket upgrade request is invalid: ${JSON.stringify(req.headers)}`)
+            Logger.log(`[Server] Valid origin: ${this.validOrigin}`)
             return false
         } else {
             return true
@@ -56,7 +55,7 @@ export class Server {
         this.pdfFilePathEncoder = new PdfFilePathEncoder(extension)
         this.httpServer = http.createServer((request, response) => this.handler(request, response))
         this.initializeHttpServer()
-        this.extension.logger.addLogMessage('[Server] Creating LaTeX Workshop http and websocket server.')
+        Logger.log('[Server] Creating LaTeX Workshop http and websocket server.')
     }
 
     dispose() {
@@ -66,7 +65,7 @@ export class Server {
     get port(): number {
         const portNum = this.address?.port
         if (portNum === undefined) {
-            this.extension.logger.addLogMessage('Server port number is undefined.')
+            Logger.log('Server port number is undefined.')
             throw new Error('Server port number is undefined.')
         }
         return portNum
@@ -87,17 +86,17 @@ export class Server {
             const address = this.httpServer.address()
             if (address && typeof address !== 'string') {
                 this.address = address
-                this.extension.logger.addLogMessage(`[Server] Server successfully started: ${JSON.stringify(address)}`)
+                Logger.log(`[Server] Server successfully started: ${JSON.stringify(address)}`)
                 this.validOriginUri = await this.obtainValidOrigin(address.port)
-                this.extension.logger.addLogMessage(`[Server] valdOrigin is ${this.validOrigin}`)
+                Logger.log(`[Server] valdOrigin is ${this.validOrigin}`)
                 this.initializeWsServer()
                 this.eventEmitter.emit(ServerStartedEvent)
             } else {
-                this.extension.logger.addLogMessage(`[Server] Server failed to start. Address is invalid: ${JSON.stringify(address)}`)
+                Logger.log(`[Server] Server failed to start. Address is invalid: ${JSON.stringify(address)}`)
             }
         })
         this.httpServer.on('error', (err) => {
-            this.extension.logger.addLogMessage(`[Server] Error creating LaTeX Workshop http server: ${JSON.stringify(err)}.`)
+            Logger.log(`[Server] Error creating LaTeX Workshop http server: ${JSON.stringify(err)}.`)
         })
     }
 
@@ -108,10 +107,10 @@ export class Server {
     }
 
     private initializeWsServer() {
-        const wsServer = new WsServer(this.httpServer, this.extension, this.validOrigin)
+        const wsServer = new WsServer(this.httpServer, this.validOrigin)
         wsServer.on('connection', (websocket) => {
             websocket.on('message', (msg: string) => this.extension.viewer.handler(websocket, msg))
-            websocket.on('error', (err) => this.extension.logger.addLogMessage(`[Server] Error on WebSocket connection. ${JSON.stringify(err)}`))
+            websocket.on('error', (err) => Logger.log(`[Server] Error on WebSocket connection. ${JSON.stringify(err)}`))
         })
     }
 
@@ -124,8 +123,8 @@ export class Server {
     private checkHttpOrigin(req: http.IncomingMessage, response: http.ServerResponse): boolean {
         const reqOrigin = req.headers['origin']
         if (reqOrigin !== undefined && reqOrigin !== this.validOrigin) {
-            this.extension.logger.addLogMessage(`[Server] Origin in http request is invalid: ${JSON.stringify(req.headers)}`)
-            this.extension.logger.addLogMessage(`[Server] Valid origin: ${this.validOrigin}`)
+            Logger.log(`[Server] Origin in http request is invalid: ${JSON.stringify(req.headers)}`)
+            Logger.log(`[Server] Valid origin: ${this.validOrigin}`)
             response.writeHead(403)
             response.end()
             return false
@@ -166,17 +165,17 @@ export class Server {
             const s = request.url.replace('/', '')
             const fileUri = this.pdfFilePathEncoder.decodePathWithPrefix(s)
             if (this.extension.viewer.getClientSet(fileUri) === undefined) {
-                this.extension.logger.addLogMessage(`Invalid PDF request: ${fileUri.toString(true)}`)
+                Logger.log(`Invalid PDF request: ${fileUri.toString(true)}`)
                 return
             }
             try {
                 const buf: Buffer = await this.extension.lwfs.readFileAsBuffer(fileUri)
                 this.sendOkResponse(response, buf, 'application/pdf')
-                this.extension.logger.addLogMessage(`Preview PDF file: ${fileUri.toString(true)}`)
+                Logger.log(`Preview PDF file: ${fileUri.toString(true)}`)
             } catch (e) {
-                this.extension.logger.addLogMessage(`Error reading PDF file: ${fileUri.toString(true)}`)
+                Logger.log(`Error reading PDF file: ${fileUri.toString(true)}`)
                 if (e instanceof Error) {
-                    this.extension.logger.logError(e)
+                    Logger.logError(e)
                 }
                 response.writeHead(404)
                 response.end()

--- a/src/components/server.ts
+++ b/src/components/server.ts
@@ -65,7 +65,7 @@ export class Server {
     get port(): number {
         const portNum = this.address?.port
         if (portNum === undefined) {
-            logger.log('Server port number is undefined.')
+            logger.log('[Server] Server port number is undefined.')
             throw new Error('Server port number is undefined.')
         }
         return portNum
@@ -165,13 +165,13 @@ export class Server {
             const s = request.url.replace('/', '')
             const fileUri = this.pdfFilePathEncoder.decodePathWithPrefix(s)
             if (this.extension.viewer.getClientSet(fileUri) === undefined) {
-                logger.log(`Invalid PDF request: ${fileUri.toString(true)}`)
+                logger.log(`[Server] Invalid PDF request: ${fileUri.toString(true)}`)
                 return
             }
             try {
                 const buf: Buffer = await this.extension.lwfs.readFileAsBuffer(fileUri)
                 this.sendOkResponse(response, buf, 'application/pdf')
-                logger.log(`Preview PDF file: ${fileUri.toString(true)}`)
+                logger.log(`[Server] Preview PDF file: ${fileUri.toString(true)}`)
             } catch (e) {
                 logger.logError(`[Server] Error reading PDF ${fileUri.toString(true)}`, e)
                 response.writeHead(404)

--- a/src/components/texdoc.ts
+++ b/src/components/texdoc.ts
@@ -2,7 +2,10 @@ import * as vscode from 'vscode'
 import * as cs from 'cross-spawn'
 
 import type { Extension } from '../main'
-import * as logger from './logger'
+
+import { getLogger } from './logger'
+
+const logger = getLogger('TeXDoc')
 
 export class TeXDoc {
     private readonly extension: Extension
@@ -30,7 +33,7 @@ export class TeXDoc {
         })
 
         proc.on('error', err => {
-            logger.log(`[TeXDoc] Cannot run texdoc: ${err.message}, ${stderr}`)
+            logger.log(`Cannot run texdoc: ${err.message}, ${stderr}`)
             void logger.showErrorMessage('Texdoc failed. Please refer to LaTeX Workshop Output for details.')
         })
 
@@ -41,14 +44,14 @@ export class TeXDoc {
             } else {
                 const regex = new RegExp(`(no documentation found)|(Documentation for ${pkg} could not be found)`)
                 if (stdout.match(regex) || stderr.match(regex)) {
-                    logger.log(`[TeXDoc] Cannot find documentation for ${pkg}.`)
+                    logger.log(`Cannot find documentation for ${pkg}.`)
                     void logger.showErrorMessage(`Cannot find documentation for ${pkg}.`)
                 } else {
-                    logger.log(`[TeXDoc] Opening documentation for ${pkg}.`)
+                    logger.log(`Opening documentation for ${pkg}.`)
                 }
             }
-            logger.log(`[TeXDoc] texdoc stdout: ${stdout}`)
-            logger.log(`[TeXDoc] texdoc stderr: ${stderr}`)
+            logger.log(`texdoc stdout: ${stdout}`)
+            logger.log(`texdoc stderr: ${stderr}`)
         })
     }
 

--- a/src/components/texdoc.ts
+++ b/src/components/texdoc.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode'
 import * as cs from 'cross-spawn'
 
 import type { Extension } from '../main'
+import { Logger } from './logger'
 
 export class TeXDoc {
     private readonly extension: Extension
@@ -15,7 +16,7 @@ export class TeXDoc {
         const texdocPath = configuration.get('texdoc.path') as string
         const texdocArgs = Array.from(configuration.get('texdoc.args') as string[])
         texdocArgs.push(pkg)
-        this.extension.logger.logCommand('Run texdoc command', texdocPath, texdocArgs)
+        Logger.logCommand('Run texdoc command', texdocPath, texdocArgs)
         const proc = cs.spawn(texdocPath, texdocArgs)
 
         let stdout = ''
@@ -29,25 +30,25 @@ export class TeXDoc {
         })
 
         proc.on('error', err => {
-            this.extension.logger.addLogMessage(`Cannot run texdoc: ${err.message}, ${stderr}`)
-            void this.extension.logger.showErrorMessage('Texdoc failed. Please refer to LaTeX Workshop Output for details.')
+            Logger.log(`Cannot run texdoc: ${err.message}, ${stderr}`)
+            void Logger.showErrorMessage('Texdoc failed. Please refer to LaTeX Workshop Output for details.')
         })
 
         proc.on('exit', exitCode => {
             if (exitCode !== 0) {
-                this.extension.logger.addLogMessage(`Cannot find documentation for ${pkg}.`)
-                void this.extension.logger.showErrorMessage('Texdoc failed. Please refer to LaTeX Workshop Output for details.')
+                Logger.log(`Cannot find documentation for ${pkg}.`)
+                void Logger.showErrorMessage('Texdoc failed. Please refer to LaTeX Workshop Output for details.')
             } else {
                 const regex = new RegExp(`(no documentation found)|(Documentation for ${pkg} could not be found)`)
                 if (stdout.match(regex) || stderr.match(regex)) {
-                    this.extension.logger.addLogMessage(`Cannot find documentation for ${pkg}.`)
-                    void this.extension.logger.showErrorMessage(`Cannot find documentation for ${pkg}.`)
+                    Logger.log(`Cannot find documentation for ${pkg}.`)
+                    void Logger.showErrorMessage(`Cannot find documentation for ${pkg}.`)
                 } else {
-                    this.extension.logger.addLogMessage(`Opening documentation for ${pkg}.`)
+                    Logger.log(`Opening documentation for ${pkg}.`)
                 }
             }
-            this.extension.logger.addLogMessage(`texdoc stdout: ${stdout}`)
-            this.extension.logger.addLogMessage(`texdoc stderr: ${stderr}`)
+            Logger.log(`texdoc stdout: ${stdout}`)
+            Logger.log(`texdoc stderr: ${stderr}`)
         })
     }
 

--- a/src/components/texdoc.ts
+++ b/src/components/texdoc.ts
@@ -30,25 +30,25 @@ export class TeXDoc {
         })
 
         proc.on('error', err => {
-            logger.log(`Cannot run texdoc: ${err.message}, ${stderr}`)
+            logger.log(`[TeXDoc] Cannot run texdoc: ${err.message}, ${stderr}`)
             void logger.showErrorMessage('Texdoc failed. Please refer to LaTeX Workshop Output for details.')
         })
 
         proc.on('exit', exitCode => {
             if (exitCode !== 0) {
-                logger.log(`Cannot find documentation for ${pkg}.`)
+                logger.logError(`Cannot find documentation for ${pkg}.`, exitCode)
                 void logger.showErrorMessage('Texdoc failed. Please refer to LaTeX Workshop Output for details.')
             } else {
                 const regex = new RegExp(`(no documentation found)|(Documentation for ${pkg} could not be found)`)
                 if (stdout.match(regex) || stderr.match(regex)) {
-                    logger.log(`Cannot find documentation for ${pkg}.`)
+                    logger.log(`[TeXDoc] Cannot find documentation for ${pkg}.`)
                     void logger.showErrorMessage(`Cannot find documentation for ${pkg}.`)
                 } else {
-                    logger.log(`Opening documentation for ${pkg}.`)
+                    logger.log(`[TeXDoc] Opening documentation for ${pkg}.`)
                 }
             }
-            logger.log(`texdoc stdout: ${stdout}`)
-            logger.log(`texdoc stderr: ${stderr}`)
+            logger.log(`[TeXDoc] texdoc stdout: ${stdout}`)
+            logger.log(`[TeXDoc] texdoc stderr: ${stderr}`)
         })
     }
 

--- a/src/components/texdoc.ts
+++ b/src/components/texdoc.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode'
 import * as cs from 'cross-spawn'
 
 import type { Extension } from '../main'
-import { Logger } from './logger'
+import * as logger from './logger'
 
 export class TeXDoc {
     private readonly extension: Extension
@@ -16,7 +16,7 @@ export class TeXDoc {
         const texdocPath = configuration.get('texdoc.path') as string
         const texdocArgs = Array.from(configuration.get('texdoc.args') as string[])
         texdocArgs.push(pkg)
-        Logger.logCommand('Run texdoc command', texdocPath, texdocArgs)
+        logger.logCommand('Run texdoc command', texdocPath, texdocArgs)
         const proc = cs.spawn(texdocPath, texdocArgs)
 
         let stdout = ''
@@ -30,25 +30,25 @@ export class TeXDoc {
         })
 
         proc.on('error', err => {
-            Logger.log(`Cannot run texdoc: ${err.message}, ${stderr}`)
-            void Logger.showErrorMessage('Texdoc failed. Please refer to LaTeX Workshop Output for details.')
+            logger.log(`Cannot run texdoc: ${err.message}, ${stderr}`)
+            void logger.showErrorMessage('Texdoc failed. Please refer to LaTeX Workshop Output for details.')
         })
 
         proc.on('exit', exitCode => {
             if (exitCode !== 0) {
-                Logger.log(`Cannot find documentation for ${pkg}.`)
-                void Logger.showErrorMessage('Texdoc failed. Please refer to LaTeX Workshop Output for details.')
+                logger.log(`Cannot find documentation for ${pkg}.`)
+                void logger.showErrorMessage('Texdoc failed. Please refer to LaTeX Workshop Output for details.')
             } else {
                 const regex = new RegExp(`(no documentation found)|(Documentation for ${pkg} could not be found)`)
                 if (stdout.match(regex) || stderr.match(regex)) {
-                    Logger.log(`Cannot find documentation for ${pkg}.`)
-                    void Logger.showErrorMessage(`Cannot find documentation for ${pkg}.`)
+                    logger.log(`Cannot find documentation for ${pkg}.`)
+                    void logger.showErrorMessage(`Cannot find documentation for ${pkg}.`)
                 } else {
-                    Logger.log(`Opening documentation for ${pkg}.`)
+                    logger.log(`Opening documentation for ${pkg}.`)
                 }
             }
-            Logger.log(`texdoc stdout: ${stdout}`)
-            Logger.log(`texdoc stderr: ${stderr}`)
+            logger.log(`texdoc stdout: ${stdout}`)
+            logger.log(`texdoc stderr: ${stderr}`)
         })
     }
 

--- a/src/components/viewer.ts
+++ b/src/components/viewer.ts
@@ -14,7 +14,7 @@ import {Client} from './viewerlib/client'
 import {PdfViewerPanel, PdfViewerPanelSerializer, PdfViewerPanelService} from './viewerlib/pdfviewerpanel'
 import {PdfViewerManagerService} from './viewerlib/pdfviewermanager'
 import {ViewerPageLoaded} from './eventbus'
-import { Logger } from './logger'
+import * as logger from './logger'
 export {PdfViewerHookProvider} from './viewerlib/pdfviewerhook'
 
 
@@ -68,7 +68,7 @@ export class Viewer {
      * refreshes all the PDF viewers.
      */
     refreshExistingViewer(sourceFile?: string, pdfFile?: string): void {
-        Logger.log(`Call refreshExistingViewer: ${JSON.stringify({sourceFile})}`)
+        logger.log(`Call refreshExistingViewer: ${JSON.stringify({sourceFile})}`)
         const pdfUri = pdfFile ? vscode.Uri.file(pdfFile) : (sourceFile ? this.tex2pdf(sourceFile, true) : undefined)
         if (pdfUri === undefined) {
             this.clientMap.forEach(clientSet => {
@@ -80,10 +80,10 @@ export class Viewer {
         }
         const clientSet = this.getClientSet(pdfUri)
         if (!clientSet) {
-            Logger.log(`Not found PDF viewers to refresh: ${pdfFile}`)
+            logger.log(`Not found PDF viewers to refresh: ${pdfFile}`)
             return
         }
-        Logger.log(`Refresh PDF viewer: ${pdfFile}`)
+        logger.log(`Refresh PDF viewer: ${pdfFile}`)
         clientSet.forEach(client => {
             client.send({type: 'refresh'})
         })
@@ -92,8 +92,8 @@ export class Viewer {
     private async checkViewer(sourceFile: string, respectOutDir: boolean = true): Promise<string | undefined> {
         const pdfFile = this.tex2pdf(sourceFile, respectOutDir)
         if (!await this.extension.lwfs.exists(pdfFile)) {
-            Logger.log(`Cannot find PDF file ${pdfFile}`)
-            Logger.displayStatus('check', 'statusBar.foreground', `Cannot view file PDF file. File not found: ${pdfFile}`, 'warning')
+            logger.log(`Cannot find PDF file ${pdfFile}`)
+            logger.refreshStatus('check', 'statusBar.foreground', `Cannot view file PDF file. File not found: ${pdfFile}`, 'warning')
             return
         }
         const url = `http://127.0.0.1:${this.extension.server.port}/viewer.html?file=${this.encodePathWithPrefix(pdfFile)}`
@@ -114,18 +114,15 @@ export class Viewer {
         this.createClientSet(pdfFileUri)
         this.extension.cacher.watchPdfFile(pdfFileUri)
         try {
-            Logger.log(`Serving PDF file at ${url}`)
+            logger.log(`Serving PDF file at ${url}`)
             await vscode.env.openExternal(vscode.Uri.parse(url, true))
-            Logger.log(`Open PDF viewer for ${pdfFileUri.toString(true)}`)
+            logger.log(`Open PDF viewer for ${pdfFileUri.toString(true)}`)
         } catch (e: unknown) {
             void vscode.window.showInputBox({
                 prompt: 'Unable to open browser. Please copy and visit this link.',
                 value: url
             })
-            Logger.log(`Something bad happened when opening PDF viewer for ${pdfFileUri.toString(true)}`)
-            if (e instanceof Error) {
-                Logger.logError(e)
-            }
+            logger.logError(`[Viewer] Failed opening PDF viewer for ${pdfFileUri.toString(true)}`, e)
         }
     }
 
@@ -160,7 +157,7 @@ export class Viewer {
         if (activeDocument) {
             await openWebviewPanel(panel.webviewPanel, tabEditorGroup, activeDocument, preserveFocus)
         }
-        Logger.log(`Open PDF tab for ${pdfFileUri.toString(true)}`)
+        logger.log(`Open PDF tab for ${pdfFileUri.toString(true)}`)
     }
 
     private async createPdfViewerPanel(pdfFileUri: vscode.Uri, viewColumn: vscode.ViewColumn): Promise<PdfViewerPanel> {
@@ -200,8 +197,8 @@ export class Viewer {
         if (args) {
             args = args.map(arg => arg.replace('%PDF%', pdfFile))
         }
-        Logger.log(`Open external viewer for ${pdfFile}`)
-        Logger.logCommand('Execute the external PDF viewer command', command, args)
+        logger.log(`Open external viewer for ${pdfFile}`)
+        logger.logCommand('Execute the external PDF viewer command', command, args)
         const proc = cs.spawn(command, args, {cwd: path.dirname(sourceFile), detached: true})
         let stdout = ''
         proc.stdout.on('data', newStdout => {
@@ -212,8 +209,8 @@ export class Viewer {
             stderr += newStderr
         })
         const cb = () => {
-            void Logger.log(`The external PDF viewer stdout: ${stdout}`)
-            void Logger.log(`The external PDF viewer stderr: ${stderr}`)
+            void logger.log(`The external PDF viewer stdout: ${stdout}`)
+            void logger.log(`The external PDF viewer stderr: ${stderr}`)
         }
         proc.on('error', cb)
         proc.on('exit', cb)
@@ -228,7 +225,7 @@ export class Viewer {
     handler(websocket: ws, msg: string): void {
         const data = JSON.parse(msg) as ClientRequest
         if (data.type !== 'ping') {
-            Logger.log(`Handle data type: ${data.type}`)
+            logger.log(`Handle data type: ${data.type}`)
         }
         switch (data.type) {
             case 'open': {
@@ -248,7 +245,7 @@ export class Viewer {
                 this.extension.eventBus.fire(ViewerPageLoaded)
                 const configuration = vscode.workspace.getConfiguration('latex-workshop')
                 if (configuration.get('synctex.afterBuild.enabled') as boolean) {
-                    Logger.log('SyncTex after build invoked.')
+                    logger.log('SyncTex after build invoked.')
                     const uri = vscode.Uri.parse(data.pdfFileUri, true)
                     this.extension.locator.syncTeX(undefined, undefined, uri.fsPath)
                 }
@@ -276,7 +273,7 @@ export class Viewer {
                             }
                         },
                         reason => {
-                            Logger.log(`Unknown error when opening URI. Error: ${JSON.stringify(reason)}, URI: ${data.url}`)
+                            logger.log(`Unknown error when opening URI. Error: ${JSON.stringify(reason)}, URI: ${data.url}`)
                         })
                 }
                 break
@@ -286,11 +283,11 @@ export class Viewer {
                 break
             }
             case 'add_log': {
-                Logger.log(`[PDF Viewer] ${data.message}`)
+                logger.log(`[PDF Viewer] ${data.message}`)
                 break
             }
             default: {
-                Logger.log(`Unknown websocket message: ${msg}`)
+                logger.log(`Unknown websocket message: ${msg}`)
                 break
             }
         }
@@ -348,7 +345,7 @@ export class Viewer {
         const pdfFileUri = vscode.Uri.file(pdfFile)
         const clientSet = this.getClientSet(pdfFileUri)
         if (clientSet === undefined) {
-            Logger.log(`PDF is not viewed: ${pdfFile}`)
+            logger.log(`PDF is not viewed: ${pdfFile}`)
             return
         }
         const needDelay = this.revealWebviewPanel(pdfFileUri)
@@ -356,7 +353,7 @@ export class Viewer {
             setTimeout(() => {
                 client.send({type: 'synctex', data: record})
             }, needDelay ? 200 : 0)
-            Logger.log(`Try to synctex ${pdfFile}`)
+            logger.log(`Try to synctex ${pdfFile}`)
         }
     }
 

--- a/src/components/viewer.ts
+++ b/src/components/viewer.ts
@@ -68,7 +68,7 @@ export class Viewer {
      * refreshes all the PDF viewers.
      */
     refreshExistingViewer(sourceFile?: string, pdfFile?: string): void {
-        logger.log(`Call refreshExistingViewer: ${JSON.stringify({sourceFile})}`)
+        logger.log(`[Viewer] Call refreshExistingViewer: ${JSON.stringify({sourceFile})}`)
         const pdfUri = pdfFile ? vscode.Uri.file(pdfFile) : (sourceFile ? this.tex2pdf(sourceFile, true) : undefined)
         if (pdfUri === undefined) {
             this.clientMap.forEach(clientSet => {
@@ -80,10 +80,10 @@ export class Viewer {
         }
         const clientSet = this.getClientSet(pdfUri)
         if (!clientSet) {
-            logger.log(`Not found PDF viewers to refresh: ${pdfFile}`)
+            logger.log(`[Viewer] Not found PDF viewers to refresh: ${pdfFile}`)
             return
         }
-        logger.log(`Refresh PDF viewer: ${pdfFile}`)
+        logger.log(`[Viewer] Refresh PDF viewer: ${pdfFile}`)
         clientSet.forEach(client => {
             client.send({type: 'refresh'})
         })
@@ -92,7 +92,7 @@ export class Viewer {
     private async checkViewer(sourceFile: string, respectOutDir: boolean = true): Promise<string | undefined> {
         const pdfFile = this.tex2pdf(sourceFile, respectOutDir)
         if (!await this.extension.lwfs.exists(pdfFile)) {
-            logger.log(`Cannot find PDF file ${pdfFile}`)
+            logger.log(`[Viewer] Cannot find PDF file ${pdfFile}`)
             logger.refreshStatus('check', 'statusBar.foreground', `Cannot view file PDF file. File not found: ${pdfFile}`, 'warning')
             return
         }
@@ -114,9 +114,9 @@ export class Viewer {
         this.createClientSet(pdfFileUri)
         this.extension.cacher.watchPdfFile(pdfFileUri)
         try {
-            logger.log(`Serving PDF file at ${url}`)
+            logger.log(`[Viewer] Serving PDF file at ${url}`)
             await vscode.env.openExternal(vscode.Uri.parse(url, true))
-            logger.log(`Open PDF viewer for ${pdfFileUri.toString(true)}`)
+            logger.log(`[Viewer] Open PDF viewer for ${pdfFileUri.toString(true)}`)
         } catch (e: unknown) {
             void vscode.window.showInputBox({
                 prompt: 'Unable to open browser. Please copy and visit this link.',
@@ -157,7 +157,7 @@ export class Viewer {
         if (activeDocument) {
             await openWebviewPanel(panel.webviewPanel, tabEditorGroup, activeDocument, preserveFocus)
         }
-        logger.log(`Open PDF tab for ${pdfFileUri.toString(true)}`)
+        logger.log(`[Viewer] Open PDF tab for ${pdfFileUri.toString(true)}`)
     }
 
     private async createPdfViewerPanel(pdfFileUri: vscode.Uri, viewColumn: vscode.ViewColumn): Promise<PdfViewerPanel> {
@@ -197,7 +197,7 @@ export class Viewer {
         if (args) {
             args = args.map(arg => arg.replace('%PDF%', pdfFile))
         }
-        logger.log(`Open external viewer for ${pdfFile}`)
+        logger.log(`[Viewer] Open external viewer for ${pdfFile}`)
         logger.logCommand('Execute the external PDF viewer command', command, args)
         const proc = cs.spawn(command, args, {cwd: path.dirname(sourceFile), detached: true})
         let stdout = ''
@@ -209,8 +209,8 @@ export class Viewer {
             stderr += newStderr
         })
         const cb = () => {
-            void logger.log(`The external PDF viewer stdout: ${stdout}`)
-            void logger.log(`The external PDF viewer stderr: ${stderr}`)
+            void logger.log(`[Viewer] The external PDF viewer stdout: ${stdout}`)
+            void logger.log(`[Viewer] The external PDF viewer stderr: ${stderr}`)
         }
         proc.on('error', cb)
         proc.on('exit', cb)
@@ -225,7 +225,7 @@ export class Viewer {
     handler(websocket: ws, msg: string): void {
         const data = JSON.parse(msg) as ClientRequest
         if (data.type !== 'ping') {
-            logger.log(`Handle data type: ${data.type}`)
+            logger.log(`[Viewer] Handle data type: ${data.type}`)
         }
         switch (data.type) {
             case 'open': {
@@ -245,7 +245,7 @@ export class Viewer {
                 this.extension.eventBus.fire(ViewerPageLoaded)
                 const configuration = vscode.workspace.getConfiguration('latex-workshop')
                 if (configuration.get('synctex.afterBuild.enabled') as boolean) {
-                    logger.log('SyncTex after build invoked.')
+                    logger.log('[Viewer] SyncTex after build invoked.')
                     const uri = vscode.Uri.parse(data.pdfFileUri, true)
                     this.extension.locator.syncTeX(undefined, undefined, uri.fsPath)
                 }
@@ -273,7 +273,7 @@ export class Viewer {
                             }
                         },
                         reason => {
-                            logger.log(`Unknown error when opening URI. Error: ${JSON.stringify(reason)}, URI: ${data.url}`)
+                            logger.log(`[Viewer] Unknown error when opening URI. Error: ${JSON.stringify(reason)}, URI: ${data.url}`)
                         })
                 }
                 break
@@ -283,11 +283,11 @@ export class Viewer {
                 break
             }
             case 'add_log': {
-                logger.log(`[PDF Viewer] ${data.message}`)
+                logger.log(`[Viewer] ${data.message}`)
                 break
             }
             default: {
-                logger.log(`Unknown websocket message: ${msg}`)
+                logger.log(`[Viewer] Unknown websocket message: ${msg}`)
                 break
             }
         }
@@ -345,7 +345,7 @@ export class Viewer {
         const pdfFileUri = vscode.Uri.file(pdfFile)
         const clientSet = this.getClientSet(pdfFileUri)
         if (clientSet === undefined) {
-            logger.log(`PDF is not viewed: ${pdfFile}`)
+            logger.log(`[Viewer] PDF is not viewed: ${pdfFile}`)
             return
         }
         const needDelay = this.revealWebviewPanel(pdfFileUri)
@@ -353,7 +353,7 @@ export class Viewer {
             setTimeout(() => {
                 client.send({type: 'synctex', data: record})
             }, needDelay ? 200 : 0)
-            logger.log(`Try to synctex ${pdfFile}`)
+            logger.log(`[Viewer] Try to synctex ${pdfFile}`)
         }
     }
 

--- a/src/components/viewerlib/pdfviewerpanel.ts
+++ b/src/components/viewerlib/pdfviewerpanel.ts
@@ -52,7 +52,7 @@ export class PdfViewerPanelSerializer implements vscode.WebviewPanelSerializer {
 
     async deserializeWebviewPanel(panel: vscode.WebviewPanel, argState: {state: PdfViewerState}): Promise<void> {
         await this.extension.server.serverStarted
-        logger.log(`Restoring the PDF viewer at the column ${panel.viewColumn} from the state: ${JSON.stringify(argState)}`)
+        logger.log(`[Viewer][Panel] Restoring at column ${panel.viewColumn} with state ${JSON.stringify(argState.state)}.`)
         const state = argState.state
         let pdfFileUri: vscode.Uri | undefined
         if (state.path) {
@@ -61,13 +61,13 @@ export class PdfViewerPanelSerializer implements vscode.WebviewPanelSerializer {
             pdfFileUri = vscode.Uri.parse(state.pdfFileUri, true)
         }
         if (!pdfFileUri) {
-            logger.log('Error of restoring PDF viewer: the path of PDF file is undefined.')
+            logger.log('[Viewer][Panel] Failed restoring viewer with undefined PDF path.')
             panel.webview.html = '<!DOCTYPE html> <html lang="en"><meta charset="utf-8"/><br>The path of PDF file is undefined.</html>'
             return
         }
         if (! await this.extension.lwfs.exists(pdfFileUri)) {
             const s = escapeHtml(pdfFileUri.toString())
-            logger.log(`Error of restoring PDF viewer: file not found ${pdfFileUri.toString(true)} .`)
+            logger.log(`[Viewer][Panel] Failed restoring viewer with non-existent PDF ${pdfFileUri.toString(true)} .`)
             panel.webview.html = `<!DOCTYPE html> <html lang="en"><meta charset="utf-8"/><br>File not found: ${s}</html>`
             return
         }
@@ -141,7 +141,7 @@ export class PdfViewerPanelService {
         const iframeSrcOrigin = `${url.scheme}://${url.authority}`
         const iframeSrcUrl = url.toString(true)
         await this.tweakForCodespaces(url)
-        logger.log(`The internal PDF viewer url: ${iframeSrcUrl}`)
+        logger.log(`[Viewer][Panel] Internal PDF viewer at ${iframeSrcUrl} .`)
         const rebroadcast: boolean = this.getKeyboardEventConfig()
         return `
         <!DOCTYPE html><html><head><meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; frame-src ${iframeSrcOrigin}; script-src 'unsafe-inline'; style-src 'unsafe-inline';"></head>

--- a/src/components/viewerlib/pdfviewerpanel.ts
+++ b/src/components/viewerlib/pdfviewerpanel.ts
@@ -6,6 +6,7 @@ import type {PanelRequest, PdfViewerState} from '../../../types/latex-workshop-p
 import {escapeHtml, sleep} from '../../utils/utils'
 import type {PdfViewerManagerService} from './pdfviewermanager'
 import {ViewerStatusChanged} from '../eventbus'
+import { Logger } from '../logger'
 
 
 export class PdfViewerPanel {
@@ -51,7 +52,7 @@ export class PdfViewerPanelSerializer implements vscode.WebviewPanelSerializer {
 
     async deserializeWebviewPanel(panel: vscode.WebviewPanel, argState: {state: PdfViewerState}): Promise<void> {
         await this.extension.server.serverStarted
-        this.extension.logger.addLogMessage(`Restoring the PDF viewer at the column ${panel.viewColumn} from the state: ${JSON.stringify(argState)}`)
+        Logger.log(`Restoring the PDF viewer at the column ${panel.viewColumn} from the state: ${JSON.stringify(argState)}`)
         const state = argState.state
         let pdfFileUri: vscode.Uri | undefined
         if (state.path) {
@@ -60,13 +61,13 @@ export class PdfViewerPanelSerializer implements vscode.WebviewPanelSerializer {
             pdfFileUri = vscode.Uri.parse(state.pdfFileUri, true)
         }
         if (!pdfFileUri) {
-            this.extension.logger.addLogMessage('Error of restoring PDF viewer: the path of PDF file is undefined.')
+            Logger.log('Error of restoring PDF viewer: the path of PDF file is undefined.')
             panel.webview.html = '<!DOCTYPE html> <html lang="en"><meta charset="utf-8"/><br>The path of PDF file is undefined.</html>'
             return
         }
         if (! await this.extension.lwfs.exists(pdfFileUri)) {
             const s = escapeHtml(pdfFileUri.toString())
-            this.extension.logger.addLogMessage(`Error of restoring PDF viewer: file not found ${pdfFileUri.toString(true)}.`)
+            Logger.log(`Error of restoring PDF viewer: file not found ${pdfFileUri.toString(true)}.`)
             panel.webview.html = `<!DOCTYPE html> <html lang="en"><meta charset="utf-8"/><br>File not found: ${s}</html>`
             return
         }
@@ -140,7 +141,7 @@ export class PdfViewerPanelService {
         const iframeSrcOrigin = `${url.scheme}://${url.authority}`
         const iframeSrcUrl = url.toString(true)
         await this.tweakForCodespaces(url)
-        this.extension.logger.addLogMessage(`The internal PDF viewer url: ${iframeSrcUrl}`)
+        Logger.log(`The internal PDF viewer url: ${iframeSrcUrl}`)
         const rebroadcast: boolean = this.getKeyboardEventConfig()
         return `
         <!DOCTYPE html><html><head><meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; frame-src ${iframeSrcOrigin}; script-src 'unsafe-inline'; style-src 'unsafe-inline';"></head>

--- a/src/components/viewerlib/pdfviewerpanel.ts
+++ b/src/components/viewerlib/pdfviewerpanel.ts
@@ -6,8 +6,10 @@ import type {PanelRequest, PdfViewerState} from '../../../types/latex-workshop-p
 import {escapeHtml, sleep} from '../../utils/utils'
 import type {PdfViewerManagerService} from './pdfviewermanager'
 import {ViewerStatusChanged} from '../eventbus'
-import * as logger from '../logger'
 
+import { getLogger } from '../logger'
+
+const logger = getLogger('Viewer', 'Panel')
 
 export class PdfViewerPanel {
     private readonly extension: Extension
@@ -52,7 +54,7 @@ export class PdfViewerPanelSerializer implements vscode.WebviewPanelSerializer {
 
     async deserializeWebviewPanel(panel: vscode.WebviewPanel, argState: {state: PdfViewerState}): Promise<void> {
         await this.extension.server.serverStarted
-        logger.log(`[Viewer][Panel] Restoring at column ${panel.viewColumn} with state ${JSON.stringify(argState.state)}.`)
+        logger.log(`Restoring at column ${panel.viewColumn} with state ${JSON.stringify(argState.state)}.`)
         const state = argState.state
         let pdfFileUri: vscode.Uri | undefined
         if (state.path) {
@@ -61,13 +63,13 @@ export class PdfViewerPanelSerializer implements vscode.WebviewPanelSerializer {
             pdfFileUri = vscode.Uri.parse(state.pdfFileUri, true)
         }
         if (!pdfFileUri) {
-            logger.log('[Viewer][Panel] Failed restoring viewer with undefined PDF path.')
+            logger.log('Failed restoring viewer with undefined PDF path.')
             panel.webview.html = '<!DOCTYPE html> <html lang="en"><meta charset="utf-8"/><br>The path of PDF file is undefined.</html>'
             return
         }
         if (! await this.extension.lwfs.exists(pdfFileUri)) {
             const s = escapeHtml(pdfFileUri.toString())
-            logger.log(`[Viewer][Panel] Failed restoring viewer with non-existent PDF ${pdfFileUri.toString(true)} .`)
+            logger.log(`Failed restoring viewer with non-existent PDF ${pdfFileUri.toString(true)} .`)
             panel.webview.html = `<!DOCTYPE html> <html lang="en"><meta charset="utf-8"/><br>File not found: ${s}</html>`
             return
         }
@@ -141,7 +143,7 @@ export class PdfViewerPanelService {
         const iframeSrcOrigin = `${url.scheme}://${url.authority}`
         const iframeSrcUrl = url.toString(true)
         await this.tweakForCodespaces(url)
-        logger.log(`[Viewer][Panel] Internal PDF viewer at ${iframeSrcUrl} .`)
+        logger.log(`Internal PDF viewer at ${iframeSrcUrl} .`)
         const rebroadcast: boolean = this.getKeyboardEventConfig()
         return `
         <!DOCTYPE html><html><head><meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; frame-src ${iframeSrcOrigin}; script-src 'unsafe-inline'; style-src 'unsafe-inline';"></head>

--- a/src/components/viewerlib/pdfviewerpanel.ts
+++ b/src/components/viewerlib/pdfviewerpanel.ts
@@ -6,7 +6,7 @@ import type {PanelRequest, PdfViewerState} from '../../../types/latex-workshop-p
 import {escapeHtml, sleep} from '../../utils/utils'
 import type {PdfViewerManagerService} from './pdfviewermanager'
 import {ViewerStatusChanged} from '../eventbus'
-import { Logger } from '../logger'
+import * as logger from '../logger'
 
 
 export class PdfViewerPanel {
@@ -52,7 +52,7 @@ export class PdfViewerPanelSerializer implements vscode.WebviewPanelSerializer {
 
     async deserializeWebviewPanel(panel: vscode.WebviewPanel, argState: {state: PdfViewerState}): Promise<void> {
         await this.extension.server.serverStarted
-        Logger.log(`Restoring the PDF viewer at the column ${panel.viewColumn} from the state: ${JSON.stringify(argState)}`)
+        logger.log(`Restoring the PDF viewer at the column ${panel.viewColumn} from the state: ${JSON.stringify(argState)}`)
         const state = argState.state
         let pdfFileUri: vscode.Uri | undefined
         if (state.path) {
@@ -61,13 +61,13 @@ export class PdfViewerPanelSerializer implements vscode.WebviewPanelSerializer {
             pdfFileUri = vscode.Uri.parse(state.pdfFileUri, true)
         }
         if (!pdfFileUri) {
-            Logger.log('Error of restoring PDF viewer: the path of PDF file is undefined.')
+            logger.log('Error of restoring PDF viewer: the path of PDF file is undefined.')
             panel.webview.html = '<!DOCTYPE html> <html lang="en"><meta charset="utf-8"/><br>The path of PDF file is undefined.</html>'
             return
         }
         if (! await this.extension.lwfs.exists(pdfFileUri)) {
             const s = escapeHtml(pdfFileUri.toString())
-            Logger.log(`Error of restoring PDF viewer: file not found ${pdfFileUri.toString(true)}.`)
+            logger.log(`Error of restoring PDF viewer: file not found ${pdfFileUri.toString(true)} .`)
             panel.webview.html = `<!DOCTYPE html> <html lang="en"><meta charset="utf-8"/><br>File not found: ${s}</html>`
             return
         }
@@ -141,7 +141,7 @@ export class PdfViewerPanelService {
         const iframeSrcOrigin = `${url.scheme}://${url.authority}`
         const iframeSrcUrl = url.toString(true)
         await this.tweakForCodespaces(url)
-        Logger.log(`The internal PDF viewer url: ${iframeSrcUrl}`)
+        logger.log(`The internal PDF viewer url: ${iframeSrcUrl}`)
         const rebroadcast: boolean = this.getKeyboardEventConfig()
         return `
         <!DOCTYPE html><html><head><meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; frame-src ${iframeSrcOrigin}; script-src 'unsafe-inline'; style-src 'unsafe-inline';"></head>

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,6 @@ import * as process from 'process'
 
 import {Commander} from './commander'
 import {LaTeXCommanderTreeView} from './components/commander'
-import * as logger from './components/logger'
 import {LwFileSystem} from './components/lwfs'
 import {Manager} from './components/manager'
 import {Builder} from './components/builder'
@@ -40,6 +39,10 @@ import {SelectionRangeProvider} from './providers/selection'
 import { BibtexFormatter, BibtexFormatterProvider } from './providers/bibtexformatter'
 import {SnippetView} from './components/snippetview'
 import { Cacher } from './components/cacher'
+
+import { getLogger } from './components/logger'
+
+const logger = getLogger('Extension')
 
 
 function conflictExtensionCheck() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -80,8 +80,8 @@ function registerLatexWorkshopCommands(extension: Extension, context: vscode.Ext
         vscode.commands.registerCommand('latex-workshop.citation', () => extension.commander.citation()),
         vscode.commands.registerCommand('latex-workshop.addtexroot', () => extension.commander.addTexRoot()),
         vscode.commands.registerCommand('latex-workshop.wordcount', () => extension.commander.wordcount()),
-        vscode.commands.registerCommand('latex-workshop.log', () => extension.commander.log()),
-        vscode.commands.registerCommand('latex-workshop.compilerlog', () => extension.commander.log('compiler')),
+        vscode.commands.registerCommand('latex-workshop.log', () => extension.commander.showLog()),
+        vscode.commands.registerCommand('latex-workshop.compilerlog', () => extension.commander.showLog('compiler')),
         vscode.commands.registerCommand('latex-workshop.code-action', (d: vscode.TextDocument, r: vscode.Range, c: number, m: string) => extension.codeActions.runCodeAction(d, r, c, m)),
         vscode.commands.registerCommand('latex-workshop.goto-section', (filePath: string, lineNumber: number) => extension.commander.gotoSection(filePath, lineNumber)),
         vscode.commands.registerCommand('latex-workshop.navigate-envpair', () => extension.commander.navigateToEnvPair()),
@@ -158,7 +158,7 @@ export function activate(context: vscode.ExtensionContext): ReturnType<typeof ge
             return
         }
         if (extension.manager.hasTexId(e.languageId)) {
-            extension.logger.addLogMessage(`onDidSaveTextDocument triggered: ${e.uri.toString(true)}`)
+            Logger.log(`onDidSaveTextDocument triggered: ${e.uri.toString(true)}`)
             extension.linter.lintRootFileIfEnabled()
             void extension.builder.buildOnSaveIfEnabled(e.fileName)
             extension.counter.countOnSaveIfEnabled(e.fileName)
@@ -206,13 +206,13 @@ export function activate(context: vscode.ExtensionContext): ReturnType<typeof ge
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
 
         if (vscode.window.visibleTextEditors.filter(editor => extension.manager.hasTexId(editor.document.languageId)).length > 0) {
-            extension.logger.status.show()
+            Logger.status.show()
             if (configuration.get('view.autoFocus.enabled') && !isLaTeXActive) {
                 void vscode.commands.executeCommand('workbench.view.extension.latex-workshop-activitybar').then(() => vscode.commands.executeCommand('workbench.action.focusActiveEditorGroup'))
             }
             isLaTeXActive = true
         } else if (vscode.window.activeTextEditor && vscode.window.activeTextEditor.document.languageId.toLowerCase() === 'log') {
-            extension.logger.status.show()
+            Logger.status.show()
         }
         if (e && extension.lwfs.isVirtualUri(e.document.uri)){
             return
@@ -281,7 +281,7 @@ function registerProviders(extension: Extension, context: vscode.ExtensionContex
     const registerTrigger = () => {
         const userTriggersLatex = configuration.get('intellisense.triggers.latex') as string[]
         const latexTriggers = ['\\', ','].concat(userTriggersLatex)
-        extension.logger.addLogMessage(`Trigger characters for intellisense of LaTeX documents: ${JSON.stringify(latexTriggers)}`)
+        Logger.log(`Trigger characters for intellisense of LaTeX documents: ${JSON.stringify(latexTriggers)}`)
 
         triggerDisposable = vscode.languages.registerCompletionItemProvider(latexDoctexSelector, extension.completer, ...latexTriggers)
         context.subscriptions.push(triggerDisposable)
@@ -342,7 +342,6 @@ function registerProviders(extension: Extension, context: vscode.ExtensionContex
 export class Extension {
     readonly extensionRoot: string
     readonly context: vscode.ExtensionContext
-    readonly logger: Logger
     readonly eventBus = new EventBus()
     readonly lwfs: LwFileSystem
     readonly commander: Commander
@@ -378,10 +377,10 @@ export class Extension {
         this.context = context
         // We must create an instance of Logger first to enable
         // adding log messages during initialization.
-        this.logger = new Logger()
+        Logger.initializeStatusBarItem()
         this.addLogFundamentals()
-        this.configuration = new Configuration(this)
-        this.lwfs = new LwFileSystem(this)
+        this.configuration = new Configuration()
+        this.lwfs = new LwFileSystem()
         this.commander = new Commander(this)
         this.cacher = new Cacher(this)
         this.manager = new Manager(this)
@@ -398,8 +397,8 @@ export class Extension {
         this.counter = new Counter(this)
         this.codeActions = new CodeActions(this)
         this.texMagician = new TeXMagician(this)
-        this.envPair = new EnvPair(this)
-        this.section = new Section(this)
+        this.envPair = new EnvPair()
+        this.section = new Section()
         this.latexCommanderTreeView = new LaTeXCommanderTreeView(this)
         this.structureViewer = new StructureTreeView(this)
         this.snippetView = new SnippetView(this)
@@ -408,7 +407,7 @@ export class Extension {
         this.mathPreview = new MathPreview(this)
         this.bibtexFormatter = new BibtexFormatter(this)
         this.mathPreviewPanel = new MathPreviewPanel(this)
-        this.logger.addLogMessage('LaTeX Workshop initialized.')
+        Logger.log('LaTeX Workshop initialized.')
     }
 
     async dispose() {
@@ -419,17 +418,17 @@ export class Extension {
     }
 
     private addLogFundamentals() {
-        this.logger.addLogMessage('Initializing LaTeX Workshop.')
-        this.logger.addLogMessage(`Extension root: ${this.extensionRoot}`)
-        this.logger.addLogMessage(`$PATH: ${process.env.PATH}`)
-        this.logger.addLogMessage(`$SHELL: ${process.env.SHELL}`)
-        this.logger.addLogMessage(`$LANG: ${process.env.LANG}`)
-        this.logger.addLogMessage(`$LC_ALL: ${process.env.LC_ALL}`)
-        this.logger.addLogMessage(`process.platform: ${process.platform}`)
-        this.logger.addLogMessage(`process.arch: ${process.arch}`)
-        this.logger.addLogMessage(`vscode.env.appName: ${vscode.env.appName}`)
-        this.logger.addLogMessage(`vscode.env.remoteName: ${vscode.env.remoteName}`)
-        this.logger.addLogMessage(`vscode.env.uiKind: ${vscode.env.uiKind}`)
+        Logger.log('Initializing LaTeX Workshop.')
+        Logger.log(`Extension root: ${this.extensionRoot}`)
+        Logger.log(`$PATH: ${process.env.PATH}`)
+        Logger.log(`$SHELL: ${process.env.SHELL}`)
+        Logger.log(`$LANG: ${process.env.LANG}`)
+        Logger.log(`$LC_ALL: ${process.env.LC_ALL}`)
+        Logger.log(`process.platform: ${process.platform}`)
+        Logger.log(`process.arch: ${process.arch}`)
+        Logger.log(`vscode.env.appName: ${vscode.env.appName}`)
+        Logger.log(`vscode.env.remoteName: ${vscode.env.remoteName}`)
+        Logger.log(`vscode.env.uiKind: ${vscode.env.uiKind}`)
     }
 
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,7 @@ import * as process from 'process'
 
 import {Commander} from './commander'
 import {LaTeXCommanderTreeView} from './components/commander'
-import {Logger} from './components/logger'
+import * as logger from './components/logger'
 import {LwFileSystem} from './components/lwfs'
 import {Manager} from './components/manager'
 import {Builder} from './components/builder'
@@ -158,7 +158,7 @@ export function activate(context: vscode.ExtensionContext): ReturnType<typeof ge
             return
         }
         if (extension.manager.hasTexId(e.languageId)) {
-            Logger.log(`onDidSaveTextDocument triggered: ${e.uri.toString(true)}`)
+            logger.log(`onDidSaveTextDocument triggered: ${e.uri.toString(true)}`)
             extension.linter.lintRootFileIfEnabled()
             void extension.builder.buildOnSaveIfEnabled(e.fileName)
             extension.counter.countOnSaveIfEnabled(e.fileName)
@@ -206,13 +206,13 @@ export function activate(context: vscode.ExtensionContext): ReturnType<typeof ge
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
 
         if (vscode.window.visibleTextEditors.filter(editor => extension.manager.hasTexId(editor.document.languageId)).length > 0) {
-            Logger.status.show()
+            logger.showStatus()
             if (configuration.get('view.autoFocus.enabled') && !isLaTeXActive) {
                 void vscode.commands.executeCommand('workbench.view.extension.latex-workshop-activitybar').then(() => vscode.commands.executeCommand('workbench.action.focusActiveEditorGroup'))
             }
             isLaTeXActive = true
         } else if (vscode.window.activeTextEditor && vscode.window.activeTextEditor.document.languageId.toLowerCase() === 'log') {
-            Logger.status.show()
+            logger.showStatus()
         }
         if (e && extension.lwfs.isVirtualUri(e.document.uri)){
             return
@@ -281,7 +281,7 @@ function registerProviders(extension: Extension, context: vscode.ExtensionContex
     const registerTrigger = () => {
         const userTriggersLatex = configuration.get('intellisense.triggers.latex') as string[]
         const latexTriggers = ['\\', ','].concat(userTriggersLatex)
-        Logger.log(`Trigger characters for intellisense of LaTeX documents: ${JSON.stringify(latexTriggers)}`)
+        logger.log(`Trigger characters for intellisense of LaTeX documents: ${JSON.stringify(latexTriggers)}`)
 
         triggerDisposable = vscode.languages.registerCompletionItemProvider(latexDoctexSelector, extension.completer, ...latexTriggers)
         context.subscriptions.push(triggerDisposable)
@@ -377,7 +377,7 @@ export class Extension {
         this.context = context
         // We must create an instance of Logger first to enable
         // adding log messages during initialization.
-        Logger.initializeStatusBarItem()
+        logger.initializeStatusBarItem()
         this.addLogFundamentals()
         this.configuration = new Configuration()
         this.lwfs = new LwFileSystem()
@@ -407,7 +407,7 @@ export class Extension {
         this.mathPreview = new MathPreview(this)
         this.bibtexFormatter = new BibtexFormatter(this)
         this.mathPreviewPanel = new MathPreviewPanel(this)
-        Logger.log('LaTeX Workshop initialized.')
+        logger.log('LaTeX Workshop initialized.')
     }
 
     async dispose() {
@@ -418,17 +418,17 @@ export class Extension {
     }
 
     private addLogFundamentals() {
-        Logger.log('Initializing LaTeX Workshop.')
-        Logger.log(`Extension root: ${this.extensionRoot}`)
-        Logger.log(`$PATH: ${process.env.PATH}`)
-        Logger.log(`$SHELL: ${process.env.SHELL}`)
-        Logger.log(`$LANG: ${process.env.LANG}`)
-        Logger.log(`$LC_ALL: ${process.env.LC_ALL}`)
-        Logger.log(`process.platform: ${process.platform}`)
-        Logger.log(`process.arch: ${process.arch}`)
-        Logger.log(`vscode.env.appName: ${vscode.env.appName}`)
-        Logger.log(`vscode.env.remoteName: ${vscode.env.remoteName}`)
-        Logger.log(`vscode.env.uiKind: ${vscode.env.uiKind}`)
+        logger.log('Initializing LaTeX Workshop.')
+        logger.log(`Extension root: ${this.extensionRoot}`)
+        logger.log(`$PATH: ${process.env.PATH}`)
+        logger.log(`$SHELL: ${process.env.SHELL}`)
+        logger.log(`$LANG: ${process.env.LANG}`)
+        logger.log(`$LC_ALL: ${process.env.LC_ALL}`)
+        logger.log(`process.platform: ${process.platform}`)
+        logger.log(`process.arch: ${process.arch}`)
+        logger.log(`vscode.env.appName: ${vscode.env.appName}`)
+        logger.log(`vscode.env.remoteName: ${vscode.env.remoteName}`)
+        logger.log(`vscode.env.uiKind: ${vscode.env.uiKind}`)
     }
 
 }

--- a/src/providers/bibtexcompletion.ts
+++ b/src/providers/bibtexcompletion.ts
@@ -3,7 +3,10 @@ import * as fs from 'fs'
 
 import type { Extension } from '../main'
 import {BibtexFormatConfig} from './bibtexformatterlib/bibtexutils'
-import * as logger from '../components/logger'
+
+import { getLogger } from '../components/logger'
+
+const logger = getLogger('Intelli', 'Bib')
 
 type DataBibtexJsonType = typeof import('../../data/bibtex-entries.json')
 type DataBibtexOptionalJsonType = typeof import('../../data/bibtex-optional-entries.json')
@@ -63,13 +66,13 @@ export class BibtexCompleter implements vscode.CompletionItemProvider {
                 entriesReplacements = configuration.get('intellisense.biblatexJSON.replace') as {[key: string]: string[]}
                 break
             default:
-                logger.log(`[Intelli][Bib] Unknown citation backend: ${citationBackend}`)
+                logger.log(`Unknown citation backend: ${citationBackend}`)
                 return
         }
         try {
             this.loadDefaultItems(entriesFile, optEntriesFile, entriesReplacements)
         } catch (err) {
-            logger.log(`[Intelli][Bib] Error reading data: ${err}.`)
+            logger.log(`Error reading data: ${err}.`)
         }
     }
 

--- a/src/providers/bibtexcompletion.ts
+++ b/src/providers/bibtexcompletion.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs'
 
 import type { Extension } from '../main'
 import {BibtexFormatConfig} from './bibtexformatterlib/bibtexutils'
+import { Logger } from '../components/logger'
 
 type DataBibtexJsonType = typeof import('../../data/bibtex-entries.json')
 type DataBibtexOptionalJsonType = typeof import('../../data/bibtex-optional-entries.json')
@@ -21,7 +22,7 @@ export class BibtexCompleter implements vscode.CompletionItemProvider {
         } else {
             this.scope = vscode.workspace.workspaceFolders?.[0]
         }
-        this.bibtexFormatConfig = new BibtexFormatConfig(extension, this.scope)
+        this.bibtexFormatConfig = new BibtexFormatConfig(this.scope)
         this.initialize()
         vscode.workspace.onDidChangeConfiguration((e: vscode.ConfigurationChangeEvent) => {
             if (e.affectsConfiguration('latex-workshop.bibtex-format', this.scope) ||
@@ -62,13 +63,13 @@ export class BibtexCompleter implements vscode.CompletionItemProvider {
                 entriesReplacements = configuration.get('intellisense.biblatexJSON.replace') as {[key: string]: string[]}
                 break
             default:
-                this.extension.logger.addLogMessage(`Unknown citation backend: ${citationBackend}`)
+                Logger.log(`Unknown citation backend: ${citationBackend}`)
                 return
         }
         try {
             this.loadDefaultItems(entriesFile, optEntriesFile, entriesReplacements)
         } catch (err) {
-            this.extension.logger.addLogMessage(`Error reading data: ${err}.`)
+            Logger.log(`Error reading data: ${err}.`)
         }
     }
 

--- a/src/providers/bibtexcompletion.ts
+++ b/src/providers/bibtexcompletion.ts
@@ -63,13 +63,13 @@ export class BibtexCompleter implements vscode.CompletionItemProvider {
                 entriesReplacements = configuration.get('intellisense.biblatexJSON.replace') as {[key: string]: string[]}
                 break
             default:
-                logger.log(`Unknown citation backend: ${citationBackend}`)
+                logger.log(`[Intelli][Bib] Unknown citation backend: ${citationBackend}`)
                 return
         }
         try {
             this.loadDefaultItems(entriesFile, optEntriesFile, entriesReplacements)
         } catch (err) {
-            logger.log(`Error reading data: ${err}.`)
+            logger.log(`[Intelli][Bib] Error reading data: ${err}.`)
         }
     }
 

--- a/src/providers/bibtexcompletion.ts
+++ b/src/providers/bibtexcompletion.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs'
 
 import type { Extension } from '../main'
 import {BibtexFormatConfig} from './bibtexformatterlib/bibtexutils'
-import { Logger } from '../components/logger'
+import * as logger from '../components/logger'
 
 type DataBibtexJsonType = typeof import('../../data/bibtex-entries.json')
 type DataBibtexOptionalJsonType = typeof import('../../data/bibtex-optional-entries.json')
@@ -63,13 +63,13 @@ export class BibtexCompleter implements vscode.CompletionItemProvider {
                 entriesReplacements = configuration.get('intellisense.biblatexJSON.replace') as {[key: string]: string[]}
                 break
             default:
-                Logger.log(`Unknown citation backend: ${citationBackend}`)
+                logger.log(`Unknown citation backend: ${citationBackend}`)
                 return
         }
         try {
             this.loadDefaultItems(entriesFile, optEntriesFile, entriesReplacements)
         } catch (err) {
-            Logger.log(`Error reading data: ${err}.`)
+            logger.log(`Error reading data: ${err}.`)
         }
     }
 

--- a/src/providers/bibtexformatter.ts
+++ b/src/providers/bibtexformatter.ts
@@ -5,7 +5,10 @@ import {performance} from 'perf_hooks'
 import type { Extension } from '../main'
 import {BibtexUtils} from './bibtexformatterlib/bibtexutils'
 import type {BibtexEntry} from './bibtexformatterlib/bibtexutils'
-import * as logger from '../components/logger'
+
+import { getLogger } from '../components/logger'
+
+const logger = getLogger('Format', 'Bib')
 
 export class BibtexFormatter {
 
@@ -21,17 +24,17 @@ export class BibtexFormatter {
 
     async bibtexFormat(sort: boolean, align: boolean) {
         if (!vscode.window.activeTextEditor) {
-            logger.log('[Format][Bib] Exit formatting. The active textEditor is undefined.')
+            logger.log('Exit formatting. The active textEditor is undefined.')
             return
         }
         if (vscode.window.activeTextEditor.document.languageId !== 'bibtex') {
-            logger.log('[Format][Bib] Exit formatting. The active textEditor is not of bibtex type.')
+            logger.log('Exit formatting. The active textEditor is not of bibtex type.')
             return
         }
         const doc = vscode.window.activeTextEditor.document
         const t0 = performance.now() // Measure performance
         this.duplicatesDiagnostics.clear()
-        logger.log('[Format][Bib] Start bibtex formatting on user request.')
+        logger.log('Start bibtex formatting on user request.')
         const edits = await this.formatDocument(doc, sort, align)
         if (edits.length === 0) {
             return
@@ -45,7 +48,7 @@ export class BibtexFormatter {
             if (success) {
                 this.duplicatesDiagnostics.set(doc.uri, this.diags)
                 const t1 = performance.now()
-                logger.log(`[Format][Bib] BibTeX action successful. Took ${t1 - t0} ms.`)
+                logger.log(`BibTeX action successful. Took ${t1 - t0} ms.`)
             } else {
                 void logger.showErrorMessage('Something went wrong while processing the bibliography.')
             }
@@ -63,7 +66,7 @@ export class BibtexFormatter {
 
         const ast = await this.extension.pegParser.parseBibtex(document.getText(range)).catch((error) => {
             if (error instanceof(Error)) {
-                logger.log('[Format][Bib] Bibtex parser failed.')
+                logger.log('Bibtex parser failed.')
                 logger.log(error.message)
                 void logger.showErrorMessage('Bibtex parser failed with error: ' + error.message)
             }
@@ -148,7 +151,7 @@ export class BibtexFormatter {
             // We need to figure out the line changes in order to highlight properly
             lineDelta += (sortedEntryLocations[i].end.line - sortedEntryLocations[i].start.line) - (entryLocations[i].end.line - entryLocations[i].start.line)
         }
-        logger.log('[Format][Bib] Formatted ' + document.fileName)
+        logger.log('Formatted ' + document.fileName)
         return edits
     }
 }
@@ -164,13 +167,13 @@ export class BibtexFormatterProvider implements vscode.DocumentFormattingEditPro
 
     public provideDocumentFormattingEdits(document: vscode.TextDocument, _options: vscode.FormattingOptions, _token: vscode.CancellationToken): vscode.ProviderResult<vscode.TextEdit[]> {
         const sort = vscode.workspace.getConfiguration('latex-workshop', document).get('bibtex-format.sort.enabled') as boolean
-        logger.log('[Format][Bib] Start bibtex formatting on behalf of VSCode\'s formatter.')
+        logger.log('Start bibtex formatting on behalf of VSCode\'s formatter.')
         return this.formatter.formatDocument(document, sort, true)
     }
 
     public provideDocumentRangeFormattingEdits(document: vscode.TextDocument, range: vscode.Range, _options: vscode.FormattingOptions, _token: vscode.CancellationToken): vscode.ProviderResult<vscode.TextEdit[]> {
         const sort = vscode.workspace.getConfiguration('latex-workshop', document).get('bibtex-format.sort.enabled') as boolean
-        logger.log('[Format][Bib] Start bibtex selection formatting on behalf of VSCode\'s formatter.')
+        logger.log('Start bibtex selection formatting on behalf of VSCode\'s formatter.')
         return this.formatter.formatDocument(document, sort, true, range)
     }
 

--- a/src/providers/bibtexformatter.ts
+++ b/src/providers/bibtexformatter.ts
@@ -21,17 +21,17 @@ export class BibtexFormatter {
 
     async bibtexFormat(sort: boolean, align: boolean) {
         if (!vscode.window.activeTextEditor) {
-            logger.log('Exit formatting. The active textEditor is undefined.')
+            logger.log('[Format][Bib] Exit formatting. The active textEditor is undefined.')
             return
         }
         if (vscode.window.activeTextEditor.document.languageId !== 'bibtex') {
-            logger.log('Exit formatting. The active textEditor is not of bibtex type.')
+            logger.log('[Format][Bib] Exit formatting. The active textEditor is not of bibtex type.')
             return
         }
         const doc = vscode.window.activeTextEditor.document
         const t0 = performance.now() // Measure performance
         this.duplicatesDiagnostics.clear()
-        logger.log('Start bibtex formatting on user request.')
+        logger.log('[Format][Bib] Start bibtex formatting on user request.')
         const edits = await this.formatDocument(doc, sort, align)
         if (edits.length === 0) {
             return
@@ -45,7 +45,7 @@ export class BibtexFormatter {
             if (success) {
                 this.duplicatesDiagnostics.set(doc.uri, this.diags)
                 const t1 = performance.now()
-                logger.log(`BibTeX action successful. Took ${t1 - t0} ms.`)
+                logger.log(`[Format][Bib] BibTeX action successful. Took ${t1 - t0} ms.`)
             } else {
                 void logger.showErrorMessage('Something went wrong while processing the bibliography.')
             }
@@ -63,7 +63,7 @@ export class BibtexFormatter {
 
         const ast = await this.extension.pegParser.parseBibtex(document.getText(range)).catch((error) => {
             if (error instanceof(Error)) {
-                logger.log('Bibtex parser failed.')
+                logger.log('[Format][Bib] Bibtex parser failed.')
                 logger.log(error.message)
                 void logger.showErrorMessage('Bibtex parser failed with error: ' + error.message)
             }
@@ -148,7 +148,7 @@ export class BibtexFormatter {
             // We need to figure out the line changes in order to highlight properly
             lineDelta += (sortedEntryLocations[i].end.line - sortedEntryLocations[i].start.line) - (entryLocations[i].end.line - entryLocations[i].start.line)
         }
-        logger.log('Formatted ' + document.fileName)
+        logger.log('[Format][Bib] Formatted ' + document.fileName)
         return edits
     }
 }
@@ -164,13 +164,13 @@ export class BibtexFormatterProvider implements vscode.DocumentFormattingEditPro
 
     public provideDocumentFormattingEdits(document: vscode.TextDocument, _options: vscode.FormattingOptions, _token: vscode.CancellationToken): vscode.ProviderResult<vscode.TextEdit[]> {
         const sort = vscode.workspace.getConfiguration('latex-workshop', document).get('bibtex-format.sort.enabled') as boolean
-        logger.log('Start bibtex formatting on behalf of VSCode\'s formatter.')
+        logger.log('[Format][Bib] Start bibtex formatting on behalf of VSCode\'s formatter.')
         return this.formatter.formatDocument(document, sort, true)
     }
 
     public provideDocumentRangeFormattingEdits(document: vscode.TextDocument, range: vscode.Range, _options: vscode.FormattingOptions, _token: vscode.CancellationToken): vscode.ProviderResult<vscode.TextEdit[]> {
         const sort = vscode.workspace.getConfiguration('latex-workshop', document).get('bibtex-format.sort.enabled') as boolean
-        logger.log('Start bibtex selection formatting on behalf of VSCode\'s formatter.')
+        logger.log('[Format][Bib] Start bibtex selection formatting on behalf of VSCode\'s formatter.')
         return this.formatter.formatDocument(document, sort, true, range)
     }
 

--- a/src/providers/bibtexformatter.ts
+++ b/src/providers/bibtexformatter.ts
@@ -5,7 +5,7 @@ import {performance} from 'perf_hooks'
 import type { Extension } from '../main'
 import {BibtexUtils} from './bibtexformatterlib/bibtexutils'
 import type {BibtexEntry} from './bibtexformatterlib/bibtexutils'
-import { Logger } from '../components/logger'
+import * as logger from '../components/logger'
 
 export class BibtexFormatter {
 
@@ -21,17 +21,17 @@ export class BibtexFormatter {
 
     async bibtexFormat(sort: boolean, align: boolean) {
         if (!vscode.window.activeTextEditor) {
-            Logger.log('Exit formatting. The active textEditor is undefined.')
+            logger.log('Exit formatting. The active textEditor is undefined.')
             return
         }
         if (vscode.window.activeTextEditor.document.languageId !== 'bibtex') {
-            Logger.log('Exit formatting. The active textEditor is not of bibtex type.')
+            logger.log('Exit formatting. The active textEditor is not of bibtex type.')
             return
         }
         const doc = vscode.window.activeTextEditor.document
         const t0 = performance.now() // Measure performance
         this.duplicatesDiagnostics.clear()
-        Logger.log('Start bibtex formatting on user request.')
+        logger.log('Start bibtex formatting on user request.')
         const edits = await this.formatDocument(doc, sort, align)
         if (edits.length === 0) {
             return
@@ -45,9 +45,9 @@ export class BibtexFormatter {
             if (success) {
                 this.duplicatesDiagnostics.set(doc.uri, this.diags)
                 const t1 = performance.now()
-                Logger.log(`BibTeX action successful. Took ${t1 - t0} ms.`)
+                logger.log(`BibTeX action successful. Took ${t1 - t0} ms.`)
             } else {
-                void Logger.showErrorMessage('Something went wrong while processing the bibliography.')
+                void logger.showErrorMessage('Something went wrong while processing the bibliography.')
             }
         })
 
@@ -63,9 +63,9 @@ export class BibtexFormatter {
 
         const ast = await this.extension.pegParser.parseBibtex(document.getText(range)).catch((error) => {
             if (error instanceof(Error)) {
-                Logger.log('Bibtex parser failed.')
-                Logger.log(error.message)
-                void Logger.showErrorMessage('Bibtex parser failed with error: ' + error.message)
+                logger.log('Bibtex parser failed.')
+                logger.log(error.message)
+                void logger.showErrorMessage('Bibtex parser failed with error: ' + error.message)
             }
             return undefined
         })
@@ -135,7 +135,7 @@ export class BibtexFormatter {
                         ))
                     } else { // 'Comment Duplicates'
                         // Log duplicate entry since we aren't highlighting it
-                        Logger.log(
+                        logger.log(
                             `BibTeX-format: Duplicate entry "${entry.internalKey}" at line ${entryLocations[i].start.line + lineDelta + 1 + lineOffset}.`)
                         text = text.replace(/@/,'')
                     }
@@ -148,7 +148,7 @@ export class BibtexFormatter {
             // We need to figure out the line changes in order to highlight properly
             lineDelta += (sortedEntryLocations[i].end.line - sortedEntryLocations[i].start.line) - (entryLocations[i].end.line - entryLocations[i].start.line)
         }
-        Logger.log('Formatted ' + document.fileName)
+        logger.log('Formatted ' + document.fileName)
         return edits
     }
 }
@@ -164,13 +164,13 @@ export class BibtexFormatterProvider implements vscode.DocumentFormattingEditPro
 
     public provideDocumentFormattingEdits(document: vscode.TextDocument, _options: vscode.FormattingOptions, _token: vscode.CancellationToken): vscode.ProviderResult<vscode.TextEdit[]> {
         const sort = vscode.workspace.getConfiguration('latex-workshop', document).get('bibtex-format.sort.enabled') as boolean
-        Logger.log('Start bibtex formatting on behalf of VSCode\'s formatter.')
+        logger.log('Start bibtex formatting on behalf of VSCode\'s formatter.')
         return this.formatter.formatDocument(document, sort, true)
     }
 
     public provideDocumentRangeFormattingEdits(document: vscode.TextDocument, range: vscode.Range, _options: vscode.FormattingOptions, _token: vscode.CancellationToken): vscode.ProviderResult<vscode.TextEdit[]> {
         const sort = vscode.workspace.getConfiguration('latex-workshop', document).get('bibtex-format.sort.enabled') as boolean
-        Logger.log('Start bibtex selection formatting on behalf of VSCode\'s formatter.')
+        logger.log('Start bibtex selection formatting on behalf of VSCode\'s formatter.')
         return this.formatter.formatDocument(document, sort, true, range)
     }
 

--- a/src/providers/bibtexformatterlib/bibtexutils.ts
+++ b/src/providers/bibtexformatterlib/bibtexutils.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode'
 import {bibtexParser} from 'latex-utensils'
 
-import type { Extension } from '../../main'
+import { Logger } from '../../components/logger'
 
 export declare type BibtexEntry = bibtexParser.Entry | bibtexParser.StringEntry
 
@@ -26,8 +26,6 @@ function getBibtexFormatTab(tab: string): string | undefined {
 }
 
 export class BibtexFormatConfig {
-    private readonly extension: Extension
-    // private scope: vscode.WorkspaceFolder | undefined
     tab !: string
     left !: string
     right !: string
@@ -39,8 +37,7 @@ export class BibtexFormatConfig {
     fieldsOrder !: string[]
     firstEntries !: string[]
 
-    constructor(extension: Extension, scope: vscode.ConfigurationScope | undefined) {
-        this.extension = extension
+    constructor(scope: vscode.ConfigurationScope | undefined) {
         this.loadConfiguration(scope)
     }
 
@@ -49,8 +46,8 @@ export class BibtexFormatConfig {
         const leftright = config.get('bibtex-format.surround') === 'Curly braces' ? [ '{', '}' ] : [ '"', '"']
         let tabs: string | undefined = getBibtexFormatTab(config.get('bibtex-format.tab') as string)
         if (tabs === undefined) {
-            this.extension.logger.addLogMessage(`Wrong value for bibtex-format.tab: ${config.get('bibtex-format.tab')}`)
-            this.extension.logger.addLogMessage('Setting bibtex-format.tab to \'2 spaces\'')
+            Logger.log(`Wrong value for bibtex-format.tab: ${config.get('bibtex-format.tab')}`)
+            Logger.log('Setting bibtex-format.tab to \'2 spaces\'')
             tabs = '  '
         }
         this.tab = tabs
@@ -63,7 +60,7 @@ export class BibtexFormatConfig {
         this.sortFields = config.get('bibtex-fields.sort.enabled') as boolean
         this.fieldsOrder = config.get('bibtex-fields.order') as string[]
         this.firstEntries = config.get('bibtex-entries.first') as string[]
-        this.extension.logger.addLogMessage(`Bibtex format config: ${this.stringify()}`)
+        Logger.log(`Bibtex format config: ${this.stringify()}`)
     }
 
     stringify(): string {
@@ -87,8 +84,8 @@ export class BibtexFormatConfig {
 export class BibtexUtils {
     readonly bibtexFormatConfig: BibtexFormatConfig
 
-    constructor(extension: Extension, scope: vscode.ConfigurationScope | undefined) {
-        this.bibtexFormatConfig = new BibtexFormatConfig(extension, scope)
+    constructor(scope: vscode.ConfigurationScope | undefined) {
+        this.bibtexFormatConfig = new BibtexFormatConfig(scope)
     }
 
     /**

--- a/src/providers/bibtexformatterlib/bibtexutils.ts
+++ b/src/providers/bibtexformatterlib/bibtexutils.ts
@@ -46,8 +46,8 @@ export class BibtexFormatConfig {
         const leftright = config.get('bibtex-format.surround') === 'Curly braces' ? [ '{', '}' ] : [ '"', '"']
         let tabs: string | undefined = getBibtexFormatTab(config.get('bibtex-format.tab') as string)
         if (tabs === undefined) {
-            logger.log(`Wrong value for bibtex-format.tab: ${config.get('bibtex-format.tab')}`)
-            logger.log('Setting bibtex-format.tab to \'2 spaces\'')
+            logger.log(`[Format][Bib] Wrong value for bibtex-format.tab: ${config.get('bibtex-format.tab')}`)
+            logger.log('[Format][Bib]Setting bibtex-format.tab to \'2 spaces\'')
             tabs = '  '
         }
         this.tab = tabs
@@ -60,7 +60,7 @@ export class BibtexFormatConfig {
         this.sortFields = config.get('bibtex-fields.sort.enabled') as boolean
         this.fieldsOrder = config.get('bibtex-fields.order') as string[]
         this.firstEntries = config.get('bibtex-entries.first') as string[]
-        logger.log(`Bibtex format config: ${this.stringify()}`)
+        logger.log(`[Format][Bib] Bibtex format config: ${this.stringify()}`)
     }
 
     stringify(): string {

--- a/src/providers/bibtexformatterlib/bibtexutils.ts
+++ b/src/providers/bibtexformatterlib/bibtexutils.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode'
 import {bibtexParser} from 'latex-utensils'
 
-import { Logger } from '../../components/logger'
+import * as logger from '../../components/logger'
 
 export declare type BibtexEntry = bibtexParser.Entry | bibtexParser.StringEntry
 
@@ -46,8 +46,8 @@ export class BibtexFormatConfig {
         const leftright = config.get('bibtex-format.surround') === 'Curly braces' ? [ '{', '}' ] : [ '"', '"']
         let tabs: string | undefined = getBibtexFormatTab(config.get('bibtex-format.tab') as string)
         if (tabs === undefined) {
-            Logger.log(`Wrong value for bibtex-format.tab: ${config.get('bibtex-format.tab')}`)
-            Logger.log('Setting bibtex-format.tab to \'2 spaces\'')
+            logger.log(`Wrong value for bibtex-format.tab: ${config.get('bibtex-format.tab')}`)
+            logger.log('Setting bibtex-format.tab to \'2 spaces\'')
             tabs = '  '
         }
         this.tab = tabs
@@ -60,7 +60,7 @@ export class BibtexFormatConfig {
         this.sortFields = config.get('bibtex-fields.sort.enabled') as boolean
         this.fieldsOrder = config.get('bibtex-fields.order') as string[]
         this.firstEntries = config.get('bibtex-entries.first') as string[]
-        Logger.log(`Bibtex format config: ${this.stringify()}`)
+        logger.log(`Bibtex format config: ${this.stringify()}`)
     }
 
     stringify(): string {

--- a/src/providers/bibtexformatterlib/bibtexutils.ts
+++ b/src/providers/bibtexformatterlib/bibtexutils.ts
@@ -1,7 +1,9 @@
 import * as vscode from 'vscode'
 import {bibtexParser} from 'latex-utensils'
 
-import * as logger from '../../components/logger'
+import { getLogger } from '../../components/logger'
+
+const logger = getLogger('Format', 'Bib')
 
 export declare type BibtexEntry = bibtexParser.Entry | bibtexParser.StringEntry
 
@@ -46,8 +48,8 @@ export class BibtexFormatConfig {
         const leftright = config.get('bibtex-format.surround') === 'Curly braces' ? [ '{', '}' ] : [ '"', '"']
         let tabs: string | undefined = getBibtexFormatTab(config.get('bibtex-format.tab') as string)
         if (tabs === undefined) {
-            logger.log(`[Format][Bib] Wrong value for bibtex-format.tab: ${config.get('bibtex-format.tab')}`)
-            logger.log('[Format][Bib]Setting bibtex-format.tab to \'2 spaces\'')
+            logger.log(`Wrong value for bibtex-format.tab: ${config.get('bibtex-format.tab')}`)
+            logger.log('Setting bibtex-format.tab to \'2 spaces\'')
             tabs = '  '
         }
         this.tab = tabs
@@ -60,7 +62,7 @@ export class BibtexFormatConfig {
         this.sortFields = config.get('bibtex-fields.sort.enabled') as boolean
         this.fieldsOrder = config.get('bibtex-fields.order') as string[]
         this.firstEntries = config.get('bibtex-entries.first') as string[]
-        logger.log(`[Format][Bib] Bibtex format config: ${this.stringify()}`)
+        logger.log(`Bibtex format config: ${this.stringify()}`)
     }
 
     stringify(): string {

--- a/src/providers/completer/citation.ts
+++ b/src/providers/completer/citation.ts
@@ -7,6 +7,7 @@ import * as eventbus from '../../components/eventbus'
 import {trimMultiLineString} from '../../utils/utils'
 import {computeFilteringRange} from './completerutils'
 import type { IProvider, ICompletionItem } from '../completion'
+import { Logger } from '../../components/logger'
 
 
 class Fields extends Map<string, string> {
@@ -244,10 +245,10 @@ export class Citation implements IProvider {
      * @param fileName The path of `.bib` file.
      */
     async parseBibFile(fileName: string) {
-        this.extension.logger.addLogMessage(`Parsing .bib entries from ${fileName}`)
+        Logger.log(`Parsing .bib entries from ${fileName}`)
         const configuration = vscode.workspace.getConfiguration('latex-workshop', vscode.Uri.file(fileName))
         if (fs.statSync(fileName).size >= (configuration.get('bibtex.maxFileSize') as number) * 1024 * 1024) {
-            this.extension.logger.addLogMessage(`Bib file is too large, ignoring it: ${fileName}`)
+            Logger.log(`Bib file is too large, ignoring it: ${fileName}`)
             this.bibEntries.delete(fileName)
             return
         }
@@ -256,7 +257,7 @@ export class Citation implements IProvider {
         const ast = await this.extension.pegParser.parseBibtex(bibtex).catch((e) => {
             if (bibtexParser.isSyntaxError(e)) {
                 const line = e.location.start.line
-                this.extension.logger.addLogMessage(`Error parsing BibTeX: line ${line} in ${fileName}.`)
+                Logger.log(`Error parsing BibTeX: line ${line} in ${fileName}.`)
             }
             throw e
         })
@@ -282,12 +283,12 @@ export class Citation implements IProvider {
                 newEntry.push(item)
             })
         this.bibEntries.set(fileName, newEntry)
-        this.extension.logger.addLogMessage(`Parsed ${newEntry.length} bib entries from ${fileName}.`)
+        Logger.log(`Parsed ${newEntry.length} bib entries from ${fileName}.`)
         this.extension.eventBus.fire(eventbus.FileParsed, fileName)
     }
 
     removeEntriesInFile(file: string) {
-        this.extension.logger.addLogMessage(`Remove parsed bib entries for ${file}`)
+        Logger.log(`Remove parsed bib entries for ${file}`)
         this.bibEntries.delete(file)
     }
 

--- a/src/providers/completer/citation.ts
+++ b/src/providers/completer/citation.ts
@@ -245,10 +245,10 @@ export class Citation implements IProvider {
      * @param fileName The path of `.bib` file.
      */
     async parseBibFile(fileName: string) {
-        logger.log(`Parsing .bib entries from ${fileName}`)
+        logger.log(`[Intelli][Citation] Parsing .bib entries from ${fileName}`)
         const configuration = vscode.workspace.getConfiguration('latex-workshop', vscode.Uri.file(fileName))
         if (fs.statSync(fileName).size >= (configuration.get('bibtex.maxFileSize') as number) * 1024 * 1024) {
-            logger.log(`Bib file is too large, ignoring it: ${fileName}`)
+            logger.log(`[Intelli][Citation] Bib file is too large, ignoring it: ${fileName}`)
             this.bibEntries.delete(fileName)
             return
         }
@@ -257,7 +257,7 @@ export class Citation implements IProvider {
         const ast = await this.extension.pegParser.parseBibtex(bibtex).catch((e) => {
             if (bibtexParser.isSyntaxError(e)) {
                 const line = e.location.start.line
-                logger.log(`Error parsing BibTeX: line ${line} in ${fileName} .`)
+                logger.log(`[Intelli][Citation] Error parsing BibTeX: line ${line} in ${fileName} .`)
             }
             throw e
         })
@@ -283,12 +283,12 @@ export class Citation implements IProvider {
                 newEntry.push(item)
             })
         this.bibEntries.set(fileName, newEntry)
-        logger.log(`Parsed ${newEntry.length} bib entries from ${fileName} .`)
+        logger.log(`[Intelli][Citation] Parsed ${newEntry.length} bib entries from ${fileName} .`)
         this.extension.eventBus.fire(eventbus.FileParsed, fileName)
     }
 
     removeEntriesInFile(file: string) {
-        logger.log(`Remove parsed bib entries for ${file}`)
+        logger.log(`[Intelli][Citation] Remove parsed bib entries for ${file}`)
         this.bibEntries.delete(file)
     }
 

--- a/src/providers/completer/citation.ts
+++ b/src/providers/completer/citation.ts
@@ -7,7 +7,7 @@ import * as eventbus from '../../components/eventbus'
 import {trimMultiLineString} from '../../utils/utils'
 import {computeFilteringRange} from './completerutils'
 import type { IProvider, ICompletionItem } from '../completion'
-import { Logger } from '../../components/logger'
+import * as logger from '../../components/logger'
 
 
 class Fields extends Map<string, string> {
@@ -245,10 +245,10 @@ export class Citation implements IProvider {
      * @param fileName The path of `.bib` file.
      */
     async parseBibFile(fileName: string) {
-        Logger.log(`Parsing .bib entries from ${fileName}`)
+        logger.log(`Parsing .bib entries from ${fileName}`)
         const configuration = vscode.workspace.getConfiguration('latex-workshop', vscode.Uri.file(fileName))
         if (fs.statSync(fileName).size >= (configuration.get('bibtex.maxFileSize') as number) * 1024 * 1024) {
-            Logger.log(`Bib file is too large, ignoring it: ${fileName}`)
+            logger.log(`Bib file is too large, ignoring it: ${fileName}`)
             this.bibEntries.delete(fileName)
             return
         }
@@ -257,7 +257,7 @@ export class Citation implements IProvider {
         const ast = await this.extension.pegParser.parseBibtex(bibtex).catch((e) => {
             if (bibtexParser.isSyntaxError(e)) {
                 const line = e.location.start.line
-                Logger.log(`Error parsing BibTeX: line ${line} in ${fileName}.`)
+                logger.log(`Error parsing BibTeX: line ${line} in ${fileName} .`)
             }
             throw e
         })
@@ -283,12 +283,12 @@ export class Citation implements IProvider {
                 newEntry.push(item)
             })
         this.bibEntries.set(fileName, newEntry)
-        Logger.log(`Parsed ${newEntry.length} bib entries from ${fileName}.`)
+        logger.log(`Parsed ${newEntry.length} bib entries from ${fileName} .`)
         this.extension.eventBus.fire(eventbus.FileParsed, fileName)
     }
 
     removeEntriesInFile(file: string) {
-        Logger.log(`Remove parsed bib entries for ${file}`)
+        logger.log(`Remove parsed bib entries for ${file}`)
         this.bibEntries.delete(file)
     }
 

--- a/src/providers/completer/citation.ts
+++ b/src/providers/completer/citation.ts
@@ -7,8 +7,10 @@ import * as eventbus from '../../components/eventbus'
 import {trimMultiLineString} from '../../utils/utils'
 import {computeFilteringRange} from './completerutils'
 import type { IProvider, ICompletionItem } from '../completion'
-import * as logger from '../../components/logger'
 
+import { getLogger } from '../../components/logger'
+
+const logger = getLogger('Intelli', 'Citation')
 
 class Fields extends Map<string, string> {
 
@@ -245,10 +247,10 @@ export class Citation implements IProvider {
      * @param fileName The path of `.bib` file.
      */
     async parseBibFile(fileName: string) {
-        logger.log(`[Intelli][Citation] Parsing .bib entries from ${fileName}`)
+        logger.log(`Parsing .bib entries from ${fileName}`)
         const configuration = vscode.workspace.getConfiguration('latex-workshop', vscode.Uri.file(fileName))
         if (fs.statSync(fileName).size >= (configuration.get('bibtex.maxFileSize') as number) * 1024 * 1024) {
-            logger.log(`[Intelli][Citation] Bib file is too large, ignoring it: ${fileName}`)
+            logger.log(`Bib file is too large, ignoring it: ${fileName}`)
             this.bibEntries.delete(fileName)
             return
         }
@@ -257,7 +259,7 @@ export class Citation implements IProvider {
         const ast = await this.extension.pegParser.parseBibtex(bibtex).catch((e) => {
             if (bibtexParser.isSyntaxError(e)) {
                 const line = e.location.start.line
-                logger.log(`[Intelli][Citation] Error parsing BibTeX: line ${line} in ${fileName} .`)
+                logger.log(`Error parsing BibTeX: line ${line} in ${fileName} .`)
             }
             throw e
         })
@@ -283,12 +285,12 @@ export class Citation implements IProvider {
                 newEntry.push(item)
             })
         this.bibEntries.set(fileName, newEntry)
-        logger.log(`[Intelli][Citation] Parsed ${newEntry.length} bib entries from ${fileName} .`)
+        logger.log(`Parsed ${newEntry.length} bib entries from ${fileName} .`)
         this.extension.eventBus.fire(eventbus.FileParsed, fileName)
     }
 
     removeEntriesInFile(file: string) {
-        logger.log(`[Intelli][Citation] Remove parsed bib entries for ${file}`)
+        logger.log(`Remove parsed bib entries for ${file}`)
         this.bibEntries.delete(file)
     }
 

--- a/src/providers/completer/command.ts
+++ b/src/providers/completer/command.ts
@@ -9,7 +9,10 @@ import {CmdEnvSuggestion, splitSignatureString, filterNonLetterSuggestions, filt
 import {CommandSignatureDuplicationDetector, CommandNameDuplicationDetector} from './commandlib/commandfinder'
 import {SurroundCommand} from './commandlib/surround'
 import { Environment, EnvSnippetType } from './environment'
-import * as logger from '../../components/logger'
+
+import { getLogger } from '../../components/logger'
+
+const logger = getLogger('Intelli', 'Command')
 
 type DataUnimathSymbolsJsonType = typeof import('../../../data/unimathsymbols.json')
 type DataCmdsJsonType = typeof import('../../../data/commands.json')
@@ -277,8 +280,8 @@ export class Command implements IProvider {
             if (isCmdWithSnippet(cmds[key])) {
                 commands.push(this.entryCmdToCompletion(key, cmds[key]))
             } else {
-                logger.log(`[Intelli][Command] Cannot parse intellisense file for ${packageName}.`)
-                logger.log(`[Intelli][Command] Missing field in entry: "${key}": ${JSON.stringify(cmds[key])}.`)
+                logger.log(`Cannot parse intellisense file for ${packageName}.`)
+                logger.log(`Missing field in entry: "${key}": ${JSON.stringify(cmds[key])}.`)
             }
         })
         this.packageCmds.set(packageName, commands)

--- a/src/providers/completer/command.ts
+++ b/src/providers/completer/command.ts
@@ -277,8 +277,8 @@ export class Command implements IProvider {
             if (isCmdWithSnippet(cmds[key])) {
                 commands.push(this.entryCmdToCompletion(key, cmds[key]))
             } else {
-                logger.log(`Cannot parse intellisense file for ${packageName}.`)
-                logger.log(`Missing field in entry: "${key}": ${JSON.stringify(cmds[key])}.`)
+                logger.log(`[Intelli][Command] Cannot parse intellisense file for ${packageName}.`)
+                logger.log(`[Intelli][Command] Missing field in entry: "${key}": ${JSON.stringify(cmds[key])}.`)
             }
         })
         this.packageCmds.set(packageName, commands)

--- a/src/providers/completer/command.ts
+++ b/src/providers/completer/command.ts
@@ -9,6 +9,7 @@ import {CmdEnvSuggestion, splitSignatureString, filterNonLetterSuggestions, filt
 import {CommandSignatureDuplicationDetector, CommandNameDuplicationDetector} from './commandlib/commandfinder'
 import {SurroundCommand} from './commandlib/surround'
 import { Environment, EnvSnippetType } from './environment'
+import { Logger } from '../../components/logger'
 
 type DataUnimathSymbolsJsonType = typeof import('../../../data/unimathsymbols.json')
 type DataCmdsJsonType = typeof import('../../../data/commands.json')
@@ -276,8 +277,8 @@ export class Command implements IProvider {
             if (isCmdWithSnippet(cmds[key])) {
                 commands.push(this.entryCmdToCompletion(key, cmds[key]))
             } else {
-                this.extension.logger.addLogMessage(`Cannot parse intellisense file for ${packageName}.`)
-                this.extension.logger.addLogMessage(`Missing field in entry: "${key}": ${JSON.stringify(cmds[key])}.`)
+                Logger.log(`Cannot parse intellisense file for ${packageName}.`)
+                Logger.log(`Missing field in entry: "${key}": ${JSON.stringify(cmds[key])}.`)
             }
         })
         this.packageCmds.set(packageName, commands)

--- a/src/providers/completer/command.ts
+++ b/src/providers/completer/command.ts
@@ -9,7 +9,7 @@ import {CmdEnvSuggestion, splitSignatureString, filterNonLetterSuggestions, filt
 import {CommandSignatureDuplicationDetector, CommandNameDuplicationDetector} from './commandlib/commandfinder'
 import {SurroundCommand} from './commandlib/surround'
 import { Environment, EnvSnippetType } from './environment'
-import { Logger } from '../../components/logger'
+import * as logger from '../../components/logger'
 
 type DataUnimathSymbolsJsonType = typeof import('../../../data/unimathsymbols.json')
 type DataCmdsJsonType = typeof import('../../../data/commands.json')
@@ -277,8 +277,8 @@ export class Command implements IProvider {
             if (isCmdWithSnippet(cmds[key])) {
                 commands.push(this.entryCmdToCompletion(key, cmds[key]))
             } else {
-                Logger.log(`Cannot parse intellisense file for ${packageName}.`)
-                Logger.log(`Missing field in entry: "${key}": ${JSON.stringify(cmds[key])}.`)
+                logger.log(`Cannot parse intellisense file for ${packageName}.`)
+                logger.log(`Missing field in entry: "${key}": ${JSON.stringify(cmds[key])}.`)
             }
         })
         this.packageCmds.set(packageName, commands)

--- a/src/providers/completer/environment.ts
+++ b/src/providers/completer/environment.ts
@@ -285,8 +285,8 @@ export class Environment implements IProvider {
             if (isEnv(envs[key])) {
                 environments.push(envs[key])
             } else {
-                logger.log(`Cannot parse intellisense file for ${packageName}`)
-                logger.log(`Missing field in entry: "${key}": ${JSON.stringify(envs[key])}`)
+                logger.log(`[Intelli][Environment] Cannot parse intellisense file for ${packageName}`)
+                logger.log(`[Intelli][Environment] Missing field in entry: "${key}": ${JSON.stringify(envs[key])}`)
                 delete envs[key]
             }
         })

--- a/src/providers/completer/environment.ts
+++ b/src/providers/completer/environment.ts
@@ -7,7 +7,10 @@ import type { ICompletionItem } from '../completion'
 import type { IProvider } from '../completion'
 import {CommandSignatureDuplicationDetector} from './commandlib/commandfinder'
 import {CmdEnvSuggestion, splitSignatureString, filterNonLetterSuggestions, filterArgumentHint} from './completerutils'
-import * as logger from '../../components/logger'
+
+import { getLogger } from '../../components/logger'
+
+const logger = getLogger('Intelli', 'Environment')
 
 type DataEnvsJsonType = typeof import('../../../data/environments.json')
 
@@ -285,8 +288,8 @@ export class Environment implements IProvider {
             if (isEnv(envs[key])) {
                 environments.push(envs[key])
             } else {
-                logger.log(`[Intelli][Environment] Cannot parse intellisense file for ${packageName}`)
-                logger.log(`[Intelli][Environment] Missing field in entry: "${key}": ${JSON.stringify(envs[key])}`)
+                logger.log(`Cannot parse intellisense file for ${packageName}`)
+                logger.log(`Missing field in entry: "${key}": ${JSON.stringify(envs[key])}`)
                 delete envs[key]
             }
         })

--- a/src/providers/completer/environment.ts
+++ b/src/providers/completer/environment.ts
@@ -7,6 +7,7 @@ import type { ICompletionItem } from '../completion'
 import type { IProvider } from '../completion'
 import {CommandSignatureDuplicationDetector} from './commandlib/commandfinder'
 import {CmdEnvSuggestion, splitSignatureString, filterNonLetterSuggestions, filterArgumentHint} from './completerutils'
+import { Logger } from '../../components/logger'
 
 type DataEnvsJsonType = typeof import('../../../data/environments.json')
 
@@ -284,8 +285,8 @@ export class Environment implements IProvider {
             if (isEnv(envs[key])) {
                 environments.push(envs[key])
             } else {
-                this.extension.logger.addLogMessage(`Cannot parse intellisense file for ${packageName}`)
-                this.extension.logger.addLogMessage(`Missing field in entry: "${key}": ${JSON.stringify(envs[key])}`)
+                Logger.log(`Cannot parse intellisense file for ${packageName}`)
+                Logger.log(`Missing field in entry: "${key}": ${JSON.stringify(envs[key])}`)
                 delete envs[key]
             }
         })

--- a/src/providers/completer/environment.ts
+++ b/src/providers/completer/environment.ts
@@ -7,7 +7,7 @@ import type { ICompletionItem } from '../completion'
 import type { IProvider } from '../completion'
 import {CommandSignatureDuplicationDetector} from './commandlib/commandfinder'
 import {CmdEnvSuggestion, splitSignatureString, filterNonLetterSuggestions, filterArgumentHint} from './completerutils'
-import { Logger } from '../../components/logger'
+import * as logger from '../../components/logger'
 
 type DataEnvsJsonType = typeof import('../../../data/environments.json')
 
@@ -285,8 +285,8 @@ export class Environment implements IProvider {
             if (isEnv(envs[key])) {
                 environments.push(envs[key])
             } else {
-                Logger.log(`Cannot parse intellisense file for ${packageName}`)
-                Logger.log(`Missing field in entry: "${key}": ${JSON.stringify(envs[key])}`)
+                logger.log(`Cannot parse intellisense file for ${packageName}`)
+                logger.log(`Missing field in entry: "${key}": ${JSON.stringify(envs[key])}`)
                 delete envs[key]
             }
         })
@@ -304,7 +304,7 @@ export class Environment implements IProvider {
             vscode.CompletionItemKind.Module,
             item.option)
         suggestion.detail = `\\begin{${item.name}}${item.snippet?.replace(/\$\{\d+:([^$}]*)\}/g, '$1')}\n...\n\\end{${item.name}}`
-        suggestion.documentation = `Environment ${item.name}.`
+        suggestion.documentation = `Environment ${item.name} .`
         if (item.package) {
             suggestion.documentation += ` From package: ${item.package}.`
         }

--- a/src/providers/completer/input.ts
+++ b/src/providers/completer/input.ts
@@ -6,6 +6,7 @@ import * as micromatch from 'micromatch'
 import type { Extension } from '../../main'
 import type { IProvider } from '../completion'
 import {stripCommentsAndVerbatim} from '../../utils/utils'
+import { Logger } from '../../components/logger'
 
 const ignoreFiles = ['**/.vscode', '**/.vscodeignore', '**/.gitignore']
 
@@ -154,7 +155,7 @@ export class Input extends InputAbstract {
     getBaseDir(currentFile: string, _importFromDir: string, command: string): string[] {
         let baseDir: string[] = []
         if (this.extension.manager.rootDir === undefined) {
-            this.extension.logger.addLogMessage(`No root dir can be found. The current root file should be undefined, is ${this.extension.manager.rootFile}. How did you get here?`)
+            Logger.log(`No root dir can be found. The current root file should be undefined, is ${this.extension.manager.rootFile}. How did you get here?`)
             return []
         }
         // If there is no root, 'root relative' and 'both' should fall back to 'file relative'

--- a/src/providers/completer/input.ts
+++ b/src/providers/completer/input.ts
@@ -6,10 +6,12 @@ import * as micromatch from 'micromatch'
 import type { Extension } from '../../main'
 import type { IProvider } from '../completion'
 import {stripCommentsAndVerbatim} from '../../utils/utils'
-import * as logger from '../../components/logger'
+
+import { getLogger } from '../../components/logger'
+
+const logger = getLogger('Intelli', 'Input')
 
 const ignoreFiles = ['**/.vscode', '**/.vscodeignore', '**/.gitignore']
-
 
 abstract class InputAbstract implements IProvider {
     protected readonly extension: Extension
@@ -155,7 +157,7 @@ export class Input extends InputAbstract {
     getBaseDir(currentFile: string, _importFromDir: string, command: string): string[] {
         let baseDir: string[] = []
         if (this.extension.manager.rootDir === undefined) {
-            logger.log(`[Intelli][Input] No root dir can be found. The current root file should be undefined, is ${this.extension.manager.rootFile}. How did you get here?`)
+            logger.log(`No root dir can be found. The current root file should be undefined, is ${this.extension.manager.rootFile}. How did you get here?`)
             return []
         }
         // If there is no root, 'root relative' and 'both' should fall back to 'file relative'

--- a/src/providers/completer/input.ts
+++ b/src/providers/completer/input.ts
@@ -6,7 +6,7 @@ import * as micromatch from 'micromatch'
 import type { Extension } from '../../main'
 import type { IProvider } from '../completion'
 import {stripCommentsAndVerbatim} from '../../utils/utils'
-import { Logger } from '../../components/logger'
+import * as logger from '../../components/logger'
 
 const ignoreFiles = ['**/.vscode', '**/.vscodeignore', '**/.gitignore']
 
@@ -155,7 +155,7 @@ export class Input extends InputAbstract {
     getBaseDir(currentFile: string, _importFromDir: string, command: string): string[] {
         let baseDir: string[] = []
         if (this.extension.manager.rootDir === undefined) {
-            Logger.log(`No root dir can be found. The current root file should be undefined, is ${this.extension.manager.rootFile}. How did you get here?`)
+            logger.log(`No root dir can be found. The current root file should be undefined, is ${this.extension.manager.rootFile}. How did you get here?`)
             return []
         }
         // If there is no root, 'root relative' and 'both' should fall back to 'file relative'

--- a/src/providers/completer/input.ts
+++ b/src/providers/completer/input.ts
@@ -155,7 +155,7 @@ export class Input extends InputAbstract {
     getBaseDir(currentFile: string, _importFromDir: string, command: string): string[] {
         let baseDir: string[] = []
         if (this.extension.manager.rootDir === undefined) {
-            logger.log(`No root dir can be found. The current root file should be undefined, is ${this.extension.manager.rootFile}. How did you get here?`)
+            logger.log(`[Intelli][Input] No root dir can be found. The current root file should be undefined, is ${this.extension.manager.rootFile}. How did you get here?`)
             return []
         }
         // If there is no root, 'root relative' and 'both' should fall back to 'file relative'

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -17,6 +17,7 @@ import {Glossary} from './completer/glossary'
 import type {ReferenceDocType} from './completer/reference'
 import {escapeRegExp} from '../utils/utils'
 import {resolvePkgFile} from './completer/commandlib/commandfinder'
+import { Logger } from '../components/logger'
 
 export type PkgType = {includes: string[], cmds: {[key: string]: CmdType}, envs: {[key: string]: EnvType}, options: string[]}
 
@@ -67,7 +68,7 @@ export class Completer implements vscode.CompletionItemProvider {
         try {
             this.loadDefaultItems()
         } catch (err) {
-            this.extension.logger.addLogMessage(`Error reading data: ${err}.`)
+            Logger.log(`Error reading data: ${err}.`)
         }
     }
 
@@ -93,7 +94,7 @@ export class Completer implements vscode.CompletionItemProvider {
 
             this.packagesLoaded.push(packageName)
         } catch (e) {
-            this.extension.logger.addLogMessage(`Cannot parse intellisense file: ${filePath}`)
+            Logger.log(`Cannot parse intellisense file: ${filePath}`)
         }
     }
 
@@ -243,7 +244,7 @@ export class Completer implements vscode.CompletionItemProvider {
                 break
             default:
                 // This shouldn't be possible, so mark as error case in log.
-                this.extension.logger.addLogMessage(`Error - trying to complete unknown type ${type}`)
+                Logger.log(`Error - trying to complete unknown type ${type}`)
                 return []
         }
         const result = line.match(reg)

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -17,7 +17,7 @@ import {Glossary} from './completer/glossary'
 import type {ReferenceDocType} from './completer/reference'
 import {escapeRegExp} from '../utils/utils'
 import {resolvePkgFile} from './completer/commandlib/commandfinder'
-import { Logger } from '../components/logger'
+import * as logger from '../components/logger'
 
 export type PkgType = {includes: string[], cmds: {[key: string]: CmdType}, envs: {[key: string]: EnvType}, options: string[]}
 
@@ -68,7 +68,7 @@ export class Completer implements vscode.CompletionItemProvider {
         try {
             this.loadDefaultItems()
         } catch (err) {
-            Logger.log(`Error reading data: ${err}.`)
+            logger.log(`Error reading data: ${err}.`)
         }
     }
 
@@ -94,7 +94,7 @@ export class Completer implements vscode.CompletionItemProvider {
 
             this.packagesLoaded.push(packageName)
         } catch (e) {
-            Logger.log(`Cannot parse intellisense file: ${filePath}`)
+            logger.log(`Cannot parse intellisense file: ${filePath}`)
         }
     }
 
@@ -244,7 +244,7 @@ export class Completer implements vscode.CompletionItemProvider {
                 break
             default:
                 // This shouldn't be possible, so mark as error case in log.
-                Logger.log(`Error - trying to complete unknown type ${type}`)
+                logger.log(`Error - trying to complete unknown type ${type}`)
                 return []
         }
         const result = line.match(reg)

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -17,7 +17,10 @@ import {Glossary} from './completer/glossary'
 import type {ReferenceDocType} from './completer/reference'
 import {escapeRegExp} from '../utils/utils'
 import {resolvePkgFile} from './completer/commandlib/commandfinder'
-import * as logger from '../components/logger'
+
+import { getLogger } from '../components/logger'
+
+const logger = getLogger('Intelli')
 
 export type PkgType = {includes: string[], cmds: {[key: string]: CmdType}, envs: {[key: string]: EnvType}, options: string[]}
 
@@ -68,7 +71,7 @@ export class Completer implements vscode.CompletionItemProvider {
         try {
             this.loadDefaultItems()
         } catch (err) {
-            logger.log(`[Intelli] Error reading data: ${err}.`)
+            logger.log(`Error reading data: ${err}.`)
         }
     }
 
@@ -94,7 +97,7 @@ export class Completer implements vscode.CompletionItemProvider {
 
             this.packagesLoaded.push(packageName)
         } catch (e) {
-            logger.log(`[Intelli] Cannot parse intellisense file: ${filePath}`)
+            logger.log(`Cannot parse intellisense file: ${filePath}`)
         }
     }
 
@@ -244,7 +247,7 @@ export class Completer implements vscode.CompletionItemProvider {
                 break
             default:
                 // This shouldn't be possible, so mark as error case in log.
-                logger.log(`[Intelli] Error - trying to complete unknown type ${type}`)
+                logger.log(`Error - trying to complete unknown type ${type}`)
                 return []
         }
         const result = line.match(reg)

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -68,7 +68,7 @@ export class Completer implements vscode.CompletionItemProvider {
         try {
             this.loadDefaultItems()
         } catch (err) {
-            logger.log(`Error reading data: ${err}.`)
+            logger.log(`[Intelli] Error reading data: ${err}.`)
         }
     }
 
@@ -94,7 +94,7 @@ export class Completer implements vscode.CompletionItemProvider {
 
             this.packagesLoaded.push(packageName)
         } catch (e) {
-            logger.log(`Cannot parse intellisense file: ${filePath}`)
+            logger.log(`[Intelli] Cannot parse intellisense file: ${filePath}`)
         }
     }
 
@@ -244,7 +244,7 @@ export class Completer implements vscode.CompletionItemProvider {
                 break
             default:
                 // This shouldn't be possible, so mark as error case in log.
-                logger.log(`Error - trying to complete unknown type ${type}`)
+                logger.log(`[Intelli] Error - trying to complete unknown type ${type}`)
                 return []
         }
         const result = line.match(reg)

--- a/src/providers/latexformatter.ts
+++ b/src/providers/latexformatter.ts
@@ -6,7 +6,10 @@ import * as os from 'os'
 
 import type { Extension } from '../main'
 import {replaceArgumentPlaceholders} from '../utils/utils'
-import * as logger from '../components/logger'
+
+import { getLogger } from '../components/logger'
+
+const logger = getLogger('Format', 'TeX')
 
 const fullRange = (doc: vscode.TextDocument) => doc.validateRange(new vscode.Range(0, 0, Number.MAX_VALUE, Number.MAX_VALUE))
 
@@ -45,26 +48,26 @@ export class LaTexFormatter {
         } else if (this.machineOs === mac.name) {
             this.currentOs = mac
         } else {
-            logger.log('[Format][TeX] LaTexFormatter: Unsupported OS')
+            logger.log('LaTexFormatter: Unsupported OS')
         }
     }
 
     public async formatDocument(document: vscode.TextDocument, range?: vscode.Range): Promise<vscode.TextEdit[]> {
         if (this.#formatting) {
-            logger.log('[Format][TeX] Formatting in progress. Aborted.')
+            logger.log('Formatting in progress. Aborted.')
         }
         this.#formatting = true
         const configuration = vscode.workspace.getConfiguration('latex-workshop', document.uri)
         const pathMeta = configuration.get('latexindent.path') as string
         this.formatterArgs = configuration.get('latexindent.args') as string[]
-        logger.log('[Format][TeX] Start formatting with latexindent.')
+        logger.log('Start formatting with latexindent.')
         try {
             if (pathMeta !== this.formatter) {
                 this.formatter = pathMeta
                 const latexindentPresent = await this.checkPath()
                 if (!latexindentPresent) {
-                    logger.log(`[Format][TeX] Can not find latexindent in PATH: ${this.formatter}`)
-                    logger.log(`[Format][TeX] PATH: ${process.env.PATH}`)
+                    logger.log(`Can not find latexindent in PATH: ${this.formatter}`)
+                    logger.log(`PATH: ${process.env.PATH}`)
                     void logger.showErrorMessage('Can not find latexindent in PATH.')
                     return []
                 }
@@ -80,7 +83,7 @@ export class LaTexFormatter {
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         const useDocker = configuration.get('docker.enabled') as boolean
         if (useDocker) {
-            logger.log('[Format][TeX] Use Docker to invoke the command.')
+            logger.log('Use Docker to invoke the command.')
             if (process.platform === 'win32') {
                 this.formatter = path.resolve(this.extension.extensionRoot, './scripts/latexindent.bat')
             } else {
@@ -94,20 +97,20 @@ export class LaTexFormatter {
             if (fs.existsSync(this.formatter)) {
                 return Promise.resolve(true)
             } else {
-                logger.log(`[Format][TeX] The path of latexindent is absolute and not found: ${this.formatter}`)
+                logger.log(`The path of latexindent is absolute and not found: ${this.formatter}`)
                 return Promise.resolve(false)
             }
         }
 
         if (!this.currentOs) {
-            logger.log('[Format][TeX] The current platform is undefined.')
+            logger.log('The current platform is undefined.')
             return Promise.resolve(false)
         }
         const checker = this.currentOs.checker
         const fileExt = this.currentOs.fileExt
 
         return new Promise((resolve, _reject) => {
-            logger.log(`[Format][TeX] Checking latexindent: ${checker} ${this.formatter}`)
+            logger.log(`Checking latexindent: ${checker} ${this.formatter}`)
             const check1 = cs.spawn(checker, [this.formatter])
             let stdout1: string = ''
             let stderr1: string = ''
@@ -117,9 +120,9 @@ export class LaTexFormatter {
             check1.stderr.on('data', d => { stderr1 += d})
             check1.on('close', code1 => {
                 if (code1) {
-                    logger.log(`[Format][TeX] Error when checking latexindent: ${stderr1}`)
+                    logger.log(`Error when checking latexindent: ${stderr1}`)
                     this.formatter += fileExt
-                    logger.log(`[Format][TeX] Checking latexindent: ${checker} ${this.formatter}`)
+                    logger.log(`Checking latexindent: ${checker} ${this.formatter}`)
                     const check2 = cs.spawn(checker, [this.formatter])
                     let stdout2: string = ''
                     let stderr2: string = ''
@@ -130,14 +133,14 @@ export class LaTexFormatter {
                     check2.on('close', code2 => {
                         if (code2) {
                             resolve(false)
-                            logger.log(`[Format][TeX] Error when checking latexindent: ${stderr2}`)
+                            logger.log(`Error when checking latexindent: ${stderr2}`)
                         } else {
-                            logger.log(`[Format][TeX] Checking latexindent is ok: ${stdout2}`)
+                            logger.log(`Checking latexindent is ok: ${stdout2}`)
                             resolve(true)
                         }
                     })
                 } else {
-                    logger.log(`[Format][TeX] Checking latexindent is ok: ${stdout1}`)
+                    logger.log(`Checking latexindent is ok: ${stdout1}`)
                     resolve(true)
                 }
             })
@@ -150,7 +153,7 @@ export class LaTexFormatter {
             const useDocker = configuration.get('docker.enabled') as boolean
 
             if (!vscode.window.activeTextEditor) {
-                logger.log('[Format][TeX] Exit formatting. The active textEditor is undefined.')
+                logger.log('Exit formatting. The active textEditor is undefined.')
                 return
             }
             const options = vscode.window.activeTextEditor.options
@@ -184,7 +187,7 @@ export class LaTexFormatter {
             })
 
             logger.logCommand('Format with command', this.formatter, this.formatterArgs)
-            logger.log(`[Format][TeX] Format args: ${JSON.stringify(args)}`)
+            logger.log(`Format args: ${JSON.stringify(args)}`)
             const worker = cs.spawn(this.formatter, args, { stdio: 'pipe', cwd: documentDirectory })
             // handle stdout/stderr
             const stdoutBuffer: string[] = []
@@ -194,22 +197,22 @@ export class LaTexFormatter {
             worker.on('error', err => {
                 removeTemporaryFiles()
                 void logger.showErrorMessage('Formatting failed. Please refer to LaTeX Workshop Output for details.')
-                logger.log(`[Format][TeX] Formatting failed: ${err.message}`)
-                logger.log(`[Format][TeX] stderr: ${stderrBuffer.join('')}`)
+                logger.log(`Formatting failed: ${err.message}`)
+                logger.log(`stderr: ${stderrBuffer.join('')}`)
                 resolve([])
             })
             worker.on('close', code => {
                 removeTemporaryFiles()
                 if (code !== 0) {
                     void logger.showErrorMessage('Formatting failed. Please refer to LaTeX Workshop Output for details.')
-                    logger.log(`[Format][TeX] Formatting failed with exit code ${code}`)
-                    logger.log(`[Format][TeX] stderr: ${stderrBuffer.join('')}`)
+                    logger.log(`Formatting failed with exit code ${code}`)
+                    logger.log(`stderr: ${stderrBuffer.join('')}`)
                     return resolve([])
                 }
                 const stdout = stdoutBuffer.join('')
                 if (stdout !== '') {
                     const edit = [vscode.TextEdit.replace(range ? range : fullRange(document), stdout)]
-                    logger.log('[Format][TeX] Formatted ' + document.fileName)
+                    logger.log('Formatted ' + document.fileName)
                     return resolve(edit)
                 }
 

--- a/src/providers/preview/graphicspreview.ts
+++ b/src/providers/preview/graphicspreview.ts
@@ -94,7 +94,7 @@ export class GraphicsPreview {
             newOpts = { height: opts.height * scale , width: opts.width * scale, pageNumber: opts.pageNumber }
             dataUrl = await this.extension.snippetView.renderPdf(vscode.Uri.file(pdfFilePath), newOpts)
             if (dataUrl && dataUrl.length >= maxDataUrlLength) {
-                logger.log(`Data URL still too large: ${pdfFilePath}`)
+                logger.log(`[Preview][Graphics] Data URL still too large: ${pdfFilePath}`)
                 return undefined
             }
             return dataUrl

--- a/src/providers/preview/graphicspreview.ts
+++ b/src/providers/preview/graphicspreview.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode'
 import * as fs from 'fs'
 import * as path from 'path'
 import type { Extension } from '../../main'
+import { Logger } from '../../components/logger'
 
 
 export class GraphicsPreview {
@@ -93,14 +94,14 @@ export class GraphicsPreview {
             newOpts = { height: opts.height * scale , width: opts.width * scale, pageNumber: opts.pageNumber }
             dataUrl = await this.extension.snippetView.renderPdf(vscode.Uri.file(pdfFilePath), newOpts)
             if (dataUrl && dataUrl.length >= maxDataUrlLength) {
-                this.extension.logger.addLogMessage(`Data URL still too large: ${pdfFilePath}`)
+                Logger.log(`Data URL still too large: ${pdfFilePath}`)
                 return undefined
             }
             return dataUrl
         } catch (e: unknown) {
-            this.extension.logger.addLogMessage(`Failed to renderGraphicsAsDataUrl: ${pdfFilePath}`)
+            Logger.log(`Failed to renderGraphicsAsDataUrl: ${pdfFilePath}`)
             if (e instanceof Error) {
-                this.extension.logger.logError(e)
+                Logger.logError(e)
             }
             return undefined
         }

--- a/src/providers/preview/graphicspreview.ts
+++ b/src/providers/preview/graphicspreview.ts
@@ -2,8 +2,10 @@ import * as vscode from 'vscode'
 import * as fs from 'fs'
 import * as path from 'path'
 import type { Extension } from '../../main'
-import * as logger from '../../components/logger'
 
+import { getLogger } from '../../components/logger'
+
+const logger = getLogger('Preview', 'Graphics')
 
 export class GraphicsPreview {
     private readonly extension: Extension
@@ -94,12 +96,12 @@ export class GraphicsPreview {
             newOpts = { height: opts.height * scale , width: opts.width * scale, pageNumber: opts.pageNumber }
             dataUrl = await this.extension.snippetView.renderPdf(vscode.Uri.file(pdfFilePath), newOpts)
             if (dataUrl && dataUrl.length >= maxDataUrlLength) {
-                logger.log(`[Preview][Graphics] Data URL still too large: ${pdfFilePath}`)
+                logger.log(`Data URL still too large: ${pdfFilePath}`)
                 return undefined
             }
             return dataUrl
         } catch (e: unknown) {
-            logger.logError(`[Preview][Graphics] Failed rendering graphics as data url with ${pdfFilePath}`, e)
+            logger.logError(`Failed rendering graphics as data url with ${pdfFilePath}`, e)
             return undefined
         }
     }

--- a/src/providers/preview/graphicspreview.ts
+++ b/src/providers/preview/graphicspreview.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode'
 import * as fs from 'fs'
 import * as path from 'path'
 import type { Extension } from '../../main'
-import { Logger } from '../../components/logger'
+import * as logger from '../../components/logger'
 
 
 export class GraphicsPreview {
@@ -94,15 +94,12 @@ export class GraphicsPreview {
             newOpts = { height: opts.height * scale , width: opts.width * scale, pageNumber: opts.pageNumber }
             dataUrl = await this.extension.snippetView.renderPdf(vscode.Uri.file(pdfFilePath), newOpts)
             if (dataUrl && dataUrl.length >= maxDataUrlLength) {
-                Logger.log(`Data URL still too large: ${pdfFilePath}`)
+                logger.log(`Data URL still too large: ${pdfFilePath}`)
                 return undefined
             }
             return dataUrl
         } catch (e: unknown) {
-            Logger.log(`Failed to renderGraphicsAsDataUrl: ${pdfFilePath}`)
-            if (e instanceof Error) {
-                Logger.logError(e)
-            }
+            logger.logError(`[Preview][Graphics] Failed rendering graphics as data url with ${pdfFilePath}`, e)
             return undefined
         }
     }

--- a/src/providers/preview/mathpreview.ts
+++ b/src/providers/preview/mathpreview.ts
@@ -12,7 +12,7 @@ import {NewCommandFinder} from './mathpreviewlib/newcommandfinder'
 import {TexMathEnv, TeXMathEnvFinder} from './mathpreviewlib/texmathenvfinder'
 import {HoverPreviewOnRefProvider} from './mathpreviewlib/hoverpreviewonref'
 import {MathPreviewUtils} from './mathpreviewlib/mathpreviewutils'
-import { Logger } from '../../components/logger'
+import * as logger from '../../components/logger'
 
 export type {TexMathEnv} from './mathpreviewlib/texmathenvfinder'
 
@@ -56,8 +56,7 @@ export class MathPreview {
             const md = utils.svgToDataUrl(xml)
             return new vscode.Hover(new vscode.MarkdownString(this.mputils.addDummyCodeBlock(`![equation](${md})`)), tex.range )
         } catch(e) {
-            Logger.logOnRejected(e)
-            Logger.log(`Error when MathJax is rendering ${typesetArg}`)
+            logger.logError(`[Preview] Failed rendering MathJax ${typesetArg} .`, e)
             throw e
         }
     }

--- a/src/providers/preview/mathpreview.ts
+++ b/src/providers/preview/mathpreview.ts
@@ -12,10 +12,12 @@ import {NewCommandFinder} from './mathpreviewlib/newcommandfinder'
 import {TexMathEnv, TeXMathEnvFinder} from './mathpreviewlib/texmathenvfinder'
 import {HoverPreviewOnRefProvider} from './mathpreviewlib/hoverpreviewonref'
 import {MathPreviewUtils} from './mathpreviewlib/mathpreviewutils'
-import * as logger from '../../components/logger'
+
+import { getLogger } from '../../components/logger'
+
+const logger = getLogger('Preview', 'Math')
 
 export type {TexMathEnv} from './mathpreviewlib/texmathenvfinder'
-
 
 export class MathPreview {
     private color: string = '#000000'
@@ -56,7 +58,7 @@ export class MathPreview {
             const md = utils.svgToDataUrl(xml)
             return new vscode.Hover(new vscode.MarkdownString(this.mputils.addDummyCodeBlock(`![equation](${md})`)), tex.range )
         } catch(e) {
-            logger.logError(`[Preview] Failed rendering MathJax ${typesetArg} .`, e)
+            logger.logError(`Failed rendering MathJax ${typesetArg} .`, e)
             throw e
         }
     }

--- a/src/providers/preview/mathpreview.ts
+++ b/src/providers/preview/mathpreview.ts
@@ -12,12 +12,12 @@ import {NewCommandFinder} from './mathpreviewlib/newcommandfinder'
 import {TexMathEnv, TeXMathEnvFinder} from './mathpreviewlib/texmathenvfinder'
 import {HoverPreviewOnRefProvider} from './mathpreviewlib/hoverpreviewonref'
 import {MathPreviewUtils} from './mathpreviewlib/mathpreviewutils'
+import { Logger } from '../../components/logger'
 
 export type {TexMathEnv} from './mathpreviewlib/texmathenvfinder'
 
 
 export class MathPreview {
-    private readonly extension: Extension
     private color: string = '#000000'
     private readonly mj: MathJaxPool
     private readonly cursorRenderer: CursorRenderer
@@ -27,14 +27,13 @@ export class MathPreview {
     private readonly mputils: MathPreviewUtils
 
     constructor(extension: Extension) {
-        this.extension = extension
         this.mj = new MathJaxPool()
         vscode.workspace.onDidChangeConfiguration(() => this.getColor())
         this.cursorRenderer = new CursorRenderer(extension)
         this.mputils = new MathPreviewUtils()
         this.newCommandFinder = new NewCommandFinder(extension)
         this.texMathEnvFinder = new TeXMathEnvFinder()
-        this.hoverPreviewOnRefProvider = new HoverPreviewOnRefProvider(extension, this.mj, this.mputils)
+        this.hoverPreviewOnRefProvider = new HoverPreviewOnRefProvider(this.mj, this.mputils)
     }
 
     dispose() {
@@ -57,8 +56,8 @@ export class MathPreview {
             const md = utils.svgToDataUrl(xml)
             return new vscode.Hover(new vscode.MarkdownString(this.mputils.addDummyCodeBlock(`![equation](${md})`)), tex.range )
         } catch(e) {
-            this.extension.logger.logOnRejected(e)
-            this.extension.logger.addLogMessage(`Error when MathJax is rendering ${typesetArg}`)
+            Logger.logOnRejected(e)
+            Logger.log(`Error when MathJax is rendering ${typesetArg}`)
             throw e
         }
     }

--- a/src/providers/preview/mathpreviewlib/hoverpreviewonref.ts
+++ b/src/providers/preview/mathpreviewlib/hoverpreviewonref.ts
@@ -5,7 +5,10 @@ import type {MathJaxPool} from '../mathjaxpool'
 import type {ReferenceEntry} from '../../completer/reference'
 import type {TexMathEnv} from './texmathenvfinder'
 import type {MathPreviewUtils} from './mathpreviewutils'
-import * as logger from '../../../components/logger'
+
+import { getLogger } from '../../../components/logger'
+
+const logger = getLogger('Preview', 'Hover')
 
 export class HoverPreviewOnRefProvider {
     private readonly mj: MathJaxPool
@@ -44,7 +47,7 @@ export class HoverPreviewOnRefProvider {
             const svg = utils.svgToDataUrl(xml)
             return svg
         } catch(e) {
-            logger.logError(`[Preview][Hover] Failed rendering MathJax ${typesetArg} .`, e)
+            logger.logError(`Failed rendering MathJax ${typesetArg} .`, e)
             throw e
         }
     }

--- a/src/providers/preview/mathpreviewlib/hoverpreviewonref.ts
+++ b/src/providers/preview/mathpreviewlib/hoverpreviewonref.ts
@@ -5,7 +5,7 @@ import type {MathJaxPool} from '../mathjaxpool'
 import type {ReferenceEntry} from '../../completer/reference'
 import type {TexMathEnv} from './texmathenvfinder'
 import type {MathPreviewUtils} from './mathpreviewutils'
-import { Logger } from '../../../components/logger'
+import * as logger from '../../../components/logger'
 
 export class HoverPreviewOnRefProvider {
     private readonly mj: MathJaxPool
@@ -44,8 +44,7 @@ export class HoverPreviewOnRefProvider {
             const svg = utils.svgToDataUrl(xml)
             return svg
         } catch(e) {
-            Logger.logOnRejected(e)
-            Logger.log(`Error when MathJax is rendering ${typesetArg}`)
+            logger.logError(`[Preview][Hover] Failed rendering MathJax ${typesetArg} .`, e)
             throw e
         }
     }

--- a/src/providers/preview/mathpreviewlib/hoverpreviewonref.ts
+++ b/src/providers/preview/mathpreviewlib/hoverpreviewonref.ts
@@ -1,19 +1,17 @@
 import * as vscode from 'vscode'
 
-import type { Extension } from '../../../main'
 import * as utils from '../../../utils/svg'
 import type {MathJaxPool} from '../mathjaxpool'
 import type {ReferenceEntry} from '../../completer/reference'
 import type {TexMathEnv} from './texmathenvfinder'
 import type {MathPreviewUtils} from './mathpreviewutils'
+import { Logger } from '../../../components/logger'
 
 export class HoverPreviewOnRefProvider {
-    private readonly extension: Extension
     private readonly mj: MathJaxPool
     private readonly mputils: MathPreviewUtils
 
-    constructor(extension: Extension, mj: MathJaxPool, mputils: MathPreviewUtils) {
-        this.extension = extension
+    constructor(mj: MathJaxPool, mputils: MathPreviewUtils) {
         this.mj = mj
         this.mputils = mputils
     }
@@ -46,8 +44,8 @@ export class HoverPreviewOnRefProvider {
             const svg = utils.svgToDataUrl(xml)
             return svg
         } catch(e) {
-            this.extension.logger.logOnRejected(e)
-            this.extension.logger.addLogMessage(`Error when MathJax is rendering ${typesetArg}`)
+            Logger.logOnRejected(e)
+            Logger.log(`Error when MathJax is rendering ${typesetArg}`)
             throw e
         }
     }

--- a/src/providers/preview/mathpreviewlib/newcommandfinder.ts
+++ b/src/providers/preview/mathpreviewlib/newcommandfinder.ts
@@ -4,7 +4,10 @@ import {stripCommentsAndVerbatim, isNewCommand, NewCommand} from '../../../utils
 import * as path from 'path'
 
 import type { Extension } from '../../../main'
-import * as logger from '../../../components/logger'
+
+import { getLogger } from '../../../components/logger'
+
+const logger = getLogger('Preview', 'Math')
 
 export class NewCommandFinder {
     private readonly extension: Extension
@@ -34,14 +37,14 @@ export class NewCommandFinder {
             }
             const rootDir = this.extension.manager.rootDir
             if (rootDir === undefined) {
-                logger.log(`[Preview][Math] Cannot identify the absolute path of new command file ${newCommandFile} without root file.`)
+                logger.log(`Cannot identify the absolute path of new command file ${newCommandFile} without root file.`)
                 return ''
             }
             newCommandFileAbs = path.join(rootDir, newCommandFile)
         }
         commandsString = this.extension.lwfs.readFileSyncGracefully(newCommandFileAbs)
         if (commandsString === undefined) {
-            logger.log(`[Preview][Math] Cannot read file ${newCommandFileAbs}`)
+            logger.log(`Cannot read file ${newCommandFileAbs}`)
             return ''
         }
         commandsString = commandsString.replace(/^\s*$/gm, '')
@@ -68,7 +71,7 @@ export class NewCommandFinder {
                 return ''
             }
             if (exceeded) {
-                logger.log('[Preview][Math] Timeout error when parsing preambles in findProjectNewCommand.')
+                logger.log('Timeout error when parsing preambles in findProjectNewCommand.')
                 throw new Error('Timeout Error in findProjectNewCommand')
             }
             const cache = this.extension.cacher.get(tex)

--- a/src/providers/preview/mathpreviewlib/newcommandfinder.ts
+++ b/src/providers/preview/mathpreviewlib/newcommandfinder.ts
@@ -4,7 +4,7 @@ import {stripCommentsAndVerbatim, isNewCommand, NewCommand} from '../../../utils
 import * as path from 'path'
 
 import type { Extension } from '../../../main'
-import { Logger } from '../../../components/logger'
+import * as logger from '../../../components/logger'
 
 export class NewCommandFinder {
     private readonly extension: Extension
@@ -34,14 +34,14 @@ export class NewCommandFinder {
             }
             const rootDir = this.extension.manager.rootDir
             if (rootDir === undefined) {
-                Logger.log(`Cannot identify the absolute path of new command file ${newCommandFile} without root file.`)
+                logger.log(`Cannot identify the absolute path of new command file ${newCommandFile} without root file.`)
                 return ''
             }
             newCommandFileAbs = path.join(rootDir, newCommandFile)
         }
         commandsString = this.extension.lwfs.readFileSyncGracefully(newCommandFileAbs)
         if (commandsString === undefined) {
-            Logger.log(`Cannot read file ${newCommandFileAbs}`)
+            logger.log(`Cannot read file ${newCommandFileAbs}`)
             return ''
         }
         commandsString = commandsString.replace(/^\s*$/gm, '')
@@ -68,7 +68,7 @@ export class NewCommandFinder {
                 return ''
             }
             if (exceeded) {
-                Logger.log('Timeout error when parsing preambles in findProjectNewCommand.')
+                logger.log('Timeout error when parsing preambles in findProjectNewCommand.')
                 throw new Error('Timeout Error in findProjectNewCommand')
             }
             const cache = this.extension.cacher.get(tex)

--- a/src/providers/preview/mathpreviewlib/newcommandfinder.ts
+++ b/src/providers/preview/mathpreviewlib/newcommandfinder.ts
@@ -34,14 +34,14 @@ export class NewCommandFinder {
             }
             const rootDir = this.extension.manager.rootDir
             if (rootDir === undefined) {
-                logger.log(`Cannot identify the absolute path of new command file ${newCommandFile} without root file.`)
+                logger.log(`[Preview][Math] Cannot identify the absolute path of new command file ${newCommandFile} without root file.`)
                 return ''
             }
             newCommandFileAbs = path.join(rootDir, newCommandFile)
         }
         commandsString = this.extension.lwfs.readFileSyncGracefully(newCommandFileAbs)
         if (commandsString === undefined) {
-            logger.log(`Cannot read file ${newCommandFileAbs}`)
+            logger.log(`[Preview][Math] Cannot read file ${newCommandFileAbs}`)
             return ''
         }
         commandsString = commandsString.replace(/^\s*$/gm, '')
@@ -68,7 +68,7 @@ export class NewCommandFinder {
                 return ''
             }
             if (exceeded) {
-                logger.log('Timeout error when parsing preambles in findProjectNewCommand.')
+                logger.log('[Preview][Math] Timeout error when parsing preambles in findProjectNewCommand.')
                 throw new Error('Timeout Error in findProjectNewCommand')
             }
             const cache = this.extension.cacher.get(tex)

--- a/src/providers/preview/mathpreviewlib/newcommandfinder.ts
+++ b/src/providers/preview/mathpreviewlib/newcommandfinder.ts
@@ -4,6 +4,7 @@ import {stripCommentsAndVerbatim, isNewCommand, NewCommand} from '../../../utils
 import * as path from 'path'
 
 import type { Extension } from '../../../main'
+import { Logger } from '../../../components/logger'
 
 export class NewCommandFinder {
     private readonly extension: Extension
@@ -33,14 +34,14 @@ export class NewCommandFinder {
             }
             const rootDir = this.extension.manager.rootDir
             if (rootDir === undefined) {
-                this.extension.logger.addLogMessage(`Cannot identify the absolute path of new command file ${newCommandFile} without root file.`)
+                Logger.log(`Cannot identify the absolute path of new command file ${newCommandFile} without root file.`)
                 return ''
             }
             newCommandFileAbs = path.join(rootDir, newCommandFile)
         }
         commandsString = this.extension.lwfs.readFileSyncGracefully(newCommandFileAbs)
         if (commandsString === undefined) {
-            this.extension.logger.addLogMessage(`Cannot read file ${newCommandFileAbs}`)
+            Logger.log(`Cannot read file ${newCommandFileAbs}`)
             return ''
         }
         commandsString = commandsString.replace(/^\s*$/gm, '')
@@ -67,7 +68,7 @@ export class NewCommandFinder {
                 return ''
             }
             if (exceeded) {
-                this.extension.logger.addLogMessage('Timeout error when parsing preambles in findProjectNewCommand.')
+                Logger.log('Timeout error when parsing preambles in findProjectNewCommand.')
                 throw new Error('Timeout Error in findProjectNewCommand')
             }
             const cache = this.extension.cacher.get(tex)

--- a/src/providers/structure.ts
+++ b/src/providers/structure.ts
@@ -149,7 +149,7 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
 
         const content = this.extension.cacher.get(file)?.content
         if (!content) {
-            logger.log(`Error loading LaTeX during structuring: ${file} .`)
+            logger.log(`[Structure] Error loading LaTeX during structuring: ${file} .`)
             return []
         }
 
@@ -160,7 +160,7 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
         const ast = await this.extension.pegParser.parseLatex(fastparse ? stripText(content) : content).catch((e) => {
             if (latexParser.isSyntaxError(e)) {
                 const line = e.location.start.line
-                logger.log(`Error parsing LaTeX during structuring: line ${line} in ${file} .`)
+                logger.log(`[Structure] Error parsing LaTeX during structuring: line ${line} in ${file} .`)
             }
             return
         })
@@ -592,13 +592,13 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
     async buildBibTeXModel(document: vscode.TextDocument): Promise<Section[]> {
         const configuration = vscode.workspace.getConfiguration('latex-workshop', vscode.Uri.file(document.fileName))
         if (document.getText().length >= (configuration.get('bibtex.maxFileSize') as number) * 1024 * 1024) {
-            logger.log(`Bib file is too large, ignoring it: ${document.fileName}`)
+            logger.log(`[Structure] Bib file is too large, ignoring it: ${document.fileName}`)
             return []
         }
         const ast = await this.extension.pegParser.parseBibtex(document.getText()).catch((e) => {
             if (bibtexParser.isSyntaxError(e)) {
                 const line = e.location.start.line
-                logger.log(`Error parsing BibTeX: line ${line} in ${document.fileName} .`)
+                logger.log(`[Structure] Error parsing BibTeX: line ${line} in ${document.fileName} .`)
             }
             return
         })
@@ -710,7 +710,7 @@ export class StructureTreeView {
         this._viewer = vscode.window.createTreeView('latex-workshop-structure', { treeDataProvider: this._treeDataProvider, showCollapseAll: true })
         vscode.commands.registerCommand('latex-workshop.structure-toggle-follow-cursor', () => {
            this._followCursor = ! this._followCursor
-           logger.log(`Follow cursor is set to ${this._followCursor}.`)
+           logger.log(`[Structure] Follow cursor is set to ${this._followCursor}.`)
         })
 
         vscode.workspace.onDidSaveTextDocument( (e: vscode.TextDocument) => {

--- a/src/providers/structure.ts
+++ b/src/providers/structure.ts
@@ -5,7 +5,7 @@ import { latexParser,bibtexParser } from 'latex-utensils'
 import type { Extension } from '../main'
 import { resolveFile, stripText } from '../utils/utils'
 import { InputFileRegExp } from '../utils/inputfilepath'
-import { Logger } from '../components/logger'
+import * as logger from '../components/logger'
 
 export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
 
@@ -149,7 +149,7 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
 
         const content = this.extension.cacher.get(file)?.content
         if (!content) {
-            Logger.log(`Error loading LaTeX during structuring: ${file}.`)
+            logger.log(`Error loading LaTeX during structuring: ${file} .`)
             return []
         }
 
@@ -160,7 +160,7 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
         const ast = await this.extension.pegParser.parseLatex(fastparse ? stripText(content) : content).catch((e) => {
             if (latexParser.isSyntaxError(e)) {
                 const line = e.location.start.line
-                Logger.log(`Error parsing LaTeX during structuring: line ${line} in ${file}.`)
+                logger.log(`Error parsing LaTeX during structuring: line ${line} in ${file} .`)
             }
             return
         })
@@ -592,13 +592,13 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
     async buildBibTeXModel(document: vscode.TextDocument): Promise<Section[]> {
         const configuration = vscode.workspace.getConfiguration('latex-workshop', vscode.Uri.file(document.fileName))
         if (document.getText().length >= (configuration.get('bibtex.maxFileSize') as number) * 1024 * 1024) {
-            Logger.log(`Bib file is too large, ignoring it: ${document.fileName}`)
+            logger.log(`Bib file is too large, ignoring it: ${document.fileName}`)
             return []
         }
         const ast = await this.extension.pegParser.parseBibtex(document.getText()).catch((e) => {
             if (bibtexParser.isSyntaxError(e)) {
                 const line = e.location.start.line
-                Logger.log(`Error parsing BibTeX: line ${line} in ${document.fileName}.`)
+                logger.log(`Error parsing BibTeX: line ${line} in ${document.fileName} .`)
             }
             return
         })
@@ -710,7 +710,7 @@ export class StructureTreeView {
         this._viewer = vscode.window.createTreeView('latex-workshop-structure', { treeDataProvider: this._treeDataProvider, showCollapseAll: true })
         vscode.commands.registerCommand('latex-workshop.structure-toggle-follow-cursor', () => {
            this._followCursor = ! this._followCursor
-           Logger.log(`Follow cursor is set to ${this._followCursor}.`)
+           logger.log(`Follow cursor is set to ${this._followCursor}.`)
         })
 
         vscode.workspace.onDidSaveTextDocument( (e: vscode.TextDocument) => {

--- a/src/providers/structure.ts
+++ b/src/providers/structure.ts
@@ -5,6 +5,7 @@ import { latexParser,bibtexParser } from 'latex-utensils'
 import type { Extension } from '../main'
 import { resolveFile, stripText } from '../utils/utils'
 import { InputFileRegExp } from '../utils/inputfilepath'
+import { Logger } from '../components/logger'
 
 export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
 
@@ -148,7 +149,7 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
 
         const content = this.extension.cacher.get(file)?.content
         if (!content) {
-            this.extension.logger.addLogMessage(`Error loading LaTeX during structuring: ${file}.`)
+            Logger.log(`Error loading LaTeX during structuring: ${file}.`)
             return []
         }
 
@@ -159,7 +160,7 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
         const ast = await this.extension.pegParser.parseLatex(fastparse ? stripText(content) : content).catch((e) => {
             if (latexParser.isSyntaxError(e)) {
                 const line = e.location.start.line
-                this.extension.logger.addLogMessage(`Error parsing LaTeX during structuring: line ${line} in ${file}.`)
+                Logger.log(`Error parsing LaTeX during structuring: line ${line} in ${file}.`)
             }
             return
         })
@@ -591,13 +592,13 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
     async buildBibTeXModel(document: vscode.TextDocument): Promise<Section[]> {
         const configuration = vscode.workspace.getConfiguration('latex-workshop', vscode.Uri.file(document.fileName))
         if (document.getText().length >= (configuration.get('bibtex.maxFileSize') as number) * 1024 * 1024) {
-            this.extension.logger.addLogMessage(`Bib file is too large, ignoring it: ${document.fileName}`)
+            Logger.log(`Bib file is too large, ignoring it: ${document.fileName}`)
             return []
         }
         const ast = await this.extension.pegParser.parseBibtex(document.getText()).catch((e) => {
             if (bibtexParser.isSyntaxError(e)) {
                 const line = e.location.start.line
-                this.extension.logger.addLogMessage(`Error parsing BibTeX: line ${line} in ${document.fileName}.`)
+                Logger.log(`Error parsing BibTeX: line ${line} in ${document.fileName}.`)
             }
             return
         })
@@ -709,7 +710,7 @@ export class StructureTreeView {
         this._viewer = vscode.window.createTreeView('latex-workshop-structure', { treeDataProvider: this._treeDataProvider, showCollapseAll: true })
         vscode.commands.registerCommand('latex-workshop.structure-toggle-follow-cursor', () => {
            this._followCursor = ! this._followCursor
-           this.extension.logger.addLogMessage(`Follow cursor is set to ${this._followCursor}.`)
+           Logger.log(`Follow cursor is set to ${this._followCursor}.`)
         })
 
         vscode.workspace.onDidSaveTextDocument( (e: vscode.TextDocument) => {

--- a/src/providers/structure.ts
+++ b/src/providers/structure.ts
@@ -5,7 +5,10 @@ import { latexParser,bibtexParser } from 'latex-utensils'
 import type { Extension } from '../main'
 import { resolveFile, stripText } from '../utils/utils'
 import { InputFileRegExp } from '../utils/inputfilepath'
-import * as logger from '../components/logger'
+
+import { getLogger } from '../components/logger'
+
+const logger = getLogger('Structure')
 
 export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
 
@@ -149,7 +152,7 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
 
         const content = this.extension.cacher.get(file)?.content
         if (!content) {
-            logger.log(`[Structure] Error loading LaTeX during structuring: ${file} .`)
+            logger.log(`Error loading LaTeX during structuring: ${file} .`)
             return []
         }
 
@@ -160,7 +163,7 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
         const ast = await this.extension.pegParser.parseLatex(fastparse ? stripText(content) : content).catch((e) => {
             if (latexParser.isSyntaxError(e)) {
                 const line = e.location.start.line
-                logger.log(`[Structure] Error parsing LaTeX during structuring: line ${line} in ${file} .`)
+                logger.log(`Error parsing LaTeX during structuring: line ${line} in ${file} .`)
             }
             return
         })
@@ -592,13 +595,13 @@ export class SectionNodeProvider implements vscode.TreeDataProvider<Section> {
     async buildBibTeXModel(document: vscode.TextDocument): Promise<Section[]> {
         const configuration = vscode.workspace.getConfiguration('latex-workshop', vscode.Uri.file(document.fileName))
         if (document.getText().length >= (configuration.get('bibtex.maxFileSize') as number) * 1024 * 1024) {
-            logger.log(`[Structure] Bib file is too large, ignoring it: ${document.fileName}`)
+            logger.log(`Bib file is too large, ignoring it: ${document.fileName}`)
             return []
         }
         const ast = await this.extension.pegParser.parseBibtex(document.getText()).catch((e) => {
             if (bibtexParser.isSyntaxError(e)) {
                 const line = e.location.start.line
-                logger.log(`[Structure] Error parsing BibTeX: line ${line} in ${document.fileName} .`)
+                logger.log(`Error parsing BibTeX: line ${line} in ${document.fileName} .`)
             }
             return
         })
@@ -710,7 +713,7 @@ export class StructureTreeView {
         this._viewer = vscode.window.createTreeView('latex-workshop-structure', { treeDataProvider: this._treeDataProvider, showCollapseAll: true })
         vscode.commands.registerCommand('latex-workshop.structure-toggle-follow-cursor', () => {
            this._followCursor = ! this._followCursor
-           logger.log(`[Structure] Follow cursor is set to ${this._followCursor}.`)
+           logger.log(`Follow cursor is set to ${this._followCursor}.`)
         })
 
         vscode.workspace.onDidSaveTextDocument( (e: vscode.TextDocument) => {

--- a/test/suites/08_linter.test.ts
+++ b/test/suites/08_linter.test.ts
@@ -59,8 +59,9 @@ suite('Linter test suite', () => {
         await openActive(extension, fixture, 'main.tex')
 
         assert.ok(extension)
+        assert.ok(extension.manager.rootFile)
         const linter = new LaCheck(extension)
-        await linter.lintRootFile()
+        await linter.lintRootFile(extension.manager.rootFile)
         assert.strictEqual(linter.linterDiagnostics.name, 'LaCheck')
     })
 


### PR DESCRIPTION
This PR primarily does two things:

- The log messages now have a tag of form `[Builder]` to indicate the source of log, making the extension behavior more clear.
- The log messages now use placeholders of form `%WS1%` to represent workspace folders and substitute the string in messages, effectively making the log much more concise.

An internal engineering change is that the Logger class is transformed into a module, and each other module use a factory function to generate its own copy of logging functions.