### PR TITLE
Add a `singleton` mode to pdf tab viewing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1426,12 +1426,14 @@
           "enum": [
             "browser",
             "tab",
+            "singleton",
             "external"
           ],
           "markdownDescription": "The default PDF viewer.",
           "enumDescriptions": [
             "Open PDF with the default web browser.",
             "Open PDF with the built-in tab viewer.",
+            "Open PDF with the built-in tab viewer, reveal existing one if possible.",
             "[Experimental] Open PDF with the external viewer set in \"View > Pdf > External: command\"."
           ]
         },

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -108,10 +108,10 @@ export async function view(mode?: 'tab' | 'browser' | 'external' | vscode.Uri) {
     }
     const configuration = vscode.workspace.getConfiguration('latex-workshop')
     const tabEditorGroup = configuration.get('view.pdf.tab.editorGroup') as string
-    const viewer = typeof mode === 'string' ? mode : configuration.get<'tab' | 'browser' | 'external'>('view.pdf.viewer', 'tab')
+    const viewer = typeof mode === 'string' ? mode : configuration.get<'tab' | 'browser' | 'singleton' | 'external'>('view.pdf.viewer', 'tab')
     if (viewer === 'browser') {
         return lw.viewer.openBrowser(pickedRootFile)
-    } else if (viewer === 'tab') {
+    } else if (viewer === 'tab' || viewer === 'singleton') {
         return lw.viewer.openTab(pickedRootFile, tabEditorGroup, true)
     } else if (viewer === 'external') {
         lw.viewer.openExternal(pickedRootFile)

--- a/test/suites/05_viewer.test.ts
+++ b/test/suites/05_viewer.test.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode'
 import * as path from 'path'
+import * as assert from 'assert'
 import * as lw from '../../src/lw'
 import * as test from './utils'
 import { BuildDone } from '../../src/components/eventbus'
@@ -30,6 +31,25 @@ suite('PDF viewer test suite', () => {
 
         await test.build(fixture, 'main.tex')
         await test.view(fixture, 'main.pdf')
+    })
+
+    test.run('view in singleton tab', async (fixture: string) => {
+        await vscode.workspace.getConfiguration('latex-workshop').update('view.pdf.viewer', 'singleton')
+        await test.load(fixture, [
+            {src: 'base.tex', dst: 'main.tex'}
+        ], {skipCache: true})
+
+        await test.build(fixture, 'main.tex')
+        await test.view(fixture, 'main.pdf')
+        await test.sleep(250)
+        await lw.commander.view()
+        let statuses = lw.viewer.getViewerState(vscode.Uri.file(path.resolve(fixture, 'main.pdf')))
+        assert.strictEqual(statuses.length, 1)
+        await vscode.workspace.getConfiguration('latex-workshop').update('view.pdf.viewer', 'tab')
+        await lw.commander.view()
+        await test.sleep(250)
+        statuses = lw.viewer.getViewerState(vscode.Uri.file(path.resolve(fixture, 'main.pdf')))
+        assert.strictEqual(statuses.length, 2)
     })
 
     test.run('build main.tex and view it', async (fixture: string) => {


### PR DESCRIPTION
Resolves #3882 

This PR adds a `singleton` viewing mode to PDF viewing. This mode will make sure that one and only one tab is opened for each PDF. This behavior indeed is the defaule one if we used `CustomEditor` API, which has other defacts.

This PR also renames `revealWebviewPanel` function to `showInvisibleWebviewPanel`, so that the feature is more precise. The internal logic is also flattened a bit.