### PR TITLE
Add config `latex-workshop.latex.jobname`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1058,6 +1058,12 @@
           "default": "%DIR%",
           "markdownDescription": "The directory where the extension tries to find project files (e.g., PDF and SyncTeX files) are located. Both relative and absolute paths are supported. Relative path start from the root file location, so beware if it is located in sub-directory. The path must not contain a trailing slash. The LaTeX toolchain should output files to this path. For a list of supported placeholders, please visit https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#placeholders."
         },
+        "latex-workshop.latex.jobname": {
+          "scope": "resource",
+          "type": "string",
+          "default": "",
+          "markdownDescription": "The jobname argument of the compiling tool, which is used by the extension to find project files (e.g., PDF and SyncTeX files). This config should be set identical to the value provided to the `-jobname=` argument, and should not have placeholders. Leave the config empty to ignore jobname and keep the default behavior."
+        },
         "latex-workshop.latex.texDirs": {
           "scope": "window",
           "type": "array",

--- a/src/components/cacherlib/pathutils.ts
+++ b/src/components/cacherlib/pathutils.ts
@@ -16,7 +16,7 @@ const logger = getLogger('Cacher', 'Path')
 export function getFlsFilePath(texFile: string): string | undefined {
     const rootDir = path.dirname(texFile)
     const outDir = lw.manager.getOutDir(texFile)
-    const baseName = path.parse(texFile).name
+    const baseName = path.parse(lw.manager.jobname(texFile)).name
     const flsFile = path.resolve(rootDir, path.join(outDir, baseName + '.fls'))
     if (!fs.existsSync(flsFile)) {
         logger.log(`Non-existent .fls for ${texFile} .`)

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -197,7 +197,10 @@ export class Manager {
      * @param respectOutDir If `true`, the 'latex.outDir' config is respected.
      */
     tex2pdf(texPath: string) {
-        return path.resolve(path.dirname(texPath), this.getOutDir(texPath), path.basename(`${texPath.substring(0, texPath.lastIndexOf('.'))}.pdf`))
+        const config = vscode.workspace.getConfiguration('latex-workshop')
+        const jobname = config.get('latex.jobname') as string
+        const texname = texPath.substring(0, texPath.lastIndexOf('.'))
+        return path.resolve(path.dirname(texPath), this.getOutDir(texPath), path.basename(`${jobname || texname}.pdf`))
     }
 
     /**

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -191,16 +191,24 @@ export class Manager {
     }
 
     /**
+     * Returns the jobname. If empty, return the name of the input `texPath`.
+     *
+     * @param texPath The path of a LaTeX file.
+     */
+    jobname(texPath: string) {
+        const config = vscode.workspace.getConfiguration('latex-workshop')
+        const jobname = config.get('latex.jobname') as string
+        const texname = path.parse(texPath).name
+        return jobname || texname
+    }
+
+    /**
      * Returns the path of a PDF file with respect to `texPath`.
      *
      * @param texPath The path of a LaTeX file.
-     * @param respectOutDir If `true`, the 'latex.outDir' config is respected.
      */
     tex2pdf(texPath: string) {
-        const config = vscode.workspace.getConfiguration('latex-workshop')
-        const jobname = config.get('latex.jobname') as string
-        const texname = texPath.substring(0, texPath.lastIndexOf('.'))
-        return path.resolve(path.dirname(texPath), this.getOutDir(texPath), path.basename(`${jobname || texname}.pdf`))
+        return path.resolve(path.dirname(texPath), this.getOutDir(texPath), path.basename(`${this.jobname(texPath)}.pdf`))
     }
 
     /**

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -196,7 +196,7 @@ export class Manager {
      * @param texPath The path of a LaTeX file.
      */
     jobname(texPath: string) {
-        const config = vscode.workspace.getConfiguration('latex-workshop')
+        const config = vscode.workspace.getConfiguration('latex-workshop', vscode.Uri.file(texPath))
         const jobname = config.get('latex.jobname') as string
         const texname = path.parse(texPath).name
         return jobname || texname


### PR DESCRIPTION
This PR resolves #3769 by adding a new config item `latex-workshop.latex.jobname` to let the extension follow the `-jobname` argument passed to tex.

Similar to `latex-workshop.latex.outDir`, `latex-workshop.latex.jobname` also need to be manually defined besides including the `-jobname` argument in tools.