### PR TITLE
Add a command for inverting PDF colours.

### DIFF
--- a/package.json
+++ b/package.json
@@ -497,6 +497,11 @@
         "command": "latex-workshop.toggleMathPreviewPanel",
         "title": "Toggle Math Preview Panel",
         "category": "LaTeX Workshop"
+      },
+      {
+        "command": "latex-workshop.togglePdfInvertFilter",
+        "title": "Toggle PDF invert filter",
+        "category": "LaTeX Workshop"
       }
     ],
     "keybindings": [

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -493,6 +493,12 @@ export function toggleMathPreviewPanel() {
     lw.mathPreviewPanel.toggle()
 }
 
+export function togglePdfInvertFilter() {
+    const configuration = vscode.workspace.getConfiguration('latex-workshop')
+    const invert = configuration.get('view.pdf.invert') as boolean
+    configuration.update('view.pdf.invert', invert ? 0 : 1)
+}
+
 async function quickPickRootFile(rootFile: string, localRootFile: string, verb: string): Promise<string | undefined> {
     const configuration = vscode.workspace.getConfiguration('latex-workshop', vscode.Uri.file(rootFile))
     const doNotPrompt = configuration.get('latex.rootFile.doNotPrompt') as boolean

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -493,10 +493,10 @@ export function toggleMathPreviewPanel() {
     lw.mathPreviewPanel.toggle()
 }
 
-export function togglePdfInvertFilter() {
+export async function togglePdfInvertFilter() {
     const configuration = vscode.workspace.getConfiguration('latex-workshop')
     const invert = configuration.get('view.pdf.invert') as boolean
-    configuration.update('view.pdf.invert', invert ? 0 : 1)
+    await configuration.update('view.pdf.invert', invert ? 0 : 1)
 }
 
 async function quickPickRootFile(rootFile: string, localRootFile: string, verb: string): Promise<string | undefined> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -188,7 +188,9 @@ function registerLatexWorkshopCommands() {
 
         vscode.commands.registerCommand('latex-workshop.openMathPreviewPanel', () => lw.commander.openMathPreviewPanel()),
         vscode.commands.registerCommand('latex-workshop.closeMathPreviewPanel', () => lw.commander.closeMathPreviewPanel()),
-        vscode.commands.registerCommand('latex-workshop.toggleMathPreviewPanel', () => lw.commander.toggleMathPreviewPanel())
+        vscode.commands.registerCommand('latex-workshop.toggleMathPreviewPanel', () => lw.commander.toggleMathPreviewPanel()),
+
+        vscode.commands.registerCommand('latex-workshop.togglePdfInvertFilter', () => lw.commander.togglePdfInvertFilter()),
     )
 }
 


### PR DESCRIPTION
This adds an option for inverting PDF colours directly from the command palette.

This avoids the need to go to settings every time the colours need to be inverted—which I think was also the request in #3722.

Let me know if this makes sense or if anything else is needed.

https://github.com/James-Yu/LaTeX-Workshop/assets/33470490/567331b9-16ef-4614-aef0-dffba5f22a98

