### PR TITLE
Change detection of synctexFile, synctexFileGz

### DIFF
--- a/src/components/locatorlib/synctex.ts
+++ b/src/components/locatorlib/synctex.ts
@@ -95,6 +95,10 @@ export class SyncTexJs {
         } catch (e: unknown) {
             logger.logError(`Failed parsing .synctex.gz ${synctexFileGz} .`, e)
         }
+        
+        if (!fs.existsSync(synctexFile) && !fs.existsSync(synctexFileGz)) {
+            throw new SyncTexJsError(`${synctexFile}, ${synctexFileGz} not found.`)
+        }
 
         throw new SyncTexJsError('SyncTeX failed.')
     }

--- a/src/components/locatorlib/synctex.ts
+++ b/src/components/locatorlib/synctex.ts
@@ -80,12 +80,8 @@ export class SyncTexJs {
         const synctexFile = path.resolve(dir, filename + '.synctex')
         const synctexFileGz = synctexFile + '.gz'
 
-        if (!fs.existsSync(synctexFile)) {
-            throw new SyncTexJsError(`${synctexFile} not found.`)
-        }
-
-        if (!fs.existsSync(synctexFileGz)) {
-            throw new SyncTexJsError(`${synctexFileGz} not found.`)
+        if (!fs.existsSync(synctexFile) && !fs.existsSync(synctexFileGz)) {
+            throw new SyncTexJsError(`${synctexFile}, ${synctexFileGz} not found.`)
         }
 
         try {

--- a/src/components/locatorlib/synctex.ts
+++ b/src/components/locatorlib/synctex.ts
@@ -80,10 +80,6 @@ export class SyncTexJs {
         const synctexFile = path.resolve(dir, filename + '.synctex')
         const synctexFileGz = synctexFile + '.gz'
 
-        if (!fs.existsSync(synctexFile) && !fs.existsSync(synctexFileGz)) {
-            throw new SyncTexJsError(`${synctexFile}, ${synctexFileGz} not found.`)
-        }
-
         try {
             const s = fs.readFileSync(synctexFile, {encoding: 'binary'})
             return parseSyncTex(s)


### PR DESCRIPTION
Problem:

In my latex project, only the `.synctex.gz` file exists but the `.synxtex` file doesn't exist. This seems to cause synctex to fail. Here's the log

```
24:54:18][Manager] Found root file from active editor: %WS1%\example.tex
[24:54:18][Manager] Keep using the same root file: %WS1%\example.tex
[24:54:19][Commander] SYNCTEX command invoked.
[24:54:19][Locator] Forward from %WS1%\example.tex to %WS1%\example.pdf on line 227.
[24:54:19][SyncTeX] Failed parsing .synctex %WS1%\example.synctex , using .synctex.gz. Error: ENOENT: no such file or directory, open '%WS1%\example.synctex'
[24:54:19]Error: ENOENT: no such file or directory, open '%WS1%\example.synctex'
    at Object.openSync (node:fs:585:3)
    at Object.func [as openSync] (node:electron/js2c/asar_bundle:5:1812)
    at Object.readFileSync (node:fs:453:35)
    at Object.e.readFileSync (node:electron/js2c/asar_bundle:5:9160)
    at Function.parseSyncTexForPdf (c:\Users\example\.vscode\extensions\james-yu.latex-workshop-9.4.2\out\src\components\locatorlib\synctex.js:101:26)
    at Function.syncTexJsForward (c:\Users\example\.vscode\extensions\james-yu.latex-workshop-9.4.2\out\src\components\locatorlib\synctex.js:142:41)
    at Locator.syncTeX (c:\Users\example\.vscode\extensions\james-yu.latex-workshop-9.4.2\out\src\components\locator.js:160:52)
    at Object.synctex (c:\Users\example\.vscode\extensions\james-yu.latex-workshop-9.4.2\out\src\commander.js:183:16)
    at c:\Users\example\.vscode\extensions\james-yu.latex-workshop-9.4.2\out\src\main.js:128:953
    at s.h (c:\Program Files\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:94:107622)
    at s.$executeContributedCommand (c:\Program Files\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:94:108311)
    at u.N (c:\Program Files\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:104:11208)
    at u.M (c:\Program Files\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:104:10926)
    at u.H (c:\Program Files\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:104:10019)
    at u.G (c:\Program Files\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:104:9000)
    at c:\Program Files\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:104:7788
    at d.invoke (c:\Program Files\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:63:145)
    at w.deliver (c:\Program Files\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:63:2029)
    at g.fire (c:\Program Files\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:63:1667)
    at h.fire (c:\Program Files\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:72:14314)
    at c:\Program Files\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:120:15804
    at d.invoke (c:\Program Files\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:63:145)
    at w.deliver (c:\Program Files\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:63:2029)
    at g.fire (c:\Program Files\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:63:1667)
    at h.fire (c:\Program Files\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:72:14314)
    at c.y (c:\Program Files\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:72:17324)
    at c:\Program Files\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:72:15795
    at d.invoke (c:\Program Files\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:63:145)
    at w.deliver (c:\Program Files\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:63:2029)
    at g.fire (c:\Program Files\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:63:1667)
    at g.acceptChunk (c:\Program Files\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:72:12045)
    at c:\Program Files\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:72:11332
    at Socket.l (c:\Program Files\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:72:19792)
    at Socket.emit (node:events:526:28)
    at addChunk (node:internal/streams/readable:315:12)
    at readableAddChunk (node:internal/streams/readable:289:9)
    at Socket.Readable.push (node:internal/streams/readable:228:10)
    at Pipe.onStreamRead (node:internal/stream_base_commons:190:23)
[24:54:19][Viewer] Try to synctex %WS1%\example.pdf
```

Fix:

Change synctex to try parsing directly.
