### PR TITLE
Properly stringify bibtex fields containing `#`

### DIFF
--- a/src/components/parser.ts
+++ b/src/components/parser.ts
@@ -159,10 +159,23 @@ function latexmkSkipped(log: string): boolean {
     return false
 }
 
+/**
+ * Convert a bibtexParser.FieldValue to a string
+ * @param field the bibtexParser.FieldValue to parse
+ */
+function fieldValueToString(field: bibtexParser.FieldValue): string {
+    if (field.kind === 'concat') {
+        return field.content.map(value => fieldValueToString(value)).reduce((acc, cur) => {return acc + ' # ' + cur})
+    } else {
+        return field.content
+    }
+}
+
 export const parser = {
     parseLatex,
     parseLatexPreamble,
     parseBibtex,
     parseLog,
-    dispose
+    dispose,
+    fieldValueToString
 }

--- a/src/components/parser.ts
+++ b/src/components/parser.ts
@@ -159,23 +159,11 @@ function latexmkSkipped(log: string): boolean {
     return false
 }
 
-/**
- * Convert a bibtexParser.FieldValue to a string
- * @param field the bibtexParser.FieldValue to parse
- */
-function fieldValueToString(field: bibtexParser.FieldValue): string {
-    if (field.kind === 'concat') {
-        return field.content.map(value => fieldValueToString(value)).reduce((acc, cur) => {return acc + ' # ' + cur})
-    } else {
-        return field.content
-    }
-}
 
 export const parser = {
     parseLatex,
     parseLatexPreamble,
     parseBibtex,
     parseLog,
-    dispose,
-    fieldValueToString
+    dispose
 }

--- a/src/providers/structurelib/bibtex.ts
+++ b/src/providers/structurelib/bibtex.ts
@@ -7,6 +7,18 @@ import { getLogger } from '../../components/logger'
 
 const logger = getLogger('Structure', 'BibTeX')
 
+/**
+* Convert a bibtexParser.FieldValue to a string
+* @param field the bibtexParser.FieldValue to parse
+*/
+function fieldValueToString(field: bibtexParser.FieldValue): string {
+   if (field.kind === 'concat') {
+       return field.content.map(value => fieldValueToString(value)).reduce((acc, cur) => {return acc + ' # ' + cur})
+   } else {
+       return field.content
+   }
+}
+
 export async function buildBibTeX(document: vscode.TextDocument): Promise<Section[]> {
     const configuration = vscode.workspace.getConfiguration('latex-workshop', vscode.Uri.file(document.fileName))
     if (document.getText().length >= (configuration.get('bibtex.maxFileSize') as number) * 1024 * 1024) {
@@ -31,7 +43,7 @@ export async function buildBibTeX(document: vscode.TextDocument): Promise<Sectio
                 entry.location.end.line - 1,
                 document.fileName)
             entry.content.forEach(field => {
-                const content = parser.fieldValueToString(field.value)
+                const content = fieldValueToString(field.value)
                 const fielditem = new Section(
                     SectionKind.BibField,
                     `${field.name}: ${content}`,

--- a/src/providers/structurelib/bibtex.ts
+++ b/src/providers/structurelib/bibtex.ts
@@ -31,9 +31,10 @@ export async function buildBibTeX(document: vscode.TextDocument): Promise<Sectio
                 entry.location.end.line - 1,
                 document.fileName)
             entry.content.forEach(field => {
+                const content = parser.fieldValueToString(field.value)
                 const fielditem = new Section(
                     SectionKind.BibField,
-                    `${field.name}: ${field.value.content}`,
+                    `${field.name}: ${content}`,
                     vscode.TreeItemCollapsibleState.None,
                     1,
                     field.location.start.line -1,


### PR DESCRIPTION
Related to #3835.

This PR stringifies bibtex fields. This fixes

> * Finally, if string concatenation is used in a bibtex entry, the intellisense preview shows `[object Object]`. I believe this is another bug.

