### PR TITLE
Use bracket stack to `getLongestBalancedString`

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -121,39 +121,34 @@ export function trimMultiLineString(text: string): string {
  * @param s A string to be searched.
  */
 function getLongestBalancedString(s: string, bracket: 'curly' | 'square'='curly'): string | undefined {
-    const openner = bracket === 'curly' ? '{' : '['
-    const closer = bracket === 'curly' ? '}' : ']'
-    let nested = s[0] === openner ? 0 : 1
-    let i = 0
-    for (i = 0; i < s.length; i++) {
-        switch (s[i]) {
-            case openner:
-                nested++
-                break
-            case closer:
-                nested--
-                break
-            case '\\':
-                // skip an escaped character
-                i++
-                break
-            case ')':
-                // [1, 2)
-                if (openner === '[') {
-                    nested--
-                }
-                break
-            default:
+    const bracketStack: ('{' | '[' | '(')[] = []
+
+    const opener = bracket === 'curly' ? '{' : '['
+    if (s[0] !== opener) {
+        bracketStack.push(opener)
+    }
+
+    for (let i = 0; i < s.length; ++i) {
+        const char = s[i]
+        if (char === '{' || char === '[' || char === '(') {
+            bracketStack.push(char)
+        } else if (char === '}' || char === ']') {
+            const openPos = bracketStack.lastIndexOf(char === '}' ? '{' : '[')
+            if (openPos > -1) {
+                bracketStack.splice(openPos, 1)
+            }
+        } else if (char === ')') {
+            const lastBracket = bracketStack[bracketStack.length - 1]
+            if (lastBracket === '(' || lastBracket === '[') {
+                bracketStack.pop()
+            }
         }
-        if (nested === 0) {
-            break
+
+        if (bracketStack.lastIndexOf(opener) < 0) {
+            return s.substring(s[0] === opener ? 1 : 0, i)
         }
     }
-    if (nested === 0) {
-        return s.substring(s[0] === openner ? 1 : 0, i)
-    } else {
-        return undefined
-    }
+    return undefined
 }
 
 /**

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -132,8 +132,13 @@ function getLongestBalancedString(s: string, bracket: 'curly' | 'square'='curly'
         const char = s[i]
         if (char === '{' || char === '[' || char === '(') {
             bracketStack.push(char)
-        } else if (char === '}' || char === ']') {
-            const openPos = bracketStack.lastIndexOf(char === '}' ? '{' : '[')
+        } else if (char === '}') {
+            const openPos = bracketStack.lastIndexOf('{')
+            if (openPos > -1) {
+                bracketStack.splice(openPos, 1)
+            }
+        } else if (char === ']') {
+            const openPos = bracketStack.lastIndexOf('[')
             if (openPos > -1) {
                 bracketStack.splice(openPos, 1)
             }


### PR DESCRIPTION
This PR is a rewrite of the `getLongestBalancedString` function, aiming at resolving #3866 

In the previous implementation, a universal counter is used to count the nests. This should work as intended if curlies are matched with curlies, and squares match squares.

However, in order to make `\in[1,2)` work, we previously added that `)` can also close `[`. This is causing trouble with `\left[ e^{ j\pi \left( N_t-1 \right) } \right]`, as the `)` is instead of closing the `(`, but traced back to the first `[` and making the stripped string invalid.

In this PR, we use a stack to hold the sequence of brackets `{ [ (` in the context, and match only those that can match:
- `}` closes the previous `{`, no matter what's in between.
- `]` closes the previous `[`, no matter what's in between.
- `)` closes the `(` or `[` if these two are immediately preceeding the `)`, otherwise this `)` is discarded.

It works well.