### PR TITLE
Do not consider % in url encoding as comment

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -66,7 +66,7 @@ export function stripText(raw: string): string {
  * Note the number lines of the output matches the input
  */
 export function stripComments(text: string): string {
-    const reg = /(^|[^\\]|(?:(?<!\\)(?:\\\\)+))%.*$/gm
+    const reg = /(^|[^\\]|(?:(?<!\\)(?:\\\\)+))%(?![2-9A-F][0-9A-F]).*$/gm
     return text.replace(reg, '$1')
 }
 


### PR DESCRIPTION
 This PR attempts to resolve #3789 

The current `stripComments` function removes everything after a `%` sign, yet it may be generated by [HTML URL encoding](https://www.w3schools.com/tags/ref_urlencode.ASP).

This PR patched the regex in the function to look ahead for possible %-url-encoding and ignore them during stripping.