### PR TITLE
More cleaning methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -1308,6 +1308,12 @@
           ],
           "markdownDescription": "Files to clean. This property must be an array of strings. File globs such as `*.removeme`, `something?.aux` can be used. Users can also specify glob patterns like `emptyfolder*/` to remove empty folders. Non-empty folders will be ignored. The folder globs must end with a slash and the last path component must not contain the globstar `**`, otherwise the folders will not be removed. The following globs patterns are correct `['abc/', 'abc*/', '**/abc*/', 'abc/**/def/']` but these are not ['**', '**/', 'abc/**', 'abc/**/', 'abc/def**/', 'abc/d**ef/']`."
         },
+        "latex-workshop.latex.clean.jobname": {
+          "scope": "resource",
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Defines whether the globed files by `#latex-workshop.latex.clean.fileTypes#` should have the same file name as the current job name to be cleaned."
+        },
         "latex-workshop.latex.clean.command": {
           "scope": "resource",
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -1308,12 +1308,6 @@
           ],
           "markdownDescription": "Files to clean when `#latex-workshop.latex.clean.method#` is set to `glob`.. This property must be an array of strings. File globs such as `*.removeme`, `something?.aux` can be used. Users can also specify glob patterns like `emptyfolder*/` to remove empty folders. Non-empty folders will be ignored. The folder globs must end with a slash and the last path component must not contain the globstar `**`, otherwise the folders will not be removed. The following globs patterns are correct `['abc/', 'abc*/', '**/abc*/', 'abc/**/def/']` but these are not ['**', '**/', 'abc/**', 'abc/**/', 'abc/def**/', 'abc/d**ef/']`."
         },
-        "latex-workshop.latex.clean.jobname": {
-          "scope": "resource",
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "Defines whether the globed files by `#latex-workshop.latex.clean.fileTypes#` should have the same file name as the current job name to be cleaned."
-        },
         "latex-workshop.latex.clean.command": {
           "scope": "resource",
           "type": "string",
@@ -1338,10 +1332,14 @@
           "default": "glob",
           "enum": [
             "glob",
+            "globActive",
+            "globRoot",
             "command"
           ],
           "markdownEnumDescriptions": [
             "Clean all the files located in `#latex-workshop.latex.outDir#` and matching the glob patterns listed in `#latex-workshop.latex.clean.fileTypes#`.",
+            "Clean all the files located in `#latex-workshop.latex.outDir#` and matching the glob patterns listed in `#latex-workshop.latex.clean.fileTypes#`. The cleaned file will have the same as the current active LaTeX file. If the active one is not LaTeX, this config falls back to `globRoot`.",
+            "Clean all the files located in `#latex-workshop.latex.outDir#` and matching the glob patterns listed in `#latex-workshop.latex.clean.fileTypes#`. The cleaned file will have the same as the jobname or root file. If the root file is not defined, the cleaner will do nothing.",
             "Run `#latex-workshop.latex.clean.command#` to clean temporary files."
           ],
           "markdownDescription": "Define how temporary files will be cleaned."

--- a/src/components/cleaner.ts
+++ b/src/components/cleaner.ts
@@ -111,7 +111,10 @@ export class Cleaner {
 
         const explicitFolders: string[] = globAll(folderGlobsExplicit, outdir)
         const explicitFoldersSet: Set<string> = new Set(explicitFolders)
-        const filesOrFolders: string[] = globAll(fileOrFolderGlobs, outdir).filter(file => !explicitFoldersSet.has(file))
+        const jobName = (configuration.get('latex-workshop.latex.clean.jobname') as boolean && lw.manager.rootFile) ? lw.manager.jobname(lw.manager.rootFile) : undefined
+        const filesOrFolders: string[] = globAll(fileOrFolderGlobs, outdir)
+            .filter(file => !explicitFoldersSet.has(file))
+            .filter(file => jobName ? path.parse(file).name === jobName : true)
 
         // Remove files first
         for (const realPath of filesOrFolders) {

--- a/src/components/cleaner.ts
+++ b/src/components/cleaner.ts
@@ -49,7 +49,7 @@ export class Cleaner {
         const cleanMethod = configuration.get('latex.clean.method') as string
 
         const active = vscode.window.activeTextEditor
-        const rootFileName = rootFile ? lw.manager.jobname(rootFile) : undefined
+        const rootFileName = lw.manager.jobname(rootFile)
         const activeFileName = (active && lw.manager.hasTexId(active.document.languageId)) ?
             path.parse(active.document.fileName).name : rootFileName
         switch (cleanMethod) {
@@ -63,12 +63,7 @@ export class Cleaner {
                     return
                 }
             case 'globRoot':
-                if (rootFileName) {
-                    return this.cleanGlob(rootFile, rootFileName)
-                } else {
-                    logger.log('No root file or jobname is defined. Cleaning terminated.')
-                    return
-                }
+                return this.cleanGlob(rootFile, rootFileName)
             case 'cleanCommand':
                 await configuration.update('latex.clean.method', 'command')
                 void vscode.window.showInformationMessage('The cleaning method `cleanCommand` has been renamed to `command`. Your config is auto-updated.')

--- a/src/components/cleaner.ts
+++ b/src/components/cleaner.ts
@@ -49,7 +49,7 @@ export class Cleaner {
         const cleanMethod = configuration.get('latex.clean.method') as string
 
         const active = vscode.window.activeTextEditor
-        const rootFileName = lw.manager.rootFile ? lw.manager.jobname(rootFile) : undefined
+        const rootFileName = rootFile ? lw.manager.jobname(rootFile) : undefined
         const activeFileName = (active && lw.manager.hasTexId(active.document.languageId)) ?
             path.parse(active.document.fileName).name : rootFileName
         switch (cleanMethod) {

--- a/test/suites/utils.ts
+++ b/test/suites/utils.ts
@@ -149,7 +149,7 @@ export async function load(fixture: string, files: {src: string, dst: string, ws
     }
 }
 
-export async function open(filePath: string) {
+async function open(filePath: string) {
     const doc = await vscode.workspace.openTextDocument(filePath)
     await vscode.window.showTextDocument(doc)
 }


### PR DESCRIPTION
This PR resolves #3849 

This PR introduces two new cleaning methods to `latex.clean.method`, namely,
- `globActive`: Glob files. The cleaned file will have the same as the current active LaTeX file. If the active one is not LaTeX, this config falls back to `globRoot`.
- `globRoot`: The cleaned file will have the same as the jobname or root file. If the root file is not defined, the cleaner will do nothing.

Two new tests are included to test these two cases.