### PR TITLE
Add a biber logs parser to populate the problems pane

### DIFF
--- a/package.json
+++ b/package.json
@@ -1999,6 +1999,15 @@
           "default": true,
           "markdownDescription": "Show badbox information in the problems panel."
         },
+        "latex-workshop.message.biberlog.exclude": {
+          "scope": "window",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "markdownDescription": "Exclude biber log messages matching the given regexp from the problems panel."
+        },
         "latex-workshop.message.bibtexlog.exclude": {
           "scope": "window",
           "type": "array",

--- a/src/components/parser/biberlogparser.ts
+++ b/src/components/parser/biberlogparser.ts
@@ -1,0 +1,133 @@
+import * as vscode from 'vscode'
+import * as lw from '../../lw'
+import type { LogEntry } from './compilerlog'
+
+import { getLogger } from '../logger'
+
+const logger = getLogger('Parser', 'BiberLog')
+
+const bibFileInfo = /^INFO - Found BibTeX data source '(.*)'$/
+const lineError = /^ERROR - BibTeX subsystem.*, line (\d+), (.*)$/
+const missingEntryWarning = /^WARN - (I didn't find a database entry for '.*'.*)$/
+const lineWarning = /^WARN - (.* entry '(.*)' .*)$/
+
+class ParserState {
+    rootFile: string
+    bibFiles: string[] = []
+
+    constructor(rootFile: string) {
+        this.rootFile = rootFile
+    }
+
+    getCurrentBibFile(): string {
+        const file = this.bibFiles.at(-1)
+        if (file) {
+            return file
+        }
+        return this.rootFile
+    }
+}
+
+export class BiberLogParser {
+    static buildLog: LogEntry[] = []
+
+    static parse(log: string, rootFile?: string) {
+        if (rootFile === undefined) {
+            rootFile = lw.manager.rootFile
+        }
+        if (rootFile === undefined) {
+            logger.log('How can you reach this point?')
+            return []
+        }
+        const parserState = new ParserState(rootFile)
+
+        const configuration = vscode.workspace.getConfiguration('latex-workshop')
+        let excludeRegexp: RegExp[]
+        try {
+            excludeRegexp = (configuration.get('message.biberlog.exclude') as string[]).map(regexp => RegExp(regexp))
+        } catch (e) {
+            logger.logError('Invalid message.biberlog.exclude config.', e)
+            return []
+        }
+        const lines = log.split('\n')
+        this.buildLog = []
+
+        for(const line of lines) {
+            this.parseLine(line, parserState, excludeRegexp)
+        }
+
+        logger.log(`Logged ${this.buildLog.length} messages.`)
+        return this.buildLog
+    }
+
+    private static parseLine(line: string, parserState: ParserState, excludeRegexp: RegExp[]) {
+        let result: RegExpMatchArray | null = null
+
+        result = line.match(bibFileInfo)
+        if (result) {
+            const filename = this.resolveBibFile(result[1], parserState.rootFile)
+            parserState.bibFiles.push(filename)
+            logger.log(`Found BibTeX file ${filename}`)
+        }
+
+        result = line.match(lineError)
+        if (result) {
+            const lineNumber = parseInt(result[1], 10)
+            const filename = parserState.getCurrentBibFile()
+            this.pushLog('error', filename, result[2], lineNumber, excludeRegexp)
+            return
+        }
+
+        result = line.match(missingEntryWarning)
+        if (result) {
+            const lineNumber = 1
+            const filename = parserState.getCurrentBibFile()
+            this.pushLog('warning', filename, result[1], lineNumber, excludeRegexp)
+        }
+
+        result = line.match(lineWarning)
+        if (result) {
+            const keyLocation = this.findKeyLocation(result[2])
+            if (keyLocation) {
+                this.pushLog('warning', keyLocation.file, result[1], keyLocation.line, excludeRegexp)
+            }
+        }
+    }
+
+    private static pushLog(type: string, file: string, message: string, line: number, excludeRegexp: RegExp[]) {
+        for (const regexp of excludeRegexp) {
+            if (message.match(regexp)) {
+                return
+            }
+        }
+        this.buildLog.push({ type, file, text: message, line})
+    }
+
+    private static resolveBibFile(filename: string, rootFile: string): string {
+        if (!lw.cacher.get(rootFile)) {
+            return filename
+        }
+        const bibFiles = lw.cacher.getIncludedBib(rootFile)
+        for (const bib of bibFiles) {
+            if (bib.endsWith(filename)) {
+                return bib
+            }
+        }
+        logger.log(`Cannot resolve file ${filename} .`)
+        return filename
+    }
+
+    private static findKeyLocation(key: string): {file: string, line: number} | undefined {
+        const entry = lw.completer.citation.getEntry(key)
+        if (entry) {
+            const file = entry.file
+            const line = entry.position.line + 1
+            return {file, line}
+        } else {
+            logger.log(`Cannot find key ${key}`)
+            return
+        }
+    }
+
+}
+

--- a/src/components/parser/bibtexlogparser.ts
+++ b/src/components/parser/bibtexlogparser.ts
@@ -4,7 +4,7 @@ import type { LogEntry } from './compilerlog'
 
 import { getLogger } from '../logger'
 
-const logger = getLogger('Parser', 'BibLog')
+const logger = getLogger('Parser', 'BibtexLog')
 
 const multiLineWarning = /^Warning--(.+)\n--line (\d+) of file (.+)$/gm
 const singleLineWarning = /^Warning--(.+) in ([^\s]+)\s*$/gm
@@ -13,7 +13,7 @@ const badCrossReference = /^(A bad cross reference---entry ".+?"\nrefers to entr
 const multiLineCommandError = /^(.*)\n?---line (\d+) of file (.*)\n([^]+?)\nI'm skipping whatever remains of this command$/gm
 const errorAuxFile = /^(.*)---while reading file (.*)$/gm
 
-export class BibLogParser {
+export class BibtexLogParser {
     static buildLog: LogEntry[] = []
 
     static parse(log: string, rootFile?: string) {


### PR DESCRIPTION
Related to #3720 

This PR implements a parser for biber logs in order to show related errors and warnings in the problem pane.

As I am not a biber user, the parse might be incomplete but we can always improve it later. 
Biber can use several `.bib` files at the same time, so it is clear which file missing entry warnings should be associated with. I can think of three solutions
1. the tex root file
2. the last bib file read
3. all bib files 

@LinqLover @James-Yu Do you have any opinion?