### PR TITLE
Add a configuration item to choose the root file indicator.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,2606 +1,2606 @@
 {
-  "name": "latex-workshop",
-  "displayName": "LaTeX Workshop",
-  "description": "Boost LaTeX typesetting efficiency with preview, compile, autocomplete, colorize, and more.",
-  "icon": "icons/icon.png",
-  "version": "9.8.2",
-  "publisher": "James-Yu",
-  "license": "MIT",
-  "homepage": "https://github.com/James-Yu/LaTeX-Workshop",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/James-Yu/LaTeX-Workshop.git"
-  },
-  "engines": {
-    "vscode": "^1.74.0"
-  },
-  "categories": [
-    "Programming Languages",
-    "Snippets",
-    "Linters",
-    "Formatters"
-  ],
-  "keywords": [
-    "latex",
-    "tex",
-    "compile",
-    "preview",
-    "hint"
-  ],
-  "activationEvents": [
-    "onCommand:latex-workshop.activate",
-    "onWebviewPanel:latex-workshop-pdf"
-  ],
-  "main": "./out/src/main.js",
-  "capabilities": {
-    "virtualWorkspaces": {
-      "supported": "limited",
-      "description": "Only a few features are supported."
+    "name": "latex-workshop",
+    "displayName": "LaTeX Workshop",
+    "description": "Boost LaTeX typesetting efficiency with preview, compile, autocomplete, colorize, and more.",
+    "icon": "icons/icon.png",
+    "version": "9.8.2",
+    "publisher": "James-Yu",
+    "license": "MIT",
+    "homepage": "https://github.com/James-Yu/LaTeX-Workshop",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/James-Yu/LaTeX-Workshop.git"
     },
-    "untrustedWorkspaces": {
-      "supported": false
-    }
-  },
-  "contributes": {
-    "languages": [
-      {
-        "id": "tex",
-        "aliases": [
-          "TeX",
-          "tex"
-        ],
-        "extensions": [
-          ".sty",
-          ".cls",
-          ".bbx",
-          ".cbx"
-        ],
-        "configuration": "./syntax/latex-language-configuration.json"
-      },
-      {
-        "id": "doctex",
-        "aliases": [
-          "DocTeX",
-          "doctex"
-        ],
-        "extensions": [
-          ".dtx"
-        ],
-        "configuration": "./syntax/doctex-language-configuration.json"
-      },
-      {
-        "id": "latex",
-        "aliases": [
-          "LaTeX",
-          "latex"
-        ],
-        "extensions": [
-          ".tex",
-          ".ltx",
-          ".ctx"
-        ],
-        "configuration": "./syntax/latex-language-configuration.json"
-      },
-      {
-        "id": "bibtex",
-        "aliases": [
-          "BibTeX",
-          "bibtex"
-        ],
-        "extensions": [
-          ".bib"
-        ],
-        "configuration": "./syntax/bibtex-language-configuration.json"
-      },
-      {
-        "id": "bibtex-style",
-        "aliases": [
-          "BibTeX style"
-        ],
-        "extensions": [
-          ".bst"
-        ],
-        "configuration": "./syntax/bibtex-style-language-configuration.json"
-      },
-      {
-        "id": "latex-expl3",
-        "aliases": [
-          "LaTeX-Expl3"
-        ],
-        "configuration": "./syntax/latex3-language-configuration.json"
-      },
-      {
-        "id": "pweave",
-        "aliases": [
-          "Pweave"
-        ],
-        "extensions": [
-          ".pnw",
-          ".ptexw"
-        ],
-        "configuration": "./syntax/latex-language-configuration.json"
-      },
-      {
-        "id": "jlweave",
-        "aliases": [
-          "Weave.jl"
-        ],
-        "extensions": [
-          ".jnw",
-          ".jtexw"
-        ],
-        "configuration": "./syntax/latex-language-configuration.json"
-      },
-      {
-        "id": "rsweave",
-        "aliases": [
-          "R Sweave"
-        ],
-        "extensions": [
-          ".rnw",
-          ".Rnw",
-          ".Rtex",
-          ".rtex",
-          ".snw",
-          ".Snw"
-        ],
-        "configuration": "./syntax/latex-language-configuration.json"
-      },
-      {
-        "id": "cpp_embedded_latex",
-        "configuration": "./syntax/latex-cpp-embedded-language-configuration.json"
-      },
-      {
-        "id": "markdown_latex_combined",
-        "configuration": "./syntax/markdown-latex-combined-language-configuration.json"
-      }
-    ],
-    "grammars": [
-      {
-        "language": "tex",
-        "scopeName": "text.tex",
-        "path": "./syntax/TeX.tmLanguage.json"
-      },
-      {
-        "language": "doctex",
-        "scopeName": "text.tex.doctex",
-        "path": "./syntax/DocTeX.tmLanguage.json"
-      },
-      {
-        "language": "latex",
-        "scopeName": "text.tex.latex",
-        "path": "./syntax/LaTeX.tmLanguage.json",
-        "embeddedLanguages": {
-          "source.asymptote": "asymptote",
-          "source.cpp": "cpp_embedded_latex",
-          "source.css": "css",
-          "source.dot": "dot",
-          "source.gnuplot": "gnuplot",
-          "text.html": "html",
-          "source.java": "java",
-          "source.js": "javascript",
-          "source.julia": "julia",
-          "source.lua": "lua",
-          "source.python": "python",
-          "source.ruby": "ruby",
-          "source.scala": "scala",
-          "source.ts": "typescript",
-          "text.xml": "xml",
-          "source.yaml": "yaml",
-          "meta.embedded.markdown_latex_combined": "markdown_latex_combined"
-        }
-      },
-      {
-        "language": "bibtex",
-        "scopeName": "text.bibtex",
-        "path": "./syntax/Bibtex.tmLanguage.json"
-      },
-      {
-        "language": "bibtex-style",
-        "scopeName": "source.bst",
-        "path": "./syntax/BibTeX-style.tmLanguage.json"
-      },
-      {
-        "language": "latex-expl3",
-        "scopeName": "text.tex.latex.expl3",
-        "path": "./syntax/LaTeX-Expl3.tmLanguage.json"
-      },
-      {
-        "language": "markdown_latex_combined",
-        "scopeName": "text.tex.markdown_latex_combined",
-        "path": "./syntax/markdown-latex-combined.tmLanguage.json"
-      },
-      {
-        "language": "cpp_embedded_latex",
-        "scopeName": "source.cpp.embedded.latex",
-        "path": "./syntax/cpp-grammar-bailout.tmLanguage.json",
-        "embeddedLanguages": {
-          "meta.embedded.assembly.cpp": "asm"
-        }
-      },
-      {
-        "language": "pweave",
-        "scopeName": "text.tex.latex.pweave",
-        "path": "./syntax/Pweave.tmLanguage.json",
-        "embeddedLanguages": {
-          "source.python": "python"
-        }
-      },
-      {
-        "language": "jlweave",
-        "scopeName": "text.tex.latex.jlweave",
-        "path": "./syntax/JLweave.tmLanguage.json",
-        "embeddedLanguages": {
-          "source.julia": "julia"
-        }
-      },
-      {
-        "language": "rsweave",
-        "scopeName": "text.tex.latex.rsweave",
-        "path": "./syntax/RSweave.tmLanguage.json",
-        "embeddedLanguages": {
-          "source.r": "r"
-        }
-      }
-    ],
-    "snippets": [
-      {
-        "language": "latex",
-        "path": "./data/latex-snippet.json"
-      },
-      {
-        "language": "pweave",
-        "path": "./data/latex-snippet.json"
-      },
-      {
-        "language": "jlweave",
-        "path": "./data/latex-snippet.json"
-      },
-      {
-        "language": "rsweave",
-        "path": "./data/latex-snippet.json"
-      },
-      {
-        "language": "latex-expl3",
-        "path": "./data/latex-snippet.json"
-      }
-    ],
-    "commands": [
-      {
-        "command": "latex-workshop.navigate-envpair",
-        "title": "Navigate to matching begin/end",
-        "category": "LaTeX Workshop"
-      },
-      {
-        "command": "latex-workshop.select-envname",
-        "title": "Select the current environment name",
-        "category": "LaTeX Workshop"
-      },
-      {
-        "command": "latex-workshop.select-envcontent",
-        "title": "Select the current environment content",
-        "category": "LaTeX Workshop"
-      },
-      {
-        "command": "latex-workshop.select-env",
-        "title": "Select the current environment",
-        "category": "LaTeX Workshop"
-      },
-      {
-        "command": "latex-workshop.multicursor-envname",
-        "title": "Add a multicursor to the current environment name",
-        "category": "LaTeX Workshop"
-      },
-      {
-        "command": "latex-workshop.wrap-env",
-        "title": "Surround selection with \\begin{}...\\end{}",
-        "category": "LaTeX Workshop"
-      },
-      {
-        "command": "latex-workshop.surround",
-        "title": "Surround selection with LaTeX command",
-        "category": "LaTeX Workshop"
-      },
-      {
-        "command": "latex-workshop.close-env",
-        "title": "Close current environment",
-        "category": "LaTeX Workshop"
-      },
-      {
-        "command": "latex-workshop.toggle-equation-envname",
-        "title": "Toggle between \\[...\\] and \\begin{}...\\end{}",
-        "category": "LaTeX Workshop"
-      },
-      {
-        "command": "latex-workshop.saveWithoutBuilding",
-        "title": "Save without Building",
-        "category": "LaTeX Workshop"
-      },
-      {
-        "command": "latex-workshop.build",
-        "title": "Build LaTeX project",
-        "category": "LaTeX Workshop",
-        "icon": "$(debug-start)",
-        "enablement": "!virtualWorkspace"
-      },
-      {
-        "command": "latex-workshop.recipes",
-        "title": "Build with recipe",
-        "category": "LaTeX Workshop",
-        "enablement": "!virtualWorkspace"
-      },
-      {
-        "command": "latex-workshop.view",
-        "title": "View LaTeX PDF file",
-        "category": "LaTeX Workshop",
-        "icon": "$(open-preview)",
-        "enablement": "!virtualWorkspace"
-      },
-      {
-        "command": "latex-workshop.tab",
-        "title": "View LaTeX PDF file in VSCode tab",
-        "category": "LaTeX Workshop"
-      },
-      {
-        "command": "latex-workshop.viewInBrowser",
-        "title": "View LaTeX PDF file in web browser",
-        "category": "LaTeX Workshop",
-        "enablement": "!virtualWorkspace"
-      },
-      {
-        "command": "latex-workshop.viewExternal",
-        "title": "View LaTeX PDF file in external viewer",
-        "category": "LaTeX Workshop",
-        "enablement": "!virtualWorkspace"
-      },
-      {
-        "command": "latex-workshop.refresh-viewer",
-        "title": "Refresh all LaTeX PDF viewers",
-        "category": "LaTeX Workshop"
-      },
-      {
-        "command": "latex-workshop.kill",
-        "title": "Kill LaTeX compiler process",
-        "category": "LaTeX Workshop",
-        "enablement": "!virtualWorkspace"
-      },
-      {
-        "command": "latex-workshop.synctex",
-        "title": "SyncTeX from cursor",
-        "category": "LaTeX Workshop",
-        "enablement": "!virtualWorkspace"
-      },
-      {
-        "command": "latex-workshop.clean",
-        "title": "Clean up auxiliary files",
-        "category": "LaTeX Workshop",
-        "enablement": "!virtualWorkspace"
-      },
-      {
-        "command": "latex-workshop.citation",
-        "title": "Open citation browser",
-        "category": "LaTeX Workshop",
-        "enablement": "!virtualWorkspace"
-      },
-      {
-        "command": "latex-workshop.addtexroot",
-        "title": "Insert %!TeX root magic comment",
-        "category": "LaTeX Workshop"
-      },
-      {
-        "command": "latex-workshop.wordcount",
-        "title": "Count words in LaTeX document",
-        "category": "LaTeX Workshop"
-      },
-      {
-        "command": "latex-workshop.changeHostName",
-        "title": "Change server listening hostname",
-        "category": "LaTeX Workshop"
-      },
-      {
-        "command": "latex-workshop.resetHostName",
-        "title": "Reset server listening hostname to 127.0.0.1",
-        "category": "LaTeX Workshop"
-      },
-      {
-        "command": "latex-workshop.compilerlog",
-        "title": "View LaTeX compiler logs",
-        "category": "LaTeX Workshop",
-        "enablement": "!virtualWorkspace"
-      },
-      {
-        "command": "latex-workshop.log",
-        "title": "Show LaTeX Workshop messages",
-        "category": "LaTeX Workshop"
-      },
-      {
-        "command": "latex-workshop.actions",
-        "title": "LaTeX actions",
-        "category": "LaTeX Workshop"
-      },
-      {
-        "command": "latex-workshop-dev.parselog",
-        "title": "Parse current document as LaTeX logs",
-        "category": "LaTeX Workshop DevTools"
-      },
-      {
-        "command": "latex-workshop-dev.parsetex",
-        "title": "Parse current file as LaTeX AST",
-        "category": "LaTeX Workshop DevTools"
-      },
-      {
-        "command": "latex-workshop-dev.parsebib",
-        "title": "Parse current file as BibTeX AST",
-        "category": "LaTeX Workshop DevTools"
-      },
-      {
-        "command": "latex-workshop-dev.striptext",
-        "title": "Strip text and comments from LaTeX.",
-        "category": "LaTeX Workshop DevTools"
-      },
-      {
-        "command": "latex-workshop.texdoc",
-        "title": "Show package documentation",
-        "category": "LaTeX Workshop"
-      },
-      {
-        "command": "latex-workshop.texdocUsepackages",
-        "title": "Show package documentation actually used",
-        "category": "LaTeX Workshop"
-      },
-      {
-        "command": "latex-workshop.promote-sectioning",
-        "title": "Promote all the section levels used in the selection",
-        "category": "LaTeX Workshop"
-      },
-      {
-        "command": "latex-workshop.demote-sectioning",
-        "title": "Demote all the section levels used in the selection",
-        "category": "LaTeX Workshop"
-      },
-      {
-        "command": "latex-workshop.select-section",
-        "title": "Select the current section",
-        "category": "LaTeX Workshop"
-      },
-      {
-        "command": "latex-workshop.structure-toggle-follow-cursor",
-        "title": "Toggle follow cursor",
-        "category": "LaTeX Workshop"
-      },
-      {
-        "command": "latex-workshop.bibsort",
-        "title": "Sort BibTeX file",
-        "category": "LaTeX Workshop"
-      },
-      {
-        "command": "latex-workshop.bibalign",
-        "title": "Align BibTeX file",
-        "category": "LaTeX Workshop"
-      },
-      {
-        "command": "latex-workshop.bibalignsort",
-        "title": "Sort and align BibTeX file",
-        "category": "LaTeX Workshop"
-      },
-      {
-        "command": "latex-workshop.openMathPreviewPanel",
-        "title": "Open Math Preview Panel",
-        "category": "LaTeX Workshop"
-      },
-      {
-        "command": "latex-workshop.closeMathPreviewPanel",
-        "title": "Close Math Preview Panel",
-        "category": "LaTeX Workshop"
-      },
-      {
-        "command": "latex-workshop.toggleMathPreviewPanel",
-        "title": "Toggle Math Preview Panel",
-        "category": "LaTeX Workshop"
-      }
-    ],
-    "keybindings": [
-      {
-        "key": "ctrl+l alt+m",
-        "mac": "cmd+l alt+m",
-        "command": "latex-workshop.toggleMathPreviewPanel",
-        "when": "editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && config.latex-workshop.bind.altKeymap.enabled"
-      },
-      {
-        "key": "ctrl+l alt+b",
-        "mac": "cmd+l alt+b",
-        "command": "latex-workshop.build",
-        "when": "editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && config.latex-workshop.bind.altKeymap.enabled && !virtualWorkspace"
-      },
-      {
-        "key": "ctrl+l alt+c",
-        "mac": "cmd+l alt+c",
-        "command": "latex-workshop.clean",
-        "when": "editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && config.latex-workshop.bind.altKeymap.enabled && !virtualWorkspace"
-      },
-      {
-        "key": "ctrl+l alt+v",
-        "mac": "cmd+l alt+v",
-        "command": "latex-workshop.view",
-        "when": "editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && config.latex-workshop.bind.altKeymap.enabled && !virtualWorkspace"
-      },
-      {
-        "key": "ctrl+l alt+j",
-        "mac": "cmd+l alt+j",
-        "command": "latex-workshop.synctex",
-        "when": "editorTextFocus && editorLangId == 'latex' && config.latex-workshop.bind.altKeymap.enabled && !virtualWorkspace"
-      },
-      {
-        "key": "ctrl+l alt+x",
-        "mac": "cmd+l alt+x",
-        "command": "workbench.view.extension.latex-workshop-activitybar",
-        "when": "config.latex-workshop.bind.altKeymap.enabled"
-      },
-      {
-        "key": "ctrl+alt+m",
-        "mac": "cmd+alt+m",
-        "command": "latex-workshop.toggleMathPreviewPanel",
-        "when": "editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && !config.latex-workshop.bind.altKeymap.enabled"
-      },
-      {
-        "key": "ctrl+alt+b",
-        "mac": "cmd+alt+b",
-        "command": "latex-workshop.build",
-        "when": "editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && !config.latex-workshop.bind.altKeymap.enabled && !virtualWorkspace"
-      },
-      {
-        "key": "ctrl+alt+c",
-        "mac": "cmd+alt+c",
-        "command": "latex-workshop.clean",
-        "when": "editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && !config.latex-workshop.bind.altKeymap.enabled && !virtualWorkspace"
-      },
-      {
-        "key": "ctrl+alt+v",
-        "mac": "cmd+alt+v",
-        "command": "latex-workshop.view",
-        "when": "editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && !config.latex-workshop.bind.altKeymap.enabled && !virtualWorkspace"
-      },
-      {
-        "key": "ctrl+alt+j",
-        "mac": "cmd+alt+j",
-        "command": "latex-workshop.synctex",
-        "when": "editorTextFocus && editorLangId == 'latex' && !config.latex-workshop.bind.altKeymap.enabled && !virtualWorkspace"
-      },
-      {
-        "key": "ctrl+alt+x",
-        "mac": "cmd+alt+x",
-        "command": "workbench.view.extension.latex-workshop-activitybar",
-        "when": "!config.latex-workshop.bind.altKeymap.enabled"
-      },
-      {
-        "key": "ctrl+l [",
-        "mac": "cmd+l [",
-        "when": "config.latex-workshop.bind.altKeymap.enabled && editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
-        "command": "latex-workshop.promote-sectioning"
-      },
-      {
-        "key": "ctrl+l ]",
-        "mac": "cmd+l ]",
-        "when": "config.latex-workshop.bind.altKeymap.enabled && editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
-        "command": "latex-workshop.demote-sectioning"
-      },
-      {
-        "key": "ctrl+alt+[",
-        "mac": "cmd+alt+[",
-        "when": "!config.latex-workshop.bind.altKeymap.enabled && editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
-        "command": "latex-workshop.promote-sectioning"
-      },
-      {
-        "key": "ctrl+alt+]",
-        "mac": "cmd+alt+]",
-        "when": "!config.latex-workshop.bind.altKeymap.enabled && editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
-        "command": "latex-workshop.demote-sectioning"
-      },
-      {
-        "key": "ctrl+l ctrl+enter",
-        "mac": "cmd+l cmd+enter",
-        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
-        "command": "latex-workshop.shortcut.item"
-      },
-      {
-        "key": "ctrl+l ctrl+b",
-        "mac": "cmd+l cmd+b",
-        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
-        "command": "latex-workshop.shortcut.textbf"
-      },
-      {
-        "key": "ctrl+l ctrl+i",
-        "mac": "cmd+l cmd+i",
-        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
-        "command": "latex-workshop.shortcut.textit"
-      },
-      {
-        "key": "ctrl+l ctrl+u",
-        "mac": "cmd+l cmd+u",
-        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
-        "command": "latex-workshop.shortcut.underline"
-      },
-      {
-        "key": "ctrl+l ctrl+e",
-        "mac": "cmd+l cmd+e",
-        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
-        "command": "latex-workshop.shortcut.emph"
-      },
-      {
-        "key": "ctrl+l ctrl+r",
-        "mac": "cmd+l cmd+r",
-        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
-        "command": "latex-workshop.shortcut.textrm"
-      },
-      {
-        "key": "ctrl+l ctrl+t",
-        "mac": "cmd+l cmd+t",
-        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
-        "command": "latex-workshop.shortcut.texttt"
-      },
-      {
-        "key": "ctrl+l ctrl+s",
-        "mac": "cmd+l cmd+s",
-        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
-        "command": "latex-workshop.shortcut.textsl"
-      },
-      {
-        "key": "ctrl+l ctrl+c",
-        "mac": "cmd+l cmd+c",
-        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
-        "command": "latex-workshop.shortcut.textsc"
-      },
-      {
-        "key": "ctrl+l ctrl+n",
-        "mac": "cmd+l cmd+n",
-        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
-        "command": "latex-workshop.shortcut.textnormal"
-      },
-      {
-        "key": "ctrl+l ctrl+6",
-        "mac": "cmd+l cmd+6",
-        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
-        "command": "latex-workshop.shortcut.textsuperscript"
-      },
-      {
-        "key": "ctrl+l ctrl+oem_minus",
-        "mac": "cmd+l cmd+oem_minus",
-        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
-        "command": "latex-workshop.shortcut.textsubscript"
-      },
-      {
-        "key": "ctrl+m ctrl+b",
-        "mac": "ctrl+shift+m cmd+b",
-        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
-        "command": "latex-workshop.shortcut.mathbf"
-      },
-      {
-        "key": "ctrl+m ctrl+i",
-        "mac": "ctrl+shift+m cmd+i",
-        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
-        "command": "latex-workshop.shortcut.mathit"
-      },
-      {
-        "key": "ctrl+m ctrl+r",
-        "mac": "ctrl+shift+m cmd+r",
-        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
-        "command": "latex-workshop.shortcut.mathrm"
-      },
-      {
-        "key": "ctrl+m ctrl+t",
-        "mac": "ctrl+shift+m cmd+t",
-        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
-        "command": "latex-workshop.shortcut.mathtt"
-      },
-      {
-        "key": "ctrl+m ctrl+s",
-        "mac": "ctrl+shift+m cmd+s",
-        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
-        "command": "latex-workshop.shortcut.mathsf"
-      },
-      {
-        "key": "ctrl+m ctrl+shift+b",
-        "mac": "ctrl+shift+m cmd+shift+b",
-        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
-        "command": "latex-workshop.shortcut.mathbb"
-      },
-      {
-        "key": "ctrl+m ctrl+c",
-        "mac": "ctrl+shift+m cmd+c",
-        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
-        "command": "latex-workshop.shortcut.mathcal"
-      },
-      {
-        "command": "expandLineSelection",
-        "key": "ctrl+l ctrl+l",
-        "mac": "cmd+l cmd+l",
-        "when": "textInputFocus && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/"
-      },
-      {
-        "command": "editor.action.toggleTabFocusMode",
-        "key": "ctrl+l ctrl+m",
-        "mac": "cmd+l ctrl+shift+m",
-        "when": "textInputFocus && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/"
-      },
-      {
-        "key": "ctrl+l ctrl+w",
-        "mac": "cmd+l cmd+w",
-        "when": "editorTextFocus && !editorReadonly && editorHasSelection && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
-        "command": "latex-workshop.surround"
-      },
-      {
-        "command": "latex-workshop.onEnterKey",
-        "key": "enter",
-        "when": "config.latex-workshop.bind.enter.key && editorTextFocus && acceptSuggestionOnEnter && !suggestWidgetVisible && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && vim.active && vim.mode == 'Insert'"
-      },
-      {
-        "command": "latex-workshop.onEnterKey",
-        "key": "enter",
-        "when": "config.latex-workshop.bind.enter.key && editorTextFocus && !acceptSuggestionOnEnter && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && vim.active && vim.mode == 'Insert'"
-      },
-      {
-        "command": "latex-workshop.onEnterKey",
-        "key": "enter",
-        "when": "config.latex-workshop.bind.enter.key && editorTextFocus && acceptSuggestionOnEnter && !suggestWidgetVisible && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && !vim.active"
-      },
-      {
-        "command": "latex-workshop.onEnterKey",
-        "key": "enter",
-        "when": "config.latex-workshop.bind.enter.key && editorTextFocus && !acceptSuggestionOnEnter && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && !vim.active"
-      },
-      {
-        "command": "latex-workshop.onAltEnterKey",
-        "key": "alt+enter",
-        "when": "config.latex-workshop.bind.enter.key && editorTextFocus && acceptSuggestionOnEnter && !suggestWidgetVisible && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/"
-      },
-      {
-        "command": "latex-workshop.onAltEnterKey",
-        "key": "alt+enter",
-        "when": "config.latex-workshop.bind.enter.key && editorTextFocus && !acceptSuggestionOnEnter && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/"
-      }
-    ],
-    "configurationDefaults": {
-      "[latex]": {
-        "editor.formatOnPaste": false,
-        "editor.suggestSelection": "recentlyUsedByPrefix"
-      }
+    "engines": {
+        "vscode": "^1.74.0"
     },
-    "configuration": {
-      "type": "object",
-      "title": "LaTeX",
-      "properties": {
-        "latex-workshop.latex.recipes": {
-          "scope": "resource",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "name": {
-                "type": "string"
-              },
-              "tools": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              }
-            },
-            "required": [
-              "name",
-              "tools"
-            ],
-            "additionalProperties": false
-          },
-          "default": [
+    "categories": [
+        "Programming Languages",
+        "Snippets",
+        "Linters",
+        "Formatters"
+    ],
+    "keywords": [
+        "latex",
+        "tex",
+        "compile",
+        "preview",
+        "hint"
+    ],
+    "activationEvents": [
+        "onCommand:latex-workshop.activate",
+        "onWebviewPanel:latex-workshop-pdf"
+    ],
+    "main": "./out/src/main.js",
+    "capabilities": {
+        "virtualWorkspaces": {
+            "supported": "limited",
+            "description": "Only a few features are supported."
+        },
+        "untrustedWorkspaces": {
+            "supported": false
+        }
+    },
+    "contributes": {
+        "languages": [
             {
-              "name": "latexmk",
-              "tools": [
-                "latexmk"
-              ]
-            },
-            {
-              "name": "latexmk (latexmkrc)",
-              "tools": [
-                "latexmk_rconly"
-              ]
-            },
-            {
-              "name": "latexmk (lualatex)",
-              "tools": [
-                "lualatexmk"
-              ]
+                "id": "tex",
+                "aliases": [
+                    "TeX",
+                    "tex"
+                ],
+                "extensions": [
+                    ".sty",
+                    ".cls",
+                    ".bbx",
+                    ".cbx"
+                ],
+                "configuration": "./syntax/latex-language-configuration.json"
             },
             {
-              "name": "latexmk (xelatex)",
-              "tools": [
-                "xelatexmk"
-              ]
+                "id": "doctex",
+                "aliases": [
+                    "DocTeX",
+                    "doctex"
+                ],
+                "extensions": [
+                    ".dtx"
+                ],
+                "configuration": "./syntax/doctex-language-configuration.json"
             },
             {
-              "name": "pdflatex -> bibtex -> pdflatex * 2",
-              "tools": [
-                "pdflatex",
-                "bibtex",
-                "pdflatex",
-                "pdflatex"
-              ]
+                "id": "latex",
+                "aliases": [
+                    "LaTeX",
+                    "latex"
+                ],
+                "extensions": [
+                    ".tex",
+                    ".ltx",
+                    ".ctx"
+                ],
+                "configuration": "./syntax/latex-language-configuration.json"
             },
             {
-              "name": "Compile Rnw files",
-              "tools": [
-                "rnw2tex",
-                "latexmk"
-              ]
+                "id": "bibtex",
+                "aliases": [
+                    "BibTeX",
+                    "bibtex"
+                ],
+                "extensions": [
+                    ".bib"
+                ],
+                "configuration": "./syntax/bibtex-language-configuration.json"
             },
             {
-              "name": "Compile Jnw files",
-              "tools": [
-                "jnw2tex",
-                "latexmk"
-              ]
+                "id": "bibtex-style",
+                "aliases": [
+                    "BibTeX style"
+                ],
+                "extensions": [
+                    ".bst"
+                ],
+                "configuration": "./syntax/bibtex-style-language-configuration.json"
             },
             {
-              "name": "Compile Pnw files",
-              "tools": [
-                "pnw2tex",
-                "latexmk"
-              ]
+                "id": "latex-expl3",
+                "aliases": [
+                    "LaTeX-Expl3"
+                ],
+                "configuration": "./syntax/latex3-language-configuration.json"
             },
             {
-              "name": "tectonic",
-              "tools": [
-                "tectonic"
-              ]
+                "id": "pweave",
+                "aliases": [
+                    "Pweave"
+                ],
+                "extensions": [
+                    ".pnw",
+                    ".ptexw"
+                ],
+                "configuration": "./syntax/latex-language-configuration.json"
+            },
+            {
+                "id": "jlweave",
+                "aliases": [
+                    "Weave.jl"
+                ],
+                "extensions": [
+                    ".jnw",
+                    ".jtexw"
+                ],
+                "configuration": "./syntax/latex-language-configuration.json"
+            },
+            {
+                "id": "rsweave",
+                "aliases": [
+                    "R Sweave"
+                ],
+                "extensions": [
+                    ".rnw",
+                    ".Rnw",
+                    ".Rtex",
+                    ".rtex",
+                    ".snw",
+                    ".Snw"
+                ],
+                "configuration": "./syntax/latex-language-configuration.json"
+            },
+            {
+                "id": "cpp_embedded_latex",
+                "configuration": "./syntax/latex-cpp-embedded-language-configuration.json"
+            },
+            {
+                "id": "markdown_latex_combined",
+                "configuration": "./syntax/markdown-latex-combined-language-configuration.json"
             }
-          ],
-          "markdownDescription": "Define LaTeX compiling recipes. Each recipe in the list is an object containing its name and the names of tools to be used sequentially, which are defined in `#latex-workshop.latex.tools#`. By default, the first recipe is used to compile the project. For details, please visit https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#latex-recipes."
-        },
-        "latex-workshop.latex.recipe.default": {
-          "scope": "resource",
-          "type": "string",
-          "default": "first",
-          "markdownDescription": "Define which recipe is used by `#latex-workshop.build#`. It also applies to auto build. Recipes are referred to by their names as defined in `#latex-workshop.latex.recipes#`. Note there are two particular values: \n- `first` means to use the first recipe in `#latex-workshop.latex.recipes#`;\n- `lastUsed` means to use the last run recipe."
-        },
-        "latex-workshop.latex.tools": {
-          "scope": "resource",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "name": {
-                "type": "string"
-              },
-              "command": {
-                "type": "string"
-              },
-              "args": {
-                "type": "array",
-                "items": {
-                  "type": "string"
+        ],
+        "grammars": [
+            {
+                "language": "tex",
+                "scopeName": "text.tex",
+                "path": "./syntax/TeX.tmLanguage.json"
+            },
+            {
+                "language": "doctex",
+                "scopeName": "text.tex.doctex",
+                "path": "./syntax/DocTeX.tmLanguage.json"
+            },
+            {
+                "language": "latex",
+                "scopeName": "text.tex.latex",
+                "path": "./syntax/LaTeX.tmLanguage.json",
+                "embeddedLanguages": {
+                    "source.asymptote": "asymptote",
+                    "source.cpp": "cpp_embedded_latex",
+                    "source.css": "css",
+                    "source.dot": "dot",
+                    "source.gnuplot": "gnuplot",
+                    "text.html": "html",
+                    "source.java": "java",
+                    "source.js": "javascript",
+                    "source.julia": "julia",
+                    "source.lua": "lua",
+                    "source.python": "python",
+                    "source.ruby": "ruby",
+                    "source.scala": "scala",
+                    "source.ts": "typescript",
+                    "text.xml": "xml",
+                    "source.yaml": "yaml",
+                    "meta.embedded.markdown_latex_combined": "markdown_latex_combined"
                 }
-              },
-              "env": {
-                "type": "object"
-              }
-            },
-            "required": [
-              "name",
-              "command"
-            ],
-            "additionalProperties": false
-          },
-          "default": [
-            {
-              "name": "latexmk",
-              "command": "latexmk",
-              "args": [
-                "-synctex=1",
-                "-interaction=nonstopmode",
-                "-file-line-error",
-                "-pdf",
-                "-outdir=%OUTDIR%",
-                "%DOC%"
-              ],
-              "env": {}
             },
             {
-              "name": "lualatexmk",
-              "command": "latexmk",
-              "args": [
-                "-synctex=1",
-                "-interaction=nonstopmode",
-                "-file-line-error",
-                "-lualatex",
-                "-outdir=%OUTDIR%",
-                "%DOC%"
-              ],
-              "env": {}
+                "language": "bibtex",
+                "scopeName": "text.bibtex",
+                "path": "./syntax/Bibtex.tmLanguage.json"
             },
             {
-              "name": "xelatexmk",
-              "command": "latexmk",
-              "args": [
-                "-synctex=1",
-                "-interaction=nonstopmode",
-                "-file-line-error",
-                "-xelatex",
-                "-outdir=%OUTDIR%",
-                "%DOC%"
-              ],
-              "env": {}
+                "language": "bibtex-style",
+                "scopeName": "source.bst",
+                "path": "./syntax/BibTeX-style.tmLanguage.json"
             },
             {
-              "name": "latexmk_rconly",
-              "command": "latexmk",
-              "args": [
-                "%DOC%"
-              ],
-              "env": {}
+                "language": "latex-expl3",
+                "scopeName": "text.tex.latex.expl3",
+                "path": "./syntax/LaTeX-Expl3.tmLanguage.json"
             },
             {
-              "name": "pdflatex",
-              "command": "pdflatex",
-              "args": [
-                "-synctex=1",
-                "-interaction=nonstopmode",
-                "-file-line-error",
-                "%DOC%"
-              ],
-              "env": {}
+                "language": "markdown_latex_combined",
+                "scopeName": "text.tex.markdown_latex_combined",
+                "path": "./syntax/markdown-latex-combined.tmLanguage.json"
             },
             {
-              "name": "bibtex",
-              "command": "bibtex",
-              "args": [
-                "%DOCFILE%"
-              ],
-              "env": {}
+                "language": "cpp_embedded_latex",
+                "scopeName": "source.cpp.embedded.latex",
+                "path": "./syntax/cpp-grammar-bailout.tmLanguage.json",
+                "embeddedLanguages": {
+                    "meta.embedded.assembly.cpp": "asm"
+                }
             },
             {
-              "name": "rnw2tex",
-              "command": "Rscript",
-              "args": [
-                "-e",
-                "knitr::opts_knit$set(concordance = TRUE); knitr::knit('%DOCFILE_EXT%')"
-              ],
-              "env": {}
+                "language": "pweave",
+                "scopeName": "text.tex.latex.pweave",
+                "path": "./syntax/Pweave.tmLanguage.json",
+                "embeddedLanguages": {
+                    "source.python": "python"
+                }
             },
             {
-              "name": "jnw2tex",
-              "command": "julia",
-              "args": [
-                "-e",
-                "using Weave; weave(\"%DOC_EXT%\", doctype=\"tex\")"
-              ],
-              "env": {}
+                "language": "jlweave",
+                "scopeName": "text.tex.latex.jlweave",
+                "path": "./syntax/JLweave.tmLanguage.json",
+                "embeddedLanguages": {
+                    "source.julia": "julia"
+                }
             },
             {
-              "name": "jnw2texminted",
-              "command": "julia",
-              "args": [
-                "-e",
-                "using Weave; weave(\"%DOC_EXT%\", doctype=\"texminted\")"
-              ],
-              "env": {}
-            },
-            {
-              "name": "pnw2tex",
-              "command": "pweave",
-              "args": [
-                "-f",
-                "tex",
-                "%DOC_EXT%"
-              ],
-              "env": {}
-            },
-            {
-              "name": "pnw2texminted",
-              "command": "pweave",
-              "args": [
-                "-f",
-                "texminted",
-                "%DOC_EXT%"
-              ],
-              "env": {}
-            },
-            {
-              "name": "tectonic",
-              "command": "tectonic",
-              "args": [
-                "--synctex",
-                "--keep-logs",
-                "%DOC%.tex"
-              ],
-              "env": {}
+                "language": "rsweave",
+                "scopeName": "text.tex.latex.rsweave",
+                "path": "./syntax/RSweave.tmLanguage.json",
+                "embeddedLanguages": {
+                    "source.r": "r"
+                }
             }
-          ],
-          "markdownDescription": "Define LaTeX compiling tools to be used in recipes. Each tool is labeled by its `name`. When invoked, `command` is spawned with arguments defined in `args` and environment variables defined in `env`. Typically no spaces should appear in each argument unless in paths. List of available placeholders: `%DOC%`, `%DOC_W32%, %DOC_EXT%`, `%DOC_EXT_W32%`, `%DOCFILE%`, `%DOCFILE_EXT%`, `%DIR%`, `%DIR_W32%`, `%TMPDIR%` and `%OUTDIR%`, `%OUTDIR_W32%`. Please visit https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#placeholders for a complete list of all placeholders."
+        ],
+        "snippets": [
+            {
+                "language": "latex",
+                "path": "./data/latex-snippet.json"
+            },
+            {
+                "language": "pweave",
+                "path": "./data/latex-snippet.json"
+            },
+            {
+                "language": "jlweave",
+                "path": "./data/latex-snippet.json"
+            },
+            {
+                "language": "rsweave",
+                "path": "./data/latex-snippet.json"
+            },
+            {
+                "language": "latex-expl3",
+                "path": "./data/latex-snippet.json"
+            }
+        ],
+        "commands": [
+            {
+                "command": "latex-workshop.navigate-envpair",
+                "title": "Navigate to matching begin/end",
+                "category": "LaTeX Workshop"
+            },
+            {
+                "command": "latex-workshop.select-envname",
+                "title": "Select the current environment name",
+                "category": "LaTeX Workshop"
+            },
+            {
+                "command": "latex-workshop.select-envcontent",
+                "title": "Select the current environment content",
+                "category": "LaTeX Workshop"
+            },
+            {
+                "command": "latex-workshop.select-env",
+                "title": "Select the current environment",
+                "category": "LaTeX Workshop"
+            },
+            {
+                "command": "latex-workshop.multicursor-envname",
+                "title": "Add a multicursor to the current environment name",
+                "category": "LaTeX Workshop"
+            },
+            {
+                "command": "latex-workshop.wrap-env",
+                "title": "Surround selection with \\begin{}...\\end{}",
+                "category": "LaTeX Workshop"
+            },
+            {
+                "command": "latex-workshop.surround",
+                "title": "Surround selection with LaTeX command",
+                "category": "LaTeX Workshop"
+            },
+            {
+                "command": "latex-workshop.close-env",
+                "title": "Close current environment",
+                "category": "LaTeX Workshop"
+            },
+            {
+                "command": "latex-workshop.toggle-equation-envname",
+                "title": "Toggle between \\[...\\] and \\begin{}...\\end{}",
+                "category": "LaTeX Workshop"
+            },
+            {
+                "command": "latex-workshop.saveWithoutBuilding",
+                "title": "Save without Building",
+                "category": "LaTeX Workshop"
+            },
+            {
+                "command": "latex-workshop.build",
+                "title": "Build LaTeX project",
+                "category": "LaTeX Workshop",
+                "icon": "$(debug-start)",
+                "enablement": "!virtualWorkspace"
+            },
+            {
+                "command": "latex-workshop.recipes",
+                "title": "Build with recipe",
+                "category": "LaTeX Workshop",
+                "enablement": "!virtualWorkspace"
+            },
+            {
+                "command": "latex-workshop.view",
+                "title": "View LaTeX PDF file",
+                "category": "LaTeX Workshop",
+                "icon": "$(open-preview)",
+                "enablement": "!virtualWorkspace"
+            },
+            {
+                "command": "latex-workshop.tab",
+                "title": "View LaTeX PDF file in VSCode tab",
+                "category": "LaTeX Workshop"
+            },
+            {
+                "command": "latex-workshop.viewInBrowser",
+                "title": "View LaTeX PDF file in web browser",
+                "category": "LaTeX Workshop",
+                "enablement": "!virtualWorkspace"
+            },
+            {
+                "command": "latex-workshop.viewExternal",
+                "title": "View LaTeX PDF file in external viewer",
+                "category": "LaTeX Workshop",
+                "enablement": "!virtualWorkspace"
+            },
+            {
+                "command": "latex-workshop.refresh-viewer",
+                "title": "Refresh all LaTeX PDF viewers",
+                "category": "LaTeX Workshop"
+            },
+            {
+                "command": "latex-workshop.kill",
+                "title": "Kill LaTeX compiler process",
+                "category": "LaTeX Workshop",
+                "enablement": "!virtualWorkspace"
+            },
+            {
+                "command": "latex-workshop.synctex",
+                "title": "SyncTeX from cursor",
+                "category": "LaTeX Workshop",
+                "enablement": "!virtualWorkspace"
+            },
+            {
+                "command": "latex-workshop.clean",
+                "title": "Clean up auxiliary files",
+                "category": "LaTeX Workshop",
+                "enablement": "!virtualWorkspace"
+            },
+            {
+                "command": "latex-workshop.citation",
+                "title": "Open citation browser",
+                "category": "LaTeX Workshop",
+                "enablement": "!virtualWorkspace"
+            },
+            {
+                "command": "latex-workshop.addtexroot",
+                "title": "Insert %!TeX root magic comment",
+                "category": "LaTeX Workshop"
+            },
+            {
+                "command": "latex-workshop.wordcount",
+                "title": "Count words in LaTeX document",
+                "category": "LaTeX Workshop"
+            },
+            {
+                "command": "latex-workshop.changeHostName",
+                "title": "Change server listening hostname",
+                "category": "LaTeX Workshop"
+            },
+            {
+                "command": "latex-workshop.resetHostName",
+                "title": "Reset server listening hostname to 127.0.0.1",
+                "category": "LaTeX Workshop"
+            },
+            {
+                "command": "latex-workshop.compilerlog",
+                "title": "View LaTeX compiler logs",
+                "category": "LaTeX Workshop",
+                "enablement": "!virtualWorkspace"
+            },
+            {
+                "command": "latex-workshop.log",
+                "title": "Show LaTeX Workshop messages",
+                "category": "LaTeX Workshop"
+            },
+            {
+                "command": "latex-workshop.actions",
+                "title": "LaTeX actions",
+                "category": "LaTeX Workshop"
+            },
+            {
+                "command": "latex-workshop-dev.parselog",
+                "title": "Parse current document as LaTeX logs",
+                "category": "LaTeX Workshop DevTools"
+            },
+            {
+                "command": "latex-workshop-dev.parsetex",
+                "title": "Parse current file as LaTeX AST",
+                "category": "LaTeX Workshop DevTools"
+            },
+            {
+                "command": "latex-workshop-dev.parsebib",
+                "title": "Parse current file as BibTeX AST",
+                "category": "LaTeX Workshop DevTools"
+            },
+            {
+                "command": "latex-workshop-dev.striptext",
+                "title": "Strip text and comments from LaTeX.",
+                "category": "LaTeX Workshop DevTools"
+            },
+            {
+                "command": "latex-workshop.texdoc",
+                "title": "Show package documentation",
+                "category": "LaTeX Workshop"
+            },
+            {
+                "command": "latex-workshop.texdocUsepackages",
+                "title": "Show package documentation actually used",
+                "category": "LaTeX Workshop"
+            },
+            {
+                "command": "latex-workshop.promote-sectioning",
+                "title": "Promote all the section levels used in the selection",
+                "category": "LaTeX Workshop"
+            },
+            {
+                "command": "latex-workshop.demote-sectioning",
+                "title": "Demote all the section levels used in the selection",
+                "category": "LaTeX Workshop"
+            },
+            {
+                "command": "latex-workshop.select-section",
+                "title": "Select the current section",
+                "category": "LaTeX Workshop"
+            },
+            {
+                "command": "latex-workshop.structure-toggle-follow-cursor",
+                "title": "Toggle follow cursor",
+                "category": "LaTeX Workshop"
+            },
+            {
+                "command": "latex-workshop.bibsort",
+                "title": "Sort BibTeX file",
+                "category": "LaTeX Workshop"
+            },
+            {
+                "command": "latex-workshop.bibalign",
+                "title": "Align BibTeX file",
+                "category": "LaTeX Workshop"
+            },
+            {
+                "command": "latex-workshop.bibalignsort",
+                "title": "Sort and align BibTeX file",
+                "category": "LaTeX Workshop"
+            },
+            {
+                "command": "latex-workshop.openMathPreviewPanel",
+                "title": "Open Math Preview Panel",
+                "category": "LaTeX Workshop"
+            },
+            {
+                "command": "latex-workshop.closeMathPreviewPanel",
+                "title": "Close Math Preview Panel",
+                "category": "LaTeX Workshop"
+            },
+            {
+                "command": "latex-workshop.toggleMathPreviewPanel",
+                "title": "Toggle Math Preview Panel",
+                "category": "LaTeX Workshop"
+            }
+        ],
+        "keybindings": [
+            {
+                "key": "ctrl+l alt+m",
+                "mac": "cmd+l alt+m",
+                "command": "latex-workshop.toggleMathPreviewPanel",
+                "when": "editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && config.latex-workshop.bind.altKeymap.enabled"
+            },
+            {
+                "key": "ctrl+l alt+b",
+                "mac": "cmd+l alt+b",
+                "command": "latex-workshop.build",
+                "when": "editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && config.latex-workshop.bind.altKeymap.enabled && !virtualWorkspace"
+            },
+            {
+                "key": "ctrl+l alt+c",
+                "mac": "cmd+l alt+c",
+                "command": "latex-workshop.clean",
+                "when": "editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && config.latex-workshop.bind.altKeymap.enabled && !virtualWorkspace"
+            },
+            {
+                "key": "ctrl+l alt+v",
+                "mac": "cmd+l alt+v",
+                "command": "latex-workshop.view",
+                "when": "editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && config.latex-workshop.bind.altKeymap.enabled && !virtualWorkspace"
+            },
+            {
+                "key": "ctrl+l alt+j",
+                "mac": "cmd+l alt+j",
+                "command": "latex-workshop.synctex",
+                "when": "editorTextFocus && editorLangId == 'latex' && config.latex-workshop.bind.altKeymap.enabled && !virtualWorkspace"
+            },
+            {
+                "key": "ctrl+l alt+x",
+                "mac": "cmd+l alt+x",
+                "command": "workbench.view.extension.latex-workshop-activitybar",
+                "when": "config.latex-workshop.bind.altKeymap.enabled"
+            },
+            {
+                "key": "ctrl+alt+m",
+                "mac": "cmd+alt+m",
+                "command": "latex-workshop.toggleMathPreviewPanel",
+                "when": "editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && !config.latex-workshop.bind.altKeymap.enabled"
+            },
+            {
+                "key": "ctrl+alt+b",
+                "mac": "cmd+alt+b",
+                "command": "latex-workshop.build",
+                "when": "editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && !config.latex-workshop.bind.altKeymap.enabled && !virtualWorkspace"
+            },
+            {
+                "key": "ctrl+alt+c",
+                "mac": "cmd+alt+c",
+                "command": "latex-workshop.clean",
+                "when": "editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && !config.latex-workshop.bind.altKeymap.enabled && !virtualWorkspace"
+            },
+            {
+                "key": "ctrl+alt+v",
+                "mac": "cmd+alt+v",
+                "command": "latex-workshop.view",
+                "when": "editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && !config.latex-workshop.bind.altKeymap.enabled && !virtualWorkspace"
+            },
+            {
+                "key": "ctrl+alt+j",
+                "mac": "cmd+alt+j",
+                "command": "latex-workshop.synctex",
+                "when": "editorTextFocus && editorLangId == 'latex' && !config.latex-workshop.bind.altKeymap.enabled && !virtualWorkspace"
+            },
+            {
+                "key": "ctrl+alt+x",
+                "mac": "cmd+alt+x",
+                "command": "workbench.view.extension.latex-workshop-activitybar",
+                "when": "!config.latex-workshop.bind.altKeymap.enabled"
+            },
+            {
+                "key": "ctrl+l [",
+                "mac": "cmd+l [",
+                "when": "config.latex-workshop.bind.altKeymap.enabled && editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
+                "command": "latex-workshop.promote-sectioning"
+            },
+            {
+                "key": "ctrl+l ]",
+                "mac": "cmd+l ]",
+                "when": "config.latex-workshop.bind.altKeymap.enabled && editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
+                "command": "latex-workshop.demote-sectioning"
+            },
+            {
+                "key": "ctrl+alt+[",
+                "mac": "cmd+alt+[",
+                "when": "!config.latex-workshop.bind.altKeymap.enabled && editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
+                "command": "latex-workshop.promote-sectioning"
+            },
+            {
+                "key": "ctrl+alt+]",
+                "mac": "cmd+alt+]",
+                "when": "!config.latex-workshop.bind.altKeymap.enabled && editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
+                "command": "latex-workshop.demote-sectioning"
+            },
+            {
+                "key": "ctrl+l ctrl+enter",
+                "mac": "cmd+l cmd+enter",
+                "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
+                "command": "latex-workshop.shortcut.item"
+            },
+            {
+                "key": "ctrl+l ctrl+b",
+                "mac": "cmd+l cmd+b",
+                "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
+                "command": "latex-workshop.shortcut.textbf"
+            },
+            {
+                "key": "ctrl+l ctrl+i",
+                "mac": "cmd+l cmd+i",
+                "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
+                "command": "latex-workshop.shortcut.textit"
+            },
+            {
+                "key": "ctrl+l ctrl+u",
+                "mac": "cmd+l cmd+u",
+                "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
+                "command": "latex-workshop.shortcut.underline"
+            },
+            {
+                "key": "ctrl+l ctrl+e",
+                "mac": "cmd+l cmd+e",
+                "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
+                "command": "latex-workshop.shortcut.emph"
+            },
+            {
+                "key": "ctrl+l ctrl+r",
+                "mac": "cmd+l cmd+r",
+                "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
+                "command": "latex-workshop.shortcut.textrm"
+            },
+            {
+                "key": "ctrl+l ctrl+t",
+                "mac": "cmd+l cmd+t",
+                "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
+                "command": "latex-workshop.shortcut.texttt"
+            },
+            {
+                "key": "ctrl+l ctrl+s",
+                "mac": "cmd+l cmd+s",
+                "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
+                "command": "latex-workshop.shortcut.textsl"
+            },
+            {
+                "key": "ctrl+l ctrl+c",
+                "mac": "cmd+l cmd+c",
+                "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
+                "command": "latex-workshop.shortcut.textsc"
+            },
+            {
+                "key": "ctrl+l ctrl+n",
+                "mac": "cmd+l cmd+n",
+                "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
+                "command": "latex-workshop.shortcut.textnormal"
+            },
+            {
+                "key": "ctrl+l ctrl+6",
+                "mac": "cmd+l cmd+6",
+                "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
+                "command": "latex-workshop.shortcut.textsuperscript"
+            },
+            {
+                "key": "ctrl+l ctrl+oem_minus",
+                "mac": "cmd+l cmd+oem_minus",
+                "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
+                "command": "latex-workshop.shortcut.textsubscript"
+            },
+            {
+                "key": "ctrl+m ctrl+b",
+                "mac": "ctrl+shift+m cmd+b",
+                "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
+                "command": "latex-workshop.shortcut.mathbf"
+            },
+            {
+                "key": "ctrl+m ctrl+i",
+                "mac": "ctrl+shift+m cmd+i",
+                "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
+                "command": "latex-workshop.shortcut.mathit"
+            },
+            {
+                "key": "ctrl+m ctrl+r",
+                "mac": "ctrl+shift+m cmd+r",
+                "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
+                "command": "latex-workshop.shortcut.mathrm"
+            },
+            {
+                "key": "ctrl+m ctrl+t",
+                "mac": "ctrl+shift+m cmd+t",
+                "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
+                "command": "latex-workshop.shortcut.mathtt"
+            },
+            {
+                "key": "ctrl+m ctrl+s",
+                "mac": "ctrl+shift+m cmd+s",
+                "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
+                "command": "latex-workshop.shortcut.mathsf"
+            },
+            {
+                "key": "ctrl+m ctrl+shift+b",
+                "mac": "ctrl+shift+m cmd+shift+b",
+                "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
+                "command": "latex-workshop.shortcut.mathbb"
+            },
+            {
+                "key": "ctrl+m ctrl+c",
+                "mac": "ctrl+shift+m cmd+c",
+                "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
+                "command": "latex-workshop.shortcut.mathcal"
+            },
+            {
+                "command": "expandLineSelection",
+                "key": "ctrl+l ctrl+l",
+                "mac": "cmd+l cmd+l",
+                "when": "textInputFocus && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/"
+            },
+            {
+                "command": "editor.action.toggleTabFocusMode",
+                "key": "ctrl+l ctrl+m",
+                "mac": "cmd+l ctrl+shift+m",
+                "when": "textInputFocus && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/"
+            },
+            {
+                "key": "ctrl+l ctrl+w",
+                "mac": "cmd+l cmd+w",
+                "when": "editorTextFocus && !editorReadonly && editorHasSelection && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
+                "command": "latex-workshop.surround"
+            },
+            {
+                "command": "latex-workshop.onEnterKey",
+                "key": "enter",
+                "when": "config.latex-workshop.bind.enter.key && editorTextFocus && acceptSuggestionOnEnter && !suggestWidgetVisible && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && vim.active && vim.mode == 'Insert'"
+            },
+            {
+                "command": "latex-workshop.onEnterKey",
+                "key": "enter",
+                "when": "config.latex-workshop.bind.enter.key && editorTextFocus && !acceptSuggestionOnEnter && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && vim.active && vim.mode == 'Insert'"
+            },
+            {
+                "command": "latex-workshop.onEnterKey",
+                "key": "enter",
+                "when": "config.latex-workshop.bind.enter.key && editorTextFocus && acceptSuggestionOnEnter && !suggestWidgetVisible && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && !vim.active"
+            },
+            {
+                "command": "latex-workshop.onEnterKey",
+                "key": "enter",
+                "when": "config.latex-workshop.bind.enter.key && editorTextFocus && !acceptSuggestionOnEnter && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && !vim.active"
+            },
+            {
+                "command": "latex-workshop.onAltEnterKey",
+                "key": "alt+enter",
+                "when": "config.latex-workshop.bind.enter.key && editorTextFocus && acceptSuggestionOnEnter && !suggestWidgetVisible && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/"
+            },
+            {
+                "command": "latex-workshop.onAltEnterKey",
+                "key": "alt+enter",
+                "when": "config.latex-workshop.bind.enter.key && editorTextFocus && !acceptSuggestionOnEnter && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/"
+            }
+        ],
+        "configurationDefaults": {
+            "[latex]": {
+                "editor.formatOnPaste": false,
+                "editor.suggestSelection": "recentlyUsedByPrefix"
+            }
         },
-        "latex-workshop.latex.magic.args": {
-          "scope": "resource",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": [
-            "-synctex=1",
-            "-interaction=nonstopmode",
-            "-file-line-error",
-            "%DOC%"
-          ],
-          "markdownDescription": "Define the arguments to be input to magic command executable. This can be overridden by using \"% !TeX options\"."
+        "configuration": {
+            "type": "object",
+            "title": "LaTeX",
+            "properties": {
+                "latex-workshop.latex.recipes": {
+                    "scope": "resource",
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "tools": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "tools"
+                        ],
+                        "additionalProperties": false
+                    },
+                    "default": [
+                        {
+                            "name": "latexmk",
+                            "tools": [
+                                "latexmk"
+                            ]
+                        },
+                        {
+                            "name": "latexmk (latexmkrc)",
+                            "tools": [
+                                "latexmk_rconly"
+                            ]
+                        },
+                        {
+                            "name": "latexmk (lualatex)",
+                            "tools": [
+                                "lualatexmk"
+                            ]
+                        },
+                        {
+                            "name": "latexmk (xelatex)",
+                            "tools": [
+                                "xelatexmk"
+                            ]
+                        },
+                        {
+                            "name": "pdflatex -> bibtex -> pdflatex * 2",
+                            "tools": [
+                                "pdflatex",
+                                "bibtex",
+                                "pdflatex",
+                                "pdflatex"
+                            ]
+                        },
+                        {
+                            "name": "Compile Rnw files",
+                            "tools": [
+                                "rnw2tex",
+                                "latexmk"
+                            ]
+                        },
+                        {
+                            "name": "Compile Jnw files",
+                            "tools": [
+                                "jnw2tex",
+                                "latexmk"
+                            ]
+                        },
+                        {
+                            "name": "Compile Pnw files",
+                            "tools": [
+                                "pnw2tex",
+                                "latexmk"
+                            ]
+                        },
+                        {
+                            "name": "tectonic",
+                            "tools": [
+                                "tectonic"
+                            ]
+                        }
+                    ],
+                    "markdownDescription": "Define LaTeX compiling recipes. Each recipe in the list is an object containing its name and the names of tools to be used sequentially, which are defined in `#latex-workshop.latex.tools#`. By default, the first recipe is used to compile the project. For details, please visit https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#latex-recipes."
+                },
+                "latex-workshop.latex.recipe.default": {
+                    "scope": "resource",
+                    "type": "string",
+                    "default": "first",
+                    "markdownDescription": "Define which recipe is used by `#latex-workshop.build#`. It also applies to auto build. Recipes are referred to by their names as defined in `#latex-workshop.latex.recipes#`. Note there are two particular values: \n- `first` means to use the first recipe in `#latex-workshop.latex.recipes#`;\n- `lastUsed` means to use the last run recipe."
+                },
+                "latex-workshop.latex.tools": {
+                    "scope": "resource",
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "command": {
+                                "type": "string"
+                            },
+                            "args": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "env": {
+                                "type": "object"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "command"
+                        ],
+                        "additionalProperties": false
+                    },
+                    "default": [
+                        {
+                            "name": "latexmk",
+                            "command": "latexmk",
+                            "args": [
+                                "-synctex=1",
+                                "-interaction=nonstopmode",
+                                "-file-line-error",
+                                "-pdf",
+                                "-outdir=%OUTDIR%",
+                                "%DOC%"
+                            ],
+                            "env": {}
+                        },
+                        {
+                            "name": "lualatexmk",
+                            "command": "latexmk",
+                            "args": [
+                                "-synctex=1",
+                                "-interaction=nonstopmode",
+                                "-file-line-error",
+                                "-lualatex",
+                                "-outdir=%OUTDIR%",
+                                "%DOC%"
+                            ],
+                            "env": {}
+                        },
+                        {
+                            "name": "xelatexmk",
+                            "command": "latexmk",
+                            "args": [
+                                "-synctex=1",
+                                "-interaction=nonstopmode",
+                                "-file-line-error",
+                                "-xelatex",
+                                "-outdir=%OUTDIR%",
+                                "%DOC%"
+                            ],
+                            "env": {}
+                        },
+                        {
+                            "name": "latexmk_rconly",
+                            "command": "latexmk",
+                            "args": [
+                                "%DOC%"
+                            ],
+                            "env": {}
+                        },
+                        {
+                            "name": "pdflatex",
+                            "command": "pdflatex",
+                            "args": [
+                                "-synctex=1",
+                                "-interaction=nonstopmode",
+                                "-file-line-error",
+                                "%DOC%"
+                            ],
+                            "env": {}
+                        },
+                        {
+                            "name": "bibtex",
+                            "command": "bibtex",
+                            "args": [
+                                "%DOCFILE%"
+                            ],
+                            "env": {}
+                        },
+                        {
+                            "name": "rnw2tex",
+                            "command": "Rscript",
+                            "args": [
+                                "-e",
+                                "knitr::opts_knit$set(concordance = TRUE); knitr::knit('%DOCFILE_EXT%')"
+                            ],
+                            "env": {}
+                        },
+                        {
+                            "name": "jnw2tex",
+                            "command": "julia",
+                            "args": [
+                                "-e",
+                                "using Weave; weave(\"%DOC_EXT%\", doctype=\"tex\")"
+                            ],
+                            "env": {}
+                        },
+                        {
+                            "name": "jnw2texminted",
+                            "command": "julia",
+                            "args": [
+                                "-e",
+                                "using Weave; weave(\"%DOC_EXT%\", doctype=\"texminted\")"
+                            ],
+                            "env": {}
+                        },
+                        {
+                            "name": "pnw2tex",
+                            "command": "pweave",
+                            "args": [
+                                "-f",
+                                "tex",
+                                "%DOC_EXT%"
+                            ],
+                            "env": {}
+                        },
+                        {
+                            "name": "pnw2texminted",
+                            "command": "pweave",
+                            "args": [
+                                "-f",
+                                "texminted",
+                                "%DOC_EXT%"
+                            ],
+                            "env": {}
+                        },
+                        {
+                            "name": "tectonic",
+                            "command": "tectonic",
+                            "args": [
+                                "--synctex",
+                                "--keep-logs",
+                                "%DOC%.tex"
+                            ],
+                            "env": {}
+                        }
+                    ],
+                    "markdownDescription": "Define LaTeX compiling tools to be used in recipes. Each tool is labeled by its `name`. When invoked, `command` is spawned with arguments defined in `args` and environment variables defined in `env`. Typically no spaces should appear in each argument unless in paths. List of available placeholders: `%DOC%`, `%DOC_W32%, %DOC_EXT%`, `%DOC_EXT_W32%`, `%DOCFILE%`, `%DOCFILE_EXT%`, `%DIR%`, `%DIR_W32%`, `%TMPDIR%` and `%OUTDIR%`, `%OUTDIR_W32%`. Please visit https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#placeholders for a complete list of all placeholders."
+                },
+                "latex-workshop.latex.magic.args": {
+                    "scope": "resource",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [
+                        "-synctex=1",
+                        "-interaction=nonstopmode",
+                        "-file-line-error",
+                        "%DOC%"
+                    ],
+                    "markdownDescription": "Define the arguments to be input to magic command executable. This can be overridden by using \"% !TeX options\"."
+                },
+                "latex-workshop.latex.magic.bib.args": {
+                    "scope": "resource",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [
+                        "%DOCFILE%"
+                    ],
+                    "markdownDescription": "Define the arguments to be input to BIB magic command executable. This can be overridden by using \"% !BIB options\"."
+                },
+                "latex-workshop.latex.external.build.command": {
+                    "scope": "resource",
+                    "type": "string",
+                    "default": "",
+                    "markdownDescription": "The external command to execute when calling latex-workshop.build. This is useful when compiling relies on a Makefile or a bespoke script. When defined, it completely bypasses the recipes and root file detection mechanism."
+                },
+                "latex-workshop.latex.external.build.args": {
+                    "scope": "resource",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [],
+                    "markdownDescription": "The arguments of `#latex-workshop.latex.external.build.command#` when calling latex-workshop.build."
+                },
+                "latex-workshop.latex.build.forceRecipeUsage": {
+                    "scope": "resource",
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "Force the use the recipe mechanism even if some magic comments are present."
+                },
+                "latex-workshop.latex.outDir": {
+                    "scope": "resource",
+                    "type": "string",
+                    "default": "%DIR%",
+                    "markdownDescription": "The directory where the extension tries to find project files (e.g., PDF and SyncTeX files) are located. Both relative and absolute paths are supported. Relative path start from the root file location, so beware if it is located in sub-directory. The path must not contain a trailing slash. The LaTeX toolchain should output files to this path. For a list of supported placeholders, please visit https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#placeholders."
+                },
+                "latex-workshop.latex.jobname": {
+                    "scope": "resource",
+                    "type": "string",
+                    "default": "",
+                    "markdownDescription": "The jobname argument of the compiling tool, which is used by the extension to find project files (e.g., PDF and SyncTeX files). This config should be set identical to the value provided to the `-jobname=` argument, and should not have placeholders. Leave the config empty to ignore jobname and keep the default behavior."
+                },
+                "latex-workshop.latex.texDirs": {
+                    "scope": "window",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [],
+                    "markdownDescription": "List of directories where to look for extra input `.tex` files. \nAbsolute paths are required. You may also need to set the environment variable `TEXINPUTS` properly for the LaTeX compiler to find the `.tex` files, see the `env` parameter of [recipes](https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#latex-recipes)."
+                },
+                "latex-workshop.latex.verbatimEnvs": {
+                    "scope": "window",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [
+                        "verbatim",
+                        "lstlisting",
+                        "minted"
+                    ],
+                    "markdownDescription": "List environments with verbatim-like content. These environments are stripped off the `.tex` files before any parsing occurs. Note that this variable has no effect on syntax highlighting."
+                },
+                "latex-workshop.kpsewhich.path": {
+                    "scope": "window",
+                    "type": "string",
+                    "default": "kpsewhich",
+                    "markdownDescription": "Define the location of the kpsewhich executable file."
+                },
+                "latex-workshop.kpsewhich.enabled": {
+                    "scope": "window",
+                    "type": "boolean",
+                    "default": false,
+                    "markdownDescription": "Use kpsewhich as defined by `#latex-workshop.kpsewhich.path#` to resolve bibliography files in addition to looking into the directories listed in `#latex-workshop.latex.bibDirs#`."
+                },
+                "latex-workshop.latex.bibDirs": {
+                    "scope": "window",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [],
+                    "markdownDescription": "List of directories where to look for `.bib` files. Absolute paths are required. This setting is only used by the intellisense feature, you may also need to set the environment variable `BIBINPUTS` properly for the LaTeX compiler to find the `.bib` files."
+                },
+                "latex-workshop.latex.search.rootFiles.include": {
+                    "scope": "resource",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [
+                        "**/*.tex",
+                        "**/*.rnw",
+                        "**/*.Rnw"
+                    ],
+                    "markdownDescription": "Patterns of files to consider for the root detection mechanism. Relative paths are computed from the workspace folder. To detect the root file and the tex file tree, we parse all the `.tex` listed here. If you want to specify all `.tex` files inside directory, say `foo`, and all its subdirectories recursively, you need to use `**/foo/**/*.tex`. If you only want to match `.tex` files at the top level of the workspace, use `*.tex`. For more details, see https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#multi-file-projects"
+                },
+                "latex-workshop.latex.search.rootFiles.exclude": {
+                    "scope": "resource",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [],
+                    "markdownDescription": "Patterns of files to exclude from the root detection mechanism. See also `#latex-workshop.latex.search.rootFiles.include#`. For more details, see the https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#multi-file-projects."
+                },
+                "latex-workshop.latex.rootFile.useSubFile": {
+                    "scope": "resource",
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "When the `subfile` package is used, either the main file or any subfile containing `\\documentclass[main.tex]{subfile}` can be LaTeXing. When `true`, the extension uses the subfile as the rootFile for the `autobuild`, `clean` and `synctex` commands."
+                },
+                "latex-workshop.latex.rootFile.doNotPrompt": {
+                    "scope": "resource",
+                    "type": "boolean",
+                    "default": false,
+                    "markdownDescription": "When the `subfile` package is used, either the main file or any subfile containing `\\documentclass[main.tex]{subfile}` can be LaTeXing. When `false`, the `build` and `view` commands  ask the user's choice first. When `true`, the subfile is used when `#latex-workshop.latex.rootFile.useSubFile#` is also `true`, otherwise the rootFile is used."
+                },
+                "latex-workshop.latex.rootFile.indicator": {
+                    "scope": "resource",
+                    "type": "string",
+                    "default": "\\documentclass[]{}",
+                    "enum": [
+                        "\\documentclass[]{}",
+                        "\\begin{document}"
+                    ],
+                    "markdownDescription": "Determine if the root file is detected based on the presence of \\documentclass[]{} or \\begin{document}."
+                },
+                "latex-workshop.latex.watch.usePolling": {
+                    "scope": "window",
+                    "type": "boolean",
+                    "default": false,
+                    "deprecationMessage": "Deprecated: This config is deprecated and has no use.",
+                    "markdownDeprecationMessage": "**Deprecated**: This config is deprecated and has no use."
+                },
+                "latex-workshop.latex.watch.interval": {
+                    "scope": "window",
+                    "type": "number",
+                    "default": 300,
+                    "deprecationMessage": "Deprecated: This config is deprecated and has no use.",
+                    "markdownDeprecationMessage": "**Deprecated**: This config is deprecated and has no use."
+                },
+                "latex-workshop.latex.watch.delay": {
+                    "scope": "window",
+                    "type": "number",
+                    "default": 250,
+                    "deprecationMessage": "Deprecated: This config is deprecated and has no use.",
+                    "markdownDeprecationMessage": "**Deprecated**: This config is deprecated and has no use."
+                },
+                "latex-workshop.latex.watch.pdf.delay": {
+                    "scope": "window",
+                    "type": "number",
+                    "default": 250,
+                    "markdownDescription": "Defines the time delay before confirming a PDF-like binary file is fully changed. Increase this value if you encounter repeated viewer refreshes and/or loss of PDF scrolling position. LaTeX Workshop internally monitors file change events and initiates auto-builds and/or PDF viewing refresh. When LaTeX is changing large files (particularly binary files like PDFs), multiple consecutive file change events may be emitted, potentially causing file corruption issues. We use this config to control the file polling delay before confirming that the file change has been stabilized. Note that non-binary files such as `.tex`, `.bib`, and `.cls` are not affected."
+                },
+                "latex-workshop.latex.watch.files.ignore": {
+                    "scope": "window",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [
+                        "**/*.bbx",
+                        "**/*.bbl",
+                        "**/*.cbx",
+                        "**/*.cfg",
+                        "**/*.clo",
+                        "**/*.cnf",
+                        "**/*.def",
+                        "**/*.dfu",
+                        "**/*.enc",
+                        "**/*.fd",
+                        "**/*.fmt",
+                        "**/*.lbx",
+                        "**/*.map",
+                        "**/*.mkii",
+                        "**/*.pfb",
+                        "**/*.tfm",
+                        "**/*.vf",
+                        "**/*.code.tex",
+                        "**/*.sty",
+                        "**/texmf-{dist,var}/**",
+                        "**/Local/MiKTeX/**",
+                        "**/Local/Programs/MiKTeX/**",
+                        "**/Roaming/MiKTeX/**",
+                        "**/Program*/MiKTeX*/**",
+                        "**/.miktex/texmfs/**",
+                        "/var/cache/miktex-texmf/**",
+                        "/usr/local/share/miktex-texmf/**",
+                        "**/Library/Application Support/MiKTeX/texmfs/**",
+                        "/dev/null"
+                    ],
+                    "markdownDescription": "Files to ignore from the watching mechanism, i.e., no intellisense or build-on-file-change. However, document structure/outline and build-on-save won't be affected. This property must be an array of glob patterns. The patterns are matched against the absolute file path. To ignore everything inside the `texmf` tree, `**/texmf/**` can be used."
+                },
+                "latex-workshop.latex.autoBuild.run": {
+                    "scope": "resource",
+                    "type": "string",
+                    "enum": [
+                        "never",
+                        "onSave",
+                        "onFileChange"
+                    ],
+                    "enumDescriptions": [
+                        "Never run auto build",
+                        "Auto build whenever a file is saved",
+                        "Auto build whenever a dependency file changes on disk"
+                    ],
+                    "default": "onFileChange",
+                    "markdownDescription": "When the extension shall auto build LaTeX project using the default (first) recipe. \n- `onSave` builds the project upon saving a `tex` file in vscode.\n- `onFileChange` builds the project upon detecting a file change in any of the dependencies, even modified by other applications.\n\n Note that `onSave` is more restrictive than `onFileChange` "
+                },
+                "latex-workshop.latex.autoBuild.interval": {
+                    "scope": "resource",
+                    "type": "integer",
+                    "default": 1000,
+                    "markdownDescription": "The minimal time interval in milliseconds for an auto build to trigger after the previous (manual and auto) build. This value is recommended to be greater than ~500."
+                },
+                "latex-workshop.latex.autoBuild.cleanAndRetry.enabled": {
+                    "scope": "resource",
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "Delete LaTeX auxiliary files when errors occur during build and retry. This property defines whether LaTeX Workshop will try to clean and build the project once again after errors happen in the build toolchain."
+                },
+                "latex-workshop.latex.build.clearLog.everyRecipeStep.enabled": {
+                    "scope": "resource",
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "Clear the LaTeX Compiler logs before every step of a recipe. Set this property to false to keep the logs of all tools in a recipe."
+                },
+                "latex-workshop.latex.autoClean.run": {
+                    "scope": "resource",
+                    "type": "string",
+                    "enum": [
+                        "never",
+                        "onFailed",
+                        "onSucceeded",
+                        "onBuilt"
+                    ],
+                    "enumDescriptions": [
+                        "Never clean the project",
+                        "Clean compilation fails",
+                        "Clean compilation successes",
+                        "Clean after build, be it successful or not"
+                    ],
+                    "default": "never",
+                    "markdownDescription": "When LaTeX auxiliary files should be deleted. The folder to be cleaned is defined in `#latex-workshop.latex.outDir#`.\n- `onFailed` cleans the project when compilation fails.\n- `onBuilt` cleans the project when compilation is done, whether successful or failed."
+                },
+                "latex-workshop.latex.clean.subfolder.enabled": {
+                    "scope": "resource",
+                    "type": "boolean",
+                    "default": false,
+                    "markdownDescription": "Delete LaTeX auxiliary files recursively in sub-folders of `#latex-workshop.latex.outDir#`. Note that sub-folders are not removed."
+                },
+                "latex-workshop.latex.clean.fileTypes": {
+                    "scope": "resource",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [
+                        "*.aux",
+                        "*.bbl",
+                        "*.blg",
+                        "*.idx",
+                        "*.ind",
+                        "*.lof",
+                        "*.lot",
+                        "*.out",
+                        "*.toc",
+                        "*.acn",
+                        "*.acr",
+                        "*.alg",
+                        "*.glg",
+                        "*.glo",
+                        "*.gls",
+                        "*.fls",
+                        "*.log",
+                        "*.fdb_latexmk",
+                        "*.snm",
+                        "*.synctex(busy)",
+                        "*.synctex.gz(busy)",
+                        "*.nav",
+                        "*.vrb"
+                    ],
+                    "markdownDescription": "Files to clean when `#latex-workshop.latex.clean.method#` is set to `glob`.. This property must be an array of strings. File globs such as `*.removeme`, `something?.aux` can be used. Users can also specify glob patterns like `emptyfolder*/` to remove empty folders. Non-empty folders will be ignored. The folder globs must end with a slash and the last path component must not contain the globstar `**`, otherwise the folders will not be removed. The following globs patterns are correct `['abc/', 'abc*/', '**/abc*/', 'abc/**/def/']` but these are not ['**', '**/', 'abc/**', 'abc/**/', 'abc/def**/', 'abc/d**ef/']`."
+                },
+                "latex-workshop.latex.clean.command": {
+                    "scope": "resource",
+                    "type": "string",
+                    "default": "latexmk",
+                    "markdownDescription": "The command to be used to remove temporary files when `#latex-workshop.latex.clean.method#` is set to `command`."
+                },
+                "latex-workshop.latex.clean.args": {
+                    "scope": "resource",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [
+                        "-c",
+                        "%TEX%"
+                    ],
+                    "markdownDescription": "The arguments of `#latex-workshop.latex.clean.command#`. Placeholders listed in https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#placeholders can be used to populate the argument strings. Besides, an additional `%TEX%` placeholder refers to the full path of the tex file from which the clean command is called."
+                },
+                "latex-workshop.latex.clean.method": {
+                    "scope": "resource",
+                    "type": "string",
+                    "default": "glob",
+                    "enum": [
+                        "glob",
+                        "command"
+                    ],
+                    "markdownEnumDescriptions": [
+                        "Clean all the files located in `#latex-workshop.latex.outDir#` and matching the glob patterns listed in `#latex-workshop.latex.clean.fileTypes#`.",
+                        "Run `#latex-workshop.latex.clean.command#` to clean temporary files."
+                    ],
+                    "markdownDescription": "Define how temporary files will be cleaned."
+                },
+                "latex-workshop.latex.option.maxPrintLine.enabled": {
+                    "scope": "resource",
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "Add `--max-print-line` option to LaTeX build commands. This flag tells some MikTeX compilers to produce non hard wrapped log messages. Non hard wrapped log messages are required for the _Problem_ Pane to properly display messages."
+                },
+                "latex-workshop.view.outline.sections": {
+                    "scope": "window",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [
+                        "part",
+                        "chapter",
+                        "section",
+                        "subsection",
+                        "subsubsection"
+                    ],
+                    "markdownDescription": "The section names of LaTeX outline hierarchy. It is also used by the folding mechanism. This property is an array of case-sensitive strings in the order of document structure hierarchy. For multiple tags in the same level, separate the tags with `|` as delimiters, e.g., `section|alternative`."
+                },
+                "latex-workshop.view.outline.commands": {
+                    "scope": "window",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [
+                        "label"
+                    ],
+                    "markdownDescription": "The names of the commands to be shown in the outline/structure views. The commands must be called in the form `\\commandname{arg}`."
+                },
+                "latex-workshop.view.outline.fastparse.enabled": {
+                    "scope": "window",
+                    "type": "boolean",
+                    "default": true,
+                    "deprecationMessage": "Deprecated: This config has been renamed to `latex-workshop.intellisense.fastparse.enabled`.",
+                    "markdownDeprecationMessage": "**Deprecated**: This config has been renamed to `#latex-workshop.intellisense.fastparse.enabled#`."
+                },
+                "latex-workshop.view.outline.floats.enabled": {
+                    "scope": "window",
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "Show the floating objects (figures and tables) in the outline/structure views."
+                },
+                "latex-workshop.view.outline.floats.number.enabled": {
+                    "scope": "window",
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "Show the float number in the outline/structure views."
+                },
+                "latex-workshop.view.outline.floats.caption.enabled": {
+                    "scope": "window",
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "Show the float caption in the outline/structure views."
+                },
+                "latex-workshop.view.outline.numbers.enabled": {
+                    "scope": "window",
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "Show the sectioning numbers in the outline/structure views."
+                },
+                "latex-workshop.view.autoFocus.enabled": {
+                    "scope": "window",
+                    "type": "boolean",
+                    "default": false,
+                    "markdownDescription": "Auto focus the LaTeX view when switching from non-tex to tex files. This will cause the view to appear consistently upon activating the extension."
+                },
+                "latex-workshop.view.pdf.viewer": {
+                    "scope": "window",
+                    "type": "string",
+                    "default": "tab",
+                    "enum": [
+                        "browser",
+                        "tab",
+                        "external"
+                    ],
+                    "markdownDescription": "The default PDF viewer.",
+                    "enumDescriptions": [
+                        "Open PDF with the default web browser.",
+                        "Open PDF with the built-in tab viewer.",
+                        "[Experimental] Open PDF with the external viewer set in \"View > Pdf > External: command\"."
+                    ]
+                },
+                "latex-workshop.view.pdf.tab.editorGroup": {
+                    "scope": "window",
+                    "type": "string",
+                    "default": "right",
+                    "enum": [
+                        "current",
+                        "left",
+                        "right",
+                        "above",
+                        "below"
+                    ],
+                    "markdownDescription": "The editor group in which to open the tab viewer.",
+                    "enumDescriptions": [
+                        "Use the current editor group",
+                        "Put the viewer tab in a new group on the left of the current one",
+                        "Put the viewer tab in a new group on the right of the current one",
+                        "Put the viewer tab in a new group above the current one",
+                        "Put the viewer tab in a new group below the current one"
+                    ]
+                },
+                "latex-workshop.view.pdf.tab.openDelay": {
+                    "scope": "window",
+                    "type": "number",
+                    "default": 1000,
+                    "markdownDescription": "Defines the delay in milliseconds to wait for a tab opening. Please increase the value if you encounter a focus issue after opening a tab."
+                },
+                "latex-workshop.view.pdf.ref.viewer": {
+                    "type": "string",
+                    "default": "auto",
+                    "enum": [
+                        "auto",
+                        "tabOrBrowser",
+                        "external"
+                    ],
+                    "markdownDescription": "PDF viewer used for [View on PDF] link on \\ref."
+                },
+                "latex-workshop.viewer.pdf.internal.port": {
+                    "scope": "window",
+                    "type": "number",
+                    "default": "0",
+                    "markdownDescription": "Define the port to listen on for communicating with the internal viewer. The default value \"0\" means the port is chosen randomly by the application. If this config is set, only one Visual Studio Code instance with this extension active can be opened. Otherwise, a port conflict may happen."
+                },
+                "latex-workshop.view.pdf.internal.synctex.keybinding": {
+                    "scope": "window",
+                    "type": "string",
+                    "default": "ctrl-click",
+                    "enum": [
+                        "ctrl-click",
+                        "double-click"
+                    ],
+                    "markdownDescription": " Which keybinding to use for the internal viewer for reverse synctex. `ctrl`/`cmd` + click (default) or double click."
+                },
+                "latex-workshop.viewer.pdf.internal.keyboardEvent": {
+                    "scope": "window",
+                    "type": "string",
+                    "default": "auto",
+                    "enum": [
+                        "auto",
+                        "force",
+                        "never"
+                    ],
+                    "markdownDescription": "Rebroadcasting KeyboardEvent on the internal viewers. If keyboard shortcuts on the internal viewer do not work well, change this setting."
+                },
+                "latex-workshop.view.pdf.external.viewer.command": {
+                    "scope": "window",
+                    "type": "string",
+                    "default": "",
+                    "markdownDescription": "The command to execute when using external viewer. This function is not officially supported."
+                },
+                "latex-workshop.view.pdf.external.viewer.args": {
+                    "scope": "window",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [
+                        "%PDF%"
+                    ],
+                    "markdownDescription": "The arguments for `#latex-workshop.view.pdf.external.viewer.command#` when using external viewer. This function is not officially supported. %PDF% is the placeholder for the absolute path to the generated PDF file."
+                },
+                "latex-workshop.view.pdf.external.synctex.command": {
+                    "scope": "window",
+                    "type": "string",
+                    "default": "",
+                    "markdownDescription": "The command to execute when forward synctex to external viewer. This function is not officially supported."
+                },
+                "latex-workshop.view.pdf.external.synctex.args": {
+                    "scope": "window",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [
+                        "%LINE%",
+                        "%PDF%",
+                        "%TEX%"
+                    ],
+                    "markdownDescription": "The arguments for `#latex-workshop.view.pdf.external.synctex.args#` when forward synctex to external viewer. %LINE% is the line number, %PDF% is the placeholder for the absolute path to the generated PDF file, and %TEX% is the source LaTeX file path with `.tex` extension from which syncTeX is fired."
+                },
+                "latex-workshop.view.pdf.zoom": {
+                    "scope": "window",
+                    "type": "string",
+                    "default": "auto",
+                    "markdownDescription": "The default zoom level of the PDF viewer. This default value will be passed to the viewer upon opening. Possible values are `auto`, `page-actual`, `page-fit`, `page-width`, and one-based scale values (e.g., 0.5 for 50%, 2.0 for 200%)."
+                },
+                "latex-workshop.view.pdf.trim": {
+                    "scope": "window",
+                    "type": "number",
+                    "default": 0,
+                    "enum": [
+                        0,
+                        1,
+                        2,
+                        3
+                    ],
+                    "markdownDescription": "The default trim mode of the PDF viewer.",
+                    "enumDescriptions": [
+                        "No page trimming",
+                        "Trim 5% at margin",
+                        "Trim 10% at margin",
+                        "Trim 15% at margin"
+                    ]
+                },
+                "latex-workshop.view.pdf.scrollMode": {
+                    "scope": "window",
+                    "type": "number",
+                    "default": 0,
+                    "markdownDescription": "The default scroll mode of the PDF viewer. This default value will be passed to the viewer upon opening. Possible values are `0` (vertical), `1`(horizontal), `2` (wrapped), `3` (page)."
+                },
+                "latex-workshop.view.pdf.spreadMode": {
+                    "scope": "window",
+                    "type": "number",
+                    "default": 0,
+                    "markdownDescription": "The default spread mode of the PDF viewer. This default value will be passed to the viewer upon opening. Possible values are `0` (none), `1` (odd) and `2` (even)."
+                },
+                "latex-workshop.view.pdf.hand": {
+                    "scope": "window",
+                    "type": "boolean",
+                    "default": false,
+                    "markdownDescription": "Define if the hand tool is enabled by default in the PDF viewer."
+                },
+                "latex-workshop.view.pdf.invertMode.enabled": {
+                    "scope": "window",
+                    "type": "string",
+                    "enum": [
+                        "auto",
+                        "always",
+                        "compat",
+                        "never"
+                    ],
+                    "default": "compat",
+                    "markdownDescription": "Enable the CSS invert filter.",
+                    "enumDescriptions": [
+                        "Enable the invert filter when using a dark theme.",
+                        "Always enable invert filter.",
+                        "Enable the invert filter only if `invert > 0`.",
+                        "Disable the invert filter"
+                    ]
+                },
+                "latex-workshop.view.pdf.invert": {
+                    "scope": "window",
+                    "type": "number",
+                    "default": 0,
+                    "markdownDescription": " Define the CSS invert filter level of the PDF viewer. This config can invert the color of PDF. Possible values are from 0 to 1."
+                },
+                "latex-workshop.view.pdf.invertMode.brightness": {
+                    "scope": "window",
+                    "type": "number",
+                    "default": 1,
+                    "markdownDescription": " Define the CSS brightness filter level of the PDF viewer when the invert mode is enabled. Possible values are from 0 to 2."
+                },
+                "latex-workshop.view.pdf.invertMode.grayscale": {
+                    "scope": "window",
+                    "type": "number",
+                    "default": 0.6,
+                    "markdownDescription": " Define the CSS grayscale filter level of the PDF viewer when the invert mode is enabled. Possible values are from 0 to 1."
+                },
+                "latex-workshop.view.pdf.invertMode.hueRotate": {
+                    "scope": "window",
+                    "type": "number",
+                    "default": 180,
+                    "markdownDescription": " Define the CSS hue-rotate filter angle of the PDF viewer when the invert mode is enabled. Possible values are from 0 to 360."
+                },
+                "latex-workshop.view.pdf.invertMode.sepia": {
+                    "scope": "window",
+                    "type": "number",
+                    "default": 0,
+                    "markdownDescription": " Define the CSS sepia filter level of the PDF viewer when the invert mode is enabled. Possible values are from 0 to 1."
+                },
+                "latex-workshop.view.pdf.color.light.pageColorsForeground": {
+                    "scope": "window",
+                    "type": "string",
+                    "default": "",
+                    "markdownDescription": " The foreground color of the PDF document 1) in tab viewer when the vscode color theme is light, and 2) in browser when the OS theme is light. The string must represent a color in HTML."
+                },
+                "latex-workshop.view.pdf.color.light.pageColorsBackground": {
+                    "scope": "window",
+                    "type": "string",
+                    "default": "",
+                    "markdownDescription": " The background color of the PDF document 1) in tab viewer when the vscode color theme is light, and 2) in browser when the OS theme is light. The string must represent a color in HTML."
+                },
+                "latex-workshop.view.pdf.color.light.backgroundColor": {
+                    "scope": "window",
+                    "type": "string",
+                    "default": "#ffffff",
+                    "markdownDescription": " The background color of the viewer 1) in tab viewer when the vscode color theme is light, and 2) in browser when the OS theme is light. The string must represent a color in HTML."
+                },
+                "latex-workshop.view.pdf.color.light.pageBorderColor": {
+                    "scope": "window",
+                    "type": "string",
+                    "default": "lightgrey",
+                    "markdownDescription": " The border color of the PDF pages 1) in tab viewer when the vscode color theme is light, and 2) in browser when the OS theme is light. The string must represent a color in HTML."
+                },
+                "latex-workshop.view.pdf.color.dark.pageColorsForeground": {
+                    "scope": "window",
+                    "type": "string",
+                    "default": "",
+                    "markdownDescription": " The foreground color of the PDF document 1) in tab viewer when the vscode color theme is dark, and 2) in browser when the OS theme is dark. The string must represent a color in HTML."
+                },
+                "latex-workshop.view.pdf.color.dark.pageColorsBackground": {
+                    "scope": "window",
+                    "type": "string",
+                    "default": "",
+                    "markdownDescription": " The background color of the PDF document 1) in tab viewer when the vscode color theme is dark, and 2) in browser when the OS theme is dark. The string must represent a color in HTML."
+                },
+                "latex-workshop.view.pdf.color.dark.backgroundColor": {
+                    "scope": "window",
+                    "type": "string",
+                    "default": "#ffffff",
+                    "markdownDescription": " The background color of the viewer 1) in tab viewer when the vscode color theme is dark, and 2) in browser when the OS theme is dark. The string must represent a color in HTML."
+                },
+                "latex-workshop.view.pdf.color.dark.pageBorderColor": {
+                    "scope": "window",
+                    "type": "string",
+                    "default": "lightgrey",
+                    "markdownDescription": " The border color of the PDF pages 1) in tab viewer when the vscode color theme is dark, and 2) in browser when the OS theme is dark. The string must represent a color in HTML."
+                },
+                "latex-workshop.synctex.path": {
+                    "scope": "window",
+                    "type": "string",
+                    "default": "synctex",
+                    "markdownDescription": "Define the location of SyncTeX executive file. Additional arguments, e.g., synctex modes and position of click, will be appended to this command."
+                },
+                "latex-workshop.synctex.afterBuild.enabled": {
+                    "scope": "window",
+                    "type": "boolean",
+                    "default": false,
+                    "markdownDescription": "Execute forward synctex at cursor position after compiling LaTeX project."
+                },
+                "latex-workshop.synctex.synctexjs.enabled": {
+                    "scope": "window",
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "Enable using a builtin synctex function. The command set in latex-workshop.synctex.path will not be used."
+                },
+                "latex-workshop.linting.chktex.enabled": {
+                    "scope": "resource",
+                    "type": "boolean",
+                    "default": false,
+                    "markdownDescription": "Enable linting LaTeX with `chktex`. Check `#latex-workshop.linting.run#` to control when `chktex` is executed if this config is set to `true."
+                },
+                "latex-workshop.linting.lacheck.enabled": {
+                    "scope": "resource",
+                    "type": "boolean",
+                    "default": false,
+                    "markdownDescription": "Enable linting LaTeX with `lacheck`. Check `#latex-workshop.linting.run#` to control when `lacheck` is executed if this config is set to `true."
+                },
+                "latex-workshop.linting.run": {
+                    "scope": "resource",
+                    "type": "string",
+                    "enum": [
+                        "onSave",
+                        "onType"
+                    ],
+                    "enumDescriptions": [
+                        "Lint the whole LaTeX project upon saving",
+                        "Lint the active document when input is stopped"
+                    ],
+                    "default": "onSave",
+                    "markdownDescription": "When LaTeX should be linted.\n- `onSave`: the whole LaTeX project will be linted upon saving.\n- `onType`: the active document will be linted when input is stopped for a period of time defined in `#latex-workshop.linting.delay#`. It also implies `onSave`."
+                },
+                "latex-workshop.linting.chktex.exec.path": {
+                    "scope": "window",
+                    "type": "string",
+                    "default": "chktex",
+                    "markdownDescription": "Define the location of ChkTeX executive file. This command will be joint with `#latex-workshop.linting.chktex.exec.args#` and required arguments to form a complete command of ChkTeX."
+                },
+                "latex-workshop.linting.chktex.exec.args": {
+                    "scope": "resource",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [
+                        "-wall",
+                        "-n22",
+                        "-n30",
+                        "-e16",
+                        "-q"
+                    ],
+                    "markdownDescription": "Linter arguments to check LaTeX syntax of the current file state in real time with ChkTeX. Arguments must be in separate strings in the array. Additional arguments, i.e., `-I0 -f%f:%l:%c:%d:%k:%n:%m\\n` will be appended when constructing the command. Current file contents will be piped to the command through stdin."
+                },
+                "latex-workshop.linting.chktex.convertOutput.column.enabled": {
+                    "scope": "resource",
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "Enable converting ChkTeX outputs' column numbers for non-ASCII characters."
+                },
+                "latex-workshop.linting.chktex.convertOutput.column.chktexrcTabSize": {
+                    "scope": "resource",
+                    "type": "number",
+                    "default": -1,
+                    "markdownDescription": "Write the `TabSize` number from `.chktexrc`. The default value \"-1\" means that LaTeX Workshop will try to find `.chktexrc` and to read the value from it."
+                },
+                "latex-workshop.linting.delay": {
+                    "scope": "resource",
+                    "type": "number",
+                    "default": 500,
+                    "markdownDescription": "Defines the delay in milliseconds for linter to wait after stopped typing. This config only matters when `#latex-workshop.linting.run#` is set to `onType`."
+                },
+                "latex-workshop.linting.lacheck.exec.path": {
+                    "scope": "window",
+                    "type": "string",
+                    "default": "lacheck",
+                    "markdownDescription": "Define the location of LaCheck executive file."
+                },
+                "latex-workshop.check.duplicatedLabels.enabled": {
+                    "scope": "window",
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "Enable checking for duplicated labels. A new check is triggered every time the intellisense data is updated, see `#latex-workshop.intellisense.update.aggressive.enabled#`."
+                },
+                "latex-workshop.texcount.path": {
+                    "scope": "window",
+                    "type": "string",
+                    "default": "texcount",
+                    "markdownDescription": "Define the location of TeXCount executive file/script. This command will be joint with `#latex-workshop.texcount.args#` and required arguments to form a complete command of TeXCount."
+                },
+                "latex-workshop.texcount.args": {
+                    "scope": "resource",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [],
+                    "markdownDescription": "TeXCount arguments to count words in the LaTeX documents of the entire project from the root file, or the current document. Arguments must be in separate strings in the array. Additional arguments, i.e., `-merge %DOC%` for the project and the current document path for counting current file will be appended when constructing the command."
+                },
+                "latex-workshop.texcount.autorun": {
+                    "scope": "resource",
+                    "type": "string",
+                    "enum": [
+                        "onSave",
+                        "never"
+                    ],
+                    "enumDescriptions": [
+                        "Count words in the current document",
+                        "Never automatically call texcount"
+                    ],
+                    "default": "never",
+                    "markdownDescription": "When to call `texcount`. Default is never."
+                },
+                "latex-workshop.texcount.interval": {
+                    "scope": "resource",
+                    "type": "number",
+                    "default": 1000,
+                    "markdownDescription": "The minimal time interval between two consecutive runs of `texcount` in milliseconds when `#latex-workshop.texcount.run#` is set to `onSave`."
+                },
+                "latex-workshop.intellisense.fastparse.enabled": {
+                    "scope": "window",
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "Use fast LaTeX parsing algorithm to build outline/structure. This is done by inherently removing texts and comments before building AST. Enabling this will not tamper the document, but may result in incomplete outline/structure."
+                },
+                "latex-workshop.intellisense.update.aggressive.enabled": {
+                    "scope": "window",
+                    "type": "boolean",
+                    "default": false,
+                    "markdownDescription": "Defines whether the extension aggressively parses the changed content after stopped typing. Disable this config will let the extension only update intellisense after saving changed files."
+                },
+                "latex-workshop.intellisense.update.delay": {
+                    "scope": "window",
+                    "type": "number",
+                    "default": 1000,
+                    "markdownDescription": "Defines the delay in milliseconds for the extension to update current active file content for intellisense after stopped typing. This config works only when `intellisense.update.aggressive.enabled` is enabled. Lower this value to let the extension know newly defined commands/references/environments more quickly, at the cost of more frequent content parsing: more computational burden."
+                },
+                "latex-workshop.intellisense.atSuggestion.user": {
+                    "scope": "window",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "default": {},
+                    "markdownDescription": "Dictionary of `\"@prefix\": \"snippet command\"` to add to, replace, or remove the default suggestions in `data/at-suggestions.json`. The key of the dictionary is the triggering string, which **must** starts with `@` regardless of `#latex-workshop.intellisense.atSuggestion.trigger.latex#`. The value of the dictionary is the snippet to be inserted. If the key is identical to a default snippet defined in `data/at-suggestions.json`, the new value in the dictionary is used for suggestion. If the value is an empty string, the snippet is removed from suggestion. For example, `{ \"@.\": \"\\cdot\", \"@6\": \"\" }`."
+                },
+                "latex-workshop.intellisense.command.user": {
+                    "scope": "window",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "default": {},
+                    "markdownDescription": "Dictionary of `\"command name\": \"command snippet\"` to add to, replace, or remove the default ones in `data/commands.json`. The key of the dictionary is the command name with optional braces indicating the command arguments. The value of the dictionary is the snippet to be inserted. If the key is identical to a default command suggestion defined in `data/commands.json`, the new value in the dictionary is used for suggestion. If the value is an empty string, the command is removed from suggestion. Leading backslashes will be added to both the name and snippet by the extension, so don't include them in this config. For example, `{\"mycommand[]{}\": \"notsamecommand[${2:option}]{$TM_SELECTED_TEXT$1}\", \"parbox{}{}\": \"parbox{${2:width}}{$TM_SELECTED_TEXT$1}\", \"overline{}\": \"\"}` adds a new command with name `mycommand[]{} that inserts `\\notsamecommand[]{}`, replaces the default snippet of `\\parbox{}{}` to make it include current selected text, and removes `\\overline{}` from suggestion."
+                },
+                "latex-workshop.intellisense.citation.type": {
+                    "scope": "window",
+                    "type": "string",
+                    "enum": [
+                        "inline",
+                        "browser"
+                    ],
+                    "default": "inline",
+                    "markdownDescription": "Defines which type of hint to show when intellisense provides citation suggestions.",
+                    "enumDescriptions": [
+                        "Use the inline intellisense to provide citation completion items.",
+                        "Use a dropdown menu to provide citation completion items."
+                    ]
+                },
+                "latex-workshop.intellisense.citation.label": {
+                    "scope": "resource",
+                    "type": "string",
+                    "enum": [
+                        "bibtex key",
+                        "title",
+                        "authors"
+                    ],
+                    "default": "bibtex key",
+                    "markdownDescription": "Defines what to show as suggestion labels when intellisense provides citation suggestions in inline mode.",
+                    "enumDescriptions": [
+                        "Show bibtex keys in the inline mode.",
+                        "Show publication titles in the inline mode.",
+                        "Show publication authors in the inline mode."
+                    ]
+                },
+                "latex-workshop.intellisense.citation.format": {
+                    "scope": "resource",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [
+                        "author",
+                        "title",
+                        "journal",
+                        "publisher",
+                        "booktitle",
+                        "year"
+                    ],
+                    "markdownDescription": "List of fields to display for citation preview and intellisense. This list is also used as the filter text to narrow down the intellisense suggestions."
+                },
+                "latex-workshop.intellisense.triggers.latex": {
+                    "scope": "window",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [
+                        "{"
+                    ],
+                    "markdownDescription": "Additional trigger characters for intellisense of LaTeX documents."
+                },
+                "latex-workshop.intellisense.atSuggestion.trigger.latex": {
+                    "scope": "window",
+                    "type": "string",
+                    "default": "@",
+                    "markdownDescription": "Character to trigger snippet suggestions as part of intellisense. Set this variable to `''` to deactivate these suggestions."
+                },
+                "latex-workshop.intellisense.atSuggestionJSON.replace": {
+                    "scope": "window",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "default": {},
+                    "deprecationMessage": "Deprecated: This config has been renamed to `latex-workshop.intellisense.atSuggestion.user`.",
+                    "markdownDeprecationMessage": "**Deprecated**: This config has been renamed to `#latex-workshop.intellisense.atSuggestion.user#`."
+                },
+                "latex-workshop.intellisense.file.exclude": {
+                    "scope": "resource",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [
+                        "**/*.aux",
+                        "**/*.bbl",
+                        "**/*.bcf",
+                        "**/*.blg",
+                        "**/*.idx",
+                        "**/*.ind",
+                        "**/*.lof",
+                        "**/*.lot",
+                        "**/*.out",
+                        "**/*.toc",
+                        "**/*.acn",
+                        "**/*.acr",
+                        "**/*.alg",
+                        "**/*.glg",
+                        "**/*.glo",
+                        "**/*.gls",
+                        "**/*.ist",
+                        "**/*.fls",
+                        "**/*.log",
+                        "**/*.nav",
+                        "**/*.snm",
+                        "**/*.fdb_latexmk",
+                        "**/*.synctex.gz",
+                        "**/*.run.xml"
+                    ],
+                    "markdownDescription": "Patterns to ignore in file completion"
+                },
+                "latex-workshop.intellisense.file.base": {
+                    "scope": "resource",
+                    "type": "string",
+                    "enum": [
+                        "root relative",
+                        "file relative",
+                        "both"
+                    ],
+                    "default": "root relative",
+                    "markdownDescription": "Specify the base directory for file completion",
+                    "enumDescriptions": [
+                        "Completion from the root file directory",
+                        "Completion from the current file directory",
+                        "both"
+                    ]
+                },
+                "latex-workshop.intellisense.label.command": {
+                    "scope": "window",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [
+                        "label",
+                        "linelabel"
+                    ],
+                    "markdownDescription": "The name of LaTeX commands that indicates a label definition. The command must accept one mandatory argument of the label reference string, e.g, \\linelabel{ref-str}."
+                },
+                "latex-workshop.intellisense.label.keyval": {
+                    "scope": "window",
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "Scan for labels defined as `label={some tex}` to add to the reference intellisense menu. The braces are mandatory."
+                },
+                "latex-workshop.intellisense.unimathsymbols.enabled": {
+                    "scope": "window",
+                    "type": "boolean",
+                    "default": false,
+                    "markdownDescription": "When `\\` is typed, show unimath symbols in the dropdown selector."
+                },
+                "latex-workshop.intellisense.package.enabled": {
+                    "scope": "window",
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "Auto-complete commands and environments from used packages."
+                },
+                "latex-workshop.intellisense.package.extra": {
+                    "scope": "window",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [],
+                    "markdownDescription": "List of extra packages to always add to the auto-completion mechanism. When `#latex-workshop.intellisense.package.enabled#` is set to `true`, the commands and environments defined in these extra packages will be added to the intellisense suggestions."
+                },
+                "latex-workshop.intellisense.package.exclude": {
+                    "scope": "window",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [],
+                    "markdownDescription": "List of packages to exclude from the auto-completion mechanism. When `#latex-workshop.intellisense.package.enabled#` is set to `true`, the commands and environments defined in these packages will not be added to the intellisense suggestions. This setting has a higher priority over `#latex-workshop.intellisense.package.extra#`. You may include the string \"lw-default\" in the list to remove all default commands and environments."
+                },
+                "latex-workshop.intellisense.package.env.enabled": {
+                    "scope": "window",
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "If true, every environment provided by an included package is available by a snippet `\\envname`. Only applies when `#latex-workshop.intellisense.package.enabled#` is true. "
+                },
+                "latex-workshop.intellisense.package.dirs": {
+                    "scope": "window",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [],
+                    "markdownDescription": "List of extra directories to look for package completion files in addition to those provided by the extension. See https://github.com/James-Yu/LaTeX-Workshop/wiki/Intellisense#commands-starting-with- to learn how to generate these files. Files found in these directories have a higher priority over the default ones. This setting is only relevant when `#latex-workshop.intellisense.package.env.enabled#` is true."
+                },
+                "latex-workshop.intellisense.includegraphics.preview.enabled": {
+                    "scope": "window",
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "Enable preview for `\\includegraphics` completion."
+                },
+                "latex-workshop.message.badbox.show": {
+                    "scope": "window",
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "Show badbox information in the problems panel."
+                },
+                "latex-workshop.message.biberlog.exclude": {
+                    "scope": "window",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [],
+                    "markdownDescription": "Exclude biber log messages matching the given regexp from the problems panel."
+                },
+                "latex-workshop.message.bibtexlog.exclude": {
+                    "scope": "window",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [],
+                    "markdownDescription": "Exclude bibtex log messages matching the given regexp from the problems panel."
+                },
+                "latex-workshop.message.latexlog.exclude": {
+                    "scope": "window",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [],
+                    "markdownDescription": "Exclude latex log messages matching the given regexp from the problems panel."
+                },
+                "latex-workshop.message.information.show": {
+                    "scope": "window",
+                    "type": "boolean",
+                    "default": false,
+                    "markdownDescription": "Display information messages in popup notifications."
+                },
+                "latex-workshop.message.warning.show": {
+                    "scope": "window",
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "Display warning messages in popup notifications."
+                },
+                "latex-workshop.message.error.show": {
+                    "scope": "window",
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "Display error messages in popup notifications."
+                },
+                "latex-workshop.message.log.show": {
+                    "scope": "window",
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "Display LaTeX Workshop debug log in output panel. This property defines whether LaTeX Workshop will output its debug log to the log panel."
+                },
+                "latex-workshop.message.convertFilenameEncoding": {
+                    "scope": "window",
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "Convert the encoding of filenames if necessary when displaying them in the problems panel."
+                },
+                "latex-workshop.latexindent.path": {
+                    "scope": "window",
+                    "type": "string",
+                    "default": "latexindent",
+                    "markdownDescription": "Define the location of the latexindent executable file."
+                },
+                "latex-workshop.latexindent.args": {
+                    "scope": "resource",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [
+                        "-c",
+                        "%DIR%/",
+                        "%TMPFILE%",
+                        "-y=defaultIndent: '%INDENT%'"
+                    ],
+                    "markdownDescription": "Define the command line arguments for latexindent. In the addition to the placeholders defined at https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#placeholders, the following placeholders are accepted\n- %TMPFILE%: The full path of the raw TeX file to be formatted. At this moment you need to use it as an input file of `latexindent`.\n- %INDENT%: The indent character of the file, typically `\t`, `' '`, `' '`.\n\nNote that the option `-c` requires a trailing slash."
+                },
+                "latex-workshop.docker.enabled": {
+                    "scope": "window",
+                    "type": "boolean",
+                    "default": false,
+                    "markdownDescription": "Enable docker-based LaTeX distribution support. Do not set this item to `true` unless you are aware of what it means. This extension will use the images defined in `#latex-workshop.docker.image.latex#` to execute `latexmk`, `synctex`, `texcount`, and `latexindent`."
+                },
+                "latex-workshop.docker.image.latex": {
+                    "scope": "window",
+                    "type": "string",
+                    "default": "",
+                    "markdownDescription": "Define the image for `latexmk`, `synctex`, `texcount`, and `latexindent`."
+                },
+                "latex-workshop.showContextMenu": {
+                    "scope": "window",
+                    "type": "boolean",
+                    "default": false,
+                    "markdownDescription": "Enable the LaTeX contextual menu. This menu is deactivated as it is available through the new LaTeX badge. Just set this variable to `true` to recover the menu."
+                },
+                "latex-workshop.bind.enter.key": {
+                    "scope": "window",
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "Enable the automatic insertion of `\\item` on a newline when pressing `Enter` in a line starting in `\\item`."
+                },
+                "latex-workshop.bind.altKeymap.enabled": {
+                    "scope": "window",
+                    "type": "boolean",
+                    "default": false,
+                    "markdownDescription": "Use alternative keymap combo, i.e., `ctrl`+`l` `alt`+`key`, to replace the default `ctrl`/`cmd`+`alt` shortcuts."
+                },
+                "latex-workshop.hover.ref.enabled": {
+                    "scope": "window",
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "Enable Hover on References."
+                },
+                "latex-workshop.hover.ref.number.enabled": {
+                    "scope": "window",
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "Show number assigned to the reference in the previous compilation."
+                },
+                "latex-workshop.hover.citation.enabled": {
+                    "scope": "window",
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "Enable Hover on Citations."
+                },
+                "latex-workshop.hover.command.enabled": {
+                    "scope": "window",
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "Enable Hover on Commands to show the possible signatures."
+                },
+                "latex-workshop.hover.preview.enabled": {
+                    "scope": "window",
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "Enable Hover Preview."
+                },
+                "latex-workshop.hover.preview.maxLines": {
+                    "scope": "window",
+                    "type": "number",
+                    "default": 20,
+                    "markdownDescription": "Maximum number of lines between the beginning of the math environment and the cursor position to allow preview."
+                },
+                "latex-workshop.hover.preview.scale": {
+                    "scope": "window",
+                    "type": "number",
+                    "default": 1,
+                    "markdownDescription": "Scaling of Hover Preview."
+                },
+                "latex-workshop.hover.preview.newcommand.parseTeXFile.enabled": {
+                    "scope": "window",
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "Enable newcommands defined in the current TeX file to be included in Hover Preview."
+                },
+                "latex-workshop.hover.preview.newcommand.newcommandFile": {
+                    "scope": "window",
+                    "type": "string",
+                    "default": "",
+                    "markdownDescription": "Set the path of a file containing newcommands to be used in Hover Preview. If the path is relative, it is joined with the root dir."
+                },
+                "latex-workshop.hover.preview.cursor.enabled": {
+                    "scope": "window",
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "Render cursor in Hover Preview at the current position."
+                },
+                "latex-workshop.hover.preview.cursor.symbol": {
+                    "scope": "window",
+                    "type": "string",
+                    "default": "\\!|\\!",
+                    "markdownDescription": "Cursor symbol in Hover Preview."
+                },
+                "latex-workshop.hover.preview.cursor.color": {
+                    "scope": "window",
+                    "type": "string",
+                    "default": "auto",
+                    "enum": [
+                        "auto",
+                        "black",
+                        "blue",
+                        "brown",
+                        "cyan",
+                        "darkgray",
+                        "gray",
+                        "green",
+                        "lightgray",
+                        "lime",
+                        "magenta",
+                        "olive",
+                        "orange",
+                        "pink",
+                        "purple",
+                        "red",
+                        "teal",
+                        "violet",
+                        "white",
+                        "yellow"
+                    ],
+                    "markdownDescription": "The color of cursor in Hover Preview."
+                },
+                "latex-workshop.hover.preview.mathjax.extensions": {
+                    "scope": "window",
+                    "type": "array",
+                    "default": [],
+                    "markdownDescription": "MathJax extensions to load for Hover Preview. See [the list](https://docs.mathjax.org/en/latest/input/tex/extensions/index.html). Note that the following extensions are loaded by default: `ams`, `color`, `newcommand`, `noerrors`, and `noundefined`. They cannot be disabled.",
+                    "items": {
+                        "type": "string",
+                        "enum": [
+                            "amscd",
+                            "bbox",
+                            "boldsymbol",
+                            "braket",
+                            "bussproofs",
+                            "cancel",
+                            "cases",
+                            "centernot",
+                            "colortbl",
+                            "empheq",
+                            "enclose",
+                            "extpfeil",
+                            "gensymb",
+                            "html",
+                            "mathtools",
+                            "mhchem",
+                            "physics",
+                            "textcomp",
+                            "textmacros",
+                            "unicode",
+                            "upgreek",
+                            "verb"
+                        ]
+                    },
+                    "uniqueItems": true
+                },
+                "latex-workshop.intellisense.optionalArgsEntries.enabled": {
+                    "scope": "window",
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "Some LaTeX commands can have several forms, each with different arguments. If set to True, the intellisense completion list will have one entry for each form of a given command. Default is true."
+                },
+                "latex-workshop.intellisense.argumentHint.enabled": {
+                    "scope": "window",
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "Many snippets use text hints of the form `${\\d:some_tex}` for their argument. You may prefer to hide instead by setting this configuration to `false`."
+                },
+                "latex-workshop.intellisense.citation.backend": {
+                    "scope": "resource",
+                    "type": "string",
+                    "enum": [
+                        "bibtex",
+                        "biblatex"
+                    ],
+                    "default": "bibtex",
+                    "markdownDescription": "Backend to use for citation intellisense."
+                },
+                "latex-workshop.intellisense.bibtexJSON.replace": {
+                    "scope": "resource",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": {},
+                    "markdownDescription": "Dictionary of `\"entry name\": [\"array\", \"of\", \"fields\"]` to replace the default fields used in `data/bibtex-entries.json`. See `data/bibtex-entries.json` for the list of fields for each entry. This variable is used when `#latex-workshop.intellisense.citation.backend#` is set to `biblatex`."
+                },
+                "latex-workshop.intellisense.biblatexJSON.replace": {
+                    "scope": "resource",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": {},
+                    "markdownDescription": "Dictionary of `\"entry name\": [\"array\", \"of\", \"fields\"]` to replace the default fields used in `data/biblatex-entries.json`. See `data/biblatex-entries.json` for the list of fields for each entry. This variable is used when `#latex-workshop.intellisense.citation.backend#` is set to `bibtex`."
+                },
+                "latex-workshop.intellisense.commandsJSON.replace": {
+                    "scope": "window",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "default": {},
+                    "deprecationMessage": "Deprecated: This config has been superseded by config `latex-workshop.intellisense.command.user`, which provides more features.",
+                    "markdownDeprecationMessage": "**Deprecated**: This config has been superseded by config `#latex-workshop.intellisense.command.user#`, which provides more features."
+                },
+                "latex-workshop.texdoc.path": {
+                    "scope": "window",
+                    "type": "string",
+                    "default": "texdoc",
+                    "markdownDescription": "Define the location of the `texdoc` executable. This command is used to show a package documentation."
+                },
+                "latex-workshop.texdoc.args": {
+                    "scope": "window",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [
+                        "--view"
+                    ],
+                    "markdownDescription": "Texdoc arguments to see a package documentation. Arguments must be in separate strings in the array. The package name is automatically appended to the arguments."
+                },
+                "latex-workshop.bibtex.maxFileSize": {
+                    "scope": "window",
+                    "type": "number",
+                    "default": 5,
+                    "markdownDescription": "Defines the maximum bibtex file size for the extension to parse in MB."
+                },
+                "latex-workshop.bibtex-format.tab": {
+                    "scope": "resource",
+                    "type": "string",
+                    "default": "2 spaces",
+                    "markdownDescription": "Indentation for each field. The string can be `\"tab\"` or of the form `\"X spaces\"` or simply `\"X\"` where `X` is a number."
+                },
+                "latex-workshop.bibtex-format.surround": {
+                    "scope": "resource",
+                    "type": "string",
+                    "enum": [
+                        "Curly braces",
+                        "Quotation marks"
+                    ],
+                    "default": "Curly braces",
+                    "description": "Surround each field value with either {Curly braces} or \"Quotation marks\"."
+                },
+                "latex-workshop.bibtex-format.case": {
+                    "scope": "resource",
+                    "type": "string",
+                    "enum": [
+                        "UPPERCASE",
+                        "lowercase"
+                    ],
+                    "default": "lowercase",
+                    "description": "Determines if field names should be formatted like 'AUTHOR' or 'author'."
+                },
+                "latex-workshop.bibtex-format.trailingComma": {
+                    "scope": "resource",
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Keep the trailing comma of the last field item."
+                },
+                "latex-workshop.bibtex-format.sortby": {
+                    "scope": "resource",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "markdownDescription": "An array of strings to sort by. Either a bibtex field name (title, author, year, etc.), or `\"year-desc\"` to sort by year in descending order, or `\"key\"` for the entry key, or `\"type\"` for the entry type (article, book, misc, etc.). E.g. `[\"author\", \"year-desc\", \"title\"]`.",
+                    "default": [
+                        "key"
+                    ]
+                },
+                "latex-workshop.bibtex-format.handleDuplicates": {
+                    "scope": "resource",
+                    "type": "string",
+                    "enum": [
+                        "Ignore Duplicates",
+                        "Highlight Duplicates",
+                        "Comment Duplicates"
+                    ],
+                    "default": "Highlight Duplicates",
+                    "markdownDescription": "How to handle duplicates found by the bibtex sorting functions. Duplicates are decided according to the `bibtex-format.sortby` config."
+                },
+                "latex-workshop.bibtex-format.sort.enabled": {
+                    "scope": "resource",
+                    "type": "boolean",
+                    "default": false,
+                    "markdownDescription": "Sort content when calling VSCode format on a .bib file."
+                },
+                "latex-workshop.bibtex-format.align-equal.enabled": {
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "Align equal signs when calling VSCode format on a .bib file."
+                },
+                "latex-workshop.bibtex-entries.first": {
+                    "scope": "resource",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [
+                        "string",
+                        "xdata"
+                    ],
+                    "markdownDescription": "When `#latex-workshop.bibtex-fields.sort.enabled#` is true, these fields are put at the top, in the order defined by the array."
+                },
+                "latex-workshop.bibtex-fields.sort.enabled": {
+                    "scope": "resource",
+                    "type": "boolean",
+                    "default": false,
+                    "markdownDescription": "Sort fields inside every entry. The sorting order is defined by `#latex-workshop.bibtex-fields.order#`. This variable only has effect when formatting bibtex aligns fields. It is not possible to sort entries without aligning them."
+                },
+                "latex-workshop.bibtex-fields.order": {
+                    "scope": "resource",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [],
+                    "markdownDescription": "When `#latex-workshop.bibtex-fields.sort.enabled#` is true, sort fields according the order defined here and then alphabetically for non listed fields."
+                },
+                "latex-workshop.mathpreviewpanel.cursor.enabled": {
+                    "scope": "window",
+                    "type": "boolean",
+                    "default": false,
+                    "markdownDescription": "[Experimental] Render a cursor on the math preview panel. **This feature is experimental. If you report an issue to us on this feature, we will not fix it. We will not accept any pull requests.**"
+                },
+                "latex-workshop.mathpreviewpanel.editorGroup": {
+                    "scope": "window",
+                    "type": "string",
+                    "default": "below",
+                    "enum": [
+                        "current",
+                        "left",
+                        "right",
+                        "above",
+                        "below"
+                    ],
+                    "markdownDescription": "The editor group in which to open the math preview panel.",
+                    "enumDescriptions": [
+                        "Use the current editor group",
+                        "Put the math preview panel in a new group on the left of the current one",
+                        "Put the math preview panel in a new group on the right of the current one",
+                        "Put the math preview panel in a new group above the current one",
+                        "Put the math preview panel in a new group below the current one"
+                    ]
+                },
+                "latex-workshop.selection.smart.latex.enabled": {
+                    "scope": "window",
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "Enable AST based smart selection. Command ids are `editor.action.smartSelect.expand` and `editor.action.smartSelect.shrink`."
+                },
+                "latex-workshop.codespaces.portforwarding.openDelay": {
+                    "scope": "window",
+                    "type": "number",
+                    "default": 20000,
+                    "markdownDescription": "Delay to wait for GitHub Codespaces Authentication of port forwarding to be resolved, in milliseconds."
+                }
+            }
         },
-        "latex-workshop.latex.magic.bib.args": {
-          "scope": "resource",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": [
-            "%DOCFILE%"
-          ],
-          "markdownDescription": "Define the arguments to be input to BIB magic command executable. This can be overridden by using \"% !BIB options\"."
-        },
-        "latex-workshop.latex.external.build.command": {
-          "scope": "resource",
-          "type": "string",
-          "default": "",
-          "markdownDescription": "The external command to execute when calling latex-workshop.build. This is useful when compiling relies on a Makefile or a bespoke script. When defined, it completely bypasses the recipes and root file detection mechanism."
-        },
-        "latex-workshop.latex.external.build.args": {
-          "scope": "resource",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": [],
-          "markdownDescription": "The arguments of `#latex-workshop.latex.external.build.command#` when calling latex-workshop.build."
-        },
-        "latex-workshop.latex.build.forceRecipeUsage": {
-          "scope": "resource",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Force the use the recipe mechanism even if some magic comments are present."
-        },
-        "latex-workshop.latex.outDir": {
-          "scope": "resource",
-          "type": "string",
-          "default": "%DIR%",
-          "markdownDescription": "The directory where the extension tries to find project files (e.g., PDF and SyncTeX files) are located. Both relative and absolute paths are supported. Relative path start from the root file location, so beware if it is located in sub-directory. The path must not contain a trailing slash. The LaTeX toolchain should output files to this path. For a list of supported placeholders, please visit https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#placeholders."
-        },
-        "latex-workshop.latex.jobname": {
-          "scope": "resource",
-          "type": "string",
-          "default": "",
-          "markdownDescription": "The jobname argument of the compiling tool, which is used by the extension to find project files (e.g., PDF and SyncTeX files). This config should be set identical to the value provided to the `-jobname=` argument, and should not have placeholders. Leave the config empty to ignore jobname and keep the default behavior."
-        },
-        "latex-workshop.latex.texDirs": {
-          "scope": "window",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": [],
-          "markdownDescription": "List of directories where to look for extra input `.tex` files. \nAbsolute paths are required. You may also need to set the environment variable `TEXINPUTS` properly for the LaTeX compiler to find the `.tex` files, see the `env` parameter of [recipes](https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#latex-recipes)."
-        },
-        "latex-workshop.latex.verbatimEnvs": {
-          "scope": "window",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": [
-            "verbatim",
-            "lstlisting",
-            "minted"
-          ],
-          "markdownDescription": "List environments with verbatim-like content. These environments are stripped off the `.tex` files before any parsing occurs. Note that this variable has no effect on syntax highlighting."
-        },
-        "latex-workshop.kpsewhich.path": {
-          "scope": "window",
-          "type": "string",
-          "default": "kpsewhich",
-          "markdownDescription": "Define the location of the kpsewhich executable file."
-        },
-        "latex-workshop.kpsewhich.enabled": {
-          "scope": "window",
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "Use kpsewhich as defined by `#latex-workshop.kpsewhich.path#` to resolve bibliography files in addition to looking into the directories listed in `#latex-workshop.latex.bibDirs#`."
-        },
-        "latex-workshop.latex.bibDirs": {
-          "scope": "window",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": [],
-          "markdownDescription": "List of directories where to look for `.bib` files. Absolute paths are required. This setting is only used by the intellisense feature, you may also need to set the environment variable `BIBINPUTS` properly for the LaTeX compiler to find the `.bib` files."
-        },
-        "latex-workshop.latex.search.rootFiles.include": {
-          "scope": "resource",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": [
-            "**/*.tex",
-            "**/*.rnw",
-            "**/*.Rnw"
-          ],
-          "markdownDescription": "Patterns of files to consider for the root detection mechanism. Relative paths are computed from the workspace folder. To detect the root file and the tex file tree, we parse all the `.tex` listed here. If you want to specify all `.tex` files inside directory, say `foo`, and all its subdirectories recursively, you need to use `**/foo/**/*.tex`. If you only want to match `.tex` files at the top level of the workspace, use `*.tex`. For more details, see https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#multi-file-projects"
-        },
-        "latex-workshop.latex.search.rootFiles.exclude": {
-          "scope": "resource",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": [],
-          "markdownDescription": "Patterns of files to exclude from the root detection mechanism. See also `#latex-workshop.latex.search.rootFiles.include#`. For more details, see the https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#multi-file-projects."
-        },
-        "latex-workshop.latex.rootFile.useSubFile": {
-          "scope": "resource",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "When the `subfile` package is used, either the main file or any subfile containing `\\documentclass[main.tex]{subfile}` can be LaTeXing. When `true`, the extension uses the subfile as the rootFile for the `autobuild`, `clean` and `synctex` commands."
-        },
-        "latex-workshop.latex.rootFile.doNotPrompt": {
-          "scope": "resource",
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "When the `subfile` package is used, either the main file or any subfile containing `\\documentclass[main.tex]{subfile}` can be LaTeXing. When `false`, the `build` and `view` commands  ask the user's choice first. When `true`, the subfile is used when `#latex-workshop.latex.rootFile.useSubFile#` is also `true`, otherwise the rootFile is used."
-        },
-        "latex-workshop.latex.rootFile.indicator": {
-            "scope": "resource",
-            "type": "string",
-            "default": "\\documentclass",
-            "enum": [
-                "\\documentclass",
-                "\\begin{document}"
+        "menus": {
+            "editor/context": [
+                {
+                    "when": "config.latex-workshop.showContextMenu && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && !virtualWorkspace",
+                    "command": "latex-workshop.build",
+                    "group": "navigation@100"
+                },
+                {
+                    "when": "config.latex-workshop.showContextMenu && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && !virtualWorkspace",
+                    "command": "latex-workshop.synctex",
+                    "group": "navigation@101"
+                }
             ],
-            "markdownDescription": "Determine the root file based on the specific indicator. If `\\documentclass`, the root file is the file containing `\\documentclass`. If `\\begin{document}`, the root file is the file containing `\\begin{document}`."
-        },
-        "latex-workshop.latex.watch.usePolling": {
-          "scope": "window",
-          "type": "boolean",
-          "default": false,
-          "deprecationMessage": "Deprecated: This config is deprecated and has no use.",
-          "markdownDeprecationMessage": "**Deprecated**: This config is deprecated and has no use."
-        },
-        "latex-workshop.latex.watch.interval": {
-          "scope": "window",
-          "type": "number",
-          "default": 300,
-          "deprecationMessage": "Deprecated: This config is deprecated and has no use.",
-          "markdownDeprecationMessage": "**Deprecated**: This config is deprecated and has no use."
-        },
-        "latex-workshop.latex.watch.delay": {
-          "scope": "window",
-          "type": "number",
-          "default": 250,
-          "deprecationMessage": "Deprecated: This config is deprecated and has no use.",
-          "markdownDeprecationMessage": "**Deprecated**: This config is deprecated and has no use."
-        },
-        "latex-workshop.latex.watch.pdf.delay": {
-          "scope": "window",
-          "type": "number",
-          "default": 250,
-          "markdownDescription": "Defines the time delay before confirming a PDF-like binary file is fully changed. Increase this value if you encounter repeated viewer refreshes and/or loss of PDF scrolling position. LaTeX Workshop internally monitors file change events and initiates auto-builds and/or PDF viewing refresh. When LaTeX is changing large files (particularly binary files like PDFs), multiple consecutive file change events may be emitted, potentially causing file corruption issues. We use this config to control the file polling delay before confirming that the file change has been stabilized. Note that non-binary files such as `.tex`, `.bib`, and `.cls` are not affected."
-        },
-        "latex-workshop.latex.watch.files.ignore": {
-          "scope": "window",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": [
-            "**/*.bbx",
-            "**/*.bbl",
-            "**/*.cbx",
-            "**/*.cfg",
-            "**/*.clo",
-            "**/*.cnf",
-            "**/*.def",
-            "**/*.dfu",
-            "**/*.enc",
-            "**/*.fd",
-            "**/*.fmt",
-            "**/*.lbx",
-            "**/*.map",
-            "**/*.mkii",
-            "**/*.pfb",
-            "**/*.tfm",
-            "**/*.vf",
-            "**/*.code.tex",
-            "**/*.sty",
-            "**/texmf-{dist,var}/**",
-            "**/Local/MiKTeX/**",
-            "**/Local/Programs/MiKTeX/**",
-            "**/Roaming/MiKTeX/**",
-            "**/Program*/MiKTeX*/**",
-            "**/.miktex/texmfs/**",
-            "/var/cache/miktex-texmf/**",
-            "/usr/local/share/miktex-texmf/**",
-            "**/Library/Application Support/MiKTeX/texmfs/**",
-            "/dev/null"
-          ],
-          "markdownDescription": "Files to ignore from the watching mechanism, i.e., no intellisense or build-on-file-change. However, document structure/outline and build-on-save won't be affected. This property must be an array of glob patterns. The patterns are matched against the absolute file path. To ignore everything inside the `texmf` tree, `**/texmf/**` can be used."
-        },
-        "latex-workshop.latex.autoBuild.run": {
-          "scope": "resource",
-          "type": "string",
-          "enum": [
-            "never",
-            "onSave",
-            "onFileChange"
-          ],
-          "enumDescriptions": [
-            "Never run auto build",
-            "Auto build whenever a file is saved",
-            "Auto build whenever a dependency file changes on disk"
-          ],
-          "default": "onFileChange",
-          "markdownDescription": "When the extension shall auto build LaTeX project using the default (first) recipe. \n- `onSave` builds the project upon saving a `tex` file in vscode.\n- `onFileChange` builds the project upon detecting a file change in any of the dependencies, even modified by other applications.\n\n Note that `onSave` is more restrictive than `onFileChange` "
-        },
-        "latex-workshop.latex.autoBuild.interval": {
-          "scope": "resource",
-          "type": "integer",
-          "default": 1000,
-          "markdownDescription": "The minimal time interval in milliseconds for an auto build to trigger after the previous (manual and auto) build. This value is recommended to be greater than ~500."
-        },
-        "latex-workshop.latex.autoBuild.cleanAndRetry.enabled": {
-          "scope": "resource",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Delete LaTeX auxiliary files when errors occur during build and retry. This property defines whether LaTeX Workshop will try to clean and build the project once again after errors happen in the build toolchain."
-        },
-        "latex-workshop.latex.build.clearLog.everyRecipeStep.enabled": {
-          "scope": "resource",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Clear the LaTeX Compiler logs before every step of a recipe. Set this property to false to keep the logs of all tools in a recipe."
-        },
-        "latex-workshop.latex.autoClean.run": {
-          "scope": "resource",
-          "type": "string",
-          "enum": [
-            "never",
-            "onFailed",
-            "onSucceeded",
-            "onBuilt"
-          ],
-          "enumDescriptions": [
-            "Never clean the project",
-            "Clean compilation fails",
-            "Clean compilation successes",
-            "Clean after build, be it successful or not"
-          ],
-          "default": "never",
-          "markdownDescription": "When LaTeX auxiliary files should be deleted. The folder to be cleaned is defined in `#latex-workshop.latex.outDir#`.\n- `onFailed` cleans the project when compilation fails.\n- `onBuilt` cleans the project when compilation is done, whether successful or failed."
-        },
-        "latex-workshop.latex.clean.subfolder.enabled": {
-          "scope": "resource",
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "Delete LaTeX auxiliary files recursively in sub-folders of `#latex-workshop.latex.outDir#`. Note that sub-folders are not removed."
-        },
-        "latex-workshop.latex.clean.fileTypes": {
-          "scope": "resource",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": [
-            "*.aux",
-            "*.bbl",
-            "*.blg",
-            "*.idx",
-            "*.ind",
-            "*.lof",
-            "*.lot",
-            "*.out",
-            "*.toc",
-            "*.acn",
-            "*.acr",
-            "*.alg",
-            "*.glg",
-            "*.glo",
-            "*.gls",
-            "*.fls",
-            "*.log",
-            "*.fdb_latexmk",
-            "*.snm",
-            "*.synctex(busy)",
-            "*.synctex.gz(busy)",
-            "*.nav",
-            "*.vrb"
-          ],
-          "markdownDescription": "Files to clean when `#latex-workshop.latex.clean.method#` is set to `glob`.. This property must be an array of strings. File globs such as `*.removeme`, `something?.aux` can be used. Users can also specify glob patterns like `emptyfolder*/` to remove empty folders. Non-empty folders will be ignored. The folder globs must end with a slash and the last path component must not contain the globstar `**`, otherwise the folders will not be removed. The following globs patterns are correct `['abc/', 'abc*/', '**/abc*/', 'abc/**/def/']` but these are not ['**', '**/', 'abc/**', 'abc/**/', 'abc/def**/', 'abc/d**ef/']`."
-        },
-        "latex-workshop.latex.clean.command": {
-          "scope": "resource",
-          "type": "string",
-          "default": "latexmk",
-          "markdownDescription": "The command to be used to remove temporary files when `#latex-workshop.latex.clean.method#` is set to `command`."
-        },
-        "latex-workshop.latex.clean.args": {
-          "scope": "resource",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": [
-            "-c",
-            "%TEX%"
-          ],
-          "markdownDescription": "The arguments of `#latex-workshop.latex.clean.command#`. Placeholders listed in https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#placeholders can be used to populate the argument strings. Besides, an additional `%TEX%` placeholder refers to the full path of the tex file from which the clean command is called."
-        },
-        "latex-workshop.latex.clean.method": {
-          "scope": "resource",
-          "type": "string",
-          "default": "glob",
-          "enum": [
-            "glob",
-            "command"
-          ],
-          "markdownEnumDescriptions": [
-            "Clean all the files located in `#latex-workshop.latex.outDir#` and matching the glob patterns listed in `#latex-workshop.latex.clean.fileTypes#`.",
-            "Run `#latex-workshop.latex.clean.command#` to clean temporary files."
-          ],
-          "markdownDescription": "Define how temporary files will be cleaned."
-        },
-        "latex-workshop.latex.option.maxPrintLine.enabled": {
-          "scope": "resource",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Add `--max-print-line` option to LaTeX build commands. This flag tells some MikTeX compilers to produce non hard wrapped log messages. Non hard wrapped log messages are required for the _Problem_ Pane to properly display messages."
-        },
-        "latex-workshop.view.outline.sections": {
-          "scope": "window",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": [
-            "part",
-            "chapter",
-            "section",
-            "subsection",
-            "subsubsection"
-          ],
-          "markdownDescription": "The section names of LaTeX outline hierarchy. It is also used by the folding mechanism. This property is an array of case-sensitive strings in the order of document structure hierarchy. For multiple tags in the same level, separate the tags with `|` as delimiters, e.g., `section|alternative`."
-        },
-        "latex-workshop.view.outline.commands": {
-          "scope": "window",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": [
-            "label"
-          ],
-          "markdownDescription": "The names of the commands to be shown in the outline/structure views. The commands must be called in the form `\\commandname{arg}`."
-        },
-        "latex-workshop.view.outline.fastparse.enabled": {
-          "scope": "window",
-          "type": "boolean",
-          "default": true,
-          "deprecationMessage": "Deprecated: This config has been renamed to `latex-workshop.intellisense.fastparse.enabled`.",
-          "markdownDeprecationMessage": "**Deprecated**: This config has been renamed to `#latex-workshop.intellisense.fastparse.enabled#`."
-        },
-        "latex-workshop.view.outline.floats.enabled": {
-          "scope": "window",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Show the floating objects (figures and tables) in the outline/structure views."
-        },
-        "latex-workshop.view.outline.floats.number.enabled": {
-          "scope": "window",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Show the float number in the outline/structure views."
-        },
-        "latex-workshop.view.outline.floats.caption.enabled": {
-          "scope": "window",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Show the float caption in the outline/structure views."
-        },
-        "latex-workshop.view.outline.numbers.enabled": {
-          "scope": "window",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Show the sectioning numbers in the outline/structure views."
-        },
-        "latex-workshop.view.autoFocus.enabled": {
-          "scope": "window",
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "Auto focus the LaTeX view when switching from non-tex to tex files. This will cause the view to appear consistently upon activating the extension."
-        },
-        "latex-workshop.view.pdf.viewer": {
-          "scope": "window",
-          "type": "string",
-          "default": "tab",
-          "enum": [
-            "browser",
-            "tab",
-            "external"
-          ],
-          "markdownDescription": "The default PDF viewer.",
-          "enumDescriptions": [
-            "Open PDF with the default web browser.",
-            "Open PDF with the built-in tab viewer.",
-            "[Experimental] Open PDF with the external viewer set in \"View > Pdf > External: command\"."
-          ]
-        },
-        "latex-workshop.view.pdf.tab.editorGroup": {
-          "scope": "window",
-          "type": "string",
-          "default": "right",
-          "enum": [
-            "current",
-            "left",
-            "right",
-            "above",
-            "below"
-          ],
-          "markdownDescription": "The editor group in which to open the tab viewer.",
-          "enumDescriptions": [
-            "Use the current editor group",
-            "Put the viewer tab in a new group on the left of the current one",
-            "Put the viewer tab in a new group on the right of the current one",
-            "Put the viewer tab in a new group above the current one",
-            "Put the viewer tab in a new group below the current one"
-          ]
-        },
-        "latex-workshop.view.pdf.tab.openDelay": {
-          "scope": "window",
-          "type": "number",
-          "default": 1000,
-          "markdownDescription": "Defines the delay in milliseconds to wait for a tab opening. Please increase the value if you encounter a focus issue after opening a tab."
-        },
-        "latex-workshop.view.pdf.ref.viewer": {
-          "type": "string",
-          "default": "auto",
-          "enum": [
-            "auto",
-            "tabOrBrowser",
-            "external"
-          ],
-          "markdownDescription": "PDF viewer used for [View on PDF] link on \\ref."
-        },
-        "latex-workshop.viewer.pdf.internal.port": {
-          "scope": "window",
-          "type": "number",
-          "default": "0",
-          "markdownDescription": "Define the port to listen on for communicating with the internal viewer. The default value \"0\" means the port is chosen randomly by the application. If this config is set, only one Visual Studio Code instance with this extension active can be opened. Otherwise, a port conflict may happen."
-        },
-        "latex-workshop.view.pdf.internal.synctex.keybinding": {
-          "scope": "window",
-          "type": "string",
-          "default": "ctrl-click",
-          "enum": [
-            "ctrl-click",
-            "double-click"
-          ],
-          "markdownDescription": " Which keybinding to use for the internal viewer for reverse synctex. `ctrl`/`cmd` + click (default) or double click."
-        },
-        "latex-workshop.viewer.pdf.internal.keyboardEvent": {
-          "scope": "window",
-          "type": "string",
-          "default": "auto",
-          "enum": [
-            "auto",
-            "force",
-            "never"
-          ],
-          "markdownDescription": "Rebroadcasting KeyboardEvent on the internal viewers. If keyboard shortcuts on the internal viewer do not work well, change this setting."
-        },
-        "latex-workshop.view.pdf.external.viewer.command": {
-          "scope": "window",
-          "type": "string",
-          "default": "",
-          "markdownDescription": "The command to execute when using external viewer. This function is not officially supported."
-        },
-        "latex-workshop.view.pdf.external.viewer.args": {
-          "scope": "window",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": [
-            "%PDF%"
-          ],
-          "markdownDescription": "The arguments for `#latex-workshop.view.pdf.external.viewer.command#` when using external viewer. This function is not officially supported. %PDF% is the placeholder for the absolute path to the generated PDF file."
-        },
-        "latex-workshop.view.pdf.external.synctex.command": {
-          "scope": "window",
-          "type": "string",
-          "default": "",
-          "markdownDescription": "The command to execute when forward synctex to external viewer. This function is not officially supported."
-        },
-        "latex-workshop.view.pdf.external.synctex.args": {
-          "scope": "window",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": [
-            "%LINE%",
-            "%PDF%",
-            "%TEX%"
-          ],
-          "markdownDescription": "The arguments for `#latex-workshop.view.pdf.external.synctex.args#` when forward synctex to external viewer. %LINE% is the line number, %PDF% is the placeholder for the absolute path to the generated PDF file, and %TEX% is the source LaTeX file path with `.tex` extension from which syncTeX is fired."
-        },
-        "latex-workshop.view.pdf.zoom": {
-          "scope": "window",
-          "type": "string",
-          "default": "auto",
-          "markdownDescription": "The default zoom level of the PDF viewer. This default value will be passed to the viewer upon opening. Possible values are `auto`, `page-actual`, `page-fit`, `page-width`, and one-based scale values (e.g., 0.5 for 50%, 2.0 for 200%)."
-        },
-        "latex-workshop.view.pdf.trim": {
-          "scope": "window",
-          "type": "number",
-          "default": 0,
-          "enum": [
-            0,
-            1,
-            2,
-            3
-          ],
-          "markdownDescription": "The default trim mode of the PDF viewer.",
-          "enumDescriptions": [
-            "No page trimming",
-            "Trim 5% at margin",
-            "Trim 10% at margin",
-            "Trim 15% at margin"
-          ]
-        },
-        "latex-workshop.view.pdf.scrollMode": {
-          "scope": "window",
-          "type": "number",
-          "default": 0,
-          "markdownDescription": "The default scroll mode of the PDF viewer. This default value will be passed to the viewer upon opening. Possible values are `0` (vertical), `1`(horizontal), `2` (wrapped), `3` (page)."
-        },
-        "latex-workshop.view.pdf.spreadMode": {
-          "scope": "window",
-          "type": "number",
-          "default": 0,
-          "markdownDescription": "The default spread mode of the PDF viewer. This default value will be passed to the viewer upon opening. Possible values are `0` (none), `1` (odd) and `2` (even)."
-        },
-        "latex-workshop.view.pdf.hand": {
-          "scope": "window",
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "Define if the hand tool is enabled by default in the PDF viewer."
-        },
-        "latex-workshop.view.pdf.invertMode.enabled": {
-          "scope": "window",
-          "type": "string",
-          "enum": [
-            "auto",
-            "always",
-            "compat",
-            "never"
-          ],
-          "default": "compat",
-          "markdownDescription": "Enable the CSS invert filter.",
-          "enumDescriptions": [
-            "Enable the invert filter when using a dark theme.",
-            "Always enable invert filter.",
-            "Enable the invert filter only if `invert > 0`.",
-            "Disable the invert filter"
-          ]
-        },
-        "latex-workshop.view.pdf.invert": {
-          "scope": "window",
-          "type": "number",
-          "default": 0,
-          "markdownDescription": " Define the CSS invert filter level of the PDF viewer. This config can invert the color of PDF. Possible values are from 0 to 1."
-        },
-        "latex-workshop.view.pdf.invertMode.brightness": {
-          "scope": "window",
-          "type": "number",
-          "default": 1,
-          "markdownDescription": " Define the CSS brightness filter level of the PDF viewer when the invert mode is enabled. Possible values are from 0 to 2."
-        },
-        "latex-workshop.view.pdf.invertMode.grayscale": {
-          "scope": "window",
-          "type": "number",
-          "default": 0.6,
-          "markdownDescription": " Define the CSS grayscale filter level of the PDF viewer when the invert mode is enabled. Possible values are from 0 to 1."
-        },
-        "latex-workshop.view.pdf.invertMode.hueRotate": {
-          "scope": "window",
-          "type": "number",
-          "default": 180,
-          "markdownDescription": " Define the CSS hue-rotate filter angle of the PDF viewer when the invert mode is enabled. Possible values are from 0 to 360."
-        },
-        "latex-workshop.view.pdf.invertMode.sepia": {
-          "scope": "window",
-          "type": "number",
-          "default": 0,
-          "markdownDescription": " Define the CSS sepia filter level of the PDF viewer when the invert mode is enabled. Possible values are from 0 to 1."
-        },
-        "latex-workshop.view.pdf.color.light.pageColorsForeground": {
-          "scope": "window",
-          "type": "string",
-          "default": "",
-          "markdownDescription": " The foreground color of the PDF document 1) in tab viewer when the vscode color theme is light, and 2) in browser when the OS theme is light. The string must represent a color in HTML."
-        },
-        "latex-workshop.view.pdf.color.light.pageColorsBackground": {
-          "scope": "window",
-          "type": "string",
-          "default": "",
-          "markdownDescription": " The background color of the PDF document 1) in tab viewer when the vscode color theme is light, and 2) in browser when the OS theme is light. The string must represent a color in HTML."
-        },
-        "latex-workshop.view.pdf.color.light.backgroundColor": {
-          "scope": "window",
-          "type": "string",
-          "default": "#ffffff",
-          "markdownDescription": " The background color of the viewer 1) in tab viewer when the vscode color theme is light, and 2) in browser when the OS theme is light. The string must represent a color in HTML."
-        },
-        "latex-workshop.view.pdf.color.light.pageBorderColor": {
-          "scope": "window",
-          "type": "string",
-          "default": "lightgrey",
-          "markdownDescription": " The border color of the PDF pages 1) in tab viewer when the vscode color theme is light, and 2) in browser when the OS theme is light. The string must represent a color in HTML."
-        },
-        "latex-workshop.view.pdf.color.dark.pageColorsForeground": {
-          "scope": "window",
-          "type": "string",
-          "default": "",
-          "markdownDescription": " The foreground color of the PDF document 1) in tab viewer when the vscode color theme is dark, and 2) in browser when the OS theme is dark. The string must represent a color in HTML."
-        },
-        "latex-workshop.view.pdf.color.dark.pageColorsBackground": {
-          "scope": "window",
-          "type": "string",
-          "default": "",
-          "markdownDescription": " The background color of the PDF document 1) in tab viewer when the vscode color theme is dark, and 2) in browser when the OS theme is dark. The string must represent a color in HTML."
-        },
-        "latex-workshop.view.pdf.color.dark.backgroundColor": {
-          "scope": "window",
-          "type": "string",
-          "default": "#ffffff",
-          "markdownDescription": " The background color of the viewer 1) in tab viewer when the vscode color theme is dark, and 2) in browser when the OS theme is dark. The string must represent a color in HTML."
-        },
-        "latex-workshop.view.pdf.color.dark.pageBorderColor": {
-          "scope": "window",
-          "type": "string",
-          "default": "lightgrey",
-          "markdownDescription": " The border color of the PDF pages 1) in tab viewer when the vscode color theme is dark, and 2) in browser when the OS theme is dark. The string must represent a color in HTML."
-        },
-        "latex-workshop.synctex.path": {
-          "scope": "window",
-          "type": "string",
-          "default": "synctex",
-          "markdownDescription": "Define the location of SyncTeX executive file. Additional arguments, e.g., synctex modes and position of click, will be appended to this command."
-        },
-        "latex-workshop.synctex.afterBuild.enabled": {
-          "scope": "window",
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "Execute forward synctex at cursor position after compiling LaTeX project."
-        },
-        "latex-workshop.synctex.synctexjs.enabled": {
-          "scope": "window",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Enable using a builtin synctex function. The command set in latex-workshop.synctex.path will not be used."
-        },
-        "latex-workshop.linting.chktex.enabled": {
-          "scope": "resource",
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "Enable linting LaTeX with `chktex`. Check `#latex-workshop.linting.run#` to control when `chktex` is executed if this config is set to `true."
-        },
-        "latex-workshop.linting.lacheck.enabled": {
-          "scope": "resource",
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "Enable linting LaTeX with `lacheck`. Check `#latex-workshop.linting.run#` to control when `lacheck` is executed if this config is set to `true."
-        },
-        "latex-workshop.linting.run": {
-          "scope": "resource",
-          "type": "string",
-          "enum": [
-            "onSave",
-            "onType"
-          ],
-          "enumDescriptions": [
-            "Lint the whole LaTeX project upon saving",
-            "Lint the active document when input is stopped"
-          ],
-          "default": "onSave",
-          "markdownDescription": "When LaTeX should be linted.\n- `onSave`: the whole LaTeX project will be linted upon saving.\n- `onType`: the active document will be linted when input is stopped for a period of time defined in `#latex-workshop.linting.delay#`. It also implies `onSave`."
-        },
-        "latex-workshop.linting.chktex.exec.path": {
-          "scope": "window",
-          "type": "string",
-          "default": "chktex",
-          "markdownDescription": "Define the location of ChkTeX executive file. This command will be joint with `#latex-workshop.linting.chktex.exec.args#` and required arguments to form a complete command of ChkTeX."
-        },
-        "latex-workshop.linting.chktex.exec.args": {
-          "scope": "resource",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": [
-            "-wall",
-            "-n22",
-            "-n30",
-            "-e16",
-            "-q"
-          ],
-          "markdownDescription": "Linter arguments to check LaTeX syntax of the current file state in real time with ChkTeX. Arguments must be in separate strings in the array. Additional arguments, i.e., `-I0 -f%f:%l:%c:%d:%k:%n:%m\\n` will be appended when constructing the command. Current file contents will be piped to the command through stdin."
-        },
-        "latex-workshop.linting.chktex.convertOutput.column.enabled": {
-          "scope": "resource",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Enable converting ChkTeX outputs' column numbers for non-ASCII characters."
-        },
-        "latex-workshop.linting.chktex.convertOutput.column.chktexrcTabSize": {
-          "scope": "resource",
-          "type": "number",
-          "default": -1,
-          "markdownDescription": "Write the `TabSize` number from `.chktexrc`. The default value \"-1\" means that LaTeX Workshop will try to find `.chktexrc` and to read the value from it."
-        },
-        "latex-workshop.linting.delay": {
-          "scope": "resource",
-          "type": "number",
-          "default": 500,
-          "markdownDescription": "Defines the delay in milliseconds for linter to wait after stopped typing. This config only matters when `#latex-workshop.linting.run#` is set to `onType`."
-        },
-        "latex-workshop.linting.lacheck.exec.path": {
-          "scope": "window",
-          "type": "string",
-          "default": "lacheck",
-          "markdownDescription": "Define the location of LaCheck executive file."
-        },
-        "latex-workshop.check.duplicatedLabels.enabled": {
-          "scope": "window",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Enable checking for duplicated labels. A new check is triggered every time the intellisense data is updated, see `#latex-workshop.intellisense.update.aggressive.enabled#`."
-        },
-        "latex-workshop.texcount.path": {
-          "scope": "window",
-          "type": "string",
-          "default": "texcount",
-          "markdownDescription": "Define the location of TeXCount executive file/script. This command will be joint with `#latex-workshop.texcount.args#` and required arguments to form a complete command of TeXCount."
-        },
-        "latex-workshop.texcount.args": {
-          "scope": "resource",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": [],
-          "markdownDescription": "TeXCount arguments to count words in the LaTeX documents of the entire project from the root file, or the current document. Arguments must be in separate strings in the array. Additional arguments, i.e., `-merge %DOC%` for the project and the current document path for counting current file will be appended when constructing the command."
-        },
-        "latex-workshop.texcount.autorun": {
-          "scope": "resource",
-          "type": "string",
-          "enum": [
-            "onSave",
-            "never"
-          ],
-          "enumDescriptions": [
-            "Count words in the current document",
-            "Never automatically call texcount"
-          ],
-          "default": "never",
-          "markdownDescription": "When to call `texcount`. Default is never."
-        },
-        "latex-workshop.texcount.interval": {
-          "scope": "resource",
-          "type": "number",
-          "default": 1000,
-          "markdownDescription": "The minimal time interval between two consecutive runs of `texcount` in milliseconds when `#latex-workshop.texcount.run#` is set to `onSave`."
-        },
-        "latex-workshop.intellisense.fastparse.enabled": {
-          "scope": "window",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Use fast LaTeX parsing algorithm to build outline/structure. This is done by inherently removing texts and comments before building AST. Enabling this will not tamper the document, but may result in incomplete outline/structure."
-        },
-        "latex-workshop.intellisense.update.aggressive.enabled": {
-          "scope": "window",
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "Defines whether the extension aggressively parses the changed content after stopped typing. Disable this config will let the extension only update intellisense after saving changed files."
-        },
-        "latex-workshop.intellisense.update.delay": {
-          "scope": "window",
-          "type": "number",
-          "default": 1000,
-          "markdownDescription": "Defines the delay in milliseconds for the extension to update current active file content for intellisense after stopped typing. This config works only when `intellisense.update.aggressive.enabled` is enabled. Lower this value to let the extension know newly defined commands/references/environments more quickly, at the cost of more frequent content parsing: more computational burden."
-        },
-        "latex-workshop.intellisense.atSuggestion.user": {
-          "scope": "window",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          },
-          "default": {},
-          "markdownDescription": "Dictionary of `\"@prefix\": \"snippet command\"` to add to, replace, or remove the default suggestions in `data/at-suggestions.json`. The key of the dictionary is the triggering string, which **must** starts with `@` regardless of `#latex-workshop.intellisense.atSuggestion.trigger.latex#`. The value of the dictionary is the snippet to be inserted. If the key is identical to a default snippet defined in `data/at-suggestions.json`, the new value in the dictionary is used for suggestion. If the value is an empty string, the snippet is removed from suggestion. For example, `{ \"@.\": \"\\cdot\", \"@6\": \"\" }`."
-        },
-        "latex-workshop.intellisense.command.user": {
-          "scope": "window",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          },
-          "default": {},
-          "markdownDescription": "Dictionary of `\"command name\": \"command snippet\"` to add to, replace, or remove the default ones in `data/commands.json`. The key of the dictionary is the command name with optional braces indicating the command arguments. The value of the dictionary is the snippet to be inserted. If the key is identical to a default command suggestion defined in `data/commands.json`, the new value in the dictionary is used for suggestion. If the value is an empty string, the command is removed from suggestion. Leading backslashes will be added to both the name and snippet by the extension, so don't include them in this config. For example, `{\"mycommand[]{}\": \"notsamecommand[${2:option}]{$TM_SELECTED_TEXT$1}\", \"parbox{}{}\": \"parbox{${2:width}}{$TM_SELECTED_TEXT$1}\", \"overline{}\": \"\"}` adds a new command with name `mycommand[]{} that inserts `\\notsamecommand[]{}`, replaces the default snippet of `\\parbox{}{}` to make it include current selected text, and removes `\\overline{}` from suggestion."
-        },
-        "latex-workshop.intellisense.citation.type": {
-          "scope": "window",
-          "type": "string",
-          "enum": [
-            "inline",
-            "browser"
-          ],
-          "default": "inline",
-          "markdownDescription": "Defines which type of hint to show when intellisense provides citation suggestions.",
-          "enumDescriptions": [
-            "Use the inline intellisense to provide citation completion items.",
-            "Use a dropdown menu to provide citation completion items."
-          ]
-        },
-        "latex-workshop.intellisense.citation.label": {
-          "scope": "resource",
-          "type": "string",
-          "enum": [
-            "bibtex key",
-            "title",
-            "authors"
-          ],
-          "default": "bibtex key",
-          "markdownDescription": "Defines what to show as suggestion labels when intellisense provides citation suggestions in inline mode.",
-          "enumDescriptions": [
-            "Show bibtex keys in the inline mode.",
-            "Show publication titles in the inline mode.",
-            "Show publication authors in the inline mode."
-          ]
-        },
-        "latex-workshop.intellisense.citation.format": {
-          "scope": "resource",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": [
-            "author",
-            "title",
-            "journal",
-            "publisher",
-            "booktitle",
-            "year"
-          ],
-          "markdownDescription": "List of fields to display for citation preview and intellisense. This list is also used as the filter text to narrow down the intellisense suggestions."
-        },
-        "latex-workshop.intellisense.triggers.latex": {
-          "scope": "window",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": [
-            "{"
-          ],
-          "markdownDescription": "Additional trigger characters for intellisense of LaTeX documents."
-        },
-        "latex-workshop.intellisense.atSuggestion.trigger.latex": {
-          "scope": "window",
-          "type": "string",
-          "default": "@",
-          "markdownDescription": "Character to trigger snippet suggestions as part of intellisense. Set this variable to `''` to deactivate these suggestions."
-        },
-        "latex-workshop.intellisense.atSuggestionJSON.replace": {
-          "scope": "window",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          },
-          "default": {},
-          "deprecationMessage": "Deprecated: This config has been renamed to `latex-workshop.intellisense.atSuggestion.user`.",
-          "markdownDeprecationMessage": "**Deprecated**: This config has been renamed to `#latex-workshop.intellisense.atSuggestion.user#`."
-        },
-        "latex-workshop.intellisense.file.exclude": {
-          "scope": "resource",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": [
-            "**/*.aux",
-            "**/*.bbl",
-            "**/*.bcf",
-            "**/*.blg",
-            "**/*.idx",
-            "**/*.ind",
-            "**/*.lof",
-            "**/*.lot",
-            "**/*.out",
-            "**/*.toc",
-            "**/*.acn",
-            "**/*.acr",
-            "**/*.alg",
-            "**/*.glg",
-            "**/*.glo",
-            "**/*.gls",
-            "**/*.ist",
-            "**/*.fls",
-            "**/*.log",
-            "**/*.nav",
-            "**/*.snm",
-            "**/*.fdb_latexmk",
-            "**/*.synctex.gz",
-            "**/*.run.xml"
-          ],
-          "markdownDescription": "Patterns to ignore in file completion"
-        },
-        "latex-workshop.intellisense.file.base": {
-          "scope": "resource",
-          "type": "string",
-          "enum": [
-            "root relative",
-            "file relative",
-            "both"
-          ],
-          "default": "root relative",
-          "markdownDescription": "Specify the base directory for file completion",
-          "enumDescriptions": [
-            "Completion from the root file directory",
-            "Completion from the current file directory",
-            "both"
-          ]
-        },
-        "latex-workshop.intellisense.label.command": {
-          "scope": "window",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": [
-            "label",
-            "linelabel"
-          ],
-          "markdownDescription": "The name of LaTeX commands that indicates a label definition. The command must accept one mandatory argument of the label reference string, e.g, \\linelabel{ref-str}."
-        },
-        "latex-workshop.intellisense.label.keyval": {
-          "scope": "window",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Scan for labels defined as `label={some tex}` to add to the reference intellisense menu. The braces are mandatory."
-        },
-        "latex-workshop.intellisense.unimathsymbols.enabled": {
-          "scope": "window",
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "When `\\` is typed, show unimath symbols in the dropdown selector."
-        },
-        "latex-workshop.intellisense.package.enabled": {
-          "scope": "window",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Auto-complete commands and environments from used packages."
-        },
-        "latex-workshop.intellisense.package.extra": {
-          "scope": "window",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": [],
-          "markdownDescription": "List of extra packages to always add to the auto-completion mechanism. When `#latex-workshop.intellisense.package.enabled#` is set to `true`, the commands and environments defined in these extra packages will be added to the intellisense suggestions."
-        },
-        "latex-workshop.intellisense.package.exclude": {
-          "scope": "window",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": [],
-          "markdownDescription": "List of packages to exclude from the auto-completion mechanism. When `#latex-workshop.intellisense.package.enabled#` is set to `true`, the commands and environments defined in these packages will not be added to the intellisense suggestions. This setting has a higher priority over `#latex-workshop.intellisense.package.extra#`. You may include the string \"lw-default\" in the list to remove all default commands and environments."
-        },
-        "latex-workshop.intellisense.package.env.enabled": {
-          "scope": "window",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "If true, every environment provided by an included package is available by a snippet `\\envname`. Only applies when `#latex-workshop.intellisense.package.enabled#` is true. "
-        },
-        "latex-workshop.intellisense.package.dirs": {
-          "scope": "window",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": [],
-          "markdownDescription": "List of extra directories to look for package completion files in addition to those provided by the extension. See https://github.com/James-Yu/LaTeX-Workshop/wiki/Intellisense#commands-starting-with- to learn how to generate these files. Files found in these directories have a higher priority over the default ones. This setting is only relevant when `#latex-workshop.intellisense.package.env.enabled#` is true."
-        },
-        "latex-workshop.intellisense.includegraphics.preview.enabled": {
-          "scope": "window",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Enable preview for `\\includegraphics` completion."
-        },
-        "latex-workshop.message.badbox.show": {
-          "scope": "window",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Show badbox information in the problems panel."
-        },
-        "latex-workshop.message.biberlog.exclude": {
-          "scope": "window",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": [],
-          "markdownDescription": "Exclude biber log messages matching the given regexp from the problems panel."
-        },
-        "latex-workshop.message.bibtexlog.exclude": {
-          "scope": "window",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": [],
-          "markdownDescription": "Exclude bibtex log messages matching the given regexp from the problems panel."
-        },
-        "latex-workshop.message.latexlog.exclude": {
-          "scope": "window",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": [],
-          "markdownDescription": "Exclude latex log messages matching the given regexp from the problems panel."
-        },
-        "latex-workshop.message.information.show": {
-          "scope": "window",
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "Display information messages in popup notifications."
-        },
-        "latex-workshop.message.warning.show": {
-          "scope": "window",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Display warning messages in popup notifications."
-        },
-        "latex-workshop.message.error.show": {
-          "scope": "window",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Display error messages in popup notifications."
-        },
-        "latex-workshop.message.log.show": {
-          "scope": "window",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Display LaTeX Workshop debug log in output panel. This property defines whether LaTeX Workshop will output its debug log to the log panel."
-        },
-        "latex-workshop.message.convertFilenameEncoding": {
-          "scope": "window",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Convert the encoding of filenames if necessary when displaying them in the problems panel."
-        },
-        "latex-workshop.latexindent.path": {
-          "scope": "window",
-          "type": "string",
-          "default": "latexindent",
-          "markdownDescription": "Define the location of the latexindent executable file."
-        },
-        "latex-workshop.latexindent.args": {
-          "scope": "resource",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": [
-            "-c",
-            "%DIR%/",
-            "%TMPFILE%",
-            "-y=defaultIndent: '%INDENT%'"
-          ],
-          "markdownDescription": "Define the command line arguments for latexindent. In the addition to the placeholders defined at https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#placeholders, the following placeholders are accepted\n- %TMPFILE%: The full path of the raw TeX file to be formatted. At this moment you need to use it as an input file of `latexindent`.\n- %INDENT%: The indent character of the file, typically `\t`, `' '`, `' '`.\n\nNote that the option `-c` requires a trailing slash."
-        },
-        "latex-workshop.docker.enabled": {
-          "scope": "window",
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "Enable docker-based LaTeX distribution support. Do not set this item to `true` unless you are aware of what it means. This extension will use the images defined in `#latex-workshop.docker.image.latex#` to execute `latexmk`, `synctex`, `texcount`, and `latexindent`."
-        },
-        "latex-workshop.docker.image.latex": {
-          "scope": "window",
-          "type": "string",
-          "default": "",
-          "markdownDescription": "Define the image for `latexmk`, `synctex`, `texcount`, and `latexindent`."
-        },
-        "latex-workshop.showContextMenu": {
-          "scope": "window",
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "Enable the LaTeX contextual menu. This menu is deactivated as it is available through the new LaTeX badge. Just set this variable to `true` to recover the menu."
-        },
-        "latex-workshop.bind.enter.key": {
-          "scope": "window",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Enable the automatic insertion of `\\item` on a newline when pressing `Enter` in a line starting in `\\item`."
-        },
-        "latex-workshop.bind.altKeymap.enabled": {
-          "scope": "window",
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "Use alternative keymap combo, i.e., `ctrl`+`l` `alt`+`key`, to replace the default `ctrl`/`cmd`+`alt` shortcuts."
-        },
-        "latex-workshop.hover.ref.enabled": {
-          "scope": "window",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Enable Hover on References."
-        },
-        "latex-workshop.hover.ref.number.enabled": {
-          "scope": "window",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Show number assigned to the reference in the previous compilation."
-        },
-        "latex-workshop.hover.citation.enabled": {
-          "scope": "window",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Enable Hover on Citations."
-        },
-        "latex-workshop.hover.command.enabled": {
-          "scope": "window",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Enable Hover on Commands to show the possible signatures."
-        },
-        "latex-workshop.hover.preview.enabled": {
-          "scope": "window",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Enable Hover Preview."
-        },
-        "latex-workshop.hover.preview.maxLines": {
-          "scope": "window",
-          "type": "number",
-          "default": 20,
-          "markdownDescription": "Maximum number of lines between the beginning of the math environment and the cursor position to allow preview."
-        },
-        "latex-workshop.hover.preview.scale": {
-          "scope": "window",
-          "type": "number",
-          "default": 1,
-          "markdownDescription": "Scaling of Hover Preview."
-        },
-        "latex-workshop.hover.preview.newcommand.parseTeXFile.enabled": {
-          "scope": "window",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Enable newcommands defined in the current TeX file to be included in Hover Preview."
-        },
-        "latex-workshop.hover.preview.newcommand.newcommandFile": {
-          "scope": "window",
-          "type": "string",
-          "default": "",
-          "markdownDescription": "Set the path of a file containing newcommands to be used in Hover Preview. If the path is relative, it is joined with the root dir."
-        },
-        "latex-workshop.hover.preview.cursor.enabled": {
-          "scope": "window",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Render cursor in Hover Preview at the current position."
-        },
-        "latex-workshop.hover.preview.cursor.symbol": {
-          "scope": "window",
-          "type": "string",
-          "default": "\\!|\\!",
-          "markdownDescription": "Cursor symbol in Hover Preview."
-        },
-        "latex-workshop.hover.preview.cursor.color": {
-          "scope": "window",
-          "type": "string",
-          "default": "auto",
-          "enum": [
-            "auto",
-            "black",
-            "blue",
-            "brown",
-            "cyan",
-            "darkgray",
-            "gray",
-            "green",
-            "lightgray",
-            "lime",
-            "magenta",
-            "olive",
-            "orange",
-            "pink",
-            "purple",
-            "red",
-            "teal",
-            "violet",
-            "white",
-            "yellow"
-          ],
-          "markdownDescription": "The color of cursor in Hover Preview."
-        },
-        "latex-workshop.hover.preview.mathjax.extensions": {
-          "scope": "window",
-          "type": "array",
-          "default": [],
-          "markdownDescription": "MathJax extensions to load for Hover Preview. See [the list](https://docs.mathjax.org/en/latest/input/tex/extensions/index.html). Note that the following extensions are loaded by default: `ams`, `color`, `newcommand`, `noerrors`, and `noundefined`. They cannot be disabled.",
-          "items": {
-            "type": "string",
-            "enum": [
-              "amscd",
-              "bbox",
-              "boldsymbol",
-              "braket",
-              "bussproofs",
-              "cancel",
-              "cases",
-              "centernot",
-              "colortbl",
-              "empheq",
-              "enclose",
-              "extpfeil",
-              "gensymb",
-              "html",
-              "mathtools",
-              "mhchem",
-              "physics",
-              "textcomp",
-              "textmacros",
-              "unicode",
-              "upgreek",
-              "verb"
+            "editor/title": [
+                {
+                    "when": "editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && !virtualWorkspace",
+                    "command": "latex-workshop.view",
+                    "group": "navigation@2"
+                },
+                {
+                    "when": "editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && !virtualWorkspace",
+                    "command": "latex-workshop.build",
+                    "group": "navigation@1"
+                }
+            ],
+            "view/title": [
+                {
+                    "when": "view == latex-workshop-structure",
+                    "command": "latex-workshop.structure-toggle-follow-cursor"
+                }
             ]
-          },
-          "uniqueItems": true
         },
-        "latex-workshop.intellisense.optionalArgsEntries.enabled": {
-          "scope": "window",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Some LaTeX commands can have several forms, each with different arguments. If set to True, the intellisense completion list will have one entry for each form of a given command. Default is true."
+        "viewsContainers": {
+            "activitybar": [
+                {
+                    "id": "latex-workshop-activitybar",
+                    "title": "LaTeX",
+                    "icon": "./icons/activity-bar.svg"
+                }
+            ]
         },
-        "latex-workshop.intellisense.argumentHint.enabled": {
-          "scope": "window",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Many snippets use text hints of the form `${\\d:some_tex}` for their argument. You may prefer to hide instead by setting this configuration to `false`."
+        "views": {
+            "latex-workshop-activitybar": [
+                {
+                    "id": "latex-workshop-commands",
+                    "name": "Commands",
+                    "when": "latex-workshop:enabled"
+                },
+                {
+                    "id": "latex-workshop-structure",
+                    "name": "Structure",
+                    "when": "latex-workshop:enabled"
+                },
+                {
+                    "id": "latex-workshop-snippet-view",
+                    "type": "webview",
+                    "when": "latex-workshop:enabled",
+                    "name": "Snippet View"
+                }
+            ]
         },
-        "latex-workshop.intellisense.citation.backend": {
-          "scope": "resource",
-          "type": "string",
-          "enum": [
-            "bibtex",
-            "biblatex"
-          ],
-          "default": "bibtex",
-          "markdownDescription": "Backend to use for citation intellisense."
-        },
-        "latex-workshop.intellisense.bibtexJSON.replace": {
-          "scope": "resource",
-          "type": "object",
-          "additionalProperties": {
-            "type": "array",
-            "items": {
-              "type": "string"
+        "customEditors": [
+            {
+                "viewType": "latex-workshop-pdf-hook",
+                "displayName": "LaTeX Workshop Internal PDF Viewer",
+                "selector": [
+                    {
+                        "filenamePattern": "*.pdf"
+                    },
+                    {
+                        "filenamePattern": "*.PDF"
+                    }
+                ],
+                "priority": "default"
             }
-          },
-          "default": {},
-          "markdownDescription": "Dictionary of `\"entry name\": [\"array\", \"of\", \"fields\"]` to replace the default fields used in `data/bibtex-entries.json`. See `data/bibtex-entries.json` for the list of fields for each entry. This variable is used when `#latex-workshop.intellisense.citation.backend#` is set to `biblatex`."
-        },
-        "latex-workshop.intellisense.biblatexJSON.replace": {
-          "scope": "resource",
-          "type": "object",
-          "additionalProperties": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "default": {},
-          "markdownDescription": "Dictionary of `\"entry name\": [\"array\", \"of\", \"fields\"]` to replace the default fields used in `data/biblatex-entries.json`. See `data/biblatex-entries.json` for the list of fields for each entry. This variable is used when `#latex-workshop.intellisense.citation.backend#` is set to `bibtex`."
-        },
-        "latex-workshop.intellisense.commandsJSON.replace": {
-          "scope": "window",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          },
-          "default": {},
-          "deprecationMessage": "Deprecated: This config has been superseded by config `latex-workshop.intellisense.command.user`, which provides more features.",
-          "markdownDeprecationMessage": "**Deprecated**: This config has been superseded by config `#latex-workshop.intellisense.command.user#`, which provides more features."
-        },
-        "latex-workshop.texdoc.path": {
-          "scope": "window",
-          "type": "string",
-          "default": "texdoc",
-          "markdownDescription": "Define the location of the `texdoc` executable. This command is used to show a package documentation."
-        },
-        "latex-workshop.texdoc.args": {
-          "scope": "window",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": [
-            "--view"
-          ],
-          "markdownDescription": "Texdoc arguments to see a package documentation. Arguments must be in separate strings in the array. The package name is automatically appended to the arguments."
-        },
-        "latex-workshop.bibtex.maxFileSize": {
-          "scope": "window",
-          "type": "number",
-          "default": 5,
-          "markdownDescription": "Defines the maximum bibtex file size for the extension to parse in MB."
-        },
-        "latex-workshop.bibtex-format.tab": {
-          "scope": "resource",
-          "type": "string",
-          "default": "2 spaces",
-          "markdownDescription": "Indentation for each field. The string can be `\"tab\"` or of the form `\"X spaces\"` or simply `\"X\"` where `X` is a number."
-        },
-        "latex-workshop.bibtex-format.surround": {
-          "scope": "resource",
-          "type": "string",
-          "enum": [
-            "Curly braces",
-            "Quotation marks"
-          ],
-          "default": "Curly braces",
-          "description": "Surround each field value with either {Curly braces} or \"Quotation marks\"."
-        },
-        "latex-workshop.bibtex-format.case": {
-          "scope": "resource",
-          "type": "string",
-          "enum": [
-            "UPPERCASE",
-            "lowercase"
-          ],
-          "default": "lowercase",
-          "description": "Determines if field names should be formatted like 'AUTHOR' or 'author'."
-        },
-        "latex-workshop.bibtex-format.trailingComma": {
-          "scope": "resource",
-          "type": "boolean",
-          "default": false,
-          "description": "Keep the trailing comma of the last field item."
-        },
-        "latex-workshop.bibtex-format.sortby": {
-          "scope": "resource",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "markdownDescription": "An array of strings to sort by. Either a bibtex field name (title, author, year, etc.), or `\"year-desc\"` to sort by year in descending order, or `\"key\"` for the entry key, or `\"type\"` for the entry type (article, book, misc, etc.). E.g. `[\"author\", \"year-desc\", \"title\"]`.",
-          "default": [
-            "key"
-          ]
-        },
-        "latex-workshop.bibtex-format.handleDuplicates": {
-          "scope": "resource",
-          "type": "string",
-          "enum": [
-            "Ignore Duplicates",
-            "Highlight Duplicates",
-            "Comment Duplicates"
-          ],
-          "default": "Highlight Duplicates",
-          "markdownDescription": "How to handle duplicates found by the bibtex sorting functions. Duplicates are decided according to the `bibtex-format.sortby` config."
-        },
-        "latex-workshop.bibtex-format.sort.enabled": {
-          "scope": "resource",
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "Sort content when calling VSCode format on a .bib file."
-        },
-        "latex-workshop.bibtex-format.align-equal.enabled": {
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Align equal signs when calling VSCode format on a .bib file."
-        },
-        "latex-workshop.bibtex-entries.first": {
-          "scope": "resource",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": [
-            "string",
-            "xdata"
-          ],
-          "markdownDescription": "When `#latex-workshop.bibtex-fields.sort.enabled#` is true, these fields are put at the top, in the order defined by the array."
-        },
-        "latex-workshop.bibtex-fields.sort.enabled": {
-          "scope": "resource",
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "Sort fields inside every entry. The sorting order is defined by `#latex-workshop.bibtex-fields.order#`. This variable only has effect when formatting bibtex aligns fields. It is not possible to sort entries without aligning them."
-        },
-        "latex-workshop.bibtex-fields.order": {
-          "scope": "resource",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": [],
-          "markdownDescription": "When `#latex-workshop.bibtex-fields.sort.enabled#` is true, sort fields according the order defined here and then alphabetically for non listed fields."
-        },
-        "latex-workshop.mathpreviewpanel.cursor.enabled": {
-          "scope": "window",
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "[Experimental] Render a cursor on the math preview panel. **This feature is experimental. If you report an issue to us on this feature, we will not fix it. We will not accept any pull requests.**"
-        },
-        "latex-workshop.mathpreviewpanel.editorGroup": {
-          "scope": "window",
-          "type": "string",
-          "default": "below",
-          "enum": [
-            "current",
-            "left",
-            "right",
-            "above",
-            "below"
-          ],
-          "markdownDescription": "The editor group in which to open the math preview panel.",
-          "enumDescriptions": [
-            "Use the current editor group",
-            "Put the math preview panel in a new group on the left of the current one",
-            "Put the math preview panel in a new group on the right of the current one",
-            "Put the math preview panel in a new group above the current one",
-            "Put the math preview panel in a new group below the current one"
-          ]
-        },
-        "latex-workshop.selection.smart.latex.enabled": {
-          "scope": "window",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Enable AST based smart selection. Command ids are `editor.action.smartSelect.expand` and `editor.action.smartSelect.shrink`."
-        },
-        "latex-workshop.codespaces.portforwarding.openDelay": {
-          "scope": "window",
-          "type": "number",
-          "default": 20000,
-          "markdownDescription": "Delay to wait for GitHub Codespaces Authentication of port forwarding to be resolved, in milliseconds."
-        }
-      }
+        ]
     },
-    "menus": {
-      "editor/context": [
-        {
-          "when": "config.latex-workshop.showContextMenu && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && !virtualWorkspace",
-          "command": "latex-workshop.build",
-          "group": "navigation@100"
-        },
-        {
-          "when": "config.latex-workshop.showContextMenu && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && !virtualWorkspace",
-          "command": "latex-workshop.synctex",
-          "group": "navigation@101"
-        }
-      ],
-      "editor/title": [
-        {
-          "when": "editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && !virtualWorkspace",
-          "command": "latex-workshop.view",
-          "group": "navigation@2"
-        },
-        {
-          "when": "editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && !virtualWorkspace",
-          "command": "latex-workshop.build",
-          "group": "navigation@1"
-        }
-      ],
-      "view/title": [
-        {
-          "when": "view == latex-workshop-structure",
-          "command": "latex-workshop.structure-toggle-follow-cursor"
-        }
-      ]
+    "scripts": {
+        "clean": "rimraf out/ .eslintcache",
+        "compile": "tsc -p tsconfig.json && tsc -p viewer/tsconfig.json",
+        "lint": "eslint --cache --ext .ts,.js .",
+        "lint:fix": "eslint --fix --cache --ext .ts,.js .",
+        "release": "npm run clean && npm run lint && npm run compile && vsce package",
+        "test": "node ./out/test/runTest.js",
+        "watch-src": "tsc -watch -p tsconfig.json",
+        "watch-viewer": "tsc -watch -p viewer/tsconfig.json"
     },
-    "viewsContainers": {
-      "activitybar": [
-        {
-          "id": "latex-workshop-activitybar",
-          "title": "LaTeX",
-          "icon": "./icons/activity-bar.svg"
-        }
-      ]
+    "dependencies": {
+        "cross-spawn": "7.0.3",
+        "glob": "8.0.3",
+        "iconv-lite": "0.6.3",
+        "latex-utensils": "4.6.0",
+        "mathjax-full": "3.2.2",
+        "micromatch": "4.0.5",
+        "pdfjs-dist": "3.3.122",
+        "tmp": "0.2.1",
+        "workerpool": "6.3.1",
+        "ws": "8.11.0"
     },
-    "views": {
-      "latex-workshop-activitybar": [
-        {
-          "id": "latex-workshop-commands",
-          "name": "Commands",
-          "when": "latex-workshop:enabled"
-        },
-        {
-          "id": "latex-workshop-structure",
-          "name": "Structure",
-          "when": "latex-workshop:enabled"
-        },
-        {
-          "id": "latex-workshop-snippet-view",
-          "type": "webview",
-          "when": "latex-workshop:enabled",
-          "name": "Snippet View"
-        }
-      ]
-    },
-    "customEditors": [
-      {
-        "viewType": "latex-workshop-pdf-hook",
-        "displayName": "LaTeX Workshop Internal PDF Viewer",
-        "selector": [
-          {
-            "filenamePattern": "*.pdf"
-          },
-          {
-            "filenamePattern": "*.PDF"
-          }
-        ],
-        "priority": "default"
-      }
-    ]
-  },
-  "scripts": {
-    "clean": "rimraf out/ .eslintcache",
-    "compile": "tsc -p tsconfig.json && tsc -p viewer/tsconfig.json",
-    "lint": "eslint --cache --ext .ts,.js .",
-    "lint:fix": "eslint --fix --cache --ext .ts,.js .",
-    "release": "npm run clean && npm run lint && npm run compile && vsce package",
-    "test": "node ./out/test/runTest.js",
-    "watch-src": "tsc -watch -p tsconfig.json",
-    "watch-viewer": "tsc -watch -p viewer/tsconfig.json"
-  },
-  "dependencies": {
-    "cross-spawn": "7.0.3",
-    "glob": "8.0.3",
-    "iconv-lite": "0.6.3",
-    "latex-utensils": "4.6.0",
-    "mathjax-full": "3.2.2",
-    "micromatch": "4.0.5",
-    "pdfjs-dist": "3.3.122",
-    "tmp": "0.2.1",
-    "workerpool": "6.3.1",
-    "ws": "8.11.0"
-  },
-  "devDependencies": {
-    "@types/cross-spawn": "6.0.2",
-    "@types/glob": "8.0.0",
-    "@types/micromatch": "4.0.2",
-    "@types/mocha": "9.1.1",
-    "@types/node": "16.11.68",
-    "@types/rimraf": "3.0.2",
-    "@types/tmp": "0.2.3",
-    "@types/vscode": "1.74.0",
-    "@types/workerpool": "6.1.0",
-    "@types/ws": "8.5.3",
-    "@typescript-eslint/eslint-plugin": "5.45.0",
-    "@typescript-eslint/parser": "5.45.0",
-    "@vscode/test-electron": "2.2.0",
-    "@vscode/vsce": "2.19.0",
-    "eslint": "8.28.0",
-    "mocha": "9.2.2",
-    "rimraf": "3.0.2",
-    "textmate-bailout": "1.1.0",
-    "typescript": "4.9.3",
-    "vscode-extend-language": "0.1.1"
-  }
+    "devDependencies": {
+        "@types/cross-spawn": "6.0.2",
+        "@types/glob": "8.0.0",
+        "@types/micromatch": "4.0.2",
+        "@types/mocha": "9.1.1",
+        "@types/node": "16.11.68",
+        "@types/rimraf": "3.0.2",
+        "@types/tmp": "0.2.3",
+        "@types/vscode": "1.74.0",
+        "@types/workerpool": "6.1.0",
+        "@types/ws": "8.5.3",
+        "@typescript-eslint/eslint-plugin": "5.45.0",
+        "@typescript-eslint/parser": "5.45.0",
+        "@vscode/test-electron": "2.2.0",
+        "@vscode/vsce": "2.19.0",
+        "eslint": "8.28.0",
+        "mocha": "9.2.2",
+        "rimraf": "3.0.2",
+        "textmate-bailout": "1.1.0",
+        "typescript": "4.9.3",
+        "vscode-extend-language": "0.1.1"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -1,2606 +1,2606 @@
 {
-    "name": "latex-workshop",
-    "displayName": "LaTeX Workshop",
-    "description": "Boost LaTeX typesetting efficiency with preview, compile, autocomplete, colorize, and more.",
-    "icon": "icons/icon.png",
-    "version": "9.8.2",
-    "publisher": "James-Yu",
-    "license": "MIT",
-    "homepage": "https://github.com/James-Yu/LaTeX-Workshop",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/James-Yu/LaTeX-Workshop.git"
+  "name": "latex-workshop",
+  "displayName": "LaTeX Workshop",
+  "description": "Boost LaTeX typesetting efficiency with preview, compile, autocomplete, colorize, and more.",
+  "icon": "icons/icon.png",
+  "version": "9.8.2",
+  "publisher": "James-Yu",
+  "license": "MIT",
+  "homepage": "https://github.com/James-Yu/LaTeX-Workshop",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/James-Yu/LaTeX-Workshop.git"
+  },
+  "engines": {
+    "vscode": "^1.74.0"
+  },
+  "categories": [
+    "Programming Languages",
+    "Snippets",
+    "Linters",
+    "Formatters"
+  ],
+  "keywords": [
+    "latex",
+    "tex",
+    "compile",
+    "preview",
+    "hint"
+  ],
+  "activationEvents": [
+    "onCommand:latex-workshop.activate",
+    "onWebviewPanel:latex-workshop-pdf"
+  ],
+  "main": "./out/src/main.js",
+  "capabilities": {
+    "virtualWorkspaces": {
+      "supported": "limited",
+      "description": "Only a few features are supported."
     },
-    "engines": {
-        "vscode": "^1.74.0"
-    },
-    "categories": [
-        "Programming Languages",
-        "Snippets",
-        "Linters",
-        "Formatters"
-    ],
-    "keywords": [
-        "latex",
-        "tex",
-        "compile",
-        "preview",
-        "hint"
-    ],
-    "activationEvents": [
-        "onCommand:latex-workshop.activate",
-        "onWebviewPanel:latex-workshop-pdf"
-    ],
-    "main": "./out/src/main.js",
-    "capabilities": {
-        "virtualWorkspaces": {
-            "supported": "limited",
-            "description": "Only a few features are supported."
-        },
-        "untrustedWorkspaces": {
-            "supported": false
-        }
-    },
-    "contributes": {
-        "languages": [
-            {
-                "id": "tex",
-                "aliases": [
-                    "TeX",
-                    "tex"
-                ],
-                "extensions": [
-                    ".sty",
-                    ".cls",
-                    ".bbx",
-                    ".cbx"
-                ],
-                "configuration": "./syntax/latex-language-configuration.json"
-            },
-            {
-                "id": "doctex",
-                "aliases": [
-                    "DocTeX",
-                    "doctex"
-                ],
-                "extensions": [
-                    ".dtx"
-                ],
-                "configuration": "./syntax/doctex-language-configuration.json"
-            },
-            {
-                "id": "latex",
-                "aliases": [
-                    "LaTeX",
-                    "latex"
-                ],
-                "extensions": [
-                    ".tex",
-                    ".ltx",
-                    ".ctx"
-                ],
-                "configuration": "./syntax/latex-language-configuration.json"
-            },
-            {
-                "id": "bibtex",
-                "aliases": [
-                    "BibTeX",
-                    "bibtex"
-                ],
-                "extensions": [
-                    ".bib"
-                ],
-                "configuration": "./syntax/bibtex-language-configuration.json"
-            },
-            {
-                "id": "bibtex-style",
-                "aliases": [
-                    "BibTeX style"
-                ],
-                "extensions": [
-                    ".bst"
-                ],
-                "configuration": "./syntax/bibtex-style-language-configuration.json"
-            },
-            {
-                "id": "latex-expl3",
-                "aliases": [
-                    "LaTeX-Expl3"
-                ],
-                "configuration": "./syntax/latex3-language-configuration.json"
-            },
-            {
-                "id": "pweave",
-                "aliases": [
-                    "Pweave"
-                ],
-                "extensions": [
-                    ".pnw",
-                    ".ptexw"
-                ],
-                "configuration": "./syntax/latex-language-configuration.json"
-            },
-            {
-                "id": "jlweave",
-                "aliases": [
-                    "Weave.jl"
-                ],
-                "extensions": [
-                    ".jnw",
-                    ".jtexw"
-                ],
-                "configuration": "./syntax/latex-language-configuration.json"
-            },
-            {
-                "id": "rsweave",
-                "aliases": [
-                    "R Sweave"
-                ],
-                "extensions": [
-                    ".rnw",
-                    ".Rnw",
-                    ".Rtex",
-                    ".rtex",
-                    ".snw",
-                    ".Snw"
-                ],
-                "configuration": "./syntax/latex-language-configuration.json"
-            },
-            {
-                "id": "cpp_embedded_latex",
-                "configuration": "./syntax/latex-cpp-embedded-language-configuration.json"
-            },
-            {
-                "id": "markdown_latex_combined",
-                "configuration": "./syntax/markdown-latex-combined-language-configuration.json"
-            }
-        ],
-        "grammars": [
-            {
-                "language": "tex",
-                "scopeName": "text.tex",
-                "path": "./syntax/TeX.tmLanguage.json"
-            },
-            {
-                "language": "doctex",
-                "scopeName": "text.tex.doctex",
-                "path": "./syntax/DocTeX.tmLanguage.json"
-            },
-            {
-                "language": "latex",
-                "scopeName": "text.tex.latex",
-                "path": "./syntax/LaTeX.tmLanguage.json",
-                "embeddedLanguages": {
-                    "source.asymptote": "asymptote",
-                    "source.cpp": "cpp_embedded_latex",
-                    "source.css": "css",
-                    "source.dot": "dot",
-                    "source.gnuplot": "gnuplot",
-                    "text.html": "html",
-                    "source.java": "java",
-                    "source.js": "javascript",
-                    "source.julia": "julia",
-                    "source.lua": "lua",
-                    "source.python": "python",
-                    "source.ruby": "ruby",
-                    "source.scala": "scala",
-                    "source.ts": "typescript",
-                    "text.xml": "xml",
-                    "source.yaml": "yaml",
-                    "meta.embedded.markdown_latex_combined": "markdown_latex_combined"
-                }
-            },
-            {
-                "language": "bibtex",
-                "scopeName": "text.bibtex",
-                "path": "./syntax/Bibtex.tmLanguage.json"
-            },
-            {
-                "language": "bibtex-style",
-                "scopeName": "source.bst",
-                "path": "./syntax/BibTeX-style.tmLanguage.json"
-            },
-            {
-                "language": "latex-expl3",
-                "scopeName": "text.tex.latex.expl3",
-                "path": "./syntax/LaTeX-Expl3.tmLanguage.json"
-            },
-            {
-                "language": "markdown_latex_combined",
-                "scopeName": "text.tex.markdown_latex_combined",
-                "path": "./syntax/markdown-latex-combined.tmLanguage.json"
-            },
-            {
-                "language": "cpp_embedded_latex",
-                "scopeName": "source.cpp.embedded.latex",
-                "path": "./syntax/cpp-grammar-bailout.tmLanguage.json",
-                "embeddedLanguages": {
-                    "meta.embedded.assembly.cpp": "asm"
-                }
-            },
-            {
-                "language": "pweave",
-                "scopeName": "text.tex.latex.pweave",
-                "path": "./syntax/Pweave.tmLanguage.json",
-                "embeddedLanguages": {
-                    "source.python": "python"
-                }
-            },
-            {
-                "language": "jlweave",
-                "scopeName": "text.tex.latex.jlweave",
-                "path": "./syntax/JLweave.tmLanguage.json",
-                "embeddedLanguages": {
-                    "source.julia": "julia"
-                }
-            },
-            {
-                "language": "rsweave",
-                "scopeName": "text.tex.latex.rsweave",
-                "path": "./syntax/RSweave.tmLanguage.json",
-                "embeddedLanguages": {
-                    "source.r": "r"
-                }
-            }
-        ],
-        "snippets": [
-            {
-                "language": "latex",
-                "path": "./data/latex-snippet.json"
-            },
-            {
-                "language": "pweave",
-                "path": "./data/latex-snippet.json"
-            },
-            {
-                "language": "jlweave",
-                "path": "./data/latex-snippet.json"
-            },
-            {
-                "language": "rsweave",
-                "path": "./data/latex-snippet.json"
-            },
-            {
-                "language": "latex-expl3",
-                "path": "./data/latex-snippet.json"
-            }
-        ],
-        "commands": [
-            {
-                "command": "latex-workshop.navigate-envpair",
-                "title": "Navigate to matching begin/end",
-                "category": "LaTeX Workshop"
-            },
-            {
-                "command": "latex-workshop.select-envname",
-                "title": "Select the current environment name",
-                "category": "LaTeX Workshop"
-            },
-            {
-                "command": "latex-workshop.select-envcontent",
-                "title": "Select the current environment content",
-                "category": "LaTeX Workshop"
-            },
-            {
-                "command": "latex-workshop.select-env",
-                "title": "Select the current environment",
-                "category": "LaTeX Workshop"
-            },
-            {
-                "command": "latex-workshop.multicursor-envname",
-                "title": "Add a multicursor to the current environment name",
-                "category": "LaTeX Workshop"
-            },
-            {
-                "command": "latex-workshop.wrap-env",
-                "title": "Surround selection with \\begin{}...\\end{}",
-                "category": "LaTeX Workshop"
-            },
-            {
-                "command": "latex-workshop.surround",
-                "title": "Surround selection with LaTeX command",
-                "category": "LaTeX Workshop"
-            },
-            {
-                "command": "latex-workshop.close-env",
-                "title": "Close current environment",
-                "category": "LaTeX Workshop"
-            },
-            {
-                "command": "latex-workshop.toggle-equation-envname",
-                "title": "Toggle between \\[...\\] and \\begin{}...\\end{}",
-                "category": "LaTeX Workshop"
-            },
-            {
-                "command": "latex-workshop.saveWithoutBuilding",
-                "title": "Save without Building",
-                "category": "LaTeX Workshop"
-            },
-            {
-                "command": "latex-workshop.build",
-                "title": "Build LaTeX project",
-                "category": "LaTeX Workshop",
-                "icon": "$(debug-start)",
-                "enablement": "!virtualWorkspace"
-            },
-            {
-                "command": "latex-workshop.recipes",
-                "title": "Build with recipe",
-                "category": "LaTeX Workshop",
-                "enablement": "!virtualWorkspace"
-            },
-            {
-                "command": "latex-workshop.view",
-                "title": "View LaTeX PDF file",
-                "category": "LaTeX Workshop",
-                "icon": "$(open-preview)",
-                "enablement": "!virtualWorkspace"
-            },
-            {
-                "command": "latex-workshop.tab",
-                "title": "View LaTeX PDF file in VSCode tab",
-                "category": "LaTeX Workshop"
-            },
-            {
-                "command": "latex-workshop.viewInBrowser",
-                "title": "View LaTeX PDF file in web browser",
-                "category": "LaTeX Workshop",
-                "enablement": "!virtualWorkspace"
-            },
-            {
-                "command": "latex-workshop.viewExternal",
-                "title": "View LaTeX PDF file in external viewer",
-                "category": "LaTeX Workshop",
-                "enablement": "!virtualWorkspace"
-            },
-            {
-                "command": "latex-workshop.refresh-viewer",
-                "title": "Refresh all LaTeX PDF viewers",
-                "category": "LaTeX Workshop"
-            },
-            {
-                "command": "latex-workshop.kill",
-                "title": "Kill LaTeX compiler process",
-                "category": "LaTeX Workshop",
-                "enablement": "!virtualWorkspace"
-            },
-            {
-                "command": "latex-workshop.synctex",
-                "title": "SyncTeX from cursor",
-                "category": "LaTeX Workshop",
-                "enablement": "!virtualWorkspace"
-            },
-            {
-                "command": "latex-workshop.clean",
-                "title": "Clean up auxiliary files",
-                "category": "LaTeX Workshop",
-                "enablement": "!virtualWorkspace"
-            },
-            {
-                "command": "latex-workshop.citation",
-                "title": "Open citation browser",
-                "category": "LaTeX Workshop",
-                "enablement": "!virtualWorkspace"
-            },
-            {
-                "command": "latex-workshop.addtexroot",
-                "title": "Insert %!TeX root magic comment",
-                "category": "LaTeX Workshop"
-            },
-            {
-                "command": "latex-workshop.wordcount",
-                "title": "Count words in LaTeX document",
-                "category": "LaTeX Workshop"
-            },
-            {
-                "command": "latex-workshop.changeHostName",
-                "title": "Change server listening hostname",
-                "category": "LaTeX Workshop"
-            },
-            {
-                "command": "latex-workshop.resetHostName",
-                "title": "Reset server listening hostname to 127.0.0.1",
-                "category": "LaTeX Workshop"
-            },
-            {
-                "command": "latex-workshop.compilerlog",
-                "title": "View LaTeX compiler logs",
-                "category": "LaTeX Workshop",
-                "enablement": "!virtualWorkspace"
-            },
-            {
-                "command": "latex-workshop.log",
-                "title": "Show LaTeX Workshop messages",
-                "category": "LaTeX Workshop"
-            },
-            {
-                "command": "latex-workshop.actions",
-                "title": "LaTeX actions",
-                "category": "LaTeX Workshop"
-            },
-            {
-                "command": "latex-workshop-dev.parselog",
-                "title": "Parse current document as LaTeX logs",
-                "category": "LaTeX Workshop DevTools"
-            },
-            {
-                "command": "latex-workshop-dev.parsetex",
-                "title": "Parse current file as LaTeX AST",
-                "category": "LaTeX Workshop DevTools"
-            },
-            {
-                "command": "latex-workshop-dev.parsebib",
-                "title": "Parse current file as BibTeX AST",
-                "category": "LaTeX Workshop DevTools"
-            },
-            {
-                "command": "latex-workshop-dev.striptext",
-                "title": "Strip text and comments from LaTeX.",
-                "category": "LaTeX Workshop DevTools"
-            },
-            {
-                "command": "latex-workshop.texdoc",
-                "title": "Show package documentation",
-                "category": "LaTeX Workshop"
-            },
-            {
-                "command": "latex-workshop.texdocUsepackages",
-                "title": "Show package documentation actually used",
-                "category": "LaTeX Workshop"
-            },
-            {
-                "command": "latex-workshop.promote-sectioning",
-                "title": "Promote all the section levels used in the selection",
-                "category": "LaTeX Workshop"
-            },
-            {
-                "command": "latex-workshop.demote-sectioning",
-                "title": "Demote all the section levels used in the selection",
-                "category": "LaTeX Workshop"
-            },
-            {
-                "command": "latex-workshop.select-section",
-                "title": "Select the current section",
-                "category": "LaTeX Workshop"
-            },
-            {
-                "command": "latex-workshop.structure-toggle-follow-cursor",
-                "title": "Toggle follow cursor",
-                "category": "LaTeX Workshop"
-            },
-            {
-                "command": "latex-workshop.bibsort",
-                "title": "Sort BibTeX file",
-                "category": "LaTeX Workshop"
-            },
-            {
-                "command": "latex-workshop.bibalign",
-                "title": "Align BibTeX file",
-                "category": "LaTeX Workshop"
-            },
-            {
-                "command": "latex-workshop.bibalignsort",
-                "title": "Sort and align BibTeX file",
-                "category": "LaTeX Workshop"
-            },
-            {
-                "command": "latex-workshop.openMathPreviewPanel",
-                "title": "Open Math Preview Panel",
-                "category": "LaTeX Workshop"
-            },
-            {
-                "command": "latex-workshop.closeMathPreviewPanel",
-                "title": "Close Math Preview Panel",
-                "category": "LaTeX Workshop"
-            },
-            {
-                "command": "latex-workshop.toggleMathPreviewPanel",
-                "title": "Toggle Math Preview Panel",
-                "category": "LaTeX Workshop"
-            }
-        ],
-        "keybindings": [
-            {
-                "key": "ctrl+l alt+m",
-                "mac": "cmd+l alt+m",
-                "command": "latex-workshop.toggleMathPreviewPanel",
-                "when": "editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && config.latex-workshop.bind.altKeymap.enabled"
-            },
-            {
-                "key": "ctrl+l alt+b",
-                "mac": "cmd+l alt+b",
-                "command": "latex-workshop.build",
-                "when": "editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && config.latex-workshop.bind.altKeymap.enabled && !virtualWorkspace"
-            },
-            {
-                "key": "ctrl+l alt+c",
-                "mac": "cmd+l alt+c",
-                "command": "latex-workshop.clean",
-                "when": "editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && config.latex-workshop.bind.altKeymap.enabled && !virtualWorkspace"
-            },
-            {
-                "key": "ctrl+l alt+v",
-                "mac": "cmd+l alt+v",
-                "command": "latex-workshop.view",
-                "when": "editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && config.latex-workshop.bind.altKeymap.enabled && !virtualWorkspace"
-            },
-            {
-                "key": "ctrl+l alt+j",
-                "mac": "cmd+l alt+j",
-                "command": "latex-workshop.synctex",
-                "when": "editorTextFocus && editorLangId == 'latex' && config.latex-workshop.bind.altKeymap.enabled && !virtualWorkspace"
-            },
-            {
-                "key": "ctrl+l alt+x",
-                "mac": "cmd+l alt+x",
-                "command": "workbench.view.extension.latex-workshop-activitybar",
-                "when": "config.latex-workshop.bind.altKeymap.enabled"
-            },
-            {
-                "key": "ctrl+alt+m",
-                "mac": "cmd+alt+m",
-                "command": "latex-workshop.toggleMathPreviewPanel",
-                "when": "editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && !config.latex-workshop.bind.altKeymap.enabled"
-            },
-            {
-                "key": "ctrl+alt+b",
-                "mac": "cmd+alt+b",
-                "command": "latex-workshop.build",
-                "when": "editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && !config.latex-workshop.bind.altKeymap.enabled && !virtualWorkspace"
-            },
-            {
-                "key": "ctrl+alt+c",
-                "mac": "cmd+alt+c",
-                "command": "latex-workshop.clean",
-                "when": "editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && !config.latex-workshop.bind.altKeymap.enabled && !virtualWorkspace"
-            },
-            {
-                "key": "ctrl+alt+v",
-                "mac": "cmd+alt+v",
-                "command": "latex-workshop.view",
-                "when": "editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && !config.latex-workshop.bind.altKeymap.enabled && !virtualWorkspace"
-            },
-            {
-                "key": "ctrl+alt+j",
-                "mac": "cmd+alt+j",
-                "command": "latex-workshop.synctex",
-                "when": "editorTextFocus && editorLangId == 'latex' && !config.latex-workshop.bind.altKeymap.enabled && !virtualWorkspace"
-            },
-            {
-                "key": "ctrl+alt+x",
-                "mac": "cmd+alt+x",
-                "command": "workbench.view.extension.latex-workshop-activitybar",
-                "when": "!config.latex-workshop.bind.altKeymap.enabled"
-            },
-            {
-                "key": "ctrl+l [",
-                "mac": "cmd+l [",
-                "when": "config.latex-workshop.bind.altKeymap.enabled && editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
-                "command": "latex-workshop.promote-sectioning"
-            },
-            {
-                "key": "ctrl+l ]",
-                "mac": "cmd+l ]",
-                "when": "config.latex-workshop.bind.altKeymap.enabled && editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
-                "command": "latex-workshop.demote-sectioning"
-            },
-            {
-                "key": "ctrl+alt+[",
-                "mac": "cmd+alt+[",
-                "when": "!config.latex-workshop.bind.altKeymap.enabled && editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
-                "command": "latex-workshop.promote-sectioning"
-            },
-            {
-                "key": "ctrl+alt+]",
-                "mac": "cmd+alt+]",
-                "when": "!config.latex-workshop.bind.altKeymap.enabled && editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
-                "command": "latex-workshop.demote-sectioning"
-            },
-            {
-                "key": "ctrl+l ctrl+enter",
-                "mac": "cmd+l cmd+enter",
-                "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
-                "command": "latex-workshop.shortcut.item"
-            },
-            {
-                "key": "ctrl+l ctrl+b",
-                "mac": "cmd+l cmd+b",
-                "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
-                "command": "latex-workshop.shortcut.textbf"
-            },
-            {
-                "key": "ctrl+l ctrl+i",
-                "mac": "cmd+l cmd+i",
-                "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
-                "command": "latex-workshop.shortcut.textit"
-            },
-            {
-                "key": "ctrl+l ctrl+u",
-                "mac": "cmd+l cmd+u",
-                "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
-                "command": "latex-workshop.shortcut.underline"
-            },
-            {
-                "key": "ctrl+l ctrl+e",
-                "mac": "cmd+l cmd+e",
-                "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
-                "command": "latex-workshop.shortcut.emph"
-            },
-            {
-                "key": "ctrl+l ctrl+r",
-                "mac": "cmd+l cmd+r",
-                "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
-                "command": "latex-workshop.shortcut.textrm"
-            },
-            {
-                "key": "ctrl+l ctrl+t",
-                "mac": "cmd+l cmd+t",
-                "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
-                "command": "latex-workshop.shortcut.texttt"
-            },
-            {
-                "key": "ctrl+l ctrl+s",
-                "mac": "cmd+l cmd+s",
-                "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
-                "command": "latex-workshop.shortcut.textsl"
-            },
-            {
-                "key": "ctrl+l ctrl+c",
-                "mac": "cmd+l cmd+c",
-                "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
-                "command": "latex-workshop.shortcut.textsc"
-            },
-            {
-                "key": "ctrl+l ctrl+n",
-                "mac": "cmd+l cmd+n",
-                "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
-                "command": "latex-workshop.shortcut.textnormal"
-            },
-            {
-                "key": "ctrl+l ctrl+6",
-                "mac": "cmd+l cmd+6",
-                "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
-                "command": "latex-workshop.shortcut.textsuperscript"
-            },
-            {
-                "key": "ctrl+l ctrl+oem_minus",
-                "mac": "cmd+l cmd+oem_minus",
-                "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
-                "command": "latex-workshop.shortcut.textsubscript"
-            },
-            {
-                "key": "ctrl+m ctrl+b",
-                "mac": "ctrl+shift+m cmd+b",
-                "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
-                "command": "latex-workshop.shortcut.mathbf"
-            },
-            {
-                "key": "ctrl+m ctrl+i",
-                "mac": "ctrl+shift+m cmd+i",
-                "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
-                "command": "latex-workshop.shortcut.mathit"
-            },
-            {
-                "key": "ctrl+m ctrl+r",
-                "mac": "ctrl+shift+m cmd+r",
-                "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
-                "command": "latex-workshop.shortcut.mathrm"
-            },
-            {
-                "key": "ctrl+m ctrl+t",
-                "mac": "ctrl+shift+m cmd+t",
-                "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
-                "command": "latex-workshop.shortcut.mathtt"
-            },
-            {
-                "key": "ctrl+m ctrl+s",
-                "mac": "ctrl+shift+m cmd+s",
-                "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
-                "command": "latex-workshop.shortcut.mathsf"
-            },
-            {
-                "key": "ctrl+m ctrl+shift+b",
-                "mac": "ctrl+shift+m cmd+shift+b",
-                "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
-                "command": "latex-workshop.shortcut.mathbb"
-            },
-            {
-                "key": "ctrl+m ctrl+c",
-                "mac": "ctrl+shift+m cmd+c",
-                "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
-                "command": "latex-workshop.shortcut.mathcal"
-            },
-            {
-                "command": "expandLineSelection",
-                "key": "ctrl+l ctrl+l",
-                "mac": "cmd+l cmd+l",
-                "when": "textInputFocus && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/"
-            },
-            {
-                "command": "editor.action.toggleTabFocusMode",
-                "key": "ctrl+l ctrl+m",
-                "mac": "cmd+l ctrl+shift+m",
-                "when": "textInputFocus && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/"
-            },
-            {
-                "key": "ctrl+l ctrl+w",
-                "mac": "cmd+l cmd+w",
-                "when": "editorTextFocus && !editorReadonly && editorHasSelection && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
-                "command": "latex-workshop.surround"
-            },
-            {
-                "command": "latex-workshop.onEnterKey",
-                "key": "enter",
-                "when": "config.latex-workshop.bind.enter.key && editorTextFocus && acceptSuggestionOnEnter && !suggestWidgetVisible && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && vim.active && vim.mode == 'Insert'"
-            },
-            {
-                "command": "latex-workshop.onEnterKey",
-                "key": "enter",
-                "when": "config.latex-workshop.bind.enter.key && editorTextFocus && !acceptSuggestionOnEnter && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && vim.active && vim.mode == 'Insert'"
-            },
-            {
-                "command": "latex-workshop.onEnterKey",
-                "key": "enter",
-                "when": "config.latex-workshop.bind.enter.key && editorTextFocus && acceptSuggestionOnEnter && !suggestWidgetVisible && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && !vim.active"
-            },
-            {
-                "command": "latex-workshop.onEnterKey",
-                "key": "enter",
-                "when": "config.latex-workshop.bind.enter.key && editorTextFocus && !acceptSuggestionOnEnter && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && !vim.active"
-            },
-            {
-                "command": "latex-workshop.onAltEnterKey",
-                "key": "alt+enter",
-                "when": "config.latex-workshop.bind.enter.key && editorTextFocus && acceptSuggestionOnEnter && !suggestWidgetVisible && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/"
-            },
-            {
-                "command": "latex-workshop.onAltEnterKey",
-                "key": "alt+enter",
-                "when": "config.latex-workshop.bind.enter.key && editorTextFocus && !acceptSuggestionOnEnter && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/"
-            }
-        ],
-        "configurationDefaults": {
-            "[latex]": {
-                "editor.formatOnPaste": false,
-                "editor.suggestSelection": "recentlyUsedByPrefix"
-            }
-        },
-        "configuration": {
-            "type": "object",
-            "title": "LaTeX",
-            "properties": {
-                "latex-workshop.latex.recipes": {
-                    "scope": "resource",
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "name": {
-                                "type": "string"
-                            },
-                            "tools": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "required": [
-                            "name",
-                            "tools"
-                        ],
-                        "additionalProperties": false
-                    },
-                    "default": [
-                        {
-                            "name": "latexmk",
-                            "tools": [
-                                "latexmk"
-                            ]
-                        },
-                        {
-                            "name": "latexmk (latexmkrc)",
-                            "tools": [
-                                "latexmk_rconly"
-                            ]
-                        },
-                        {
-                            "name": "latexmk (lualatex)",
-                            "tools": [
-                                "lualatexmk"
-                            ]
-                        },
-                        {
-                            "name": "latexmk (xelatex)",
-                            "tools": [
-                                "xelatexmk"
-                            ]
-                        },
-                        {
-                            "name": "pdflatex -> bibtex -> pdflatex * 2",
-                            "tools": [
-                                "pdflatex",
-                                "bibtex",
-                                "pdflatex",
-                                "pdflatex"
-                            ]
-                        },
-                        {
-                            "name": "Compile Rnw files",
-                            "tools": [
-                                "rnw2tex",
-                                "latexmk"
-                            ]
-                        },
-                        {
-                            "name": "Compile Jnw files",
-                            "tools": [
-                                "jnw2tex",
-                                "latexmk"
-                            ]
-                        },
-                        {
-                            "name": "Compile Pnw files",
-                            "tools": [
-                                "pnw2tex",
-                                "latexmk"
-                            ]
-                        },
-                        {
-                            "name": "tectonic",
-                            "tools": [
-                                "tectonic"
-                            ]
-                        }
-                    ],
-                    "markdownDescription": "Define LaTeX compiling recipes. Each recipe in the list is an object containing its name and the names of tools to be used sequentially, which are defined in `#latex-workshop.latex.tools#`. By default, the first recipe is used to compile the project. For details, please visit https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#latex-recipes."
-                },
-                "latex-workshop.latex.recipe.default": {
-                    "scope": "resource",
-                    "type": "string",
-                    "default": "first",
-                    "markdownDescription": "Define which recipe is used by `#latex-workshop.build#`. It also applies to auto build. Recipes are referred to by their names as defined in `#latex-workshop.latex.recipes#`. Note there are two particular values: \n- `first` means to use the first recipe in `#latex-workshop.latex.recipes#`;\n- `lastUsed` means to use the last run recipe."
-                },
-                "latex-workshop.latex.tools": {
-                    "scope": "resource",
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "name": {
-                                "type": "string"
-                            },
-                            "command": {
-                                "type": "string"
-                            },
-                            "args": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
-                            "env": {
-                                "type": "object"
-                            }
-                        },
-                        "required": [
-                            "name",
-                            "command"
-                        ],
-                        "additionalProperties": false
-                    },
-                    "default": [
-                        {
-                            "name": "latexmk",
-                            "command": "latexmk",
-                            "args": [
-                                "-synctex=1",
-                                "-interaction=nonstopmode",
-                                "-file-line-error",
-                                "-pdf",
-                                "-outdir=%OUTDIR%",
-                                "%DOC%"
-                            ],
-                            "env": {}
-                        },
-                        {
-                            "name": "lualatexmk",
-                            "command": "latexmk",
-                            "args": [
-                                "-synctex=1",
-                                "-interaction=nonstopmode",
-                                "-file-line-error",
-                                "-lualatex",
-                                "-outdir=%OUTDIR%",
-                                "%DOC%"
-                            ],
-                            "env": {}
-                        },
-                        {
-                            "name": "xelatexmk",
-                            "command": "latexmk",
-                            "args": [
-                                "-synctex=1",
-                                "-interaction=nonstopmode",
-                                "-file-line-error",
-                                "-xelatex",
-                                "-outdir=%OUTDIR%",
-                                "%DOC%"
-                            ],
-                            "env": {}
-                        },
-                        {
-                            "name": "latexmk_rconly",
-                            "command": "latexmk",
-                            "args": [
-                                "%DOC%"
-                            ],
-                            "env": {}
-                        },
-                        {
-                            "name": "pdflatex",
-                            "command": "pdflatex",
-                            "args": [
-                                "-synctex=1",
-                                "-interaction=nonstopmode",
-                                "-file-line-error",
-                                "%DOC%"
-                            ],
-                            "env": {}
-                        },
-                        {
-                            "name": "bibtex",
-                            "command": "bibtex",
-                            "args": [
-                                "%DOCFILE%"
-                            ],
-                            "env": {}
-                        },
-                        {
-                            "name": "rnw2tex",
-                            "command": "Rscript",
-                            "args": [
-                                "-e",
-                                "knitr::opts_knit$set(concordance = TRUE); knitr::knit('%DOCFILE_EXT%')"
-                            ],
-                            "env": {}
-                        },
-                        {
-                            "name": "jnw2tex",
-                            "command": "julia",
-                            "args": [
-                                "-e",
-                                "using Weave; weave(\"%DOC_EXT%\", doctype=\"tex\")"
-                            ],
-                            "env": {}
-                        },
-                        {
-                            "name": "jnw2texminted",
-                            "command": "julia",
-                            "args": [
-                                "-e",
-                                "using Weave; weave(\"%DOC_EXT%\", doctype=\"texminted\")"
-                            ],
-                            "env": {}
-                        },
-                        {
-                            "name": "pnw2tex",
-                            "command": "pweave",
-                            "args": [
-                                "-f",
-                                "tex",
-                                "%DOC_EXT%"
-                            ],
-                            "env": {}
-                        },
-                        {
-                            "name": "pnw2texminted",
-                            "command": "pweave",
-                            "args": [
-                                "-f",
-                                "texminted",
-                                "%DOC_EXT%"
-                            ],
-                            "env": {}
-                        },
-                        {
-                            "name": "tectonic",
-                            "command": "tectonic",
-                            "args": [
-                                "--synctex",
-                                "--keep-logs",
-                                "%DOC%.tex"
-                            ],
-                            "env": {}
-                        }
-                    ],
-                    "markdownDescription": "Define LaTeX compiling tools to be used in recipes. Each tool is labeled by its `name`. When invoked, `command` is spawned with arguments defined in `args` and environment variables defined in `env`. Typically no spaces should appear in each argument unless in paths. List of available placeholders: `%DOC%`, `%DOC_W32%, %DOC_EXT%`, `%DOC_EXT_W32%`, `%DOCFILE%`, `%DOCFILE_EXT%`, `%DIR%`, `%DIR_W32%`, `%TMPDIR%` and `%OUTDIR%`, `%OUTDIR_W32%`. Please visit https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#placeholders for a complete list of all placeholders."
-                },
-                "latex-workshop.latex.magic.args": {
-                    "scope": "resource",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "default": [
-                        "-synctex=1",
-                        "-interaction=nonstopmode",
-                        "-file-line-error",
-                        "%DOC%"
-                    ],
-                    "markdownDescription": "Define the arguments to be input to magic command executable. This can be overridden by using \"% !TeX options\"."
-                },
-                "latex-workshop.latex.magic.bib.args": {
-                    "scope": "resource",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "default": [
-                        "%DOCFILE%"
-                    ],
-                    "markdownDescription": "Define the arguments to be input to BIB magic command executable. This can be overridden by using \"% !BIB options\"."
-                },
-                "latex-workshop.latex.external.build.command": {
-                    "scope": "resource",
-                    "type": "string",
-                    "default": "",
-                    "markdownDescription": "The external command to execute when calling latex-workshop.build. This is useful when compiling relies on a Makefile or a bespoke script. When defined, it completely bypasses the recipes and root file detection mechanism."
-                },
-                "latex-workshop.latex.external.build.args": {
-                    "scope": "resource",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "default": [],
-                    "markdownDescription": "The arguments of `#latex-workshop.latex.external.build.command#` when calling latex-workshop.build."
-                },
-                "latex-workshop.latex.build.forceRecipeUsage": {
-                    "scope": "resource",
-                    "type": "boolean",
-                    "default": true,
-                    "markdownDescription": "Force the use the recipe mechanism even if some magic comments are present."
-                },
-                "latex-workshop.latex.outDir": {
-                    "scope": "resource",
-                    "type": "string",
-                    "default": "%DIR%",
-                    "markdownDescription": "The directory where the extension tries to find project files (e.g., PDF and SyncTeX files) are located. Both relative and absolute paths are supported. Relative path start from the root file location, so beware if it is located in sub-directory. The path must not contain a trailing slash. The LaTeX toolchain should output files to this path. For a list of supported placeholders, please visit https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#placeholders."
-                },
-                "latex-workshop.latex.jobname": {
-                    "scope": "resource",
-                    "type": "string",
-                    "default": "",
-                    "markdownDescription": "The jobname argument of the compiling tool, which is used by the extension to find project files (e.g., PDF and SyncTeX files). This config should be set identical to the value provided to the `-jobname=` argument, and should not have placeholders. Leave the config empty to ignore jobname and keep the default behavior."
-                },
-                "latex-workshop.latex.texDirs": {
-                    "scope": "window",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "default": [],
-                    "markdownDescription": "List of directories where to look for extra input `.tex` files. \nAbsolute paths are required. You may also need to set the environment variable `TEXINPUTS` properly for the LaTeX compiler to find the `.tex` files, see the `env` parameter of [recipes](https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#latex-recipes)."
-                },
-                "latex-workshop.latex.verbatimEnvs": {
-                    "scope": "window",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "default": [
-                        "verbatim",
-                        "lstlisting",
-                        "minted"
-                    ],
-                    "markdownDescription": "List environments with verbatim-like content. These environments are stripped off the `.tex` files before any parsing occurs. Note that this variable has no effect on syntax highlighting."
-                },
-                "latex-workshop.kpsewhich.path": {
-                    "scope": "window",
-                    "type": "string",
-                    "default": "kpsewhich",
-                    "markdownDescription": "Define the location of the kpsewhich executable file."
-                },
-                "latex-workshop.kpsewhich.enabled": {
-                    "scope": "window",
-                    "type": "boolean",
-                    "default": false,
-                    "markdownDescription": "Use kpsewhich as defined by `#latex-workshop.kpsewhich.path#` to resolve bibliography files in addition to looking into the directories listed in `#latex-workshop.latex.bibDirs#`."
-                },
-                "latex-workshop.latex.bibDirs": {
-                    "scope": "window",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "default": [],
-                    "markdownDescription": "List of directories where to look for `.bib` files. Absolute paths are required. This setting is only used by the intellisense feature, you may also need to set the environment variable `BIBINPUTS` properly for the LaTeX compiler to find the `.bib` files."
-                },
-                "latex-workshop.latex.search.rootFiles.include": {
-                    "scope": "resource",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "default": [
-                        "**/*.tex",
-                        "**/*.rnw",
-                        "**/*.Rnw"
-                    ],
-                    "markdownDescription": "Patterns of files to consider for the root detection mechanism. Relative paths are computed from the workspace folder. To detect the root file and the tex file tree, we parse all the `.tex` listed here. If you want to specify all `.tex` files inside directory, say `foo`, and all its subdirectories recursively, you need to use `**/foo/**/*.tex`. If you only want to match `.tex` files at the top level of the workspace, use `*.tex`. For more details, see https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#multi-file-projects"
-                },
-                "latex-workshop.latex.search.rootFiles.exclude": {
-                    "scope": "resource",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "default": [],
-                    "markdownDescription": "Patterns of files to exclude from the root detection mechanism. See also `#latex-workshop.latex.search.rootFiles.include#`. For more details, see the https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#multi-file-projects."
-                },
-                "latex-workshop.latex.rootFile.useSubFile": {
-                    "scope": "resource",
-                    "type": "boolean",
-                    "default": true,
-                    "markdownDescription": "When the `subfile` package is used, either the main file or any subfile containing `\\documentclass[main.tex]{subfile}` can be LaTeXing. When `true`, the extension uses the subfile as the rootFile for the `autobuild`, `clean` and `synctex` commands."
-                },
-                "latex-workshop.latex.rootFile.doNotPrompt": {
-                    "scope": "resource",
-                    "type": "boolean",
-                    "default": false,
-                    "markdownDescription": "When the `subfile` package is used, either the main file or any subfile containing `\\documentclass[main.tex]{subfile}` can be LaTeXing. When `false`, the `build` and `view` commands  ask the user's choice first. When `true`, the subfile is used when `#latex-workshop.latex.rootFile.useSubFile#` is also `true`, otherwise the rootFile is used."
-                },
-                "latex-workshop.latex.rootFile.indicator": {
-                    "scope": "resource",
-                    "type": "string",
-                    "default": "\\documentclass[]{}",
-                    "enum": [
-                        "\\documentclass[]{}",
-                        "\\begin{document}"
-                    ],
-                    "markdownDescription": "Determine if the root file is detected based on the presence of \\documentclass[]{} or \\begin{document}."
-                },
-                "latex-workshop.latex.watch.usePolling": {
-                    "scope": "window",
-                    "type": "boolean",
-                    "default": false,
-                    "deprecationMessage": "Deprecated: This config is deprecated and has no use.",
-                    "markdownDeprecationMessage": "**Deprecated**: This config is deprecated and has no use."
-                },
-                "latex-workshop.latex.watch.interval": {
-                    "scope": "window",
-                    "type": "number",
-                    "default": 300,
-                    "deprecationMessage": "Deprecated: This config is deprecated and has no use.",
-                    "markdownDeprecationMessage": "**Deprecated**: This config is deprecated and has no use."
-                },
-                "latex-workshop.latex.watch.delay": {
-                    "scope": "window",
-                    "type": "number",
-                    "default": 250,
-                    "deprecationMessage": "Deprecated: This config is deprecated and has no use.",
-                    "markdownDeprecationMessage": "**Deprecated**: This config is deprecated and has no use."
-                },
-                "latex-workshop.latex.watch.pdf.delay": {
-                    "scope": "window",
-                    "type": "number",
-                    "default": 250,
-                    "markdownDescription": "Defines the time delay before confirming a PDF-like binary file is fully changed. Increase this value if you encounter repeated viewer refreshes and/or loss of PDF scrolling position. LaTeX Workshop internally monitors file change events and initiates auto-builds and/or PDF viewing refresh. When LaTeX is changing large files (particularly binary files like PDFs), multiple consecutive file change events may be emitted, potentially causing file corruption issues. We use this config to control the file polling delay before confirming that the file change has been stabilized. Note that non-binary files such as `.tex`, `.bib`, and `.cls` are not affected."
-                },
-                "latex-workshop.latex.watch.files.ignore": {
-                    "scope": "window",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "default": [
-                        "**/*.bbx",
-                        "**/*.bbl",
-                        "**/*.cbx",
-                        "**/*.cfg",
-                        "**/*.clo",
-                        "**/*.cnf",
-                        "**/*.def",
-                        "**/*.dfu",
-                        "**/*.enc",
-                        "**/*.fd",
-                        "**/*.fmt",
-                        "**/*.lbx",
-                        "**/*.map",
-                        "**/*.mkii",
-                        "**/*.pfb",
-                        "**/*.tfm",
-                        "**/*.vf",
-                        "**/*.code.tex",
-                        "**/*.sty",
-                        "**/texmf-{dist,var}/**",
-                        "**/Local/MiKTeX/**",
-                        "**/Local/Programs/MiKTeX/**",
-                        "**/Roaming/MiKTeX/**",
-                        "**/Program*/MiKTeX*/**",
-                        "**/.miktex/texmfs/**",
-                        "/var/cache/miktex-texmf/**",
-                        "/usr/local/share/miktex-texmf/**",
-                        "**/Library/Application Support/MiKTeX/texmfs/**",
-                        "/dev/null"
-                    ],
-                    "markdownDescription": "Files to ignore from the watching mechanism, i.e., no intellisense or build-on-file-change. However, document structure/outline and build-on-save won't be affected. This property must be an array of glob patterns. The patterns are matched against the absolute file path. To ignore everything inside the `texmf` tree, `**/texmf/**` can be used."
-                },
-                "latex-workshop.latex.autoBuild.run": {
-                    "scope": "resource",
-                    "type": "string",
-                    "enum": [
-                        "never",
-                        "onSave",
-                        "onFileChange"
-                    ],
-                    "enumDescriptions": [
-                        "Never run auto build",
-                        "Auto build whenever a file is saved",
-                        "Auto build whenever a dependency file changes on disk"
-                    ],
-                    "default": "onFileChange",
-                    "markdownDescription": "When the extension shall auto build LaTeX project using the default (first) recipe. \n- `onSave` builds the project upon saving a `tex` file in vscode.\n- `onFileChange` builds the project upon detecting a file change in any of the dependencies, even modified by other applications.\n\n Note that `onSave` is more restrictive than `onFileChange` "
-                },
-                "latex-workshop.latex.autoBuild.interval": {
-                    "scope": "resource",
-                    "type": "integer",
-                    "default": 1000,
-                    "markdownDescription": "The minimal time interval in milliseconds for an auto build to trigger after the previous (manual and auto) build. This value is recommended to be greater than ~500."
-                },
-                "latex-workshop.latex.autoBuild.cleanAndRetry.enabled": {
-                    "scope": "resource",
-                    "type": "boolean",
-                    "default": true,
-                    "markdownDescription": "Delete LaTeX auxiliary files when errors occur during build and retry. This property defines whether LaTeX Workshop will try to clean and build the project once again after errors happen in the build toolchain."
-                },
-                "latex-workshop.latex.build.clearLog.everyRecipeStep.enabled": {
-                    "scope": "resource",
-                    "type": "boolean",
-                    "default": true,
-                    "markdownDescription": "Clear the LaTeX Compiler logs before every step of a recipe. Set this property to false to keep the logs of all tools in a recipe."
-                },
-                "latex-workshop.latex.autoClean.run": {
-                    "scope": "resource",
-                    "type": "string",
-                    "enum": [
-                        "never",
-                        "onFailed",
-                        "onSucceeded",
-                        "onBuilt"
-                    ],
-                    "enumDescriptions": [
-                        "Never clean the project",
-                        "Clean compilation fails",
-                        "Clean compilation successes",
-                        "Clean after build, be it successful or not"
-                    ],
-                    "default": "never",
-                    "markdownDescription": "When LaTeX auxiliary files should be deleted. The folder to be cleaned is defined in `#latex-workshop.latex.outDir#`.\n- `onFailed` cleans the project when compilation fails.\n- `onBuilt` cleans the project when compilation is done, whether successful or failed."
-                },
-                "latex-workshop.latex.clean.subfolder.enabled": {
-                    "scope": "resource",
-                    "type": "boolean",
-                    "default": false,
-                    "markdownDescription": "Delete LaTeX auxiliary files recursively in sub-folders of `#latex-workshop.latex.outDir#`. Note that sub-folders are not removed."
-                },
-                "latex-workshop.latex.clean.fileTypes": {
-                    "scope": "resource",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "default": [
-                        "*.aux",
-                        "*.bbl",
-                        "*.blg",
-                        "*.idx",
-                        "*.ind",
-                        "*.lof",
-                        "*.lot",
-                        "*.out",
-                        "*.toc",
-                        "*.acn",
-                        "*.acr",
-                        "*.alg",
-                        "*.glg",
-                        "*.glo",
-                        "*.gls",
-                        "*.fls",
-                        "*.log",
-                        "*.fdb_latexmk",
-                        "*.snm",
-                        "*.synctex(busy)",
-                        "*.synctex.gz(busy)",
-                        "*.nav",
-                        "*.vrb"
-                    ],
-                    "markdownDescription": "Files to clean when `#latex-workshop.latex.clean.method#` is set to `glob`.. This property must be an array of strings. File globs such as `*.removeme`, `something?.aux` can be used. Users can also specify glob patterns like `emptyfolder*/` to remove empty folders. Non-empty folders will be ignored. The folder globs must end with a slash and the last path component must not contain the globstar `**`, otherwise the folders will not be removed. The following globs patterns are correct `['abc/', 'abc*/', '**/abc*/', 'abc/**/def/']` but these are not ['**', '**/', 'abc/**', 'abc/**/', 'abc/def**/', 'abc/d**ef/']`."
-                },
-                "latex-workshop.latex.clean.command": {
-                    "scope": "resource",
-                    "type": "string",
-                    "default": "latexmk",
-                    "markdownDescription": "The command to be used to remove temporary files when `#latex-workshop.latex.clean.method#` is set to `command`."
-                },
-                "latex-workshop.latex.clean.args": {
-                    "scope": "resource",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "default": [
-                        "-c",
-                        "%TEX%"
-                    ],
-                    "markdownDescription": "The arguments of `#latex-workshop.latex.clean.command#`. Placeholders listed in https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#placeholders can be used to populate the argument strings. Besides, an additional `%TEX%` placeholder refers to the full path of the tex file from which the clean command is called."
-                },
-                "latex-workshop.latex.clean.method": {
-                    "scope": "resource",
-                    "type": "string",
-                    "default": "glob",
-                    "enum": [
-                        "glob",
-                        "command"
-                    ],
-                    "markdownEnumDescriptions": [
-                        "Clean all the files located in `#latex-workshop.latex.outDir#` and matching the glob patterns listed in `#latex-workshop.latex.clean.fileTypes#`.",
-                        "Run `#latex-workshop.latex.clean.command#` to clean temporary files."
-                    ],
-                    "markdownDescription": "Define how temporary files will be cleaned."
-                },
-                "latex-workshop.latex.option.maxPrintLine.enabled": {
-                    "scope": "resource",
-                    "type": "boolean",
-                    "default": true,
-                    "markdownDescription": "Add `--max-print-line` option to LaTeX build commands. This flag tells some MikTeX compilers to produce non hard wrapped log messages. Non hard wrapped log messages are required for the _Problem_ Pane to properly display messages."
-                },
-                "latex-workshop.view.outline.sections": {
-                    "scope": "window",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "default": [
-                        "part",
-                        "chapter",
-                        "section",
-                        "subsection",
-                        "subsubsection"
-                    ],
-                    "markdownDescription": "The section names of LaTeX outline hierarchy. It is also used by the folding mechanism. This property is an array of case-sensitive strings in the order of document structure hierarchy. For multiple tags in the same level, separate the tags with `|` as delimiters, e.g., `section|alternative`."
-                },
-                "latex-workshop.view.outline.commands": {
-                    "scope": "window",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "default": [
-                        "label"
-                    ],
-                    "markdownDescription": "The names of the commands to be shown in the outline/structure views. The commands must be called in the form `\\commandname{arg}`."
-                },
-                "latex-workshop.view.outline.fastparse.enabled": {
-                    "scope": "window",
-                    "type": "boolean",
-                    "default": true,
-                    "deprecationMessage": "Deprecated: This config has been renamed to `latex-workshop.intellisense.fastparse.enabled`.",
-                    "markdownDeprecationMessage": "**Deprecated**: This config has been renamed to `#latex-workshop.intellisense.fastparse.enabled#`."
-                },
-                "latex-workshop.view.outline.floats.enabled": {
-                    "scope": "window",
-                    "type": "boolean",
-                    "default": true,
-                    "markdownDescription": "Show the floating objects (figures and tables) in the outline/structure views."
-                },
-                "latex-workshop.view.outline.floats.number.enabled": {
-                    "scope": "window",
-                    "type": "boolean",
-                    "default": true,
-                    "markdownDescription": "Show the float number in the outline/structure views."
-                },
-                "latex-workshop.view.outline.floats.caption.enabled": {
-                    "scope": "window",
-                    "type": "boolean",
-                    "default": true,
-                    "markdownDescription": "Show the float caption in the outline/structure views."
-                },
-                "latex-workshop.view.outline.numbers.enabled": {
-                    "scope": "window",
-                    "type": "boolean",
-                    "default": true,
-                    "markdownDescription": "Show the sectioning numbers in the outline/structure views."
-                },
-                "latex-workshop.view.autoFocus.enabled": {
-                    "scope": "window",
-                    "type": "boolean",
-                    "default": false,
-                    "markdownDescription": "Auto focus the LaTeX view when switching from non-tex to tex files. This will cause the view to appear consistently upon activating the extension."
-                },
-                "latex-workshop.view.pdf.viewer": {
-                    "scope": "window",
-                    "type": "string",
-                    "default": "tab",
-                    "enum": [
-                        "browser",
-                        "tab",
-                        "external"
-                    ],
-                    "markdownDescription": "The default PDF viewer.",
-                    "enumDescriptions": [
-                        "Open PDF with the default web browser.",
-                        "Open PDF with the built-in tab viewer.",
-                        "[Experimental] Open PDF with the external viewer set in \"View > Pdf > External: command\"."
-                    ]
-                },
-                "latex-workshop.view.pdf.tab.editorGroup": {
-                    "scope": "window",
-                    "type": "string",
-                    "default": "right",
-                    "enum": [
-                        "current",
-                        "left",
-                        "right",
-                        "above",
-                        "below"
-                    ],
-                    "markdownDescription": "The editor group in which to open the tab viewer.",
-                    "enumDescriptions": [
-                        "Use the current editor group",
-                        "Put the viewer tab in a new group on the left of the current one",
-                        "Put the viewer tab in a new group on the right of the current one",
-                        "Put the viewer tab in a new group above the current one",
-                        "Put the viewer tab in a new group below the current one"
-                    ]
-                },
-                "latex-workshop.view.pdf.tab.openDelay": {
-                    "scope": "window",
-                    "type": "number",
-                    "default": 1000,
-                    "markdownDescription": "Defines the delay in milliseconds to wait for a tab opening. Please increase the value if you encounter a focus issue after opening a tab."
-                },
-                "latex-workshop.view.pdf.ref.viewer": {
-                    "type": "string",
-                    "default": "auto",
-                    "enum": [
-                        "auto",
-                        "tabOrBrowser",
-                        "external"
-                    ],
-                    "markdownDescription": "PDF viewer used for [View on PDF] link on \\ref."
-                },
-                "latex-workshop.viewer.pdf.internal.port": {
-                    "scope": "window",
-                    "type": "number",
-                    "default": "0",
-                    "markdownDescription": "Define the port to listen on for communicating with the internal viewer. The default value \"0\" means the port is chosen randomly by the application. If this config is set, only one Visual Studio Code instance with this extension active can be opened. Otherwise, a port conflict may happen."
-                },
-                "latex-workshop.view.pdf.internal.synctex.keybinding": {
-                    "scope": "window",
-                    "type": "string",
-                    "default": "ctrl-click",
-                    "enum": [
-                        "ctrl-click",
-                        "double-click"
-                    ],
-                    "markdownDescription": " Which keybinding to use for the internal viewer for reverse synctex. `ctrl`/`cmd` + click (default) or double click."
-                },
-                "latex-workshop.viewer.pdf.internal.keyboardEvent": {
-                    "scope": "window",
-                    "type": "string",
-                    "default": "auto",
-                    "enum": [
-                        "auto",
-                        "force",
-                        "never"
-                    ],
-                    "markdownDescription": "Rebroadcasting KeyboardEvent on the internal viewers. If keyboard shortcuts on the internal viewer do not work well, change this setting."
-                },
-                "latex-workshop.view.pdf.external.viewer.command": {
-                    "scope": "window",
-                    "type": "string",
-                    "default": "",
-                    "markdownDescription": "The command to execute when using external viewer. This function is not officially supported."
-                },
-                "latex-workshop.view.pdf.external.viewer.args": {
-                    "scope": "window",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "default": [
-                        "%PDF%"
-                    ],
-                    "markdownDescription": "The arguments for `#latex-workshop.view.pdf.external.viewer.command#` when using external viewer. This function is not officially supported. %PDF% is the placeholder for the absolute path to the generated PDF file."
-                },
-                "latex-workshop.view.pdf.external.synctex.command": {
-                    "scope": "window",
-                    "type": "string",
-                    "default": "",
-                    "markdownDescription": "The command to execute when forward synctex to external viewer. This function is not officially supported."
-                },
-                "latex-workshop.view.pdf.external.synctex.args": {
-                    "scope": "window",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "default": [
-                        "%LINE%",
-                        "%PDF%",
-                        "%TEX%"
-                    ],
-                    "markdownDescription": "The arguments for `#latex-workshop.view.pdf.external.synctex.args#` when forward synctex to external viewer. %LINE% is the line number, %PDF% is the placeholder for the absolute path to the generated PDF file, and %TEX% is the source LaTeX file path with `.tex` extension from which syncTeX is fired."
-                },
-                "latex-workshop.view.pdf.zoom": {
-                    "scope": "window",
-                    "type": "string",
-                    "default": "auto",
-                    "markdownDescription": "The default zoom level of the PDF viewer. This default value will be passed to the viewer upon opening. Possible values are `auto`, `page-actual`, `page-fit`, `page-width`, and one-based scale values (e.g., 0.5 for 50%, 2.0 for 200%)."
-                },
-                "latex-workshop.view.pdf.trim": {
-                    "scope": "window",
-                    "type": "number",
-                    "default": 0,
-                    "enum": [
-                        0,
-                        1,
-                        2,
-                        3
-                    ],
-                    "markdownDescription": "The default trim mode of the PDF viewer.",
-                    "enumDescriptions": [
-                        "No page trimming",
-                        "Trim 5% at margin",
-                        "Trim 10% at margin",
-                        "Trim 15% at margin"
-                    ]
-                },
-                "latex-workshop.view.pdf.scrollMode": {
-                    "scope": "window",
-                    "type": "number",
-                    "default": 0,
-                    "markdownDescription": "The default scroll mode of the PDF viewer. This default value will be passed to the viewer upon opening. Possible values are `0` (vertical), `1`(horizontal), `2` (wrapped), `3` (page)."
-                },
-                "latex-workshop.view.pdf.spreadMode": {
-                    "scope": "window",
-                    "type": "number",
-                    "default": 0,
-                    "markdownDescription": "The default spread mode of the PDF viewer. This default value will be passed to the viewer upon opening. Possible values are `0` (none), `1` (odd) and `2` (even)."
-                },
-                "latex-workshop.view.pdf.hand": {
-                    "scope": "window",
-                    "type": "boolean",
-                    "default": false,
-                    "markdownDescription": "Define if the hand tool is enabled by default in the PDF viewer."
-                },
-                "latex-workshop.view.pdf.invertMode.enabled": {
-                    "scope": "window",
-                    "type": "string",
-                    "enum": [
-                        "auto",
-                        "always",
-                        "compat",
-                        "never"
-                    ],
-                    "default": "compat",
-                    "markdownDescription": "Enable the CSS invert filter.",
-                    "enumDescriptions": [
-                        "Enable the invert filter when using a dark theme.",
-                        "Always enable invert filter.",
-                        "Enable the invert filter only if `invert > 0`.",
-                        "Disable the invert filter"
-                    ]
-                },
-                "latex-workshop.view.pdf.invert": {
-                    "scope": "window",
-                    "type": "number",
-                    "default": 0,
-                    "markdownDescription": " Define the CSS invert filter level of the PDF viewer. This config can invert the color of PDF. Possible values are from 0 to 1."
-                },
-                "latex-workshop.view.pdf.invertMode.brightness": {
-                    "scope": "window",
-                    "type": "number",
-                    "default": 1,
-                    "markdownDescription": " Define the CSS brightness filter level of the PDF viewer when the invert mode is enabled. Possible values are from 0 to 2."
-                },
-                "latex-workshop.view.pdf.invertMode.grayscale": {
-                    "scope": "window",
-                    "type": "number",
-                    "default": 0.6,
-                    "markdownDescription": " Define the CSS grayscale filter level of the PDF viewer when the invert mode is enabled. Possible values are from 0 to 1."
-                },
-                "latex-workshop.view.pdf.invertMode.hueRotate": {
-                    "scope": "window",
-                    "type": "number",
-                    "default": 180,
-                    "markdownDescription": " Define the CSS hue-rotate filter angle of the PDF viewer when the invert mode is enabled. Possible values are from 0 to 360."
-                },
-                "latex-workshop.view.pdf.invertMode.sepia": {
-                    "scope": "window",
-                    "type": "number",
-                    "default": 0,
-                    "markdownDescription": " Define the CSS sepia filter level of the PDF viewer when the invert mode is enabled. Possible values are from 0 to 1."
-                },
-                "latex-workshop.view.pdf.color.light.pageColorsForeground": {
-                    "scope": "window",
-                    "type": "string",
-                    "default": "",
-                    "markdownDescription": " The foreground color of the PDF document 1) in tab viewer when the vscode color theme is light, and 2) in browser when the OS theme is light. The string must represent a color in HTML."
-                },
-                "latex-workshop.view.pdf.color.light.pageColorsBackground": {
-                    "scope": "window",
-                    "type": "string",
-                    "default": "",
-                    "markdownDescription": " The background color of the PDF document 1) in tab viewer when the vscode color theme is light, and 2) in browser when the OS theme is light. The string must represent a color in HTML."
-                },
-                "latex-workshop.view.pdf.color.light.backgroundColor": {
-                    "scope": "window",
-                    "type": "string",
-                    "default": "#ffffff",
-                    "markdownDescription": " The background color of the viewer 1) in tab viewer when the vscode color theme is light, and 2) in browser when the OS theme is light. The string must represent a color in HTML."
-                },
-                "latex-workshop.view.pdf.color.light.pageBorderColor": {
-                    "scope": "window",
-                    "type": "string",
-                    "default": "lightgrey",
-                    "markdownDescription": " The border color of the PDF pages 1) in tab viewer when the vscode color theme is light, and 2) in browser when the OS theme is light. The string must represent a color in HTML."
-                },
-                "latex-workshop.view.pdf.color.dark.pageColorsForeground": {
-                    "scope": "window",
-                    "type": "string",
-                    "default": "",
-                    "markdownDescription": " The foreground color of the PDF document 1) in tab viewer when the vscode color theme is dark, and 2) in browser when the OS theme is dark. The string must represent a color in HTML."
-                },
-                "latex-workshop.view.pdf.color.dark.pageColorsBackground": {
-                    "scope": "window",
-                    "type": "string",
-                    "default": "",
-                    "markdownDescription": " The background color of the PDF document 1) in tab viewer when the vscode color theme is dark, and 2) in browser when the OS theme is dark. The string must represent a color in HTML."
-                },
-                "latex-workshop.view.pdf.color.dark.backgroundColor": {
-                    "scope": "window",
-                    "type": "string",
-                    "default": "#ffffff",
-                    "markdownDescription": " The background color of the viewer 1) in tab viewer when the vscode color theme is dark, and 2) in browser when the OS theme is dark. The string must represent a color in HTML."
-                },
-                "latex-workshop.view.pdf.color.dark.pageBorderColor": {
-                    "scope": "window",
-                    "type": "string",
-                    "default": "lightgrey",
-                    "markdownDescription": " The border color of the PDF pages 1) in tab viewer when the vscode color theme is dark, and 2) in browser when the OS theme is dark. The string must represent a color in HTML."
-                },
-                "latex-workshop.synctex.path": {
-                    "scope": "window",
-                    "type": "string",
-                    "default": "synctex",
-                    "markdownDescription": "Define the location of SyncTeX executive file. Additional arguments, e.g., synctex modes and position of click, will be appended to this command."
-                },
-                "latex-workshop.synctex.afterBuild.enabled": {
-                    "scope": "window",
-                    "type": "boolean",
-                    "default": false,
-                    "markdownDescription": "Execute forward synctex at cursor position after compiling LaTeX project."
-                },
-                "latex-workshop.synctex.synctexjs.enabled": {
-                    "scope": "window",
-                    "type": "boolean",
-                    "default": true,
-                    "markdownDescription": "Enable using a builtin synctex function. The command set in latex-workshop.synctex.path will not be used."
-                },
-                "latex-workshop.linting.chktex.enabled": {
-                    "scope": "resource",
-                    "type": "boolean",
-                    "default": false,
-                    "markdownDescription": "Enable linting LaTeX with `chktex`. Check `#latex-workshop.linting.run#` to control when `chktex` is executed if this config is set to `true."
-                },
-                "latex-workshop.linting.lacheck.enabled": {
-                    "scope": "resource",
-                    "type": "boolean",
-                    "default": false,
-                    "markdownDescription": "Enable linting LaTeX with `lacheck`. Check `#latex-workshop.linting.run#` to control when `lacheck` is executed if this config is set to `true."
-                },
-                "latex-workshop.linting.run": {
-                    "scope": "resource",
-                    "type": "string",
-                    "enum": [
-                        "onSave",
-                        "onType"
-                    ],
-                    "enumDescriptions": [
-                        "Lint the whole LaTeX project upon saving",
-                        "Lint the active document when input is stopped"
-                    ],
-                    "default": "onSave",
-                    "markdownDescription": "When LaTeX should be linted.\n- `onSave`: the whole LaTeX project will be linted upon saving.\n- `onType`: the active document will be linted when input is stopped for a period of time defined in `#latex-workshop.linting.delay#`. It also implies `onSave`."
-                },
-                "latex-workshop.linting.chktex.exec.path": {
-                    "scope": "window",
-                    "type": "string",
-                    "default": "chktex",
-                    "markdownDescription": "Define the location of ChkTeX executive file. This command will be joint with `#latex-workshop.linting.chktex.exec.args#` and required arguments to form a complete command of ChkTeX."
-                },
-                "latex-workshop.linting.chktex.exec.args": {
-                    "scope": "resource",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "default": [
-                        "-wall",
-                        "-n22",
-                        "-n30",
-                        "-e16",
-                        "-q"
-                    ],
-                    "markdownDescription": "Linter arguments to check LaTeX syntax of the current file state in real time with ChkTeX. Arguments must be in separate strings in the array. Additional arguments, i.e., `-I0 -f%f:%l:%c:%d:%k:%n:%m\\n` will be appended when constructing the command. Current file contents will be piped to the command through stdin."
-                },
-                "latex-workshop.linting.chktex.convertOutput.column.enabled": {
-                    "scope": "resource",
-                    "type": "boolean",
-                    "default": true,
-                    "markdownDescription": "Enable converting ChkTeX outputs' column numbers for non-ASCII characters."
-                },
-                "latex-workshop.linting.chktex.convertOutput.column.chktexrcTabSize": {
-                    "scope": "resource",
-                    "type": "number",
-                    "default": -1,
-                    "markdownDescription": "Write the `TabSize` number from `.chktexrc`. The default value \"-1\" means that LaTeX Workshop will try to find `.chktexrc` and to read the value from it."
-                },
-                "latex-workshop.linting.delay": {
-                    "scope": "resource",
-                    "type": "number",
-                    "default": 500,
-                    "markdownDescription": "Defines the delay in milliseconds for linter to wait after stopped typing. This config only matters when `#latex-workshop.linting.run#` is set to `onType`."
-                },
-                "latex-workshop.linting.lacheck.exec.path": {
-                    "scope": "window",
-                    "type": "string",
-                    "default": "lacheck",
-                    "markdownDescription": "Define the location of LaCheck executive file."
-                },
-                "latex-workshop.check.duplicatedLabels.enabled": {
-                    "scope": "window",
-                    "type": "boolean",
-                    "default": true,
-                    "markdownDescription": "Enable checking for duplicated labels. A new check is triggered every time the intellisense data is updated, see `#latex-workshop.intellisense.update.aggressive.enabled#`."
-                },
-                "latex-workshop.texcount.path": {
-                    "scope": "window",
-                    "type": "string",
-                    "default": "texcount",
-                    "markdownDescription": "Define the location of TeXCount executive file/script. This command will be joint with `#latex-workshop.texcount.args#` and required arguments to form a complete command of TeXCount."
-                },
-                "latex-workshop.texcount.args": {
-                    "scope": "resource",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "default": [],
-                    "markdownDescription": "TeXCount arguments to count words in the LaTeX documents of the entire project from the root file, or the current document. Arguments must be in separate strings in the array. Additional arguments, i.e., `-merge %DOC%` for the project and the current document path for counting current file will be appended when constructing the command."
-                },
-                "latex-workshop.texcount.autorun": {
-                    "scope": "resource",
-                    "type": "string",
-                    "enum": [
-                        "onSave",
-                        "never"
-                    ],
-                    "enumDescriptions": [
-                        "Count words in the current document",
-                        "Never automatically call texcount"
-                    ],
-                    "default": "never",
-                    "markdownDescription": "When to call `texcount`. Default is never."
-                },
-                "latex-workshop.texcount.interval": {
-                    "scope": "resource",
-                    "type": "number",
-                    "default": 1000,
-                    "markdownDescription": "The minimal time interval between two consecutive runs of `texcount` in milliseconds when `#latex-workshop.texcount.run#` is set to `onSave`."
-                },
-                "latex-workshop.intellisense.fastparse.enabled": {
-                    "scope": "window",
-                    "type": "boolean",
-                    "default": true,
-                    "markdownDescription": "Use fast LaTeX parsing algorithm to build outline/structure. This is done by inherently removing texts and comments before building AST. Enabling this will not tamper the document, but may result in incomplete outline/structure."
-                },
-                "latex-workshop.intellisense.update.aggressive.enabled": {
-                    "scope": "window",
-                    "type": "boolean",
-                    "default": false,
-                    "markdownDescription": "Defines whether the extension aggressively parses the changed content after stopped typing. Disable this config will let the extension only update intellisense after saving changed files."
-                },
-                "latex-workshop.intellisense.update.delay": {
-                    "scope": "window",
-                    "type": "number",
-                    "default": 1000,
-                    "markdownDescription": "Defines the delay in milliseconds for the extension to update current active file content for intellisense after stopped typing. This config works only when `intellisense.update.aggressive.enabled` is enabled. Lower this value to let the extension know newly defined commands/references/environments more quickly, at the cost of more frequent content parsing: more computational burden."
-                },
-                "latex-workshop.intellisense.atSuggestion.user": {
-                    "scope": "window",
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    },
-                    "default": {},
-                    "markdownDescription": "Dictionary of `\"@prefix\": \"snippet command\"` to add to, replace, or remove the default suggestions in `data/at-suggestions.json`. The key of the dictionary is the triggering string, which **must** starts with `@` regardless of `#latex-workshop.intellisense.atSuggestion.trigger.latex#`. The value of the dictionary is the snippet to be inserted. If the key is identical to a default snippet defined in `data/at-suggestions.json`, the new value in the dictionary is used for suggestion. If the value is an empty string, the snippet is removed from suggestion. For example, `{ \"@.\": \"\\cdot\", \"@6\": \"\" }`."
-                },
-                "latex-workshop.intellisense.command.user": {
-                    "scope": "window",
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    },
-                    "default": {},
-                    "markdownDescription": "Dictionary of `\"command name\": \"command snippet\"` to add to, replace, or remove the default ones in `data/commands.json`. The key of the dictionary is the command name with optional braces indicating the command arguments. The value of the dictionary is the snippet to be inserted. If the key is identical to a default command suggestion defined in `data/commands.json`, the new value in the dictionary is used for suggestion. If the value is an empty string, the command is removed from suggestion. Leading backslashes will be added to both the name and snippet by the extension, so don't include them in this config. For example, `{\"mycommand[]{}\": \"notsamecommand[${2:option}]{$TM_SELECTED_TEXT$1}\", \"parbox{}{}\": \"parbox{${2:width}}{$TM_SELECTED_TEXT$1}\", \"overline{}\": \"\"}` adds a new command with name `mycommand[]{} that inserts `\\notsamecommand[]{}`, replaces the default snippet of `\\parbox{}{}` to make it include current selected text, and removes `\\overline{}` from suggestion."
-                },
-                "latex-workshop.intellisense.citation.type": {
-                    "scope": "window",
-                    "type": "string",
-                    "enum": [
-                        "inline",
-                        "browser"
-                    ],
-                    "default": "inline",
-                    "markdownDescription": "Defines which type of hint to show when intellisense provides citation suggestions.",
-                    "enumDescriptions": [
-                        "Use the inline intellisense to provide citation completion items.",
-                        "Use a dropdown menu to provide citation completion items."
-                    ]
-                },
-                "latex-workshop.intellisense.citation.label": {
-                    "scope": "resource",
-                    "type": "string",
-                    "enum": [
-                        "bibtex key",
-                        "title",
-                        "authors"
-                    ],
-                    "default": "bibtex key",
-                    "markdownDescription": "Defines what to show as suggestion labels when intellisense provides citation suggestions in inline mode.",
-                    "enumDescriptions": [
-                        "Show bibtex keys in the inline mode.",
-                        "Show publication titles in the inline mode.",
-                        "Show publication authors in the inline mode."
-                    ]
-                },
-                "latex-workshop.intellisense.citation.format": {
-                    "scope": "resource",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "default": [
-                        "author",
-                        "title",
-                        "journal",
-                        "publisher",
-                        "booktitle",
-                        "year"
-                    ],
-                    "markdownDescription": "List of fields to display for citation preview and intellisense. This list is also used as the filter text to narrow down the intellisense suggestions."
-                },
-                "latex-workshop.intellisense.triggers.latex": {
-                    "scope": "window",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "default": [
-                        "{"
-                    ],
-                    "markdownDescription": "Additional trigger characters for intellisense of LaTeX documents."
-                },
-                "latex-workshop.intellisense.atSuggestion.trigger.latex": {
-                    "scope": "window",
-                    "type": "string",
-                    "default": "@",
-                    "markdownDescription": "Character to trigger snippet suggestions as part of intellisense. Set this variable to `''` to deactivate these suggestions."
-                },
-                "latex-workshop.intellisense.atSuggestionJSON.replace": {
-                    "scope": "window",
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    },
-                    "default": {},
-                    "deprecationMessage": "Deprecated: This config has been renamed to `latex-workshop.intellisense.atSuggestion.user`.",
-                    "markdownDeprecationMessage": "**Deprecated**: This config has been renamed to `#latex-workshop.intellisense.atSuggestion.user#`."
-                },
-                "latex-workshop.intellisense.file.exclude": {
-                    "scope": "resource",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "default": [
-                        "**/*.aux",
-                        "**/*.bbl",
-                        "**/*.bcf",
-                        "**/*.blg",
-                        "**/*.idx",
-                        "**/*.ind",
-                        "**/*.lof",
-                        "**/*.lot",
-                        "**/*.out",
-                        "**/*.toc",
-                        "**/*.acn",
-                        "**/*.acr",
-                        "**/*.alg",
-                        "**/*.glg",
-                        "**/*.glo",
-                        "**/*.gls",
-                        "**/*.ist",
-                        "**/*.fls",
-                        "**/*.log",
-                        "**/*.nav",
-                        "**/*.snm",
-                        "**/*.fdb_latexmk",
-                        "**/*.synctex.gz",
-                        "**/*.run.xml"
-                    ],
-                    "markdownDescription": "Patterns to ignore in file completion"
-                },
-                "latex-workshop.intellisense.file.base": {
-                    "scope": "resource",
-                    "type": "string",
-                    "enum": [
-                        "root relative",
-                        "file relative",
-                        "both"
-                    ],
-                    "default": "root relative",
-                    "markdownDescription": "Specify the base directory for file completion",
-                    "enumDescriptions": [
-                        "Completion from the root file directory",
-                        "Completion from the current file directory",
-                        "both"
-                    ]
-                },
-                "latex-workshop.intellisense.label.command": {
-                    "scope": "window",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "default": [
-                        "label",
-                        "linelabel"
-                    ],
-                    "markdownDescription": "The name of LaTeX commands that indicates a label definition. The command must accept one mandatory argument of the label reference string, e.g, \\linelabel{ref-str}."
-                },
-                "latex-workshop.intellisense.label.keyval": {
-                    "scope": "window",
-                    "type": "boolean",
-                    "default": true,
-                    "markdownDescription": "Scan for labels defined as `label={some tex}` to add to the reference intellisense menu. The braces are mandatory."
-                },
-                "latex-workshop.intellisense.unimathsymbols.enabled": {
-                    "scope": "window",
-                    "type": "boolean",
-                    "default": false,
-                    "markdownDescription": "When `\\` is typed, show unimath symbols in the dropdown selector."
-                },
-                "latex-workshop.intellisense.package.enabled": {
-                    "scope": "window",
-                    "type": "boolean",
-                    "default": true,
-                    "markdownDescription": "Auto-complete commands and environments from used packages."
-                },
-                "latex-workshop.intellisense.package.extra": {
-                    "scope": "window",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "default": [],
-                    "markdownDescription": "List of extra packages to always add to the auto-completion mechanism. When `#latex-workshop.intellisense.package.enabled#` is set to `true`, the commands and environments defined in these extra packages will be added to the intellisense suggestions."
-                },
-                "latex-workshop.intellisense.package.exclude": {
-                    "scope": "window",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "default": [],
-                    "markdownDescription": "List of packages to exclude from the auto-completion mechanism. When `#latex-workshop.intellisense.package.enabled#` is set to `true`, the commands and environments defined in these packages will not be added to the intellisense suggestions. This setting has a higher priority over `#latex-workshop.intellisense.package.extra#`. You may include the string \"lw-default\" in the list to remove all default commands and environments."
-                },
-                "latex-workshop.intellisense.package.env.enabled": {
-                    "scope": "window",
-                    "type": "boolean",
-                    "default": true,
-                    "markdownDescription": "If true, every environment provided by an included package is available by a snippet `\\envname`. Only applies when `#latex-workshop.intellisense.package.enabled#` is true. "
-                },
-                "latex-workshop.intellisense.package.dirs": {
-                    "scope": "window",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "default": [],
-                    "markdownDescription": "List of extra directories to look for package completion files in addition to those provided by the extension. See https://github.com/James-Yu/LaTeX-Workshop/wiki/Intellisense#commands-starting-with- to learn how to generate these files. Files found in these directories have a higher priority over the default ones. This setting is only relevant when `#latex-workshop.intellisense.package.env.enabled#` is true."
-                },
-                "latex-workshop.intellisense.includegraphics.preview.enabled": {
-                    "scope": "window",
-                    "type": "boolean",
-                    "default": true,
-                    "markdownDescription": "Enable preview for `\\includegraphics` completion."
-                },
-                "latex-workshop.message.badbox.show": {
-                    "scope": "window",
-                    "type": "boolean",
-                    "default": true,
-                    "markdownDescription": "Show badbox information in the problems panel."
-                },
-                "latex-workshop.message.biberlog.exclude": {
-                    "scope": "window",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "default": [],
-                    "markdownDescription": "Exclude biber log messages matching the given regexp from the problems panel."
-                },
-                "latex-workshop.message.bibtexlog.exclude": {
-                    "scope": "window",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "default": [],
-                    "markdownDescription": "Exclude bibtex log messages matching the given regexp from the problems panel."
-                },
-                "latex-workshop.message.latexlog.exclude": {
-                    "scope": "window",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "default": [],
-                    "markdownDescription": "Exclude latex log messages matching the given regexp from the problems panel."
-                },
-                "latex-workshop.message.information.show": {
-                    "scope": "window",
-                    "type": "boolean",
-                    "default": false,
-                    "markdownDescription": "Display information messages in popup notifications."
-                },
-                "latex-workshop.message.warning.show": {
-                    "scope": "window",
-                    "type": "boolean",
-                    "default": true,
-                    "markdownDescription": "Display warning messages in popup notifications."
-                },
-                "latex-workshop.message.error.show": {
-                    "scope": "window",
-                    "type": "boolean",
-                    "default": true,
-                    "markdownDescription": "Display error messages in popup notifications."
-                },
-                "latex-workshop.message.log.show": {
-                    "scope": "window",
-                    "type": "boolean",
-                    "default": true,
-                    "markdownDescription": "Display LaTeX Workshop debug log in output panel. This property defines whether LaTeX Workshop will output its debug log to the log panel."
-                },
-                "latex-workshop.message.convertFilenameEncoding": {
-                    "scope": "window",
-                    "type": "boolean",
-                    "default": true,
-                    "markdownDescription": "Convert the encoding of filenames if necessary when displaying them in the problems panel."
-                },
-                "latex-workshop.latexindent.path": {
-                    "scope": "window",
-                    "type": "string",
-                    "default": "latexindent",
-                    "markdownDescription": "Define the location of the latexindent executable file."
-                },
-                "latex-workshop.latexindent.args": {
-                    "scope": "resource",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "default": [
-                        "-c",
-                        "%DIR%/",
-                        "%TMPFILE%",
-                        "-y=defaultIndent: '%INDENT%'"
-                    ],
-                    "markdownDescription": "Define the command line arguments for latexindent. In the addition to the placeholders defined at https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#placeholders, the following placeholders are accepted\n- %TMPFILE%: The full path of the raw TeX file to be formatted. At this moment you need to use it as an input file of `latexindent`.\n- %INDENT%: The indent character of the file, typically `\t`, `' '`, `' '`.\n\nNote that the option `-c` requires a trailing slash."
-                },
-                "latex-workshop.docker.enabled": {
-                    "scope": "window",
-                    "type": "boolean",
-                    "default": false,
-                    "markdownDescription": "Enable docker-based LaTeX distribution support. Do not set this item to `true` unless you are aware of what it means. This extension will use the images defined in `#latex-workshop.docker.image.latex#` to execute `latexmk`, `synctex`, `texcount`, and `latexindent`."
-                },
-                "latex-workshop.docker.image.latex": {
-                    "scope": "window",
-                    "type": "string",
-                    "default": "",
-                    "markdownDescription": "Define the image for `latexmk`, `synctex`, `texcount`, and `latexindent`."
-                },
-                "latex-workshop.showContextMenu": {
-                    "scope": "window",
-                    "type": "boolean",
-                    "default": false,
-                    "markdownDescription": "Enable the LaTeX contextual menu. This menu is deactivated as it is available through the new LaTeX badge. Just set this variable to `true` to recover the menu."
-                },
-                "latex-workshop.bind.enter.key": {
-                    "scope": "window",
-                    "type": "boolean",
-                    "default": true,
-                    "markdownDescription": "Enable the automatic insertion of `\\item` on a newline when pressing `Enter` in a line starting in `\\item`."
-                },
-                "latex-workshop.bind.altKeymap.enabled": {
-                    "scope": "window",
-                    "type": "boolean",
-                    "default": false,
-                    "markdownDescription": "Use alternative keymap combo, i.e., `ctrl`+`l` `alt`+`key`, to replace the default `ctrl`/`cmd`+`alt` shortcuts."
-                },
-                "latex-workshop.hover.ref.enabled": {
-                    "scope": "window",
-                    "type": "boolean",
-                    "default": true,
-                    "markdownDescription": "Enable Hover on References."
-                },
-                "latex-workshop.hover.ref.number.enabled": {
-                    "scope": "window",
-                    "type": "boolean",
-                    "default": true,
-                    "markdownDescription": "Show number assigned to the reference in the previous compilation."
-                },
-                "latex-workshop.hover.citation.enabled": {
-                    "scope": "window",
-                    "type": "boolean",
-                    "default": true,
-                    "markdownDescription": "Enable Hover on Citations."
-                },
-                "latex-workshop.hover.command.enabled": {
-                    "scope": "window",
-                    "type": "boolean",
-                    "default": true,
-                    "markdownDescription": "Enable Hover on Commands to show the possible signatures."
-                },
-                "latex-workshop.hover.preview.enabled": {
-                    "scope": "window",
-                    "type": "boolean",
-                    "default": true,
-                    "markdownDescription": "Enable Hover Preview."
-                },
-                "latex-workshop.hover.preview.maxLines": {
-                    "scope": "window",
-                    "type": "number",
-                    "default": 20,
-                    "markdownDescription": "Maximum number of lines between the beginning of the math environment and the cursor position to allow preview."
-                },
-                "latex-workshop.hover.preview.scale": {
-                    "scope": "window",
-                    "type": "number",
-                    "default": 1,
-                    "markdownDescription": "Scaling of Hover Preview."
-                },
-                "latex-workshop.hover.preview.newcommand.parseTeXFile.enabled": {
-                    "scope": "window",
-                    "type": "boolean",
-                    "default": true,
-                    "markdownDescription": "Enable newcommands defined in the current TeX file to be included in Hover Preview."
-                },
-                "latex-workshop.hover.preview.newcommand.newcommandFile": {
-                    "scope": "window",
-                    "type": "string",
-                    "default": "",
-                    "markdownDescription": "Set the path of a file containing newcommands to be used in Hover Preview. If the path is relative, it is joined with the root dir."
-                },
-                "latex-workshop.hover.preview.cursor.enabled": {
-                    "scope": "window",
-                    "type": "boolean",
-                    "default": true,
-                    "markdownDescription": "Render cursor in Hover Preview at the current position."
-                },
-                "latex-workshop.hover.preview.cursor.symbol": {
-                    "scope": "window",
-                    "type": "string",
-                    "default": "\\!|\\!",
-                    "markdownDescription": "Cursor symbol in Hover Preview."
-                },
-                "latex-workshop.hover.preview.cursor.color": {
-                    "scope": "window",
-                    "type": "string",
-                    "default": "auto",
-                    "enum": [
-                        "auto",
-                        "black",
-                        "blue",
-                        "brown",
-                        "cyan",
-                        "darkgray",
-                        "gray",
-                        "green",
-                        "lightgray",
-                        "lime",
-                        "magenta",
-                        "olive",
-                        "orange",
-                        "pink",
-                        "purple",
-                        "red",
-                        "teal",
-                        "violet",
-                        "white",
-                        "yellow"
-                    ],
-                    "markdownDescription": "The color of cursor in Hover Preview."
-                },
-                "latex-workshop.hover.preview.mathjax.extensions": {
-                    "scope": "window",
-                    "type": "array",
-                    "default": [],
-                    "markdownDescription": "MathJax extensions to load for Hover Preview. See [the list](https://docs.mathjax.org/en/latest/input/tex/extensions/index.html). Note that the following extensions are loaded by default: `ams`, `color`, `newcommand`, `noerrors`, and `noundefined`. They cannot be disabled.",
-                    "items": {
-                        "type": "string",
-                        "enum": [
-                            "amscd",
-                            "bbox",
-                            "boldsymbol",
-                            "braket",
-                            "bussproofs",
-                            "cancel",
-                            "cases",
-                            "centernot",
-                            "colortbl",
-                            "empheq",
-                            "enclose",
-                            "extpfeil",
-                            "gensymb",
-                            "html",
-                            "mathtools",
-                            "mhchem",
-                            "physics",
-                            "textcomp",
-                            "textmacros",
-                            "unicode",
-                            "upgreek",
-                            "verb"
-                        ]
-                    },
-                    "uniqueItems": true
-                },
-                "latex-workshop.intellisense.optionalArgsEntries.enabled": {
-                    "scope": "window",
-                    "type": "boolean",
-                    "default": true,
-                    "markdownDescription": "Some LaTeX commands can have several forms, each with different arguments. If set to True, the intellisense completion list will have one entry for each form of a given command. Default is true."
-                },
-                "latex-workshop.intellisense.argumentHint.enabled": {
-                    "scope": "window",
-                    "type": "boolean",
-                    "default": true,
-                    "markdownDescription": "Many snippets use text hints of the form `${\\d:some_tex}` for their argument. You may prefer to hide instead by setting this configuration to `false`."
-                },
-                "latex-workshop.intellisense.citation.backend": {
-                    "scope": "resource",
-                    "type": "string",
-                    "enum": [
-                        "bibtex",
-                        "biblatex"
-                    ],
-                    "default": "bibtex",
-                    "markdownDescription": "Backend to use for citation intellisense."
-                },
-                "latex-workshop.intellisense.bibtexJSON.replace": {
-                    "scope": "resource",
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "default": {},
-                    "markdownDescription": "Dictionary of `\"entry name\": [\"array\", \"of\", \"fields\"]` to replace the default fields used in `data/bibtex-entries.json`. See `data/bibtex-entries.json` for the list of fields for each entry. This variable is used when `#latex-workshop.intellisense.citation.backend#` is set to `biblatex`."
-                },
-                "latex-workshop.intellisense.biblatexJSON.replace": {
-                    "scope": "resource",
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "default": {},
-                    "markdownDescription": "Dictionary of `\"entry name\": [\"array\", \"of\", \"fields\"]` to replace the default fields used in `data/biblatex-entries.json`. See `data/biblatex-entries.json` for the list of fields for each entry. This variable is used when `#latex-workshop.intellisense.citation.backend#` is set to `bibtex`."
-                },
-                "latex-workshop.intellisense.commandsJSON.replace": {
-                    "scope": "window",
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    },
-                    "default": {},
-                    "deprecationMessage": "Deprecated: This config has been superseded by config `latex-workshop.intellisense.command.user`, which provides more features.",
-                    "markdownDeprecationMessage": "**Deprecated**: This config has been superseded by config `#latex-workshop.intellisense.command.user#`, which provides more features."
-                },
-                "latex-workshop.texdoc.path": {
-                    "scope": "window",
-                    "type": "string",
-                    "default": "texdoc",
-                    "markdownDescription": "Define the location of the `texdoc` executable. This command is used to show a package documentation."
-                },
-                "latex-workshop.texdoc.args": {
-                    "scope": "window",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "default": [
-                        "--view"
-                    ],
-                    "markdownDescription": "Texdoc arguments to see a package documentation. Arguments must be in separate strings in the array. The package name is automatically appended to the arguments."
-                },
-                "latex-workshop.bibtex.maxFileSize": {
-                    "scope": "window",
-                    "type": "number",
-                    "default": 5,
-                    "markdownDescription": "Defines the maximum bibtex file size for the extension to parse in MB."
-                },
-                "latex-workshop.bibtex-format.tab": {
-                    "scope": "resource",
-                    "type": "string",
-                    "default": "2 spaces",
-                    "markdownDescription": "Indentation for each field. The string can be `\"tab\"` or of the form `\"X spaces\"` or simply `\"X\"` where `X` is a number."
-                },
-                "latex-workshop.bibtex-format.surround": {
-                    "scope": "resource",
-                    "type": "string",
-                    "enum": [
-                        "Curly braces",
-                        "Quotation marks"
-                    ],
-                    "default": "Curly braces",
-                    "description": "Surround each field value with either {Curly braces} or \"Quotation marks\"."
-                },
-                "latex-workshop.bibtex-format.case": {
-                    "scope": "resource",
-                    "type": "string",
-                    "enum": [
-                        "UPPERCASE",
-                        "lowercase"
-                    ],
-                    "default": "lowercase",
-                    "description": "Determines if field names should be formatted like 'AUTHOR' or 'author'."
-                },
-                "latex-workshop.bibtex-format.trailingComma": {
-                    "scope": "resource",
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Keep the trailing comma of the last field item."
-                },
-                "latex-workshop.bibtex-format.sortby": {
-                    "scope": "resource",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "markdownDescription": "An array of strings to sort by. Either a bibtex field name (title, author, year, etc.), or `\"year-desc\"` to sort by year in descending order, or `\"key\"` for the entry key, or `\"type\"` for the entry type (article, book, misc, etc.). E.g. `[\"author\", \"year-desc\", \"title\"]`.",
-                    "default": [
-                        "key"
-                    ]
-                },
-                "latex-workshop.bibtex-format.handleDuplicates": {
-                    "scope": "resource",
-                    "type": "string",
-                    "enum": [
-                        "Ignore Duplicates",
-                        "Highlight Duplicates",
-                        "Comment Duplicates"
-                    ],
-                    "default": "Highlight Duplicates",
-                    "markdownDescription": "How to handle duplicates found by the bibtex sorting functions. Duplicates are decided according to the `bibtex-format.sortby` config."
-                },
-                "latex-workshop.bibtex-format.sort.enabled": {
-                    "scope": "resource",
-                    "type": "boolean",
-                    "default": false,
-                    "markdownDescription": "Sort content when calling VSCode format on a .bib file."
-                },
-                "latex-workshop.bibtex-format.align-equal.enabled": {
-                    "type": "boolean",
-                    "default": true,
-                    "markdownDescription": "Align equal signs when calling VSCode format on a .bib file."
-                },
-                "latex-workshop.bibtex-entries.first": {
-                    "scope": "resource",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "default": [
-                        "string",
-                        "xdata"
-                    ],
-                    "markdownDescription": "When `#latex-workshop.bibtex-fields.sort.enabled#` is true, these fields are put at the top, in the order defined by the array."
-                },
-                "latex-workshop.bibtex-fields.sort.enabled": {
-                    "scope": "resource",
-                    "type": "boolean",
-                    "default": false,
-                    "markdownDescription": "Sort fields inside every entry. The sorting order is defined by `#latex-workshop.bibtex-fields.order#`. This variable only has effect when formatting bibtex aligns fields. It is not possible to sort entries without aligning them."
-                },
-                "latex-workshop.bibtex-fields.order": {
-                    "scope": "resource",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "default": [],
-                    "markdownDescription": "When `#latex-workshop.bibtex-fields.sort.enabled#` is true, sort fields according the order defined here and then alphabetically for non listed fields."
-                },
-                "latex-workshop.mathpreviewpanel.cursor.enabled": {
-                    "scope": "window",
-                    "type": "boolean",
-                    "default": false,
-                    "markdownDescription": "[Experimental] Render a cursor on the math preview panel. **This feature is experimental. If you report an issue to us on this feature, we will not fix it. We will not accept any pull requests.**"
-                },
-                "latex-workshop.mathpreviewpanel.editorGroup": {
-                    "scope": "window",
-                    "type": "string",
-                    "default": "below",
-                    "enum": [
-                        "current",
-                        "left",
-                        "right",
-                        "above",
-                        "below"
-                    ],
-                    "markdownDescription": "The editor group in which to open the math preview panel.",
-                    "enumDescriptions": [
-                        "Use the current editor group",
-                        "Put the math preview panel in a new group on the left of the current one",
-                        "Put the math preview panel in a new group on the right of the current one",
-                        "Put the math preview panel in a new group above the current one",
-                        "Put the math preview panel in a new group below the current one"
-                    ]
-                },
-                "latex-workshop.selection.smart.latex.enabled": {
-                    "scope": "window",
-                    "type": "boolean",
-                    "default": true,
-                    "markdownDescription": "Enable AST based smart selection. Command ids are `editor.action.smartSelect.expand` and `editor.action.smartSelect.shrink`."
-                },
-                "latex-workshop.codespaces.portforwarding.openDelay": {
-                    "scope": "window",
-                    "type": "number",
-                    "default": 20000,
-                    "markdownDescription": "Delay to wait for GitHub Codespaces Authentication of port forwarding to be resolved, in milliseconds."
-                }
-            }
-        },
-        "menus": {
-            "editor/context": [
-                {
-                    "when": "config.latex-workshop.showContextMenu && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && !virtualWorkspace",
-                    "command": "latex-workshop.build",
-                    "group": "navigation@100"
-                },
-                {
-                    "when": "config.latex-workshop.showContextMenu && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && !virtualWorkspace",
-                    "command": "latex-workshop.synctex",
-                    "group": "navigation@101"
-                }
-            ],
-            "editor/title": [
-                {
-                    "when": "editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && !virtualWorkspace",
-                    "command": "latex-workshop.view",
-                    "group": "navigation@2"
-                },
-                {
-                    "when": "editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && !virtualWorkspace",
-                    "command": "latex-workshop.build",
-                    "group": "navigation@1"
-                }
-            ],
-            "view/title": [
-                {
-                    "when": "view == latex-workshop-structure",
-                    "command": "latex-workshop.structure-toggle-follow-cursor"
-                }
-            ]
-        },
-        "viewsContainers": {
-            "activitybar": [
-                {
-                    "id": "latex-workshop-activitybar",
-                    "title": "LaTeX",
-                    "icon": "./icons/activity-bar.svg"
-                }
-            ]
-        },
-        "views": {
-            "latex-workshop-activitybar": [
-                {
-                    "id": "latex-workshop-commands",
-                    "name": "Commands",
-                    "when": "latex-workshop:enabled"
-                },
-                {
-                    "id": "latex-workshop-structure",
-                    "name": "Structure",
-                    "when": "latex-workshop:enabled"
-                },
-                {
-                    "id": "latex-workshop-snippet-view",
-                    "type": "webview",
-                    "when": "latex-workshop:enabled",
-                    "name": "Snippet View"
-                }
-            ]
-        },
-        "customEditors": [
-            {
-                "viewType": "latex-workshop-pdf-hook",
-                "displayName": "LaTeX Workshop Internal PDF Viewer",
-                "selector": [
-                    {
-                        "filenamePattern": "*.pdf"
-                    },
-                    {
-                        "filenamePattern": "*.PDF"
-                    }
-                ],
-                "priority": "default"
-            }
-        ]
-    },
-    "scripts": {
-        "clean": "rimraf out/ .eslintcache",
-        "compile": "tsc -p tsconfig.json && tsc -p viewer/tsconfig.json",
-        "lint": "eslint --cache --ext .ts,.js .",
-        "lint:fix": "eslint --fix --cache --ext .ts,.js .",
-        "release": "npm run clean && npm run lint && npm run compile && vsce package",
-        "test": "node ./out/test/runTest.js",
-        "watch-src": "tsc -watch -p tsconfig.json",
-        "watch-viewer": "tsc -watch -p viewer/tsconfig.json"
-    },
-    "dependencies": {
-        "cross-spawn": "7.0.3",
-        "glob": "8.0.3",
-        "iconv-lite": "0.6.3",
-        "latex-utensils": "4.6.0",
-        "mathjax-full": "3.2.2",
-        "micromatch": "4.0.5",
-        "pdfjs-dist": "3.3.122",
-        "tmp": "0.2.1",
-        "workerpool": "6.3.1",
-        "ws": "8.11.0"
-    },
-    "devDependencies": {
-        "@types/cross-spawn": "6.0.2",
-        "@types/glob": "8.0.0",
-        "@types/micromatch": "4.0.2",
-        "@types/mocha": "9.1.1",
-        "@types/node": "16.11.68",
-        "@types/rimraf": "3.0.2",
-        "@types/tmp": "0.2.3",
-        "@types/vscode": "1.74.0",
-        "@types/workerpool": "6.1.0",
-        "@types/ws": "8.5.3",
-        "@typescript-eslint/eslint-plugin": "5.45.0",
-        "@typescript-eslint/parser": "5.45.0",
-        "@vscode/test-electron": "2.2.0",
-        "@vscode/vsce": "2.19.0",
-        "eslint": "8.28.0",
-        "mocha": "9.2.2",
-        "rimraf": "3.0.2",
-        "textmate-bailout": "1.1.0",
-        "typescript": "4.9.3",
-        "vscode-extend-language": "0.1.1"
+    "untrustedWorkspaces": {
+      "supported": false
     }
+  },
+  "contributes": {
+    "languages": [
+      {
+        "id": "tex",
+        "aliases": [
+          "TeX",
+          "tex"
+        ],
+        "extensions": [
+          ".sty",
+          ".cls",
+          ".bbx",
+          ".cbx"
+        ],
+        "configuration": "./syntax/latex-language-configuration.json"
+      },
+      {
+        "id": "doctex",
+        "aliases": [
+          "DocTeX",
+          "doctex"
+        ],
+        "extensions": [
+          ".dtx"
+        ],
+        "configuration": "./syntax/doctex-language-configuration.json"
+      },
+      {
+        "id": "latex",
+        "aliases": [
+          "LaTeX",
+          "latex"
+        ],
+        "extensions": [
+          ".tex",
+          ".ltx",
+          ".ctx"
+        ],
+        "configuration": "./syntax/latex-language-configuration.json"
+      },
+      {
+        "id": "bibtex",
+        "aliases": [
+          "BibTeX",
+          "bibtex"
+        ],
+        "extensions": [
+          ".bib"
+        ],
+        "configuration": "./syntax/bibtex-language-configuration.json"
+      },
+      {
+        "id": "bibtex-style",
+        "aliases": [
+          "BibTeX style"
+        ],
+        "extensions": [
+          ".bst"
+        ],
+        "configuration": "./syntax/bibtex-style-language-configuration.json"
+      },
+      {
+        "id": "latex-expl3",
+        "aliases": [
+          "LaTeX-Expl3"
+        ],
+        "configuration": "./syntax/latex3-language-configuration.json"
+      },
+      {
+        "id": "pweave",
+        "aliases": [
+          "Pweave"
+        ],
+        "extensions": [
+          ".pnw",
+          ".ptexw"
+        ],
+        "configuration": "./syntax/latex-language-configuration.json"
+      },
+      {
+        "id": "jlweave",
+        "aliases": [
+          "Weave.jl"
+        ],
+        "extensions": [
+          ".jnw",
+          ".jtexw"
+        ],
+        "configuration": "./syntax/latex-language-configuration.json"
+      },
+      {
+        "id": "rsweave",
+        "aliases": [
+          "R Sweave"
+        ],
+        "extensions": [
+          ".rnw",
+          ".Rnw",
+          ".Rtex",
+          ".rtex",
+          ".snw",
+          ".Snw"
+        ],
+        "configuration": "./syntax/latex-language-configuration.json"
+      },
+      {
+        "id": "cpp_embedded_latex",
+        "configuration": "./syntax/latex-cpp-embedded-language-configuration.json"
+      },
+      {
+        "id": "markdown_latex_combined",
+        "configuration": "./syntax/markdown-latex-combined-language-configuration.json"
+      }
+    ],
+    "grammars": [
+      {
+        "language": "tex",
+        "scopeName": "text.tex",
+        "path": "./syntax/TeX.tmLanguage.json"
+      },
+      {
+        "language": "doctex",
+        "scopeName": "text.tex.doctex",
+        "path": "./syntax/DocTeX.tmLanguage.json"
+      },
+      {
+        "language": "latex",
+        "scopeName": "text.tex.latex",
+        "path": "./syntax/LaTeX.tmLanguage.json",
+        "embeddedLanguages": {
+          "source.asymptote": "asymptote",
+          "source.cpp": "cpp_embedded_latex",
+          "source.css": "css",
+          "source.dot": "dot",
+          "source.gnuplot": "gnuplot",
+          "text.html": "html",
+          "source.java": "java",
+          "source.js": "javascript",
+          "source.julia": "julia",
+          "source.lua": "lua",
+          "source.python": "python",
+          "source.ruby": "ruby",
+          "source.scala": "scala",
+          "source.ts": "typescript",
+          "text.xml": "xml",
+          "source.yaml": "yaml",
+          "meta.embedded.markdown_latex_combined": "markdown_latex_combined"
+        }
+      },
+      {
+        "language": "bibtex",
+        "scopeName": "text.bibtex",
+        "path": "./syntax/Bibtex.tmLanguage.json"
+      },
+      {
+        "language": "bibtex-style",
+        "scopeName": "source.bst",
+        "path": "./syntax/BibTeX-style.tmLanguage.json"
+      },
+      {
+        "language": "latex-expl3",
+        "scopeName": "text.tex.latex.expl3",
+        "path": "./syntax/LaTeX-Expl3.tmLanguage.json"
+      },
+      {
+        "language": "markdown_latex_combined",
+        "scopeName": "text.tex.markdown_latex_combined",
+        "path": "./syntax/markdown-latex-combined.tmLanguage.json"
+      },
+      {
+        "language": "cpp_embedded_latex",
+        "scopeName": "source.cpp.embedded.latex",
+        "path": "./syntax/cpp-grammar-bailout.tmLanguage.json",
+        "embeddedLanguages": {
+          "meta.embedded.assembly.cpp": "asm"
+        }
+      },
+      {
+        "language": "pweave",
+        "scopeName": "text.tex.latex.pweave",
+        "path": "./syntax/Pweave.tmLanguage.json",
+        "embeddedLanguages": {
+          "source.python": "python"
+        }
+      },
+      {
+        "language": "jlweave",
+        "scopeName": "text.tex.latex.jlweave",
+        "path": "./syntax/JLweave.tmLanguage.json",
+        "embeddedLanguages": {
+          "source.julia": "julia"
+        }
+      },
+      {
+        "language": "rsweave",
+        "scopeName": "text.tex.latex.rsweave",
+        "path": "./syntax/RSweave.tmLanguage.json",
+        "embeddedLanguages": {
+          "source.r": "r"
+        }
+      }
+    ],
+    "snippets": [
+      {
+        "language": "latex",
+        "path": "./data/latex-snippet.json"
+      },
+      {
+        "language": "pweave",
+        "path": "./data/latex-snippet.json"
+      },
+      {
+        "language": "jlweave",
+        "path": "./data/latex-snippet.json"
+      },
+      {
+        "language": "rsweave",
+        "path": "./data/latex-snippet.json"
+      },
+      {
+        "language": "latex-expl3",
+        "path": "./data/latex-snippet.json"
+      }
+    ],
+    "commands": [
+      {
+        "command": "latex-workshop.navigate-envpair",
+        "title": "Navigate to matching begin/end",
+        "category": "LaTeX Workshop"
+      },
+      {
+        "command": "latex-workshop.select-envname",
+        "title": "Select the current environment name",
+        "category": "LaTeX Workshop"
+      },
+      {
+        "command": "latex-workshop.select-envcontent",
+        "title": "Select the current environment content",
+        "category": "LaTeX Workshop"
+      },
+      {
+        "command": "latex-workshop.select-env",
+        "title": "Select the current environment",
+        "category": "LaTeX Workshop"
+      },
+      {
+        "command": "latex-workshop.multicursor-envname",
+        "title": "Add a multicursor to the current environment name",
+        "category": "LaTeX Workshop"
+      },
+      {
+        "command": "latex-workshop.wrap-env",
+        "title": "Surround selection with \\begin{}...\\end{}",
+        "category": "LaTeX Workshop"
+      },
+      {
+        "command": "latex-workshop.surround",
+        "title": "Surround selection with LaTeX command",
+        "category": "LaTeX Workshop"
+      },
+      {
+        "command": "latex-workshop.close-env",
+        "title": "Close current environment",
+        "category": "LaTeX Workshop"
+      },
+      {
+        "command": "latex-workshop.toggle-equation-envname",
+        "title": "Toggle between \\[...\\] and \\begin{}...\\end{}",
+        "category": "LaTeX Workshop"
+      },
+      {
+        "command": "latex-workshop.saveWithoutBuilding",
+        "title": "Save without Building",
+        "category": "LaTeX Workshop"
+      },
+      {
+        "command": "latex-workshop.build",
+        "title": "Build LaTeX project",
+        "category": "LaTeX Workshop",
+        "icon": "$(debug-start)",
+        "enablement": "!virtualWorkspace"
+      },
+      {
+        "command": "latex-workshop.recipes",
+        "title": "Build with recipe",
+        "category": "LaTeX Workshop",
+        "enablement": "!virtualWorkspace"
+      },
+      {
+        "command": "latex-workshop.view",
+        "title": "View LaTeX PDF file",
+        "category": "LaTeX Workshop",
+        "icon": "$(open-preview)",
+        "enablement": "!virtualWorkspace"
+      },
+      {
+        "command": "latex-workshop.tab",
+        "title": "View LaTeX PDF file in VSCode tab",
+        "category": "LaTeX Workshop"
+      },
+      {
+        "command": "latex-workshop.viewInBrowser",
+        "title": "View LaTeX PDF file in web browser",
+        "category": "LaTeX Workshop",
+        "enablement": "!virtualWorkspace"
+      },
+      {
+        "command": "latex-workshop.viewExternal",
+        "title": "View LaTeX PDF file in external viewer",
+        "category": "LaTeX Workshop",
+        "enablement": "!virtualWorkspace"
+      },
+      {
+        "command": "latex-workshop.refresh-viewer",
+        "title": "Refresh all LaTeX PDF viewers",
+        "category": "LaTeX Workshop"
+      },
+      {
+        "command": "latex-workshop.kill",
+        "title": "Kill LaTeX compiler process",
+        "category": "LaTeX Workshop",
+        "enablement": "!virtualWorkspace"
+      },
+      {
+        "command": "latex-workshop.synctex",
+        "title": "SyncTeX from cursor",
+        "category": "LaTeX Workshop",
+        "enablement": "!virtualWorkspace"
+      },
+      {
+        "command": "latex-workshop.clean",
+        "title": "Clean up auxiliary files",
+        "category": "LaTeX Workshop",
+        "enablement": "!virtualWorkspace"
+      },
+      {
+        "command": "latex-workshop.citation",
+        "title": "Open citation browser",
+        "category": "LaTeX Workshop",
+        "enablement": "!virtualWorkspace"
+      },
+      {
+        "command": "latex-workshop.addtexroot",
+        "title": "Insert %!TeX root magic comment",
+        "category": "LaTeX Workshop"
+      },
+      {
+        "command": "latex-workshop.wordcount",
+        "title": "Count words in LaTeX document",
+        "category": "LaTeX Workshop"
+      },
+      {
+        "command": "latex-workshop.changeHostName",
+        "title": "Change server listening hostname",
+        "category": "LaTeX Workshop"
+      },
+      {
+        "command": "latex-workshop.resetHostName",
+        "title": "Reset server listening hostname to 127.0.0.1",
+        "category": "LaTeX Workshop"
+      },
+      {
+        "command": "latex-workshop.compilerlog",
+        "title": "View LaTeX compiler logs",
+        "category": "LaTeX Workshop",
+        "enablement": "!virtualWorkspace"
+      },
+      {
+        "command": "latex-workshop.log",
+        "title": "Show LaTeX Workshop messages",
+        "category": "LaTeX Workshop"
+      },
+      {
+        "command": "latex-workshop.actions",
+        "title": "LaTeX actions",
+        "category": "LaTeX Workshop"
+      },
+      {
+        "command": "latex-workshop-dev.parselog",
+        "title": "Parse current document as LaTeX logs",
+        "category": "LaTeX Workshop DevTools"
+      },
+      {
+        "command": "latex-workshop-dev.parsetex",
+        "title": "Parse current file as LaTeX AST",
+        "category": "LaTeX Workshop DevTools"
+      },
+      {
+        "command": "latex-workshop-dev.parsebib",
+        "title": "Parse current file as BibTeX AST",
+        "category": "LaTeX Workshop DevTools"
+      },
+      {
+        "command": "latex-workshop-dev.striptext",
+        "title": "Strip text and comments from LaTeX.",
+        "category": "LaTeX Workshop DevTools"
+      },
+      {
+        "command": "latex-workshop.texdoc",
+        "title": "Show package documentation",
+        "category": "LaTeX Workshop"
+      },
+      {
+        "command": "latex-workshop.texdocUsepackages",
+        "title": "Show package documentation actually used",
+        "category": "LaTeX Workshop"
+      },
+      {
+        "command": "latex-workshop.promote-sectioning",
+        "title": "Promote all the section levels used in the selection",
+        "category": "LaTeX Workshop"
+      },
+      {
+        "command": "latex-workshop.demote-sectioning",
+        "title": "Demote all the section levels used in the selection",
+        "category": "LaTeX Workshop"
+      },
+      {
+        "command": "latex-workshop.select-section",
+        "title": "Select the current section",
+        "category": "LaTeX Workshop"
+      },
+      {
+        "command": "latex-workshop.structure-toggle-follow-cursor",
+        "title": "Toggle follow cursor",
+        "category": "LaTeX Workshop"
+      },
+      {
+        "command": "latex-workshop.bibsort",
+        "title": "Sort BibTeX file",
+        "category": "LaTeX Workshop"
+      },
+      {
+        "command": "latex-workshop.bibalign",
+        "title": "Align BibTeX file",
+        "category": "LaTeX Workshop"
+      },
+      {
+        "command": "latex-workshop.bibalignsort",
+        "title": "Sort and align BibTeX file",
+        "category": "LaTeX Workshop"
+      },
+      {
+        "command": "latex-workshop.openMathPreviewPanel",
+        "title": "Open Math Preview Panel",
+        "category": "LaTeX Workshop"
+      },
+      {
+        "command": "latex-workshop.closeMathPreviewPanel",
+        "title": "Close Math Preview Panel",
+        "category": "LaTeX Workshop"
+      },
+      {
+        "command": "latex-workshop.toggleMathPreviewPanel",
+        "title": "Toggle Math Preview Panel",
+        "category": "LaTeX Workshop"
+      }
+    ],
+    "keybindings": [
+      {
+        "key": "ctrl+l alt+m",
+        "mac": "cmd+l alt+m",
+        "command": "latex-workshop.toggleMathPreviewPanel",
+        "when": "editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && config.latex-workshop.bind.altKeymap.enabled"
+      },
+      {
+        "key": "ctrl+l alt+b",
+        "mac": "cmd+l alt+b",
+        "command": "latex-workshop.build",
+        "when": "editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && config.latex-workshop.bind.altKeymap.enabled && !virtualWorkspace"
+      },
+      {
+        "key": "ctrl+l alt+c",
+        "mac": "cmd+l alt+c",
+        "command": "latex-workshop.clean",
+        "when": "editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && config.latex-workshop.bind.altKeymap.enabled && !virtualWorkspace"
+      },
+      {
+        "key": "ctrl+l alt+v",
+        "mac": "cmd+l alt+v",
+        "command": "latex-workshop.view",
+        "when": "editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && config.latex-workshop.bind.altKeymap.enabled && !virtualWorkspace"
+      },
+      {
+        "key": "ctrl+l alt+j",
+        "mac": "cmd+l alt+j",
+        "command": "latex-workshop.synctex",
+        "when": "editorTextFocus && editorLangId == 'latex' && config.latex-workshop.bind.altKeymap.enabled && !virtualWorkspace"
+      },
+      {
+        "key": "ctrl+l alt+x",
+        "mac": "cmd+l alt+x",
+        "command": "workbench.view.extension.latex-workshop-activitybar",
+        "when": "config.latex-workshop.bind.altKeymap.enabled"
+      },
+      {
+        "key": "ctrl+alt+m",
+        "mac": "cmd+alt+m",
+        "command": "latex-workshop.toggleMathPreviewPanel",
+        "when": "editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && !config.latex-workshop.bind.altKeymap.enabled"
+      },
+      {
+        "key": "ctrl+alt+b",
+        "mac": "cmd+alt+b",
+        "command": "latex-workshop.build",
+        "when": "editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && !config.latex-workshop.bind.altKeymap.enabled && !virtualWorkspace"
+      },
+      {
+        "key": "ctrl+alt+c",
+        "mac": "cmd+alt+c",
+        "command": "latex-workshop.clean",
+        "when": "editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && !config.latex-workshop.bind.altKeymap.enabled && !virtualWorkspace"
+      },
+      {
+        "key": "ctrl+alt+v",
+        "mac": "cmd+alt+v",
+        "command": "latex-workshop.view",
+        "when": "editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && !config.latex-workshop.bind.altKeymap.enabled && !virtualWorkspace"
+      },
+      {
+        "key": "ctrl+alt+j",
+        "mac": "cmd+alt+j",
+        "command": "latex-workshop.synctex",
+        "when": "editorTextFocus && editorLangId == 'latex' && !config.latex-workshop.bind.altKeymap.enabled && !virtualWorkspace"
+      },
+      {
+        "key": "ctrl+alt+x",
+        "mac": "cmd+alt+x",
+        "command": "workbench.view.extension.latex-workshop-activitybar",
+        "when": "!config.latex-workshop.bind.altKeymap.enabled"
+      },
+      {
+        "key": "ctrl+l [",
+        "mac": "cmd+l [",
+        "when": "config.latex-workshop.bind.altKeymap.enabled && editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
+        "command": "latex-workshop.promote-sectioning"
+      },
+      {
+        "key": "ctrl+l ]",
+        "mac": "cmd+l ]",
+        "when": "config.latex-workshop.bind.altKeymap.enabled && editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
+        "command": "latex-workshop.demote-sectioning"
+      },
+      {
+        "key": "ctrl+alt+[",
+        "mac": "cmd+alt+[",
+        "when": "!config.latex-workshop.bind.altKeymap.enabled && editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
+        "command": "latex-workshop.promote-sectioning"
+      },
+      {
+        "key": "ctrl+alt+]",
+        "mac": "cmd+alt+]",
+        "when": "!config.latex-workshop.bind.altKeymap.enabled && editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
+        "command": "latex-workshop.demote-sectioning"
+      },
+      {
+        "key": "ctrl+l ctrl+enter",
+        "mac": "cmd+l cmd+enter",
+        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
+        "command": "latex-workshop.shortcut.item"
+      },
+      {
+        "key": "ctrl+l ctrl+b",
+        "mac": "cmd+l cmd+b",
+        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
+        "command": "latex-workshop.shortcut.textbf"
+      },
+      {
+        "key": "ctrl+l ctrl+i",
+        "mac": "cmd+l cmd+i",
+        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
+        "command": "latex-workshop.shortcut.textit"
+      },
+      {
+        "key": "ctrl+l ctrl+u",
+        "mac": "cmd+l cmd+u",
+        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
+        "command": "latex-workshop.shortcut.underline"
+      },
+      {
+        "key": "ctrl+l ctrl+e",
+        "mac": "cmd+l cmd+e",
+        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
+        "command": "latex-workshop.shortcut.emph"
+      },
+      {
+        "key": "ctrl+l ctrl+r",
+        "mac": "cmd+l cmd+r",
+        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
+        "command": "latex-workshop.shortcut.textrm"
+      },
+      {
+        "key": "ctrl+l ctrl+t",
+        "mac": "cmd+l cmd+t",
+        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
+        "command": "latex-workshop.shortcut.texttt"
+      },
+      {
+        "key": "ctrl+l ctrl+s",
+        "mac": "cmd+l cmd+s",
+        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
+        "command": "latex-workshop.shortcut.textsl"
+      },
+      {
+        "key": "ctrl+l ctrl+c",
+        "mac": "cmd+l cmd+c",
+        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
+        "command": "latex-workshop.shortcut.textsc"
+      },
+      {
+        "key": "ctrl+l ctrl+n",
+        "mac": "cmd+l cmd+n",
+        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
+        "command": "latex-workshop.shortcut.textnormal"
+      },
+      {
+        "key": "ctrl+l ctrl+6",
+        "mac": "cmd+l cmd+6",
+        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
+        "command": "latex-workshop.shortcut.textsuperscript"
+      },
+      {
+        "key": "ctrl+l ctrl+oem_minus",
+        "mac": "cmd+l cmd+oem_minus",
+        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
+        "command": "latex-workshop.shortcut.textsubscript"
+      },
+      {
+        "key": "ctrl+m ctrl+b",
+        "mac": "ctrl+shift+m cmd+b",
+        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
+        "command": "latex-workshop.shortcut.mathbf"
+      },
+      {
+        "key": "ctrl+m ctrl+i",
+        "mac": "ctrl+shift+m cmd+i",
+        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
+        "command": "latex-workshop.shortcut.mathit"
+      },
+      {
+        "key": "ctrl+m ctrl+r",
+        "mac": "ctrl+shift+m cmd+r",
+        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
+        "command": "latex-workshop.shortcut.mathrm"
+      },
+      {
+        "key": "ctrl+m ctrl+t",
+        "mac": "ctrl+shift+m cmd+t",
+        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
+        "command": "latex-workshop.shortcut.mathtt"
+      },
+      {
+        "key": "ctrl+m ctrl+s",
+        "mac": "ctrl+shift+m cmd+s",
+        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
+        "command": "latex-workshop.shortcut.mathsf"
+      },
+      {
+        "key": "ctrl+m ctrl+shift+b",
+        "mac": "ctrl+shift+m cmd+shift+b",
+        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
+        "command": "latex-workshop.shortcut.mathbb"
+      },
+      {
+        "key": "ctrl+m ctrl+c",
+        "mac": "ctrl+shift+m cmd+c",
+        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
+        "command": "latex-workshop.shortcut.mathcal"
+      },
+      {
+        "command": "expandLineSelection",
+        "key": "ctrl+l ctrl+l",
+        "mac": "cmd+l cmd+l",
+        "when": "textInputFocus && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/"
+      },
+      {
+        "command": "editor.action.toggleTabFocusMode",
+        "key": "ctrl+l ctrl+m",
+        "mac": "cmd+l ctrl+shift+m",
+        "when": "textInputFocus && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/"
+      },
+      {
+        "key": "ctrl+l ctrl+w",
+        "mac": "cmd+l cmd+w",
+        "when": "editorTextFocus && !editorReadonly && editorHasSelection && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/",
+        "command": "latex-workshop.surround"
+      },
+      {
+        "command": "latex-workshop.onEnterKey",
+        "key": "enter",
+        "when": "config.latex-workshop.bind.enter.key && editorTextFocus && acceptSuggestionOnEnter && !suggestWidgetVisible && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && vim.active && vim.mode == 'Insert'"
+      },
+      {
+        "command": "latex-workshop.onEnterKey",
+        "key": "enter",
+        "when": "config.latex-workshop.bind.enter.key && editorTextFocus && !acceptSuggestionOnEnter && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && vim.active && vim.mode == 'Insert'"
+      },
+      {
+        "command": "latex-workshop.onEnterKey",
+        "key": "enter",
+        "when": "config.latex-workshop.bind.enter.key && editorTextFocus && acceptSuggestionOnEnter && !suggestWidgetVisible && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && !vim.active"
+      },
+      {
+        "command": "latex-workshop.onEnterKey",
+        "key": "enter",
+        "when": "config.latex-workshop.bind.enter.key && editorTextFocus && !acceptSuggestionOnEnter && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && !vim.active"
+      },
+      {
+        "command": "latex-workshop.onAltEnterKey",
+        "key": "alt+enter",
+        "when": "config.latex-workshop.bind.enter.key && editorTextFocus && acceptSuggestionOnEnter && !suggestWidgetVisible && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/"
+      },
+      {
+        "command": "latex-workshop.onAltEnterKey",
+        "key": "alt+enter",
+        "when": "config.latex-workshop.bind.enter.key && editorTextFocus && !acceptSuggestionOnEnter && !editorReadonly && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/"
+      }
+    ],
+    "configurationDefaults": {
+      "[latex]": {
+        "editor.formatOnPaste": false,
+        "editor.suggestSelection": "recentlyUsedByPrefix"
+      }
+    },
+    "configuration": {
+      "type": "object",
+      "title": "LaTeX",
+      "properties": {
+        "latex-workshop.latex.recipes": {
+          "scope": "resource",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "tools": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": [
+              "name",
+              "tools"
+            ],
+            "additionalProperties": false
+          },
+          "default": [
+            {
+              "name": "latexmk",
+              "tools": [
+                "latexmk"
+              ]
+            },
+            {
+              "name": "latexmk (latexmkrc)",
+              "tools": [
+                "latexmk_rconly"
+              ]
+            },
+            {
+              "name": "latexmk (lualatex)",
+              "tools": [
+                "lualatexmk"
+              ]
+            },
+            {
+              "name": "latexmk (xelatex)",
+              "tools": [
+                "xelatexmk"
+              ]
+            },
+            {
+              "name": "pdflatex -> bibtex -> pdflatex * 2",
+              "tools": [
+                "pdflatex",
+                "bibtex",
+                "pdflatex",
+                "pdflatex"
+              ]
+            },
+            {
+              "name": "Compile Rnw files",
+              "tools": [
+                "rnw2tex",
+                "latexmk"
+              ]
+            },
+            {
+              "name": "Compile Jnw files",
+              "tools": [
+                "jnw2tex",
+                "latexmk"
+              ]
+            },
+            {
+              "name": "Compile Pnw files",
+              "tools": [
+                "pnw2tex",
+                "latexmk"
+              ]
+            },
+            {
+              "name": "tectonic",
+              "tools": [
+                "tectonic"
+              ]
+            }
+          ],
+          "markdownDescription": "Define LaTeX compiling recipes. Each recipe in the list is an object containing its name and the names of tools to be used sequentially, which are defined in `#latex-workshop.latex.tools#`. By default, the first recipe is used to compile the project. For details, please visit https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#latex-recipes."
+        },
+        "latex-workshop.latex.recipe.default": {
+          "scope": "resource",
+          "type": "string",
+          "default": "first",
+          "markdownDescription": "Define which recipe is used by `#latex-workshop.build#`. It also applies to auto build. Recipes are referred to by their names as defined in `#latex-workshop.latex.recipes#`. Note there are two particular values: \n- `first` means to use the first recipe in `#latex-workshop.latex.recipes#`;\n- `lastUsed` means to use the last run recipe."
+        },
+        "latex-workshop.latex.tools": {
+          "scope": "resource",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "command": {
+                "type": "string"
+              },
+              "args": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "env": {
+                "type": "object"
+              }
+            },
+            "required": [
+              "name",
+              "command"
+            ],
+            "additionalProperties": false
+          },
+          "default": [
+            {
+              "name": "latexmk",
+              "command": "latexmk",
+              "args": [
+                "-synctex=1",
+                "-interaction=nonstopmode",
+                "-file-line-error",
+                "-pdf",
+                "-outdir=%OUTDIR%",
+                "%DOC%"
+              ],
+              "env": {}
+            },
+            {
+              "name": "lualatexmk",
+              "command": "latexmk",
+              "args": [
+                "-synctex=1",
+                "-interaction=nonstopmode",
+                "-file-line-error",
+                "-lualatex",
+                "-outdir=%OUTDIR%",
+                "%DOC%"
+              ],
+              "env": {}
+            },
+            {
+              "name": "xelatexmk",
+              "command": "latexmk",
+              "args": [
+                "-synctex=1",
+                "-interaction=nonstopmode",
+                "-file-line-error",
+                "-xelatex",
+                "-outdir=%OUTDIR%",
+                "%DOC%"
+              ],
+              "env": {}
+            },
+            {
+              "name": "latexmk_rconly",
+              "command": "latexmk",
+              "args": [
+                "%DOC%"
+              ],
+              "env": {}
+            },
+            {
+              "name": "pdflatex",
+              "command": "pdflatex",
+              "args": [
+                "-synctex=1",
+                "-interaction=nonstopmode",
+                "-file-line-error",
+                "%DOC%"
+              ],
+              "env": {}
+            },
+            {
+              "name": "bibtex",
+              "command": "bibtex",
+              "args": [
+                "%DOCFILE%"
+              ],
+              "env": {}
+            },
+            {
+              "name": "rnw2tex",
+              "command": "Rscript",
+              "args": [
+                "-e",
+                "knitr::opts_knit$set(concordance = TRUE); knitr::knit('%DOCFILE_EXT%')"
+              ],
+              "env": {}
+            },
+            {
+              "name": "jnw2tex",
+              "command": "julia",
+              "args": [
+                "-e",
+                "using Weave; weave(\"%DOC_EXT%\", doctype=\"tex\")"
+              ],
+              "env": {}
+            },
+            {
+              "name": "jnw2texminted",
+              "command": "julia",
+              "args": [
+                "-e",
+                "using Weave; weave(\"%DOC_EXT%\", doctype=\"texminted\")"
+              ],
+              "env": {}
+            },
+            {
+              "name": "pnw2tex",
+              "command": "pweave",
+              "args": [
+                "-f",
+                "tex",
+                "%DOC_EXT%"
+              ],
+              "env": {}
+            },
+            {
+              "name": "pnw2texminted",
+              "command": "pweave",
+              "args": [
+                "-f",
+                "texminted",
+                "%DOC_EXT%"
+              ],
+              "env": {}
+            },
+            {
+              "name": "tectonic",
+              "command": "tectonic",
+              "args": [
+                "--synctex",
+                "--keep-logs",
+                "%DOC%.tex"
+              ],
+              "env": {}
+            }
+          ],
+          "markdownDescription": "Define LaTeX compiling tools to be used in recipes. Each tool is labeled by its `name`. When invoked, `command` is spawned with arguments defined in `args` and environment variables defined in `env`. Typically no spaces should appear in each argument unless in paths. List of available placeholders: `%DOC%`, `%DOC_W32%, %DOC_EXT%`, `%DOC_EXT_W32%`, `%DOCFILE%`, `%DOCFILE_EXT%`, `%DIR%`, `%DIR_W32%`, `%TMPDIR%` and `%OUTDIR%`, `%OUTDIR_W32%`. Please visit https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#placeholders for a complete list of all placeholders."
+        },
+        "latex-workshop.latex.magic.args": {
+          "scope": "resource",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "-synctex=1",
+            "-interaction=nonstopmode",
+            "-file-line-error",
+            "%DOC%"
+          ],
+          "markdownDescription": "Define the arguments to be input to magic command executable. This can be overridden by using \"% !TeX options\"."
+        },
+        "latex-workshop.latex.magic.bib.args": {
+          "scope": "resource",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "%DOCFILE%"
+          ],
+          "markdownDescription": "Define the arguments to be input to BIB magic command executable. This can be overridden by using \"% !BIB options\"."
+        },
+        "latex-workshop.latex.external.build.command": {
+          "scope": "resource",
+          "type": "string",
+          "default": "",
+          "markdownDescription": "The external command to execute when calling latex-workshop.build. This is useful when compiling relies on a Makefile or a bespoke script. When defined, it completely bypasses the recipes and root file detection mechanism."
+        },
+        "latex-workshop.latex.external.build.args": {
+          "scope": "resource",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "markdownDescription": "The arguments of `#latex-workshop.latex.external.build.command#` when calling latex-workshop.build."
+        },
+        "latex-workshop.latex.build.forceRecipeUsage": {
+          "scope": "resource",
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Force the use the recipe mechanism even if some magic comments are present."
+        },
+        "latex-workshop.latex.outDir": {
+          "scope": "resource",
+          "type": "string",
+          "default": "%DIR%",
+          "markdownDescription": "The directory where the extension tries to find project files (e.g., PDF and SyncTeX files) are located. Both relative and absolute paths are supported. Relative path start from the root file location, so beware if it is located in sub-directory. The path must not contain a trailing slash. The LaTeX toolchain should output files to this path. For a list of supported placeholders, please visit https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#placeholders."
+        },
+        "latex-workshop.latex.jobname": {
+          "scope": "resource",
+          "type": "string",
+          "default": "",
+          "markdownDescription": "The jobname argument of the compiling tool, which is used by the extension to find project files (e.g., PDF and SyncTeX files). This config should be set identical to the value provided to the `-jobname=` argument, and should not have placeholders. Leave the config empty to ignore jobname and keep the default behavior."
+        },
+        "latex-workshop.latex.texDirs": {
+          "scope": "window",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "markdownDescription": "List of directories where to look for extra input `.tex` files. \nAbsolute paths are required. You may also need to set the environment variable `TEXINPUTS` properly for the LaTeX compiler to find the `.tex` files, see the `env` parameter of [recipes](https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#latex-recipes)."
+        },
+        "latex-workshop.latex.verbatimEnvs": {
+          "scope": "window",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "verbatim",
+            "lstlisting",
+            "minted"
+          ],
+          "markdownDescription": "List environments with verbatim-like content. These environments are stripped off the `.tex` files before any parsing occurs. Note that this variable has no effect on syntax highlighting."
+        },
+        "latex-workshop.kpsewhich.path": {
+          "scope": "window",
+          "type": "string",
+          "default": "kpsewhich",
+          "markdownDescription": "Define the location of the kpsewhich executable file."
+        },
+        "latex-workshop.kpsewhich.enabled": {
+          "scope": "window",
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Use kpsewhich as defined by `#latex-workshop.kpsewhich.path#` to resolve bibliography files in addition to looking into the directories listed in `#latex-workshop.latex.bibDirs#`."
+        },
+        "latex-workshop.latex.bibDirs": {
+          "scope": "window",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "markdownDescription": "List of directories where to look for `.bib` files. Absolute paths are required. This setting is only used by the intellisense feature, you may also need to set the environment variable `BIBINPUTS` properly for the LaTeX compiler to find the `.bib` files."
+        },
+        "latex-workshop.latex.search.rootFiles.include": {
+          "scope": "resource",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "**/*.tex",
+            "**/*.rnw",
+            "**/*.Rnw"
+          ],
+          "markdownDescription": "Patterns of files to consider for the root detection mechanism. Relative paths are computed from the workspace folder. To detect the root file and the tex file tree, we parse all the `.tex` listed here. If you want to specify all `.tex` files inside directory, say `foo`, and all its subdirectories recursively, you need to use `**/foo/**/*.tex`. If you only want to match `.tex` files at the top level of the workspace, use `*.tex`. For more details, see https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#multi-file-projects"
+        },
+        "latex-workshop.latex.search.rootFiles.exclude": {
+          "scope": "resource",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "markdownDescription": "Patterns of files to exclude from the root detection mechanism. See also `#latex-workshop.latex.search.rootFiles.include#`. For more details, see the https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#multi-file-projects."
+        },
+        "latex-workshop.latex.rootFile.useSubFile": {
+          "scope": "resource",
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "When the `subfile` package is used, either the main file or any subfile containing `\\documentclass[main.tex]{subfile}` can be LaTeXing. When `true`, the extension uses the subfile as the rootFile for the `autobuild`, `clean` and `synctex` commands."
+        },
+        "latex-workshop.latex.rootFile.doNotPrompt": {
+          "scope": "resource",
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "When the `subfile` package is used, either the main file or any subfile containing `\\documentclass[main.tex]{subfile}` can be LaTeXing. When `false`, the `build` and `view` commands  ask the user's choice first. When `true`, the subfile is used when `#latex-workshop.latex.rootFile.useSubFile#` is also `true`, otherwise the rootFile is used."
+        },
+        "latex-workshop.latex.rootFile.indicator": {
+            "scope": "resource",
+            "type": "string",
+            "default": "\\documentclass[]{}",
+            "enum": [
+                "\\documentclass[]{}",
+                "\\begin{document}"
+            ],
+            "markdownDescription": "Determine if the root file is detected based on the presence of \\documentclass[]{} or \\begin{document}."
+        },
+        "latex-workshop.latex.watch.usePolling": {
+          "scope": "window",
+          "type": "boolean",
+          "default": false,
+          "deprecationMessage": "Deprecated: This config is deprecated and has no use.",
+          "markdownDeprecationMessage": "**Deprecated**: This config is deprecated and has no use."
+        },
+        "latex-workshop.latex.watch.interval": {
+          "scope": "window",
+          "type": "number",
+          "default": 300,
+          "deprecationMessage": "Deprecated: This config is deprecated and has no use.",
+          "markdownDeprecationMessage": "**Deprecated**: This config is deprecated and has no use."
+        },
+        "latex-workshop.latex.watch.delay": {
+          "scope": "window",
+          "type": "number",
+          "default": 250,
+          "deprecationMessage": "Deprecated: This config is deprecated and has no use.",
+          "markdownDeprecationMessage": "**Deprecated**: This config is deprecated and has no use."
+        },
+        "latex-workshop.latex.watch.pdf.delay": {
+          "scope": "window",
+          "type": "number",
+          "default": 250,
+          "markdownDescription": "Defines the time delay before confirming a PDF-like binary file is fully changed. Increase this value if you encounter repeated viewer refreshes and/or loss of PDF scrolling position. LaTeX Workshop internally monitors file change events and initiates auto-builds and/or PDF viewing refresh. When LaTeX is changing large files (particularly binary files like PDFs), multiple consecutive file change events may be emitted, potentially causing file corruption issues. We use this config to control the file polling delay before confirming that the file change has been stabilized. Note that non-binary files such as `.tex`, `.bib`, and `.cls` are not affected."
+        },
+        "latex-workshop.latex.watch.files.ignore": {
+          "scope": "window",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "**/*.bbx",
+            "**/*.bbl",
+            "**/*.cbx",
+            "**/*.cfg",
+            "**/*.clo",
+            "**/*.cnf",
+            "**/*.def",
+            "**/*.dfu",
+            "**/*.enc",
+            "**/*.fd",
+            "**/*.fmt",
+            "**/*.lbx",
+            "**/*.map",
+            "**/*.mkii",
+            "**/*.pfb",
+            "**/*.tfm",
+            "**/*.vf",
+            "**/*.code.tex",
+            "**/*.sty",
+            "**/texmf-{dist,var}/**",
+            "**/Local/MiKTeX/**",
+            "**/Local/Programs/MiKTeX/**",
+            "**/Roaming/MiKTeX/**",
+            "**/Program*/MiKTeX*/**",
+            "**/.miktex/texmfs/**",
+            "/var/cache/miktex-texmf/**",
+            "/usr/local/share/miktex-texmf/**",
+            "**/Library/Application Support/MiKTeX/texmfs/**",
+            "/dev/null"
+          ],
+          "markdownDescription": "Files to ignore from the watching mechanism, i.e., no intellisense or build-on-file-change. However, document structure/outline and build-on-save won't be affected. This property must be an array of glob patterns. The patterns are matched against the absolute file path. To ignore everything inside the `texmf` tree, `**/texmf/**` can be used."
+        },
+        "latex-workshop.latex.autoBuild.run": {
+          "scope": "resource",
+          "type": "string",
+          "enum": [
+            "never",
+            "onSave",
+            "onFileChange"
+          ],
+          "enumDescriptions": [
+            "Never run auto build",
+            "Auto build whenever a file is saved",
+            "Auto build whenever a dependency file changes on disk"
+          ],
+          "default": "onFileChange",
+          "markdownDescription": "When the extension shall auto build LaTeX project using the default (first) recipe. \n- `onSave` builds the project upon saving a `tex` file in vscode.\n- `onFileChange` builds the project upon detecting a file change in any of the dependencies, even modified by other applications.\n\n Note that `onSave` is more restrictive than `onFileChange` "
+        },
+        "latex-workshop.latex.autoBuild.interval": {
+          "scope": "resource",
+          "type": "integer",
+          "default": 1000,
+          "markdownDescription": "The minimal time interval in milliseconds for an auto build to trigger after the previous (manual and auto) build. This value is recommended to be greater than ~500."
+        },
+        "latex-workshop.latex.autoBuild.cleanAndRetry.enabled": {
+          "scope": "resource",
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Delete LaTeX auxiliary files when errors occur during build and retry. This property defines whether LaTeX Workshop will try to clean and build the project once again after errors happen in the build toolchain."
+        },
+        "latex-workshop.latex.build.clearLog.everyRecipeStep.enabled": {
+          "scope": "resource",
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Clear the LaTeX Compiler logs before every step of a recipe. Set this property to false to keep the logs of all tools in a recipe."
+        },
+        "latex-workshop.latex.autoClean.run": {
+          "scope": "resource",
+          "type": "string",
+          "enum": [
+            "never",
+            "onFailed",
+            "onSucceeded",
+            "onBuilt"
+          ],
+          "enumDescriptions": [
+            "Never clean the project",
+            "Clean compilation fails",
+            "Clean compilation successes",
+            "Clean after build, be it successful or not"
+          ],
+          "default": "never",
+          "markdownDescription": "When LaTeX auxiliary files should be deleted. The folder to be cleaned is defined in `#latex-workshop.latex.outDir#`.\n- `onFailed` cleans the project when compilation fails.\n- `onBuilt` cleans the project when compilation is done, whether successful or failed."
+        },
+        "latex-workshop.latex.clean.subfolder.enabled": {
+          "scope": "resource",
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Delete LaTeX auxiliary files recursively in sub-folders of `#latex-workshop.latex.outDir#`. Note that sub-folders are not removed."
+        },
+        "latex-workshop.latex.clean.fileTypes": {
+          "scope": "resource",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "*.aux",
+            "*.bbl",
+            "*.blg",
+            "*.idx",
+            "*.ind",
+            "*.lof",
+            "*.lot",
+            "*.out",
+            "*.toc",
+            "*.acn",
+            "*.acr",
+            "*.alg",
+            "*.glg",
+            "*.glo",
+            "*.gls",
+            "*.fls",
+            "*.log",
+            "*.fdb_latexmk",
+            "*.snm",
+            "*.synctex(busy)",
+            "*.synctex.gz(busy)",
+            "*.nav",
+            "*.vrb"
+          ],
+          "markdownDescription": "Files to clean when `#latex-workshop.latex.clean.method#` is set to `glob`.. This property must be an array of strings. File globs such as `*.removeme`, `something?.aux` can be used. Users can also specify glob patterns like `emptyfolder*/` to remove empty folders. Non-empty folders will be ignored. The folder globs must end with a slash and the last path component must not contain the globstar `**`, otherwise the folders will not be removed. The following globs patterns are correct `['abc/', 'abc*/', '**/abc*/', 'abc/**/def/']` but these are not ['**', '**/', 'abc/**', 'abc/**/', 'abc/def**/', 'abc/d**ef/']`."
+        },
+        "latex-workshop.latex.clean.command": {
+          "scope": "resource",
+          "type": "string",
+          "default": "latexmk",
+          "markdownDescription": "The command to be used to remove temporary files when `#latex-workshop.latex.clean.method#` is set to `command`."
+        },
+        "latex-workshop.latex.clean.args": {
+          "scope": "resource",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "-c",
+            "%TEX%"
+          ],
+          "markdownDescription": "The arguments of `#latex-workshop.latex.clean.command#`. Placeholders listed in https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#placeholders can be used to populate the argument strings. Besides, an additional `%TEX%` placeholder refers to the full path of the tex file from which the clean command is called."
+        },
+        "latex-workshop.latex.clean.method": {
+          "scope": "resource",
+          "type": "string",
+          "default": "glob",
+          "enum": [
+            "glob",
+            "command"
+          ],
+          "markdownEnumDescriptions": [
+            "Clean all the files located in `#latex-workshop.latex.outDir#` and matching the glob patterns listed in `#latex-workshop.latex.clean.fileTypes#`.",
+            "Run `#latex-workshop.latex.clean.command#` to clean temporary files."
+          ],
+          "markdownDescription": "Define how temporary files will be cleaned."
+        },
+        "latex-workshop.latex.option.maxPrintLine.enabled": {
+          "scope": "resource",
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Add `--max-print-line` option to LaTeX build commands. This flag tells some MikTeX compilers to produce non hard wrapped log messages. Non hard wrapped log messages are required for the _Problem_ Pane to properly display messages."
+        },
+        "latex-workshop.view.outline.sections": {
+          "scope": "window",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "part",
+            "chapter",
+            "section",
+            "subsection",
+            "subsubsection"
+          ],
+          "markdownDescription": "The section names of LaTeX outline hierarchy. It is also used by the folding mechanism. This property is an array of case-sensitive strings in the order of document structure hierarchy. For multiple tags in the same level, separate the tags with `|` as delimiters, e.g., `section|alternative`."
+        },
+        "latex-workshop.view.outline.commands": {
+          "scope": "window",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "label"
+          ],
+          "markdownDescription": "The names of the commands to be shown in the outline/structure views. The commands must be called in the form `\\commandname{arg}`."
+        },
+        "latex-workshop.view.outline.fastparse.enabled": {
+          "scope": "window",
+          "type": "boolean",
+          "default": true,
+          "deprecationMessage": "Deprecated: This config has been renamed to `latex-workshop.intellisense.fastparse.enabled`.",
+          "markdownDeprecationMessage": "**Deprecated**: This config has been renamed to `#latex-workshop.intellisense.fastparse.enabled#`."
+        },
+        "latex-workshop.view.outline.floats.enabled": {
+          "scope": "window",
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Show the floating objects (figures and tables) in the outline/structure views."
+        },
+        "latex-workshop.view.outline.floats.number.enabled": {
+          "scope": "window",
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Show the float number in the outline/structure views."
+        },
+        "latex-workshop.view.outline.floats.caption.enabled": {
+          "scope": "window",
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Show the float caption in the outline/structure views."
+        },
+        "latex-workshop.view.outline.numbers.enabled": {
+          "scope": "window",
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Show the sectioning numbers in the outline/structure views."
+        },
+        "latex-workshop.view.autoFocus.enabled": {
+          "scope": "window",
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Auto focus the LaTeX view when switching from non-tex to tex files. This will cause the view to appear consistently upon activating the extension."
+        },
+        "latex-workshop.view.pdf.viewer": {
+          "scope": "window",
+          "type": "string",
+          "default": "tab",
+          "enum": [
+            "browser",
+            "tab",
+            "external"
+          ],
+          "markdownDescription": "The default PDF viewer.",
+          "enumDescriptions": [
+            "Open PDF with the default web browser.",
+            "Open PDF with the built-in tab viewer.",
+            "[Experimental] Open PDF with the external viewer set in \"View > Pdf > External: command\"."
+          ]
+        },
+        "latex-workshop.view.pdf.tab.editorGroup": {
+          "scope": "window",
+          "type": "string",
+          "default": "right",
+          "enum": [
+            "current",
+            "left",
+            "right",
+            "above",
+            "below"
+          ],
+          "markdownDescription": "The editor group in which to open the tab viewer.",
+          "enumDescriptions": [
+            "Use the current editor group",
+            "Put the viewer tab in a new group on the left of the current one",
+            "Put the viewer tab in a new group on the right of the current one",
+            "Put the viewer tab in a new group above the current one",
+            "Put the viewer tab in a new group below the current one"
+          ]
+        },
+        "latex-workshop.view.pdf.tab.openDelay": {
+          "scope": "window",
+          "type": "number",
+          "default": 1000,
+          "markdownDescription": "Defines the delay in milliseconds to wait for a tab opening. Please increase the value if you encounter a focus issue after opening a tab."
+        },
+        "latex-workshop.view.pdf.ref.viewer": {
+          "type": "string",
+          "default": "auto",
+          "enum": [
+            "auto",
+            "tabOrBrowser",
+            "external"
+          ],
+          "markdownDescription": "PDF viewer used for [View on PDF] link on \\ref."
+        },
+        "latex-workshop.viewer.pdf.internal.port": {
+          "scope": "window",
+          "type": "number",
+          "default": "0",
+          "markdownDescription": "Define the port to listen on for communicating with the internal viewer. The default value \"0\" means the port is chosen randomly by the application. If this config is set, only one Visual Studio Code instance with this extension active can be opened. Otherwise, a port conflict may happen."
+        },
+        "latex-workshop.view.pdf.internal.synctex.keybinding": {
+          "scope": "window",
+          "type": "string",
+          "default": "ctrl-click",
+          "enum": [
+            "ctrl-click",
+            "double-click"
+          ],
+          "markdownDescription": " Which keybinding to use for the internal viewer for reverse synctex. `ctrl`/`cmd` + click (default) or double click."
+        },
+        "latex-workshop.viewer.pdf.internal.keyboardEvent": {
+          "scope": "window",
+          "type": "string",
+          "default": "auto",
+          "enum": [
+            "auto",
+            "force",
+            "never"
+          ],
+          "markdownDescription": "Rebroadcasting KeyboardEvent on the internal viewers. If keyboard shortcuts on the internal viewer do not work well, change this setting."
+        },
+        "latex-workshop.view.pdf.external.viewer.command": {
+          "scope": "window",
+          "type": "string",
+          "default": "",
+          "markdownDescription": "The command to execute when using external viewer. This function is not officially supported."
+        },
+        "latex-workshop.view.pdf.external.viewer.args": {
+          "scope": "window",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "%PDF%"
+          ],
+          "markdownDescription": "The arguments for `#latex-workshop.view.pdf.external.viewer.command#` when using external viewer. This function is not officially supported. %PDF% is the placeholder for the absolute path to the generated PDF file."
+        },
+        "latex-workshop.view.pdf.external.synctex.command": {
+          "scope": "window",
+          "type": "string",
+          "default": "",
+          "markdownDescription": "The command to execute when forward synctex to external viewer. This function is not officially supported."
+        },
+        "latex-workshop.view.pdf.external.synctex.args": {
+          "scope": "window",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "%LINE%",
+            "%PDF%",
+            "%TEX%"
+          ],
+          "markdownDescription": "The arguments for `#latex-workshop.view.pdf.external.synctex.args#` when forward synctex to external viewer. %LINE% is the line number, %PDF% is the placeholder for the absolute path to the generated PDF file, and %TEX% is the source LaTeX file path with `.tex` extension from which syncTeX is fired."
+        },
+        "latex-workshop.view.pdf.zoom": {
+          "scope": "window",
+          "type": "string",
+          "default": "auto",
+          "markdownDescription": "The default zoom level of the PDF viewer. This default value will be passed to the viewer upon opening. Possible values are `auto`, `page-actual`, `page-fit`, `page-width`, and one-based scale values (e.g., 0.5 for 50%, 2.0 for 200%)."
+        },
+        "latex-workshop.view.pdf.trim": {
+          "scope": "window",
+          "type": "number",
+          "default": 0,
+          "enum": [
+            0,
+            1,
+            2,
+            3
+          ],
+          "markdownDescription": "The default trim mode of the PDF viewer.",
+          "enumDescriptions": [
+            "No page trimming",
+            "Trim 5% at margin",
+            "Trim 10% at margin",
+            "Trim 15% at margin"
+          ]
+        },
+        "latex-workshop.view.pdf.scrollMode": {
+          "scope": "window",
+          "type": "number",
+          "default": 0,
+          "markdownDescription": "The default scroll mode of the PDF viewer. This default value will be passed to the viewer upon opening. Possible values are `0` (vertical), `1`(horizontal), `2` (wrapped), `3` (page)."
+        },
+        "latex-workshop.view.pdf.spreadMode": {
+          "scope": "window",
+          "type": "number",
+          "default": 0,
+          "markdownDescription": "The default spread mode of the PDF viewer. This default value will be passed to the viewer upon opening. Possible values are `0` (none), `1` (odd) and `2` (even)."
+        },
+        "latex-workshop.view.pdf.hand": {
+          "scope": "window",
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Define if the hand tool is enabled by default in the PDF viewer."
+        },
+        "latex-workshop.view.pdf.invertMode.enabled": {
+          "scope": "window",
+          "type": "string",
+          "enum": [
+            "auto",
+            "always",
+            "compat",
+            "never"
+          ],
+          "default": "compat",
+          "markdownDescription": "Enable the CSS invert filter.",
+          "enumDescriptions": [
+            "Enable the invert filter when using a dark theme.",
+            "Always enable invert filter.",
+            "Enable the invert filter only if `invert > 0`.",
+            "Disable the invert filter"
+          ]
+        },
+        "latex-workshop.view.pdf.invert": {
+          "scope": "window",
+          "type": "number",
+          "default": 0,
+          "markdownDescription": " Define the CSS invert filter level of the PDF viewer. This config can invert the color of PDF. Possible values are from 0 to 1."
+        },
+        "latex-workshop.view.pdf.invertMode.brightness": {
+          "scope": "window",
+          "type": "number",
+          "default": 1,
+          "markdownDescription": " Define the CSS brightness filter level of the PDF viewer when the invert mode is enabled. Possible values are from 0 to 2."
+        },
+        "latex-workshop.view.pdf.invertMode.grayscale": {
+          "scope": "window",
+          "type": "number",
+          "default": 0.6,
+          "markdownDescription": " Define the CSS grayscale filter level of the PDF viewer when the invert mode is enabled. Possible values are from 0 to 1."
+        },
+        "latex-workshop.view.pdf.invertMode.hueRotate": {
+          "scope": "window",
+          "type": "number",
+          "default": 180,
+          "markdownDescription": " Define the CSS hue-rotate filter angle of the PDF viewer when the invert mode is enabled. Possible values are from 0 to 360."
+        },
+        "latex-workshop.view.pdf.invertMode.sepia": {
+          "scope": "window",
+          "type": "number",
+          "default": 0,
+          "markdownDescription": " Define the CSS sepia filter level of the PDF viewer when the invert mode is enabled. Possible values are from 0 to 1."
+        },
+        "latex-workshop.view.pdf.color.light.pageColorsForeground": {
+          "scope": "window",
+          "type": "string",
+          "default": "",
+          "markdownDescription": " The foreground color of the PDF document 1) in tab viewer when the vscode color theme is light, and 2) in browser when the OS theme is light. The string must represent a color in HTML."
+        },
+        "latex-workshop.view.pdf.color.light.pageColorsBackground": {
+          "scope": "window",
+          "type": "string",
+          "default": "",
+          "markdownDescription": " The background color of the PDF document 1) in tab viewer when the vscode color theme is light, and 2) in browser when the OS theme is light. The string must represent a color in HTML."
+        },
+        "latex-workshop.view.pdf.color.light.backgroundColor": {
+          "scope": "window",
+          "type": "string",
+          "default": "#ffffff",
+          "markdownDescription": " The background color of the viewer 1) in tab viewer when the vscode color theme is light, and 2) in browser when the OS theme is light. The string must represent a color in HTML."
+        },
+        "latex-workshop.view.pdf.color.light.pageBorderColor": {
+          "scope": "window",
+          "type": "string",
+          "default": "lightgrey",
+          "markdownDescription": " The border color of the PDF pages 1) in tab viewer when the vscode color theme is light, and 2) in browser when the OS theme is light. The string must represent a color in HTML."
+        },
+        "latex-workshop.view.pdf.color.dark.pageColorsForeground": {
+          "scope": "window",
+          "type": "string",
+          "default": "",
+          "markdownDescription": " The foreground color of the PDF document 1) in tab viewer when the vscode color theme is dark, and 2) in browser when the OS theme is dark. The string must represent a color in HTML."
+        },
+        "latex-workshop.view.pdf.color.dark.pageColorsBackground": {
+          "scope": "window",
+          "type": "string",
+          "default": "",
+          "markdownDescription": " The background color of the PDF document 1) in tab viewer when the vscode color theme is dark, and 2) in browser when the OS theme is dark. The string must represent a color in HTML."
+        },
+        "latex-workshop.view.pdf.color.dark.backgroundColor": {
+          "scope": "window",
+          "type": "string",
+          "default": "#ffffff",
+          "markdownDescription": " The background color of the viewer 1) in tab viewer when the vscode color theme is dark, and 2) in browser when the OS theme is dark. The string must represent a color in HTML."
+        },
+        "latex-workshop.view.pdf.color.dark.pageBorderColor": {
+          "scope": "window",
+          "type": "string",
+          "default": "lightgrey",
+          "markdownDescription": " The border color of the PDF pages 1) in tab viewer when the vscode color theme is dark, and 2) in browser when the OS theme is dark. The string must represent a color in HTML."
+        },
+        "latex-workshop.synctex.path": {
+          "scope": "window",
+          "type": "string",
+          "default": "synctex",
+          "markdownDescription": "Define the location of SyncTeX executive file. Additional arguments, e.g., synctex modes and position of click, will be appended to this command."
+        },
+        "latex-workshop.synctex.afterBuild.enabled": {
+          "scope": "window",
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Execute forward synctex at cursor position after compiling LaTeX project."
+        },
+        "latex-workshop.synctex.synctexjs.enabled": {
+          "scope": "window",
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Enable using a builtin synctex function. The command set in latex-workshop.synctex.path will not be used."
+        },
+        "latex-workshop.linting.chktex.enabled": {
+          "scope": "resource",
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Enable linting LaTeX with `chktex`. Check `#latex-workshop.linting.run#` to control when `chktex` is executed if this config is set to `true."
+        },
+        "latex-workshop.linting.lacheck.enabled": {
+          "scope": "resource",
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Enable linting LaTeX with `lacheck`. Check `#latex-workshop.linting.run#` to control when `lacheck` is executed if this config is set to `true."
+        },
+        "latex-workshop.linting.run": {
+          "scope": "resource",
+          "type": "string",
+          "enum": [
+            "onSave",
+            "onType"
+          ],
+          "enumDescriptions": [
+            "Lint the whole LaTeX project upon saving",
+            "Lint the active document when input is stopped"
+          ],
+          "default": "onSave",
+          "markdownDescription": "When LaTeX should be linted.\n- `onSave`: the whole LaTeX project will be linted upon saving.\n- `onType`: the active document will be linted when input is stopped for a period of time defined in `#latex-workshop.linting.delay#`. It also implies `onSave`."
+        },
+        "latex-workshop.linting.chktex.exec.path": {
+          "scope": "window",
+          "type": "string",
+          "default": "chktex",
+          "markdownDescription": "Define the location of ChkTeX executive file. This command will be joint with `#latex-workshop.linting.chktex.exec.args#` and required arguments to form a complete command of ChkTeX."
+        },
+        "latex-workshop.linting.chktex.exec.args": {
+          "scope": "resource",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "-wall",
+            "-n22",
+            "-n30",
+            "-e16",
+            "-q"
+          ],
+          "markdownDescription": "Linter arguments to check LaTeX syntax of the current file state in real time with ChkTeX. Arguments must be in separate strings in the array. Additional arguments, i.e., `-I0 -f%f:%l:%c:%d:%k:%n:%m\\n` will be appended when constructing the command. Current file contents will be piped to the command through stdin."
+        },
+        "latex-workshop.linting.chktex.convertOutput.column.enabled": {
+          "scope": "resource",
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Enable converting ChkTeX outputs' column numbers for non-ASCII characters."
+        },
+        "latex-workshop.linting.chktex.convertOutput.column.chktexrcTabSize": {
+          "scope": "resource",
+          "type": "number",
+          "default": -1,
+          "markdownDescription": "Write the `TabSize` number from `.chktexrc`. The default value \"-1\" means that LaTeX Workshop will try to find `.chktexrc` and to read the value from it."
+        },
+        "latex-workshop.linting.delay": {
+          "scope": "resource",
+          "type": "number",
+          "default": 500,
+          "markdownDescription": "Defines the delay in milliseconds for linter to wait after stopped typing. This config only matters when `#latex-workshop.linting.run#` is set to `onType`."
+        },
+        "latex-workshop.linting.lacheck.exec.path": {
+          "scope": "window",
+          "type": "string",
+          "default": "lacheck",
+          "markdownDescription": "Define the location of LaCheck executive file."
+        },
+        "latex-workshop.check.duplicatedLabels.enabled": {
+          "scope": "window",
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Enable checking for duplicated labels. A new check is triggered every time the intellisense data is updated, see `#latex-workshop.intellisense.update.aggressive.enabled#`."
+        },
+        "latex-workshop.texcount.path": {
+          "scope": "window",
+          "type": "string",
+          "default": "texcount",
+          "markdownDescription": "Define the location of TeXCount executive file/script. This command will be joint with `#latex-workshop.texcount.args#` and required arguments to form a complete command of TeXCount."
+        },
+        "latex-workshop.texcount.args": {
+          "scope": "resource",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "markdownDescription": "TeXCount arguments to count words in the LaTeX documents of the entire project from the root file, or the current document. Arguments must be in separate strings in the array. Additional arguments, i.e., `-merge %DOC%` for the project and the current document path for counting current file will be appended when constructing the command."
+        },
+        "latex-workshop.texcount.autorun": {
+          "scope": "resource",
+          "type": "string",
+          "enum": [
+            "onSave",
+            "never"
+          ],
+          "enumDescriptions": [
+            "Count words in the current document",
+            "Never automatically call texcount"
+          ],
+          "default": "never",
+          "markdownDescription": "When to call `texcount`. Default is never."
+        },
+        "latex-workshop.texcount.interval": {
+          "scope": "resource",
+          "type": "number",
+          "default": 1000,
+          "markdownDescription": "The minimal time interval between two consecutive runs of `texcount` in milliseconds when `#latex-workshop.texcount.run#` is set to `onSave`."
+        },
+        "latex-workshop.intellisense.fastparse.enabled": {
+          "scope": "window",
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Use fast LaTeX parsing algorithm to build outline/structure. This is done by inherently removing texts and comments before building AST. Enabling this will not tamper the document, but may result in incomplete outline/structure."
+        },
+        "latex-workshop.intellisense.update.aggressive.enabled": {
+          "scope": "window",
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Defines whether the extension aggressively parses the changed content after stopped typing. Disable this config will let the extension only update intellisense after saving changed files."
+        },
+        "latex-workshop.intellisense.update.delay": {
+          "scope": "window",
+          "type": "number",
+          "default": 1000,
+          "markdownDescription": "Defines the delay in milliseconds for the extension to update current active file content for intellisense after stopped typing. This config works only when `intellisense.update.aggressive.enabled` is enabled. Lower this value to let the extension know newly defined commands/references/environments more quickly, at the cost of more frequent content parsing: more computational burden."
+        },
+        "latex-workshop.intellisense.atSuggestion.user": {
+          "scope": "window",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {},
+          "markdownDescription": "Dictionary of `\"@prefix\": \"snippet command\"` to add to, replace, or remove the default suggestions in `data/at-suggestions.json`. The key of the dictionary is the triggering string, which **must** starts with `@` regardless of `#latex-workshop.intellisense.atSuggestion.trigger.latex#`. The value of the dictionary is the snippet to be inserted. If the key is identical to a default snippet defined in `data/at-suggestions.json`, the new value in the dictionary is used for suggestion. If the value is an empty string, the snippet is removed from suggestion. For example, `{ \"@.\": \"\\cdot\", \"@6\": \"\" }`."
+        },
+        "latex-workshop.intellisense.command.user": {
+          "scope": "window",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {},
+          "markdownDescription": "Dictionary of `\"command name\": \"command snippet\"` to add to, replace, or remove the default ones in `data/commands.json`. The key of the dictionary is the command name with optional braces indicating the command arguments. The value of the dictionary is the snippet to be inserted. If the key is identical to a default command suggestion defined in `data/commands.json`, the new value in the dictionary is used for suggestion. If the value is an empty string, the command is removed from suggestion. Leading backslashes will be added to both the name and snippet by the extension, so don't include them in this config. For example, `{\"mycommand[]{}\": \"notsamecommand[${2:option}]{$TM_SELECTED_TEXT$1}\", \"parbox{}{}\": \"parbox{${2:width}}{$TM_SELECTED_TEXT$1}\", \"overline{}\": \"\"}` adds a new command with name `mycommand[]{} that inserts `\\notsamecommand[]{}`, replaces the default snippet of `\\parbox{}{}` to make it include current selected text, and removes `\\overline{}` from suggestion."
+        },
+        "latex-workshop.intellisense.citation.type": {
+          "scope": "window",
+          "type": "string",
+          "enum": [
+            "inline",
+            "browser"
+          ],
+          "default": "inline",
+          "markdownDescription": "Defines which type of hint to show when intellisense provides citation suggestions.",
+          "enumDescriptions": [
+            "Use the inline intellisense to provide citation completion items.",
+            "Use a dropdown menu to provide citation completion items."
+          ]
+        },
+        "latex-workshop.intellisense.citation.label": {
+          "scope": "resource",
+          "type": "string",
+          "enum": [
+            "bibtex key",
+            "title",
+            "authors"
+          ],
+          "default": "bibtex key",
+          "markdownDescription": "Defines what to show as suggestion labels when intellisense provides citation suggestions in inline mode.",
+          "enumDescriptions": [
+            "Show bibtex keys in the inline mode.",
+            "Show publication titles in the inline mode.",
+            "Show publication authors in the inline mode."
+          ]
+        },
+        "latex-workshop.intellisense.citation.format": {
+          "scope": "resource",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "author",
+            "title",
+            "journal",
+            "publisher",
+            "booktitle",
+            "year"
+          ],
+          "markdownDescription": "List of fields to display for citation preview and intellisense. This list is also used as the filter text to narrow down the intellisense suggestions."
+        },
+        "latex-workshop.intellisense.triggers.latex": {
+          "scope": "window",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "{"
+          ],
+          "markdownDescription": "Additional trigger characters for intellisense of LaTeX documents."
+        },
+        "latex-workshop.intellisense.atSuggestion.trigger.latex": {
+          "scope": "window",
+          "type": "string",
+          "default": "@",
+          "markdownDescription": "Character to trigger snippet suggestions as part of intellisense. Set this variable to `''` to deactivate these suggestions."
+        },
+        "latex-workshop.intellisense.atSuggestionJSON.replace": {
+          "scope": "window",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {},
+          "deprecationMessage": "Deprecated: This config has been renamed to `latex-workshop.intellisense.atSuggestion.user`.",
+          "markdownDeprecationMessage": "**Deprecated**: This config has been renamed to `#latex-workshop.intellisense.atSuggestion.user#`."
+        },
+        "latex-workshop.intellisense.file.exclude": {
+          "scope": "resource",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "**/*.aux",
+            "**/*.bbl",
+            "**/*.bcf",
+            "**/*.blg",
+            "**/*.idx",
+            "**/*.ind",
+            "**/*.lof",
+            "**/*.lot",
+            "**/*.out",
+            "**/*.toc",
+            "**/*.acn",
+            "**/*.acr",
+            "**/*.alg",
+            "**/*.glg",
+            "**/*.glo",
+            "**/*.gls",
+            "**/*.ist",
+            "**/*.fls",
+            "**/*.log",
+            "**/*.nav",
+            "**/*.snm",
+            "**/*.fdb_latexmk",
+            "**/*.synctex.gz",
+            "**/*.run.xml"
+          ],
+          "markdownDescription": "Patterns to ignore in file completion"
+        },
+        "latex-workshop.intellisense.file.base": {
+          "scope": "resource",
+          "type": "string",
+          "enum": [
+            "root relative",
+            "file relative",
+            "both"
+          ],
+          "default": "root relative",
+          "markdownDescription": "Specify the base directory for file completion",
+          "enumDescriptions": [
+            "Completion from the root file directory",
+            "Completion from the current file directory",
+            "both"
+          ]
+        },
+        "latex-workshop.intellisense.label.command": {
+          "scope": "window",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "label",
+            "linelabel"
+          ],
+          "markdownDescription": "The name of LaTeX commands that indicates a label definition. The command must accept one mandatory argument of the label reference string, e.g, \\linelabel{ref-str}."
+        },
+        "latex-workshop.intellisense.label.keyval": {
+          "scope": "window",
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Scan for labels defined as `label={some tex}` to add to the reference intellisense menu. The braces are mandatory."
+        },
+        "latex-workshop.intellisense.unimathsymbols.enabled": {
+          "scope": "window",
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "When `\\` is typed, show unimath symbols in the dropdown selector."
+        },
+        "latex-workshop.intellisense.package.enabled": {
+          "scope": "window",
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Auto-complete commands and environments from used packages."
+        },
+        "latex-workshop.intellisense.package.extra": {
+          "scope": "window",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "markdownDescription": "List of extra packages to always add to the auto-completion mechanism. When `#latex-workshop.intellisense.package.enabled#` is set to `true`, the commands and environments defined in these extra packages will be added to the intellisense suggestions."
+        },
+        "latex-workshop.intellisense.package.exclude": {
+          "scope": "window",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "markdownDescription": "List of packages to exclude from the auto-completion mechanism. When `#latex-workshop.intellisense.package.enabled#` is set to `true`, the commands and environments defined in these packages will not be added to the intellisense suggestions. This setting has a higher priority over `#latex-workshop.intellisense.package.extra#`. You may include the string \"lw-default\" in the list to remove all default commands and environments."
+        },
+        "latex-workshop.intellisense.package.env.enabled": {
+          "scope": "window",
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "If true, every environment provided by an included package is available by a snippet `\\envname`. Only applies when `#latex-workshop.intellisense.package.enabled#` is true. "
+        },
+        "latex-workshop.intellisense.package.dirs": {
+          "scope": "window",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "markdownDescription": "List of extra directories to look for package completion files in addition to those provided by the extension. See https://github.com/James-Yu/LaTeX-Workshop/wiki/Intellisense#commands-starting-with- to learn how to generate these files. Files found in these directories have a higher priority over the default ones. This setting is only relevant when `#latex-workshop.intellisense.package.env.enabled#` is true."
+        },
+        "latex-workshop.intellisense.includegraphics.preview.enabled": {
+          "scope": "window",
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Enable preview for `\\includegraphics` completion."
+        },
+        "latex-workshop.message.badbox.show": {
+          "scope": "window",
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Show badbox information in the problems panel."
+        },
+        "latex-workshop.message.biberlog.exclude": {
+          "scope": "window",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "markdownDescription": "Exclude biber log messages matching the given regexp from the problems panel."
+        },
+        "latex-workshop.message.bibtexlog.exclude": {
+          "scope": "window",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "markdownDescription": "Exclude bibtex log messages matching the given regexp from the problems panel."
+        },
+        "latex-workshop.message.latexlog.exclude": {
+          "scope": "window",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "markdownDescription": "Exclude latex log messages matching the given regexp from the problems panel."
+        },
+        "latex-workshop.message.information.show": {
+          "scope": "window",
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Display information messages in popup notifications."
+        },
+        "latex-workshop.message.warning.show": {
+          "scope": "window",
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Display warning messages in popup notifications."
+        },
+        "latex-workshop.message.error.show": {
+          "scope": "window",
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Display error messages in popup notifications."
+        },
+        "latex-workshop.message.log.show": {
+          "scope": "window",
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Display LaTeX Workshop debug log in output panel. This property defines whether LaTeX Workshop will output its debug log to the log panel."
+        },
+        "latex-workshop.message.convertFilenameEncoding": {
+          "scope": "window",
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Convert the encoding of filenames if necessary when displaying them in the problems panel."
+        },
+        "latex-workshop.latexindent.path": {
+          "scope": "window",
+          "type": "string",
+          "default": "latexindent",
+          "markdownDescription": "Define the location of the latexindent executable file."
+        },
+        "latex-workshop.latexindent.args": {
+          "scope": "resource",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "-c",
+            "%DIR%/",
+            "%TMPFILE%",
+            "-y=defaultIndent: '%INDENT%'"
+          ],
+          "markdownDescription": "Define the command line arguments for latexindent. In the addition to the placeholders defined at https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#placeholders, the following placeholders are accepted\n- %TMPFILE%: The full path of the raw TeX file to be formatted. At this moment you need to use it as an input file of `latexindent`.\n- %INDENT%: The indent character of the file, typically `\t`, `' '`, `' '`.\n\nNote that the option `-c` requires a trailing slash."
+        },
+        "latex-workshop.docker.enabled": {
+          "scope": "window",
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Enable docker-based LaTeX distribution support. Do not set this item to `true` unless you are aware of what it means. This extension will use the images defined in `#latex-workshop.docker.image.latex#` to execute `latexmk`, `synctex`, `texcount`, and `latexindent`."
+        },
+        "latex-workshop.docker.image.latex": {
+          "scope": "window",
+          "type": "string",
+          "default": "",
+          "markdownDescription": "Define the image for `latexmk`, `synctex`, `texcount`, and `latexindent`."
+        },
+        "latex-workshop.showContextMenu": {
+          "scope": "window",
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Enable the LaTeX contextual menu. This menu is deactivated as it is available through the new LaTeX badge. Just set this variable to `true` to recover the menu."
+        },
+        "latex-workshop.bind.enter.key": {
+          "scope": "window",
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Enable the automatic insertion of `\\item` on a newline when pressing `Enter` in a line starting in `\\item`."
+        },
+        "latex-workshop.bind.altKeymap.enabled": {
+          "scope": "window",
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Use alternative keymap combo, i.e., `ctrl`+`l` `alt`+`key`, to replace the default `ctrl`/`cmd`+`alt` shortcuts."
+        },
+        "latex-workshop.hover.ref.enabled": {
+          "scope": "window",
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Enable Hover on References."
+        },
+        "latex-workshop.hover.ref.number.enabled": {
+          "scope": "window",
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Show number assigned to the reference in the previous compilation."
+        },
+        "latex-workshop.hover.citation.enabled": {
+          "scope": "window",
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Enable Hover on Citations."
+        },
+        "latex-workshop.hover.command.enabled": {
+          "scope": "window",
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Enable Hover on Commands to show the possible signatures."
+        },
+        "latex-workshop.hover.preview.enabled": {
+          "scope": "window",
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Enable Hover Preview."
+        },
+        "latex-workshop.hover.preview.maxLines": {
+          "scope": "window",
+          "type": "number",
+          "default": 20,
+          "markdownDescription": "Maximum number of lines between the beginning of the math environment and the cursor position to allow preview."
+        },
+        "latex-workshop.hover.preview.scale": {
+          "scope": "window",
+          "type": "number",
+          "default": 1,
+          "markdownDescription": "Scaling of Hover Preview."
+        },
+        "latex-workshop.hover.preview.newcommand.parseTeXFile.enabled": {
+          "scope": "window",
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Enable newcommands defined in the current TeX file to be included in Hover Preview."
+        },
+        "latex-workshop.hover.preview.newcommand.newcommandFile": {
+          "scope": "window",
+          "type": "string",
+          "default": "",
+          "markdownDescription": "Set the path of a file containing newcommands to be used in Hover Preview. If the path is relative, it is joined with the root dir."
+        },
+        "latex-workshop.hover.preview.cursor.enabled": {
+          "scope": "window",
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Render cursor in Hover Preview at the current position."
+        },
+        "latex-workshop.hover.preview.cursor.symbol": {
+          "scope": "window",
+          "type": "string",
+          "default": "\\!|\\!",
+          "markdownDescription": "Cursor symbol in Hover Preview."
+        },
+        "latex-workshop.hover.preview.cursor.color": {
+          "scope": "window",
+          "type": "string",
+          "default": "auto",
+          "enum": [
+            "auto",
+            "black",
+            "blue",
+            "brown",
+            "cyan",
+            "darkgray",
+            "gray",
+            "green",
+            "lightgray",
+            "lime",
+            "magenta",
+            "olive",
+            "orange",
+            "pink",
+            "purple",
+            "red",
+            "teal",
+            "violet",
+            "white",
+            "yellow"
+          ],
+          "markdownDescription": "The color of cursor in Hover Preview."
+        },
+        "latex-workshop.hover.preview.mathjax.extensions": {
+          "scope": "window",
+          "type": "array",
+          "default": [],
+          "markdownDescription": "MathJax extensions to load for Hover Preview. See [the list](https://docs.mathjax.org/en/latest/input/tex/extensions/index.html). Note that the following extensions are loaded by default: `ams`, `color`, `newcommand`, `noerrors`, and `noundefined`. They cannot be disabled.",
+          "items": {
+            "type": "string",
+            "enum": [
+              "amscd",
+              "bbox",
+              "boldsymbol",
+              "braket",
+              "bussproofs",
+              "cancel",
+              "cases",
+              "centernot",
+              "colortbl",
+              "empheq",
+              "enclose",
+              "extpfeil",
+              "gensymb",
+              "html",
+              "mathtools",
+              "mhchem",
+              "physics",
+              "textcomp",
+              "textmacros",
+              "unicode",
+              "upgreek",
+              "verb"
+            ]
+          },
+          "uniqueItems": true
+        },
+        "latex-workshop.intellisense.optionalArgsEntries.enabled": {
+          "scope": "window",
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Some LaTeX commands can have several forms, each with different arguments. If set to True, the intellisense completion list will have one entry for each form of a given command. Default is true."
+        },
+        "latex-workshop.intellisense.argumentHint.enabled": {
+          "scope": "window",
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Many snippets use text hints of the form `${\\d:some_tex}` for their argument. You may prefer to hide instead by setting this configuration to `false`."
+        },
+        "latex-workshop.intellisense.citation.backend": {
+          "scope": "resource",
+          "type": "string",
+          "enum": [
+            "bibtex",
+            "biblatex"
+          ],
+          "default": "bibtex",
+          "markdownDescription": "Backend to use for citation intellisense."
+        },
+        "latex-workshop.intellisense.bibtexJSON.replace": {
+          "scope": "resource",
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "default": {},
+          "markdownDescription": "Dictionary of `\"entry name\": [\"array\", \"of\", \"fields\"]` to replace the default fields used in `data/bibtex-entries.json`. See `data/bibtex-entries.json` for the list of fields for each entry. This variable is used when `#latex-workshop.intellisense.citation.backend#` is set to `biblatex`."
+        },
+        "latex-workshop.intellisense.biblatexJSON.replace": {
+          "scope": "resource",
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "default": {},
+          "markdownDescription": "Dictionary of `\"entry name\": [\"array\", \"of\", \"fields\"]` to replace the default fields used in `data/biblatex-entries.json`. See `data/biblatex-entries.json` for the list of fields for each entry. This variable is used when `#latex-workshop.intellisense.citation.backend#` is set to `bibtex`."
+        },
+        "latex-workshop.intellisense.commandsJSON.replace": {
+          "scope": "window",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {},
+          "deprecationMessage": "Deprecated: This config has been superseded by config `latex-workshop.intellisense.command.user`, which provides more features.",
+          "markdownDeprecationMessage": "**Deprecated**: This config has been superseded by config `#latex-workshop.intellisense.command.user#`, which provides more features."
+        },
+        "latex-workshop.texdoc.path": {
+          "scope": "window",
+          "type": "string",
+          "default": "texdoc",
+          "markdownDescription": "Define the location of the `texdoc` executable. This command is used to show a package documentation."
+        },
+        "latex-workshop.texdoc.args": {
+          "scope": "window",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "--view"
+          ],
+          "markdownDescription": "Texdoc arguments to see a package documentation. Arguments must be in separate strings in the array. The package name is automatically appended to the arguments."
+        },
+        "latex-workshop.bibtex.maxFileSize": {
+          "scope": "window",
+          "type": "number",
+          "default": 5,
+          "markdownDescription": "Defines the maximum bibtex file size for the extension to parse in MB."
+        },
+        "latex-workshop.bibtex-format.tab": {
+          "scope": "resource",
+          "type": "string",
+          "default": "2 spaces",
+          "markdownDescription": "Indentation for each field. The string can be `\"tab\"` or of the form `\"X spaces\"` or simply `\"X\"` where `X` is a number."
+        },
+        "latex-workshop.bibtex-format.surround": {
+          "scope": "resource",
+          "type": "string",
+          "enum": [
+            "Curly braces",
+            "Quotation marks"
+          ],
+          "default": "Curly braces",
+          "description": "Surround each field value with either {Curly braces} or \"Quotation marks\"."
+        },
+        "latex-workshop.bibtex-format.case": {
+          "scope": "resource",
+          "type": "string",
+          "enum": [
+            "UPPERCASE",
+            "lowercase"
+          ],
+          "default": "lowercase",
+          "description": "Determines if field names should be formatted like 'AUTHOR' or 'author'."
+        },
+        "latex-workshop.bibtex-format.trailingComma": {
+          "scope": "resource",
+          "type": "boolean",
+          "default": false,
+          "description": "Keep the trailing comma of the last field item."
+        },
+        "latex-workshop.bibtex-format.sortby": {
+          "scope": "resource",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "markdownDescription": "An array of strings to sort by. Either a bibtex field name (title, author, year, etc.), or `\"year-desc\"` to sort by year in descending order, or `\"key\"` for the entry key, or `\"type\"` for the entry type (article, book, misc, etc.). E.g. `[\"author\", \"year-desc\", \"title\"]`.",
+          "default": [
+            "key"
+          ]
+        },
+        "latex-workshop.bibtex-format.handleDuplicates": {
+          "scope": "resource",
+          "type": "string",
+          "enum": [
+            "Ignore Duplicates",
+            "Highlight Duplicates",
+            "Comment Duplicates"
+          ],
+          "default": "Highlight Duplicates",
+          "markdownDescription": "How to handle duplicates found by the bibtex sorting functions. Duplicates are decided according to the `bibtex-format.sortby` config."
+        },
+        "latex-workshop.bibtex-format.sort.enabled": {
+          "scope": "resource",
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Sort content when calling VSCode format on a .bib file."
+        },
+        "latex-workshop.bibtex-format.align-equal.enabled": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Align equal signs when calling VSCode format on a .bib file."
+        },
+        "latex-workshop.bibtex-entries.first": {
+          "scope": "resource",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "string",
+            "xdata"
+          ],
+          "markdownDescription": "When `#latex-workshop.bibtex-fields.sort.enabled#` is true, these fields are put at the top, in the order defined by the array."
+        },
+        "latex-workshop.bibtex-fields.sort.enabled": {
+          "scope": "resource",
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Sort fields inside every entry. The sorting order is defined by `#latex-workshop.bibtex-fields.order#`. This variable only has effect when formatting bibtex aligns fields. It is not possible to sort entries without aligning them."
+        },
+        "latex-workshop.bibtex-fields.order": {
+          "scope": "resource",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "markdownDescription": "When `#latex-workshop.bibtex-fields.sort.enabled#` is true, sort fields according the order defined here and then alphabetically for non listed fields."
+        },
+        "latex-workshop.mathpreviewpanel.cursor.enabled": {
+          "scope": "window",
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "[Experimental] Render a cursor on the math preview panel. **This feature is experimental. If you report an issue to us on this feature, we will not fix it. We will not accept any pull requests.**"
+        },
+        "latex-workshop.mathpreviewpanel.editorGroup": {
+          "scope": "window",
+          "type": "string",
+          "default": "below",
+          "enum": [
+            "current",
+            "left",
+            "right",
+            "above",
+            "below"
+          ],
+          "markdownDescription": "The editor group in which to open the math preview panel.",
+          "enumDescriptions": [
+            "Use the current editor group",
+            "Put the math preview panel in a new group on the left of the current one",
+            "Put the math preview panel in a new group on the right of the current one",
+            "Put the math preview panel in a new group above the current one",
+            "Put the math preview panel in a new group below the current one"
+          ]
+        },
+        "latex-workshop.selection.smart.latex.enabled": {
+          "scope": "window",
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Enable AST based smart selection. Command ids are `editor.action.smartSelect.expand` and `editor.action.smartSelect.shrink`."
+        },
+        "latex-workshop.codespaces.portforwarding.openDelay": {
+          "scope": "window",
+          "type": "number",
+          "default": 20000,
+          "markdownDescription": "Delay to wait for GitHub Codespaces Authentication of port forwarding to be resolved, in milliseconds."
+        }
+      }
+    },
+    "menus": {
+      "editor/context": [
+        {
+          "when": "config.latex-workshop.showContextMenu && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && !virtualWorkspace",
+          "command": "latex-workshop.build",
+          "group": "navigation@100"
+        },
+        {
+          "when": "config.latex-workshop.showContextMenu && editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && !virtualWorkspace",
+          "command": "latex-workshop.synctex",
+          "group": "navigation@101"
+        }
+      ],
+      "editor/title": [
+        {
+          "when": "editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && !virtualWorkspace",
+          "command": "latex-workshop.view",
+          "group": "navigation@2"
+        },
+        {
+          "when": "editorLangId =~ /^latex$|^latex-expl3$|^rsweave$|^jlweave$|^pweave$/ && !virtualWorkspace",
+          "command": "latex-workshop.build",
+          "group": "navigation@1"
+        }
+      ],
+      "view/title": [
+        {
+          "when": "view == latex-workshop-structure",
+          "command": "latex-workshop.structure-toggle-follow-cursor"
+        }
+      ]
+    },
+    "viewsContainers": {
+      "activitybar": [
+        {
+          "id": "latex-workshop-activitybar",
+          "title": "LaTeX",
+          "icon": "./icons/activity-bar.svg"
+        }
+      ]
+    },
+    "views": {
+      "latex-workshop-activitybar": [
+        {
+          "id": "latex-workshop-commands",
+          "name": "Commands",
+          "when": "latex-workshop:enabled"
+        },
+        {
+          "id": "latex-workshop-structure",
+          "name": "Structure",
+          "when": "latex-workshop:enabled"
+        },
+        {
+          "id": "latex-workshop-snippet-view",
+          "type": "webview",
+          "when": "latex-workshop:enabled",
+          "name": "Snippet View"
+        }
+      ]
+    },
+    "customEditors": [
+      {
+        "viewType": "latex-workshop-pdf-hook",
+        "displayName": "LaTeX Workshop Internal PDF Viewer",
+        "selector": [
+          {
+            "filenamePattern": "*.pdf"
+          },
+          {
+            "filenamePattern": "*.PDF"
+          }
+        ],
+        "priority": "default"
+      }
+    ]
+  },
+  "scripts": {
+    "clean": "rimraf out/ .eslintcache",
+    "compile": "tsc -p tsconfig.json && tsc -p viewer/tsconfig.json",
+    "lint": "eslint --cache --ext .ts,.js .",
+    "lint:fix": "eslint --fix --cache --ext .ts,.js .",
+    "release": "npm run clean && npm run lint && npm run compile && vsce package",
+    "test": "node ./out/test/runTest.js",
+    "watch-src": "tsc -watch -p tsconfig.json",
+    "watch-viewer": "tsc -watch -p viewer/tsconfig.json"
+  },
+  "dependencies": {
+    "cross-spawn": "7.0.3",
+    "glob": "8.0.3",
+    "iconv-lite": "0.6.3",
+    "latex-utensils": "4.6.0",
+    "mathjax-full": "3.2.2",
+    "micromatch": "4.0.5",
+    "pdfjs-dist": "3.3.122",
+    "tmp": "0.2.1",
+    "workerpool": "6.3.1",
+    "ws": "8.11.0"
+  },
+  "devDependencies": {
+    "@types/cross-spawn": "6.0.2",
+    "@types/glob": "8.0.0",
+    "@types/micromatch": "4.0.2",
+    "@types/mocha": "9.1.1",
+    "@types/node": "16.11.68",
+    "@types/rimraf": "3.0.2",
+    "@types/tmp": "0.2.3",
+    "@types/vscode": "1.74.0",
+    "@types/workerpool": "6.1.0",
+    "@types/ws": "8.5.3",
+    "@typescript-eslint/eslint-plugin": "5.45.0",
+    "@typescript-eslint/parser": "5.45.0",
+    "@vscode/test-electron": "2.2.0",
+    "@vscode/vsce": "2.19.0",
+    "eslint": "8.28.0",
+    "mocha": "9.2.2",
+    "rimraf": "3.0.2",
+    "textmate-bailout": "1.1.0",
+    "typescript": "4.9.3",
+    "vscode-extend-language": "0.1.1"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1151,6 +1151,16 @@
           "default": false,
           "markdownDescription": "When the `subfile` package is used, either the main file or any subfile containing `\\documentclass[main.tex]{subfile}` can be LaTeXing. When `false`, the `build` and `view` commands  ask the user's choice first. When `true`, the subfile is used when `#latex-workshop.latex.rootFile.useSubFile#` is also `true`, otherwise the rootFile is used."
         },
+        "latex-workshop.latex.rootFile.indicator": {
+            "scope": "resource",
+            "type": "string",
+            "default": "\\documentclass",
+            "enum": [
+                "\\documentclass",
+                "\\begin{document}"
+            ],
+            "markdownDescription": "Determine the root file based on the specific indicator. If `\\documentclass`, the root file is the file containing `\\documentclass`. If `\\begin{document}`, the root file is the file containing `\\begin{document}`."
+        },
         "latex-workshop.latex.watch.usePolling": {
           "scope": "window",
           "type": "boolean",

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -48,7 +48,7 @@ export class Manager {
 
         // Create temp folder
         try {
-            this.tmpDir = tmp.dirSync({unsafeCleanup: true}).name.split(path.sep).join('/')
+            this.tmpDir = tmp.dirSync({ unsafeCleanup: true }).name.split(path.sep).join('/')
         } catch (error) {
             void vscode.window.showErrorMessage('Error during making tmpdir to build TeX files. Please check the environment variables, TEMP, TMP, and TMPDIR on your system.')
             console.log(`TEMP, TMP, and TMPDIR: ${JSON.stringify([process.env.TEMP, process.env.TMP, process.env.TMPDIR])}`)
@@ -86,24 +86,21 @@ export class Manager {
     }
 
     /**
-     * @returns the indicator if the root file
+     * Get the indicator type of the root file from the configuration.
+     * @returns The indicator of the root file.
      */
     getRootIndictor() {
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         const indicator = configuration.get('latex.rootFile.indicator')
-        let ROOT_INDICATOR = null
         switch (indicator) {
-            case '\\documentclass':
-                ROOT_INDICATOR = /\\documentclass(?:\s*\[.*\])?\s*\{.*\}/ms
-                break
+            case '\\documentclass[]{}':
+                return /\\documentclass(?:\s*\[.*\])?\s*\{.*\}/ms
             case '\\begin{document}':
-                ROOT_INDICATOR = /\\begin{document}/m
-                break
+                return /\\begin{document}/m
             default:
-                ROOT_INDICATOR = /\\documentclass(?:\s*\[.*\])?\s*\{.*\}/ms
-                break
+                logger.logError('Unknown rootFile.indicator', indicator)
+                return /\\documentclass(?:\s*\[.*\])?\s*\{.*\}/ms
         }
-        return ROOT_INDICATOR
     }
 
     /**
@@ -254,7 +251,7 @@ export class Manager {
      * @param id The language identifier
      */
     hasDoctexId(id: string) {
-            return id === 'doctex'
+        return id === 'doctex'
     }
 
     private findWorkspace(): vscode.Uri | undefined {
@@ -398,8 +395,8 @@ export class Manager {
             const rootSubFile = this.findSubFiles(content)
             const file = vscode.window.activeTextEditor.document.fileName
             if (rootSubFile) {
-               this.localRootFile = file
-               return rootSubFile
+                this.localRootFile = file
+                return rootSubFile
             } else {
                 logger.log(`Found root file from active editor: ${file}`)
                 return file
@@ -470,7 +467,7 @@ export class Manager {
                 logger.log(`Found files that might be root, choose the first one: ${candidates} .`)
                 return candidates[0]
             }
-        } catch (e) {}
+        } catch (e) { }
         return
     }
 

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -95,7 +95,7 @@ export class Manager {
             case '\\documentclass[]{}':
                 return /\\documentclass(?:\s*\[.*\])?\s*\{.*\}/ms
             case '\\begin{document}':
-                return /\\begin{document}/m
+                return /\\begin\s*{document}/m
             default:
                 logger.logError('Unknown rootFile.indicator', indicator)
                 return /\\documentclass(?:\s*\[.*\])?\s*\{.*\}/ms

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -86,10 +86,9 @@ export class Manager {
     }
 
     /**
-     * Get the indicator type of the root file from the configuration.
-     * @returns The indicator of the root file.
+     * The indicator of the root file.
      */
-    getRootIndictor() {
+    get rootIndictor() {
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         const indicator = configuration.get('latex.rootFile.indicator')
         switch (indicator) {
@@ -390,7 +389,7 @@ export class Manager {
             return
         }
         const content = utils.stripCommentsAndVerbatim(vscode.window.activeTextEditor.document.getText())
-        const result = content.match(this.getRootIndictor())
+        const result = content.match(this.rootIndictor)
         if (result) {
             const rootSubFile = this.findSubFiles(content)
             const file = vscode.window.activeTextEditor.document.fileName
@@ -448,7 +447,7 @@ export class Manager {
                     return file.fsPath
                 }
                 const content = utils.stripCommentsAndVerbatim(fs.readFileSync(file.fsPath).toString())
-                const result = content.match(this.getRootIndictor())
+                const result = content.match(this.rootIndictor)
                 if (result) {
                     // Can be a root
                     const children = await lw.cacher.getTeXChildren(file.fsPath, file.fsPath, [])

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -48,7 +48,7 @@ export class Manager {
 
         // Create temp folder
         try {
-            this.tmpDir = tmp.dirSync({ unsafeCleanup: true }).name.split(path.sep).join('/')
+            this.tmpDir = tmp.dirSync({unsafeCleanup: true}).name.split(path.sep).join('/')
         } catch (error) {
             void vscode.window.showErrorMessage('Error during making tmpdir to build TeX files. Please check the environment variables, TEMP, TMP, and TMPDIR on your system.')
             console.log(`TEMP, TMP, and TMPDIR: ${JSON.stringify([process.env.TEMP, process.env.TMP, process.env.TMPDIR])}`)
@@ -466,7 +466,7 @@ export class Manager {
                 logger.log(`Found files that might be root, choose the first one: ${candidates} .`)
                 return candidates[0]
             }
-        } catch (e) { }
+        } catch (e) {}
         return
     }
 


### PR DESCRIPTION
User can choose the root file indicator between `\documentclass` and `\begin{document}`.

Related to https://github.com/James-Yu/LaTeX-Workshop/issues/3804.