### PR TITLE
Associate log warnings with no line number to line 1

### DIFF
--- a/src/components/parserlib/latexlog.ts
+++ b/src/components/parserlib/latexlog.ts
@@ -109,7 +109,7 @@ function parseLine(line: string, state: ParserState) {
             const packageExtraLineResult = line.match(latexPackageWarningExtraLines)
             if (packageExtraLineResult) {
                 state.currentResult.text += '\n(' + packageExtraLineResult[1] + ')\t' + packageExtraLineResult[2] + (packageExtraLineResult[4] ? '.' : '')
-                state.currentResult.line = parseInt(packageExtraLineResult[3], 10)
+                state.currentResult.line = packageExtraLineResult[3] ? parseInt(packageExtraLineResult[3], 10) : 1
             } else if (state.insideError) {
                 const match = messageLine.exec(line)
                 if (match && match.length >= 2) {
@@ -175,7 +175,7 @@ function parseLine(line: string, state: ParserState) {
         state.currentResult = {
             type: 'warning',
             file: filename,
-            line: parseInt(result[4], 10),
+            line: result[4] ? parseInt(result[4], 10) : 1,
             text: result[3] + result[5]
         }
         state.searchEmptyLine = true


### PR DESCRIPTION
Close #3774 

Package warnings may not be associated to a line number in the logs. We set them to line 1. 
In many cases, it may be possible to infer the exact line at which the package is actually loaded by parsing `lw.cacher.caches[filename].ast`. I am not sure it is worth it considering the text of warning clearly states what package it is dealing with.