### PR TITLE
Swap symbols of epsilon and varepsilon

### DIFF
--- a/data/commands.json
+++ b/data/commands.json
@@ -290,10 +290,10 @@
     "detail": "δ, shortcut @d"
   },
   "epsilon": {
-    "detail": "ε, shortcut @e"
+    "detail": "ϵ, shortcut @e"
   },
   "varepsilon": {
-    "detail": "ϵ, shortcut @ve"
+    "detail": "ε, shortcut @ve"
   },
   "eta": {
     "detail": "η, shortcut @h"


### PR DESCRIPTION
I noticed that the preview symbols for `\varepsilon` and `\epsilon` are swapped around.