### PR TITLE
Update \phi and \varphi preview

### DIFF
--- a/data/commands.json
+++ b/data/commands.json
@@ -320,10 +320,10 @@
     "detail": "ω, shortcut @o"
   },
   "phi": {
-    "detail": "ϕ, shortcut @f"
+    "detail": "φ, shortcut @f"
   },
   "varphi": {
-    "detail": "ᵠ, shortcut @vf"
+    "detail": "ϕ, shortcut @vf"
   },
   "pi": {
     "detail": "π, shortcut @p"


### PR DESCRIPTION
Before: \phi = φ, \varphi = ψ
Now: \phi = ϕ, \varphi = φ