### PR TITLE
Exclude package intellisense

### DIFF
--- a/package.json
+++ b/package.json
@@ -1974,6 +1974,15 @@
           "default": [],
           "markdownDescription": "List of extra packages to always add to the auto-completion mechanism. When `#latex-workshop.intellisense.package.enabled#` is set to `true`, the commands and environments defined in these extra packages will be added to the intellisense suggestions."
         },
+        "latex-workshop.intellisense.package.exclude": {
+          "scope": "window",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "markdownDescription": "List of packages to exclude from the auto-completion mechanism. When `#latex-workshop.intellisense.package.enabled#` is set to `true`, the commands and environments defined in these packages will not be added to the intellisense suggestions. This setting has a higher priority over `#latex-workshop.intellisense.package.extra#`. You may include the string \"lw-default\" in the list to remove all default commands and environments."
+        },
         "latex-workshop.intellisense.package.env.enabled": {
           "scope": "window",
           "type": "boolean",

--- a/src/providers/completer/command.ts
+++ b/src/providers/completer/command.ts
@@ -48,7 +48,8 @@ export class Command implements IProvider {
 
     constructor() {
         lw.registerDisposable(vscode.workspace.onDidChangeConfiguration((e: vscode.ConfigurationChangeEvent) => {
-            if (!e.affectsConfiguration('latex-workshop.intellisense.command.user')) {
+            if (!e.affectsConfiguration('latex-workshop.intellisense.command.user') ||
+                !e.affectsConfiguration('latex-workshop.intellisense.package.exclude')) {
                 return
             }
             this.initialize(lw.completer.environment)
@@ -56,8 +57,9 @@ export class Command implements IProvider {
     }
 
     initialize(environment: Environment) {
-        const cmds = JSON.parse(fs.readFileSync(`${lw.extensionRoot}/data/commands.json`, {encoding: 'utf8'})) as {[key: string]: CmdType}
-        const maths = (JSON.parse(fs.readFileSync(`${lw.extensionRoot}/data/packages/tex.json`, {encoding: 'utf8'})) as PkgType).cmds
+        const loadDefault = (vscode.workspace.getConfiguration('latex-workshop').get('intellisense.package.exclude') as string[]).includes('lw-default')
+        const cmds = loadDefault ? JSON.parse(fs.readFileSync(`${lw.extensionRoot}/data/commands.json`, {encoding: 'utf8'})) as {[key: string]: CmdType} : {}
+        const maths = loadDefault ? (JSON.parse(fs.readFileSync(`${lw.extensionRoot}/data/packages/tex.json`, {encoding: 'utf8'})) as PkgType).cmds: {}
         Object.assign(maths, cmds)
         Object.entries(maths).forEach(([key, cmd]) => {
             cmd.command = key

--- a/src/providers/completer/command.ts
+++ b/src/providers/completer/command.ts
@@ -48,7 +48,7 @@ export class Command implements IProvider {
 
     constructor() {
         lw.registerDisposable(vscode.workspace.onDidChangeConfiguration((e: vscode.ConfigurationChangeEvent) => {
-            if (!e.affectsConfiguration('latex-workshop.intellisense.command.user') ||
+            if (!e.affectsConfiguration('latex-workshop.intellisense.command.user') &&
                 !e.affectsConfiguration('latex-workshop.intellisense.package.exclude')) {
                 return
             }
@@ -57,9 +57,9 @@ export class Command implements IProvider {
     }
 
     initialize(environment: Environment) {
-        const loadDefault = (vscode.workspace.getConfiguration('latex-workshop').get('intellisense.package.exclude') as string[]).includes('lw-default')
-        const cmds = loadDefault ? JSON.parse(fs.readFileSync(`${lw.extensionRoot}/data/commands.json`, {encoding: 'utf8'})) as {[key: string]: CmdType} : {}
-        const maths = loadDefault ? (JSON.parse(fs.readFileSync(`${lw.extensionRoot}/data/packages/tex.json`, {encoding: 'utf8'})) as PkgType).cmds: {}
+        const excludeDefault = (vscode.workspace.getConfiguration('latex-workshop').get('intellisense.package.exclude') as string[]).includes('lw-default')
+        const cmds = excludeDefault ? {} : JSON.parse(fs.readFileSync(`${lw.extensionRoot}/data/commands.json`, {encoding: 'utf8'})) as {[key: string]: CmdType}
+        const maths = excludeDefault ? {} : (JSON.parse(fs.readFileSync(`${lw.extensionRoot}/data/packages/tex.json`, {encoding: 'utf8'})) as PkgType).cmds
         Object.assign(maths, cmds)
         Object.entries(maths).forEach(([key, cmd]) => {
             cmd.command = key

--- a/src/providers/completer/environment.ts
+++ b/src/providers/completer/environment.ts
@@ -44,8 +44,18 @@ export class Environment implements IProvider {
     private readonly packageEnvsAsCommand = new Map<string, CmdEnvSuggestion[]>()
     private readonly packageEnvsForBegin= new Map<string, CmdEnvSuggestion[]>()
 
+    constructor() {
+        lw.registerDisposable(vscode.workspace.onDidChangeConfiguration((e: vscode.ConfigurationChangeEvent) => {
+            if (!e.affectsConfiguration('latex-workshop.intellisense.package.exclude')) {
+                return
+            }
+            this.initialize()
+        }))
+    }
+
     initialize() {
-        const envs = JSON.parse(fs.readFileSync(`${lw.extensionRoot}/data/environments.json`, {encoding: 'utf8'})) as {[key: string]: EnvType}
+        const loadDefault = (vscode.workspace.getConfiguration('latex-workshop').get('intellisense.package.exclude') as string[]).includes('lw-default')
+        const envs = loadDefault ? JSON.parse(fs.readFileSync(`${lw.extensionRoot}/data/environments.json`, {encoding: 'utf8'})) as {[key: string]: EnvType}: {}
         Object.entries(envs).forEach(([key, env]) => {
             env.name = env.name || key
             env.snippet = env.snippet || ''

--- a/src/providers/completer/environment.ts
+++ b/src/providers/completer/environment.ts
@@ -54,8 +54,8 @@ export class Environment implements IProvider {
     }
 
     initialize() {
-        const loadDefault = (vscode.workspace.getConfiguration('latex-workshop').get('intellisense.package.exclude') as string[]).includes('lw-default')
-        const envs = loadDefault ? JSON.parse(fs.readFileSync(`${lw.extensionRoot}/data/environments.json`, {encoding: 'utf8'})) as {[key: string]: EnvType}: {}
+        const excludeDefault = (vscode.workspace.getConfiguration('latex-workshop').get('intellisense.package.exclude') as string[]).includes('lw-default')
+        const envs = excludeDefault ? {} : JSON.parse(fs.readFileSync(`${lw.extensionRoot}/data/environments.json`, {encoding: 'utf8'})) as {[key: string]: EnvType}
         Object.entries(envs).forEach(([key, env]) => {
             env.name = env.name || key
             env.snippet = env.snippet || ''

--- a/test/suites/04_intellisense.test.ts
+++ b/test/suites/04_intellisense.test.ts
@@ -188,7 +188,7 @@ suite('Intellisense test suite', () => {
         assert.ok(!snippet.value.includes('${1:'))
     })
 
-    test.run('command intellisense with config `intellisense.command.user`', async (fixture: string) => {
+    test.only('command intellisense with config `intellisense.command.user`', async (fixture: string) => {
         await vscode.workspace.getConfiguration('latex-workshop').update('intellisense.command.user', {'mycommand[]{}': 'notsamecommand[${2:option}]{$TM_SELECTED_TEXT$1}', 'parbox{}{}': 'defchanged', 'overline{}': ''})
         await test.load(fixture, [
             {src: 'intellisense/base.tex', dst: 'main.tex'},
@@ -322,7 +322,7 @@ suite('Intellisense test suite', () => {
         assert.ok(!suggestions.labels.includes('algorithm2e'))
     })
 
-    test.only('intellisense with config `intellisense.package.exclude`', async (fixture: string) => {
+    test.run('intellisense with config `intellisense.package.exclude`', async (fixture: string) => {
         await vscode.workspace.getConfiguration('latex-workshop').update('intellisense.package.exclude', ['lw-default', 'import', 'listings'])
         await test.load(fixture, [
             {src: 'intellisense/base.tex', dst: 'main.tex'},

--- a/test/suites/04_intellisense.test.ts
+++ b/test/suites/04_intellisense.test.ts
@@ -37,6 +37,7 @@ suite('Intellisense test suite', () => {
         await vscode.workspace.getConfiguration('latex-workshop').update('intellisense.label.keyval', undefined)
         await vscode.workspace.getConfiguration('latex-workshop').update('intellisense.argumentHint.enabled', undefined)
         await vscode.workspace.getConfiguration('latex-workshop').update('intellisense.command.user', undefined)
+        await vscode.workspace.getConfiguration('latex-workshop').update('intellisense.package.exclude', undefined)
     })
 
     test.run('check default environment .json completion file', () => {
@@ -319,6 +320,30 @@ suite('Intellisense test suite', () => {
         ])
         suggestions = test.suggest(3, 1)
         assert.ok(!suggestions.labels.includes('algorithm2e'))
+    })
+
+    test.only('intellisense with config `intellisense.package.exclude`', async (fixture: string) => {
+        await vscode.workspace.getConfiguration('latex-workshop').update('intellisense.package.exclude', ['lw-default', 'import', 'listings'])
+        await test.load(fixture, [
+            {src: 'intellisense/base.tex', dst: 'main.tex'},
+            {src: 'intellisense/sub.tex', dst: 'sub/s.tex'}
+        ])
+        let suggestions = test.suggest(0, 1)
+        assert.ok(!suggestions.labels.includes('\\date{}'))
+        assert.ok(!suggestions.labels.includes('\\lstinline'))
+        assert.ok(!suggestions.labels.includes('\\lstinline'))
+
+        await vscode.workspace.getConfiguration('latex-workshop').update('intellisense.package.exclude', ['lw-default'])
+        suggestions = test.suggest(0, 1)
+        assert.ok(!suggestions.labels.includes('\\date{}'))
+        assert.ok(suggestions.labels.includes('\\lstinline'))
+        assert.ok(suggestions.labels.includes('\\lstinline'))
+
+        await vscode.workspace.getConfiguration('latex-workshop').update('intellisense.package.exclude', ['import', 'listings'])
+        suggestions = test.suggest(0, 1)
+        assert.ok(suggestions.labels.includes('\\date{}'))
+        assert.ok(!suggestions.labels.includes('\\lstinline'))
+        assert.ok(!suggestions.labels.includes('\\lstinline'))
     })
 
     test.run('argument intellisense of \\documentclass, \\usepackage, commands, and environments', async (fixture: string) => {


### PR DESCRIPTION
This PR adds a new config item `intellisense.package.exclude` to blacklist selected packages from intellisense suggestions. Addtionally, a `lw-default` string in the config will also disable all default commands and environments, regardless of `intellisense.package.enabled`.

Resolves #3765 