### PR TITLE
Fix for Dockerfile smell DL3008

### DIFF
--- a/samples/docker/.devcontainer/Dockerfile
+++ b/samples/docker/.devcontainer/Dockerfile
@@ -7,23 +7,23 @@ FROM ubuntu:latest
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1
+    && apt-get -y install --no-install-recommends apt-utils=2.4.* 2>&1 
 
 # Verify git and needed tools are installed
-RUN apt-get install --no-install-recommends -y git procps
+RUN apt-get install --no-install-recommends -y git=1:2.34.* procps=2:3.3.* 
 
 # Install Tex Live
 RUN apt-get update && apt-get -y upgrade \
     && apt-get -y install --no-install-recommends \
-    texlive-latex-base \
-    texlive-extra-utils \
-    texlive-latex-extra \
-    biber chktex latexmk make python3-pygments python3-pkg-resources \
-    texlive-lang-chinese \
-    texlive-lang-japanese
+    texlive-latex-base=2021.20220204-* \ 
+    texlive-extra-utils=2021.20220204-* \ 
+    texlive-latex-extra=2021.20220204-* \ 
+    biber=2.17-* chktex=1.7.* latexmk=1:4.76-* make=4.3-* python3-pygments=2.11.* python3-pkg-resources=59.6.* \ 
+    texlive-lang-chinese=2021.20220204-* \ 
+    texlive-lang-japanese=2021.20220204-* 
 
 # latexindent modules
-RUN apt-get install --no-install-recommends -y curl
+RUN apt-get install --no-install-recommends -y curl=7.81.* 
 RUN curl -L http://cpanmin.us | perl - App::cpanminus \
     && cpanm Log::Dispatch::File \
     && cpanm YAML::Tiny \


### PR DESCRIPTION
Hi!
The Dockerfile placed at "samples/docker/.devcontainer/Dockerfile" contains the best practice violation [DL3008](https://github.com/hadolint/hadolint/wiki/DL3008) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3008 occurs when the version pinning for the installed packages with apt is not specified. This could lead to unexpected behavior when building the Dockerfile.
In this pull request, we propose a fix for that smell generated by our fixing tool. We have verified that the patch is correct before opening the pull request.
To fix this smell, specifically, we use a heuristic approach that selects the most probable version tag for a given apt package corresponding to the latest version at the current date. The package versions are retrieved from the Canonical Launchpad APIs.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance