### PR TITLE
[DocTeX Syntax] Remove hard-coded whitespace requirement

### DIFF
--- a/syntax/DocTeX.tmLanguage.json
+++ b/syntax/DocTeX.tmLanguage.json
@@ -17,7 +17,7 @@
       "name": "meta.function.verb.latex"
     },
     {
-      "begin": "^(%)    (\\\\begin\\{macrocode\\})",
+      "begin": "^(%)[ \\t]*(\\\\begin\\{macrocode\\})",
       "captures": {
         "1": {
           "name": "comment.line.percentage.doctex"
@@ -26,7 +26,7 @@
           "name": "entity.name.tag.macrocode.doctex"
         }
       },
-      "end": "^(%)    (\\\\end\\{macrocode\\})",
+      "end": "^(%)[ \\t]*(\\\\end\\{macrocode\\})",
       "patterns": [
         {
           "include": "#guards"


### PR DESCRIPTION
`%    \begin{macrocode}` is currently only highlighted properly if there's exactly 4 spaces between the `%` and `\begin{macrocode}` parts. The proposed change would make the line be highlighted properly no matter how many space or tab characters are used instead. Same for `%    \end{macrocode}`.