### PR TITLE
\include suggestion does not have file extension

### DIFF
--- a/src/providers/completer/input.ts
+++ b/src/providers/completer/input.ts
@@ -129,7 +129,7 @@ abstract class InputAbstract implements IProvider {
                         }
                         item.range = range
                         item.detail = dir
-                        if (['include'].includes(command)) {
+                        if (['include', 'includeonly', 'excludeonly'].includes(command)) {
                             item.insertText = path.parse(file).name
                         }
                         suggestions.push(item)

--- a/src/providers/completer/input.ts
+++ b/src/providers/completer/input.ts
@@ -129,6 +129,9 @@ abstract class InputAbstract implements IProvider {
                         }
                         item.range = range
                         item.detail = dir
+                        if (['include'].includes(command)) {
+                            item.insertText = path.parse(file).name
+                        }
                         suggestions.push(item)
                     }
                 })

--- a/test/fixtures/armory/intellisense/base.tex
+++ b/test/fixtures/armory/intellisense/base.tex
@@ -17,4 +17,5 @@ label={eq1}
 \includeonly{sub/plain.tex}
 \import{sub/plain}
 \subimport{sub/}{plain.tex}
+\include{}
 \end{document}

--- a/test/suites/04_intellisense.test.ts
+++ b/test/suites/04_intellisense.test.ts
@@ -188,7 +188,7 @@ suite('Intellisense test suite', () => {
         assert.ok(!snippet.value.includes('${1:'))
     })
 
-    test.only('command intellisense with config `intellisense.command.user`', async (fixture: string) => {
+    test.run('command intellisense with config `intellisense.command.user`', async (fixture: string) => {
         await vscode.workspace.getConfiguration('latex-workshop').update('intellisense.command.user', {'mycommand[]{}': 'notsamecommand[${2:option}]{$TM_SELECTED_TEXT$1}', 'parbox{}{}': 'defchanged', 'overline{}': ''})
         await test.load(fixture, [
             {src: 'intellisense/base.tex', dst: 'main.tex'},
@@ -418,6 +418,11 @@ suite('Intellisense test suite', () => {
         assert.ok(suggestions.labels.includes('s.tex'))
         assert.ok(suggestions.labels.includes('plain.tex'))
         assert.ok(!suggestions.labels.includes('sub/'))
+
+        suggestions = test.suggest(19, 9)
+        const item = suggestions.items.find(suggestion => suggestion.label === 'main.tex')
+        assert.ok(item)
+        assert.strictEqual(item.insertText, 'main')
     })
 
     test.run('citation intellisense and configs intellisense.citation.*', async (fixture: string) => {


### PR DESCRIPTION
Resolves #3808 

This PR introduces a patch to remove the file extensions from `\include{}` file suggestions. The label of suggestions include the extension to distinguish multiple files with the same name, but the inserted text excludes the extension.

A new patch on test is included to test this feature.