### PR TITLE
Use better representation of \vartheta

### DIFF
--- a/data/commands.json
+++ b/data/commands.json
@@ -347,7 +347,7 @@
     "detail": "θ, shortcut @q"
   },
   "vartheta": {
-    "detail": "θ, shortcut @vq"
+    "detail": "ϑ, shortcut @vq"
   },
   "upsilon": {
     "detail": "υ, shortcut @u"


### PR DESCRIPTION
The preview for `\vartheta` did look the same as the one for `\theta`.

Before: θ
Now: ϑ