### PR TITLE
Have the PDF viewer listen on any address

### DIFF
--- a/src/components/server.ts
+++ b/src/components/server.ts
@@ -87,7 +87,7 @@ export class Server {
     private initializeHttpServer() {
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         const viewerPort = configuration.get('viewer.pdf.internal.port') as number
-        this.httpServer.listen(viewerPort, '127.0.0.1', undefined, async () => {
+        this.httpServer.listen(viewerPort, undefined, undefined, async () => {
             const address = this.httpServer.address()
             if (address && typeof address !== 'string') {
                 this.address = address


### PR DESCRIPTION
The PDF viewer only listens on `127.0.0.1`. This causes issues such as #3664. The fix is to allow the viewer's HTTP server to listen on any address, rather than the hardcoded IPv4 address `127.0.0.1`. See https://nodejs.org/api/net.html#serverlisten for more information.