### PR TITLE
Fix synctex with .Rnw formats with patchDVI

### DIFF
--- a/package.json
+++ b/package.json
@@ -832,8 +832,7 @@
             {
               "name": "Compile Rnw files",
               "tools": [
-                "rnw2tex",
-                "latexmk"
+                "rnw2tex"
               ]
             },
             {
@@ -965,7 +964,7 @@
               "command": "Rscript",
               "args": [
                 "-e",
-                "knitr::opts_knit$set(concordance = TRUE); knitr::knit('%DOCFILE_EXT%')"
+                "setwd('%OUTDIR%'); knitr::opts_knit$set(concordance=TRUE); patchDVI::knitPDF('%DOC_EXT%')"
               ],
               "env": {}
             },


### PR DESCRIPTION
This fixes the synctex issues when compiling .Rnw files:
- Originally, synctex (forward & backward) only works with the generated .tex file.
The generated .tex and *-concordance.tex files are also outside of the `%OUTDIR%` directory.
- With this fix, bidirectional synctex works with the .Rnw file, and all generated files are inside `%OUTDIR%`.

Note: For this fix to work, the user needs to install `patchDVI` R package.
I'm not familiar with VSCode extensions, but you may add some alert box, or use R code to check if the package is installed and possibly use the old compiling code as a fallback.