### PR TITLE
Add configurable default hostname

### DIFF
--- a/package.json
+++ b/package.json
@@ -1449,6 +1449,12 @@
           "default": "0",
           "markdownDescription": "Define the port to listen on for communicating with the internal viewer. The default value \"0\" means the port is chosen randomly by the application."
         },
+        "latex-workshop.viewer.pdf.internal.hostname": {
+          "scope": "window",
+          "type": "string",
+          "default": "127.0.0.1",
+          "markdownDescription": "Define the hostname to bind to for communicating with the internal viewer."
+        },
         "latex-workshop.view.pdf.internal.synctex.keybinding": {
           "scope": "window",
           "type": "string",

--- a/src/components/server.ts
+++ b/src/components/server.ts
@@ -94,7 +94,8 @@ export class Server {
         const httpServer = http.createServer((request, response) => this.handler(request, response))
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         const viewerPort = configuration.get('viewer.pdf.internal.port') as number
-        httpServer.listen(viewerPort, hostname ?? '127.0.0.1', undefined, async () => {
+        const defaultHostname = configuration.get('viewer.pdf.internal.hostname') as string
+        httpServer.listen(viewerPort, hostname ?? defaultHostname, undefined, async () => {
             const address = this.httpServer.address()
             if (address && typeof address !== 'string') {
                 this.address = address
@@ -102,7 +103,7 @@ export class Server {
                 if (hostname) {
                     logger.log(`BE AWARE: YOU ARE PUBLIC TO ${hostname} !`)
                 }
-                this.validOriginUri = await this.obtainValidOrigin(address.port, hostname ?? '127.0.0.1')
+                this.validOriginUri = await this.obtainValidOrigin(address.port, hostname ?? defaultHostname)
                 logger.log(`valdOrigin is ${this.validOrigin}`)
                 this.initializeWsServer(httpServer, this.validOrigin)
                 this.eventEmitter.emit(ServerStartedEvent)


### PR DESCRIPTION
Currently there is no option to set default hostname for which the server binds to without using gui. For premade environments it would be vital if one could preconfigure this. 