### PR TITLE
Server hostname

### DIFF
--- a/package.json
+++ b/package.json
@@ -412,6 +412,16 @@
         "category": "LaTeX Workshop"
       },
       {
+        "command": "latex-workshop.changeHostName",
+        "title": "Change server listening hostname",
+        "category": "LaTeX Workshop"
+      },
+      {
+        "command": "latex-workshop.resetHostName",
+        "title": "Reset server listening hostname to 127.0.0.1",
+        "category": "LaTeX Workshop"
+      },
+      {
         "command": "latex-workshop.compilerlog",
         "title": "View LaTeX compiler logs",
         "category": "LaTeX Workshop",

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -274,6 +274,31 @@ export function closeEnv() {
     return lw.envPair.closeEnv()
 }
 
+export async function changeHostName() {
+    logger.log('CHANGEHOSTNAME command invoked.')
+    const proceed = (await vscode.window.showInputBox({
+        prompt: 'Changing LaTeX Workshop server hostname can expose your computer to the public and is under severe security risk. CORS is also disabled. Do you want to continue?',
+        placeHolder: 'Type CONFIRM then [Enter] to continue. Press [ESC] to keep you safe.'
+    }))?.toLowerCase() === 'confirm'
+    if (!proceed) {
+        return
+    }
+    const hostname = await vscode.window.showInputBox({
+        prompt: 'Please input the new hostname that LaTeX Workshop server will listen to. This change will be reset on closing VSCode.',
+        placeHolder: '127.0.0.1'
+    })
+    if (!hostname) {
+        return
+    }
+    lw.server.initializeHttpServer(hostname)
+}
+
+export function resetHostName() {
+    logger.log('RESETHOSTNAME command invoked.')
+    lw.server.initializeHttpServer('127.0.0.1')
+    void vscode.window.showInformationMessage('LaTeX Workshop server listening to 127.0.0.1 with CORS. You are safe now.')
+}
+
 export async function actions() {
     logger.log('ACTIONS command invoked.')
     return vscode.commands.executeCommand('workbench.view.extension.latex-workshop-activitybar').then(() => vscode.commands.executeCommand('workbench.action.focusActiveEditorGroup'))

--- a/src/components/server.ts
+++ b/src/components/server.ts
@@ -26,6 +26,9 @@ class WsServer extends ws.Server {
     // - https://github.com/websockets/ws/blob/master/doc/ws.md#servershouldhandlerequest
     //
     shouldHandle(req: http.IncomingMessage): boolean {
+        if (!this.validOrigin.includes('127.0.0.1')) {
+            return true
+        }
         const reqOrigin = req.headers['origin']
         if (reqOrigin !== undefined && reqOrigin !== this.validOrigin) {
             logger.log(`Origin in WebSocket upgrade request is invalid: ${JSON.stringify(req.headers)}`)
@@ -95,7 +98,10 @@ export class Server {
             const address = this.httpServer.address()
             if (address && typeof address !== 'string') {
                 this.address = address
-                logger.log(`Server successfully started: ${JSON.stringify(address)}`)
+                logger.log(`Server successfully started: ${JSON.stringify(address)} .`)
+                if (hostname) {
+                    logger.log(`BE AWARE: YOU ARE PUBLIC TO ${hostname} !`)
+                }
                 this.validOriginUri = await this.obtainValidOrigin(address.port, hostname ?? '127.0.0.1')
                 logger.log(`valdOrigin is ${this.validOrigin}`)
                 this.initializeWsServer(httpServer, this.validOrigin)
@@ -135,6 +141,9 @@ export class Server {
     // - https://fetch.spec.whatwg.org/#http-responses
     //
     private checkHttpOrigin(req: http.IncomingMessage, response: http.ServerResponse): boolean {
+        if (!this.validOrigin.includes('127.0.0.1')) {
+            return true
+        }
         const reqOrigin = req.headers['origin']
         if (reqOrigin !== undefined && reqOrigin !== this.validOrigin) {
             logger.log(`Origin in http request is invalid: ${JSON.stringify(req.headers)}`)

--- a/src/components/viewer.ts
+++ b/src/components/viewer.ts
@@ -36,7 +36,7 @@ export class Viewer {
      * refreshes all the PDF viewers.
      */
     refreshExistingViewer(sourceFile?: string, pdfFile?: string): void {
-        logger.log(`Call refreshExistingViewer: ${JSON.stringify({sourceFile})}`)
+        logger.log(`Call refreshExistingViewer: ${JSON.stringify(sourceFile ?? pdfFile)} .`)
         const pdfUri = pdfFile ? vscode.Uri.file(pdfFile) : (sourceFile ? this.tex2pdf(sourceFile) : undefined)
         if (pdfUri === undefined) {
             PdfViewerManagerService.clientMap.forEach(clientSet => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -154,6 +154,8 @@ function registerLatexWorkshopCommands() {
         vscode.commands.registerCommand('latex-workshop.onEnterKey', () => lw.commander.onEnterKey()),
         vscode.commands.registerCommand('latex-workshop.onAltEnterKey', () => lw.commander.onEnterKey('alt')),
         vscode.commands.registerCommand('latex-workshop.revealOutputDir', () => lw.commander.revealOutputDir()),
+        vscode.commands.registerCommand('latex-workshop.changeHostName', () => lw.commander.changeHostName()),
+        vscode.commands.registerCommand('latex-workshop.resetHostName', () => lw.commander.resetHostName()),
         vscode.commands.registerCommand('latex-workshop-dev.parselog', () => lw.commander.devParseLog()),
         vscode.commands.registerCommand('latex-workshop-dev.parsetex', () => lw.commander.devParseTeX()),
         vscode.commands.registerCommand('latex-workshop-dev.parsebib', () => lw.commander.devParseBib()),


### PR DESCRIPTION
This PR is a prudent revival of #1271, which only provided configurable port feature. This PR adds two new commands to set and reset hostname of the server.

The difference is that this time, the listening hostname is not a config item, but instead a prompt asking users to first confirm and then provide a new address. In this way, the concern of copy-pasting config items from https://github.com/James-Yu/LaTeX-Workshop/pull/1271#issuecomment-479787874 can be partly resolved. This hostname change is not permanent; it is reset by the new command `latex-workshop.resetHostName` or vscode reload.

This PR, together with #3639 , should enable a more versatile usage of the server, e.g., PDF viewing within the same LAN.

This PR may also help to resolve #3670 and a series of other issues, though the major intention is just to allow for customizable hostname with some sort of protection/warning.

@jlelong may you help review the feature and implementation? Many thanks!