### PR TITLE
New config `intellisense.command.user` to add/change/delete default cmd

### DIFF
--- a/package.json
+++ b/package.json
@@ -1796,6 +1796,15 @@
           "default": 1000,
           "markdownDescription": "Defines the delay in milliseconds for the extension to update current active file content for intellisense after stopped typing. This config works only when `intellisense.update.aggressive.enabled` is enabled. Lower this value to let the extension know newly defined commands/references/environments more quickly, at the cost of more frequent content parsing: more computational burden."
         },
+        "latex-workshop.intellisense.command.user": {
+          "scope": "resource",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {},
+          "markdownDescription": "Dictionary of `\"command name\": \"command snippet\"` to add, replace, or remove the default ones in `data/commands.json`. The key of the dictionary is the command name with optional braces indicating the command arguments. The value of the dictionary is the snippet to be inserted. If the key is identical to a default command suggestion defined in `data/commands.json`, the new value in the dictionary is used for suggestion. If the value is an empty string, the command is removed from suggestion. Leading backslashes will be added to both the name and snippet by the extension, so don't include them in this config. For example, `{\"mycommand[]{}\": \"notsamecommand[${2:option}]{$TM_SELECTED_TEXT$1}\", \"parbox{}{}\": \"parbox{${2:width}}{$TM_SELECTED_TEXT$1}\", \"overline{}\": \"\"}` adds a new command with name `mycommand[]{} that inserts `\\notsamecommand[]{}`, replaces the default snippet of `\\parbox{}{}` to make it include current selected text, and removes `\\overline{}` from suggestion."
+        },
         "latex-workshop.intellisense.citation.type": {
           "scope": "window",
           "type": "string",
@@ -2251,7 +2260,8 @@
             "type": "string"
           },
           "default": {},
-          "markdownDescription": "Dictionary of `\"command name\": \"command action\"` to replace the default snippets in `data/commands.json`. Remove the leading `\\` of the command name. See `data/commands.json` for the list of command names. An empty action removes the snippet. E.g. `{ \"[\": \"[ ${1} \\\\]\", \"figure\": \"\" }`."
+          "deprecationMessage": "Deprecated: This config has been superceded by config `intellisense.command.user`, which provides more features.",
+          "markdownDeprecationMessage": "**Deprecated**: This config has been superceded by config `#intellisense.command.user#`, which provides more features."
         },
         "latex-workshop.texdoc.path": {
           "scope": "window",

--- a/package.json
+++ b/package.json
@@ -1796,6 +1796,15 @@
           "default": 1000,
           "markdownDescription": "Defines the delay in milliseconds for the extension to update current active file content for intellisense after stopped typing. This config works only when `intellisense.update.aggressive.enabled` is enabled. Lower this value to let the extension know newly defined commands/references/environments more quickly, at the cost of more frequent content parsing: more computational burden."
         },
+        "latex-workshop.intellisense.atSuggestion.user": {
+          "scope": "resource",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {},
+          "markdownDescription": "Dictionary of `\"@prefix\": \"snippet command\"` to add to, replace, or remove the default suggestions in `data/at-suggestions.json`. The key of the dictionary is the triggering string, which **must** starts with `@` regardless of `#latex-workshop.intellisense.atSuggestion.trigger.latex#`. The value of the dictionary is the snippet to be inserted. If the key is identical to a default snippet defined in `data/at-suggestions.json`, the new value in the dictionary is used for suggestion. If the value is an empty string, the snippet is removed from suggestion. For example, `{ \"@.\": \"\\cdot\", \"@6\": \"\" }`."
+        },
         "latex-workshop.intellisense.command.user": {
           "scope": "resource",
           "type": "object",
@@ -1803,7 +1812,7 @@
             "type": "string"
           },
           "default": {},
-          "markdownDescription": "Dictionary of `\"command name\": \"command snippet\"` to add, replace, or remove the default ones in `data/commands.json`. The key of the dictionary is the command name with optional braces indicating the command arguments. The value of the dictionary is the snippet to be inserted. If the key is identical to a default command suggestion defined in `data/commands.json`, the new value in the dictionary is used for suggestion. If the value is an empty string, the command is removed from suggestion. Leading backslashes will be added to both the name and snippet by the extension, so don't include them in this config. For example, `{\"mycommand[]{}\": \"notsamecommand[${2:option}]{$TM_SELECTED_TEXT$1}\", \"parbox{}{}\": \"parbox{${2:width}}{$TM_SELECTED_TEXT$1}\", \"overline{}\": \"\"}` adds a new command with name `mycommand[]{} that inserts `\\notsamecommand[]{}`, replaces the default snippet of `\\parbox{}{}` to make it include current selected text, and removes `\\overline{}` from suggestion."
+          "markdownDescription": "Dictionary of `\"command name\": \"command snippet\"` to add to, replace, or remove the default ones in `data/commands.json`. The key of the dictionary is the command name with optional braces indicating the command arguments. The value of the dictionary is the snippet to be inserted. If the key is identical to a default command suggestion defined in `data/commands.json`, the new value in the dictionary is used for suggestion. If the value is an empty string, the command is removed from suggestion. Leading backslashes will be added to both the name and snippet by the extension, so don't include them in this config. For example, `{\"mycommand[]{}\": \"notsamecommand[${2:option}]{$TM_SELECTED_TEXT$1}\", \"parbox{}{}\": \"parbox{${2:width}}{$TM_SELECTED_TEXT$1}\", \"overline{}\": \"\"}` adds a new command with name `mycommand[]{} that inserts `\\notsamecommand[]{}`, replaces the default snippet of `\\parbox{}{}` to make it include current selected text, and removes `\\overline{}` from suggestion."
         },
         "latex-workshop.intellisense.citation.type": {
           "scope": "window",
@@ -1875,7 +1884,8 @@
             "type": "string"
           },
           "default": {},
