### PR TITLE
environment `array` etc. not correctly created

### DIFF
--- a/data/environments.json
+++ b/data/environments.json
@@ -15,10 +15,10 @@
   "math": {},
   "displaymath": {},
   "split": {},
-  "array{}": {
+  "array": {
     "snippet": "{${1:cols}}"
   },
-  "subarray{}": {
+  "subarray": {
     "snippet": "{${1:align}}"
   },
   "eqnarray": {},
@@ -65,7 +65,7 @@
   "verse": {},
   "picture": {},
   "tabbing": {},
-  "tabular{}": {
+  "tabular": {
     "snippet": "{${1:cols}}"
   },
   "thebibliography": {},


### PR DESCRIPTION
When I input the following:
```
\array
```
it is supposed to get
```
\begin{array}{cols}
    
\end{array}
```
But it turns out to be
```
\begin{array{}}{cols}
    
\end{array{}}
```
The symbol `{}` should be deleted from `array{}`. 

Similar things happened to `subarray{}` and `tabular{}`.