### PR TITLE
Fix #3747 Strip % comments from bibtex for parsing

### DIFF
--- a/src/components/parser/syntax.ts
+++ b/src/components/parser/syntax.ts
@@ -3,6 +3,7 @@ import * as path from 'path'
 import * as workerpool from 'workerpool'
 import type {Proxy} from 'workerpool'
 import type {ISyntaxWorker} from './syntax_worker'
+import { stripComments } from '../../utils/utils'
 
 class SyntaxParser {
     static #instance?: SyntaxParser
@@ -39,7 +40,7 @@ class SyntaxParser {
     }
 
     async parseBibtex(s: string, options?: bibtexParser.ParserOptions): Promise<bibtexParser.BibtexAst> {
-        return (await this.proxy).parseBibtex(s, options).timeout(30000).catch(() => {return { content: [] }})
+        return (await this.proxy).parseBibtex(stripComments(s), options).timeout(30000).catch(() => {return { content: [] }})
     }
 }
 


### PR DESCRIPTION
This PR strips % comments from bibtex before AST parsing with `latex-utensils`, which currently does not support such Biber comments. The PR just reuses the well-tested `stripComments()` function to do so.