-          "markdownDescription": "Dictionary of `\"prefix\": \"snippet command\"` to replace the default suggestions in `data/at-suggestions.json` or to define a new suggestion. An empty action removes the snippet from the default list. E.g. `{ \"@.\": \"\\cdot\", \"@6\": \"\" }`. Note that in this setting, the prefix must start with `@`, no matter what the true trigger character defined by `#latex-workshop.intellisense.atSuggestion.trigger.latex#` is."
+          "deprecationMessage": "Deprecated: This config has been renamed to `intellisense.atSuggestion.user`.",
+          "markdownDeprecationMessage": "**Deprecated**: This config has been renamed to `#intellisense.atSuggestion.user#`."
         },
         "latex-workshop.intellisense.file.exclude": {
           "scope": "resource",

--- a/src/providers/completer/atsuggestion.ts
+++ b/src/providers/completer/atsuggestion.ts
@@ -31,9 +31,9 @@ export class AtSuggestion implements IProvider {
     }
 
     private initialize(suggestions: {[key: string]: AtSuggestionItemEntry}) {
-        const suggestionReplacements = vscode.workspace.getConfiguration('latex-workshop').get('intellisense.atSuggestionJSON.replace') as {[key: string]: string}
+        const userSnippets = vscode.workspace.getConfiguration('latex-workshop').get('intellisense.atSuggestion.user') as {[key: string]: string}
         this.suggestions.length = 0
-        Object.entries(suggestionReplacements).forEach(([prefix, body]) => {
+        Object.entries(userSnippets).forEach(([prefix, body]) => {
             if (body === '') {
                 return
             }
@@ -45,7 +45,7 @@ export class AtSuggestion implements IProvider {
         })
 
         Object.values(suggestions).forEach(item => {
-            if (item.prefix in suggestionReplacements) {
+            if (item.prefix in userSnippets) {
                 return
             }
             const completionItem = new vscode.CompletionItem(item.prefix.replace('@', this.triggerCharacter), vscode.CompletionItemKind.Function)

--- a/src/providers/completer/atsuggestion.ts
+++ b/src/providers/completer/atsuggestion.ts
@@ -24,7 +24,7 @@ export class AtSuggestion implements IProvider {
         const allSuggestions: {[key: string]: AtSuggestionItemEntry} = JSON.parse(fs.readFileSync(`${lw.extensionRoot}/data/at-suggestions.json`).toString()) as DataAtSuggestionJsonType
         this.initialize(allSuggestions)
         lw.registerDisposable(vscode.workspace.onDidChangeConfiguration((e: vscode.ConfigurationChangeEvent) => {
-            if (e.affectsConfiguration('latex-workshop.intellisense.atSuggestionJSON.replace')) {
+            if (e.affectsConfiguration('latex-workshop.intellisense.atSuggestion.user')) {
                 this.initialize(allSuggestions)
             }
         }))

--- a/test/suites/04_intellisense.test.ts
+++ b/test/suites/04_intellisense.test.ts
@@ -38,7 +38,7 @@ suite('Intellisense test suite', () => {
         lw.manager.rootFile = undefined
 
         await vscode.workspace.getConfiguration('latex-workshop').update('intellisense.atSuggestion.trigger.latex', undefined)
-        await vscode.workspace.getConfiguration('latex-workshop').update('intellisense.atSuggestionJSON.replace', undefined)
+        await vscode.workspace.getConfiguration('latex-workshop').update('intellisense.atSuggestion.user', undefined)
         await vscode.workspace.getConfiguration('latex-workshop').update('intellisense.citation.label', undefined)
         await vscode.workspace.getConfiguration('latex-workshop').update('intellisense.citation.format', undefined)
         await vscode.workspace.getConfiguration('latex-workshop').update('intellisense.label.keyval', undefined)
@@ -541,7 +541,7 @@ suite('Intellisense test suite', () => {
 
     test.run(suiteName, fixtureName, '@-snippet intellisense and configs intellisense.atSuggestion*', async () => {
         const replaces = {'@+': '\\sum', '@8': '', '@M': '\\sum'}
-        await vscode.workspace.getConfiguration('latex-workshop').update('intellisense.atSuggestionJSON.replace', replaces)
+        await vscode.workspace.getConfiguration('latex-workshop').update('intellisense.atSuggestion.user', replaces)
         await test.load(fixture, [
             {src: 'intellisense/base.tex', dst: 'main.tex'},
             {src: 'intellisense/sub.tex', dst: 'sub/s.tex'}

--- a/test/suites/04_intellisense.test.ts
+++ b/test/suites/04_intellisense.test.ts
@@ -43,7 +43,7 @@ suite('Intellisense test suite', () => {
         await vscode.workspace.getConfiguration('latex-workshop').update('intellisense.citation.format', undefined)
         await vscode.workspace.getConfiguration('latex-workshop').update('intellisense.label.keyval', undefined)
         await vscode.workspace.getConfiguration('latex-workshop').update('intellisense.argumentHint.enabled', undefined)
-        await vscode.workspace.getConfiguration('latex-workshop').update('intellisense.commandsJSON.replace', undefined)
+        await vscode.workspace.getConfiguration('latex-workshop').update('intellisense.command.user', undefined)
 
         if (path.basename(fixture) === 'testground') {
             rimraf(fixture + '/{*,.vscode/*}', (e) => {if (e) {console.error(e)}})
@@ -227,8 +227,8 @@ suite('Intellisense test suite', () => {
         assert.ok(!snippet.value.includes('${1:'))
     })
 
-    test.run(suiteName, fixtureName, 'command intellisense with config `intellisense.commandsJSON.replace`', async () => {
-        await vscode.workspace.getConfiguration('latex-workshop').update('intellisense.commandsJSON.replace', {'mathbb{}': ''})
+    test.only(suiteName, fixtureName, 'command intellisense with config `intellisense.command.user`', async () => {
+        await vscode.workspace.getConfiguration('latex-workshop').update('intellisense.command.user', {'mycommand[]{}': 'notsamecommand[${2:option}]{$TM_SELECTED_TEXT$1}', 'parbox{}{}': 'defchanged', 'overline{}': ''})
         await test.load(fixture, [
             {src: 'intellisense/base.tex', dst: 'main.tex'},
             {src: 'intellisense/sub.tex', dst: 'sub/s.tex'}
@@ -239,15 +239,31 @@ suite('Intellisense test suite', () => {
         assert.ok(items.length > 0)
 
         let labels = items.map(item => item.label.toString())
-        assert.ok(!labels.includes('\\mathbb{}'))
+        assert.ok(labels.includes('\\mycommand[]{}'))
+        assert.ok(labels.includes('\\parbox{}{}'))
+        let parbox = items.filter(item => item.label === '\\parbox{}{}')[0].insertText
+        if (typeof parbox === 'string') {
+            assert.strictEqual(parbox, 'defchanged')
+        } else {
+            assert.strictEqual(parbox?.value, 'defchanged')
+        }
+        assert.ok(!labels.includes('\\overline{}'))
 
-        await vscode.workspace.getConfiguration('latex-workshop').update('intellisense.commandsJSON.replace', undefined)
+        await vscode.workspace.getConfiguration('latex-workshop').update('intellisense.command.user', undefined)
         items = test.suggest(result.doc, new vscode.Position(0, 1))
         assert.ok(items)
         assert.ok(items.length > 0)
 
         labels = items.map(item => item.label.toString())
-        assert.ok(labels.includes('\\mathbb{}'))
+        assert.ok(!labels.includes('\\mycommand[]{}'))
+        assert.ok(labels.includes('\\parbox{}{}'))
+        parbox = items.filter(item => item.label === '\\parbox{}{}')[0].insertText
+        if (typeof parbox === 'string') {
+            assert.notStrictEqual(parbox, 'defchanged')
+        } else {
+            assert.notStrictEqual(parbox?.value, 'defchanged')
+        }
+        assert.ok(labels.includes('\\overline{}'))
     })
 
     test.run(suiteName, fixtureName, 'reference intellisense and config intellisense.label.keyval', async () => {


### PR DESCRIPTION
This PR adds a new config `intellisense.command.user`, which is almost an in-place substitution of the original `intellisense.commandsJSON.replace`. The new config shares the same data format of the previous one, and can also change snippets of default commands or remove them by empty snippets. In addition, entries in the new config are added to the command suggestion list, making the config add/change/delete commands compared to the previous change/delete only.

This PR is primarily inspired by #3646 . I cannot recall the original initiative on preventing `intellisense.commandsJSON.replace` to add entries.

There are also other `*JSON.replace` configs. This PR does not touch them, and I am not sure if it is a good idea to make their behavior and name consistent. It seems that the current @-suggestion.replace can already add.