### PR TITLE
Change caption in BTA to top, add a BTB snippet

### DIFF
--- a/data/latex-snippet.json
+++ b/data/latex-snippet.json
@@ -91,6 +91,11 @@
 	},
 	"table": {
 		"prefix": "BTA",
+		"body": "\\begin{table}[${1:htbp}]\n\t\\centering\t\\caption{${2:<caption>}}\n\t\\label{${3:<label>}}\n\\begin{tabular}{${4:<columns>}}\n\t\t${0:${TM_SELECTED_TEXT}}\n\t\\end{tabular}\n\\end{table}",
+		"description": "table"
+	},
+	"table and bottom caption": {
+		"prefix": "BTB",
 		"body": "\\begin{table}[${1:htbp}]\n\t\\centering\\begin{tabular}{${4:<columns>}}\n\t\t${0:${TM_SELECTED_TEXT}}\n\t\\end{tabular}\n\t\\caption{${2:<caption>}}\n\t\\label{${3:<label>}}\n\\end{table}",
 		"description": "table"
 	},

--- a/data/latex-snippet.json
+++ b/data/latex-snippet.json
@@ -89,12 +89,12 @@
 		"body": "\\begin{figure}[${1:htbp}]\n\t\\centering\n\t${0:${TM_SELECTED_TEXT}}\n\t\\caption{${2:<caption>}}\n\t\\label{${3:<label>}}\n\\end{figure}",
 		"description": "figure"
 	},
-	"table": {
+	"table (caption after tabular)": {
 		"prefix": "BTA",
 		"body": "\\begin{table}[${1:htbp}]\n\t\\centering\\begin{tabular}{${4:<columns>}}\n\t\t${0:${TM_SELECTED_TEXT}}\n\t\\end{tabular}\n\t\\caption{${2:<caption>}}\n\t\\label{${3:<label>}}\n\\end{table}",
 		"description": "table"
 	},
-	"table and top caption": {
+	"table (caption before tabular)": {
 		"prefix": "BTT",
 		"body": "\\begin{table}[${1:htbp}]\n\t\\centering\t\\caption{${2:<caption>}}\n\t\\label{${3:<label>}}\n\\begin{tabular}{${4:<columns>}}\n\t\t${0:${TM_SELECTED_TEXT}}\n\t\\end{tabular}\n\\end{table}",
 		"description": "table"

--- a/data/latex-snippet.json
+++ b/data/latex-snippet.json
@@ -95,7 +95,7 @@
 		"description": "table"
 	},
 	"table (caption before tabular)": {
-		"prefix": "BTT",
+		"prefix": "BTB",
 		"body": "\\begin{table}[${1:htbp}]\n\t\\centering\t\\caption{${2:<caption>}}\n\t\\label{${3:<label>}}\n\\begin{tabular}{${4:<columns>}}\n\t\t${0:${TM_SELECTED_TEXT}}\n\t\\end{tabular}\n\\end{table}",
 		"description": "table"
 	},

--- a/data/latex-snippet.json
+++ b/data/latex-snippet.json
@@ -91,12 +91,12 @@
 	},
 	"table": {
 		"prefix": "BTA",
-		"body": "\\begin{table}[${1:htbp}]\n\t\\centering\t\\caption{${2:<caption>}}\n\t\\label{${3:<label>}}\n\\begin{tabular}{${4:<columns>}}\n\t\t${0:${TM_SELECTED_TEXT}}\n\t\\end{tabular}\n\\end{table}",
+		"body": "\\begin{table}[${1:htbp}]\n\t\\centering\\begin{tabular}{${4:<columns>}}\n\t\t${0:${TM_SELECTED_TEXT}}\n\t\\end{tabular}\n\t\\caption{${2:<caption>}}\n\t\\label{${3:<label>}}\n\\end{table}",
 		"description": "table"
 	},
-	"table and bottom caption": {
-		"prefix": "BTB",
-		"body": "\\begin{table}[${1:htbp}]\n\t\\centering\\begin{tabular}{${4:<columns>}}\n\t\t${0:${TM_SELECTED_TEXT}}\n\t\\end{tabular}\n\t\\caption{${2:<caption>}}\n\t\\label{${3:<label>}}\n\\end{table}",
+	"table and top caption": {
+		"prefix": "BTT",
+		"body": "\\begin{table}[${1:htbp}]\n\t\\centering\t\\caption{${2:<caption>}}\n\t\\label{${3:<label>}}\n\\begin{tabular}{${4:<columns>}}\n\t\t${0:${TM_SELECTED_TEXT}}\n\t\\end{tabular}\n\\end{table}",
 		"description": "table"
 	},
 	"tikzpicture": {


### PR DESCRIPTION
This PR fixes #3831.

This PR changed the position of table caption in snippet `BTA` to the beginning of `table` environment, before `tabular` environment.

The original `BTA` layout is preserved in a new snippet `BTB`, in which the second `B` stands for ta**b**le and also **b**ottom.