### PR TITLE
Fix syntax highlighting for citation keys containing numbers

### DIFF
--- a/syntax/LaTeX.tmLanguage.json
+++ b/syntax/LaTeX.tmLanguage.json
@@ -1730,7 +1730,7 @@
 					"match": "((%).*)$"
 				},
 				{
-					"match": "[\\p{Alphabetic}:.-]+",
+					"match": "[\\p{Alphabetic}\\p{Number}\\.:/*!^_-]",
 					"name": "constant.other.reference.citation.latex"
 				}
 			]


### PR DESCRIPTION
This is a continuation of #2855

Currently, citation keys containing numbers (which is very common for academic writing, such as the year of publication) are not properly highlighted. 

With this fix, numbers (and some other symbols such as underscore) are captured by syntax highlighting.

I was not able to find any "official" list of forbidden characters, but [this post ](https://tex.stackexchange.com/questions/335298/bibtexs-formal-format-for-citation-key-field)makes a few good points.