### PR TITLE
Let ) may also close [ when stripping text

### DIFF
--- a/src/components/parser.ts
+++ b/src/components/parser.ts
@@ -28,7 +28,7 @@ function dispose() {
  * @return undefined if parsing fails
  */
 async function parseLatex(s: string, options?: latexParser.ParserOptions): Promise<latexParser.LatexAst | undefined> {
-    return (await proxy).parseLatex(s, options).timeout(3000).catch(() => undefined)
+    return (await proxy).parseLatex(s, options).timeout(3000)//.catch(() => undefined)
 }
 
 async function parseLatexPreamble(s: string): Promise<latexParser.AstPreamble> {

--- a/src/components/parser.ts
+++ b/src/components/parser.ts
@@ -28,7 +28,7 @@ function dispose() {
  * @return undefined if parsing fails
  */
 async function parseLatex(s: string, options?: latexParser.ParserOptions): Promise<latexParser.LatexAst | undefined> {
-    return (await proxy).parseLatex(s, options).timeout(3000)//.catch(() => undefined)
+    return (await proxy).parseLatex(s, options).timeout(3000).catch(() => undefined)
 }
 
 async function parseLatexPreamble(s: string): Promise<latexParser.AstPreamble> {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -137,6 +137,12 @@ function getLongestBalancedString(s: string, bracket: 'curly' | 'square'='curly'
                 // skip an escaped character
                 i++
                 break
+            case ')':
+                // [1, 2)
+                if (openner === '[') {
+                    nested--
+                }
+                break
             default:
         }
         if (nested === 0) {


### PR DESCRIPTION
This PR partially resolves #3813.

Previously, stripping text before AST considers `[` can be only closed by `]`. This is causing a lot of trouble for range definitions like `[1, 2)`, as the next `]` at a random position is used to close the brace.

This PR makes the `getLongestBalancedString` function take `)` to close `[`. I've tested some use cases and this change indeed creates more authentic stripped tex code.

Nonetheless, the current `utensils` parser is still sometime problematic, especially there are errors in brace pairs. I will look into the issue and work on `parser.ts` to see if there's anything can be done from the extension side.