### PR TITLE
Custom Editor API

### DIFF
--- a/package.json
+++ b/package.json
@@ -1454,13 +1454,10 @@
         },
         "latex-workshop.view.pdf.tab.openDelay": {
           "scope": "window",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          },
-          "default": {},
-          "deprecationMessage": "Deprecated: This config has been removed.",
-          "markdownDeprecationMessage": "**Deprecated**: This config has been removed."
+          "type": "number",
+          "default": 1000,
+          "deprecationMessage": "Deprecated: This config has no use and has been removed.",
+          "markdownDeprecationMessage": "**Deprecated**: This config has no use and has been removed."
         },
         "latex-workshop.view.pdf.ref.viewer": {
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -1420,14 +1420,16 @@
             "browser",
             "tab",
             "singleton",
-            "external"
+            "external",
+            "customEditor"
           ],
           "markdownDescription": "The default PDF viewer.",
           "enumDescriptions": [
             "Open PDF with the default web browser.",
             "Open PDF with the built-in tab viewer.",
             "Open PDF with the built-in tab viewer, reveal existing one if possible.",
-            "[Experimental] Open PDF with the external viewer set in \"View > Pdf > External: command\"."
+            "[Experimental] Open PDF with the external viewer set in \"View > Pdf > External: command\".",
+            "Open PDF with the built-in tab viewer, treating it as a custom editor."
           ]
         },
         "latex-workshop.view.pdf.tab.editorGroup": {
@@ -1450,11 +1452,32 @@
             "Put the viewer tab in a new group below the current one"
           ]
         },
+        "latex-workshop.view.pdf.tab.viewColumn": {
+          "scope": "window",
+          "type": "string",
+          "default": "Beside",
+          "markdownDescription": "The view column in which to open the tab viewer, if treating it as a custom editor.",
+          "enum": [
+            "Active",
+            "Beside",
+            "One",
+            "Two",
+            "Three"
+          ],
+          "enumDescriptions": [
+            "Use the currently active editor group",
+            "Use the column next to the current editor",
+            "Use the first editor column",
+            "Use the second editor column",
+            "Use the third editor column"
+          ]
+        },
         "latex-workshop.view.pdf.tab.openDelay": {
           "scope": "window",
           "type": "number",
           "default": 1000,
-          "markdownDescription": "Defines the delay in milliseconds to wait for a tab opening. Please increase the value if you encounter a focus issue after opening a tab."
+          "markdownDescription": "Defines the delay in milliseconds to wait for a tab opening. Please increase the value if you encounter a focus issue after opening a tab.",
+          "markdownDeprecationMessage": "Deprecated, does not have any effect."
         },
         "latex-workshop.view.pdf.ref.viewer": {
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -1429,7 +1429,7 @@
             "Open PDF with the built-in tab viewer.",
             "Open PDF with the built-in tab viewer, reveal existing one if possible.",
             "[Experimental] Open PDF with the external viewer set in \"View > Pdf > External: command\".",
-            "Open PDF with the built-in tab viewer, treating it as a custom editor."
+            "[Experimental] Open PDF with the built-in tab viewer, using the vscode custom editor API."
           ]
         },
         "latex-workshop.view.pdf.tab.editorGroup": {
@@ -1452,32 +1452,15 @@
             "Put the viewer tab in a new group below the current one"
           ]
         },
-        "latex-workshop.view.pdf.tab.viewColumn": {
-          "scope": "window",
-          "type": "string",
-          "default": "Beside",
-          "markdownDescription": "The view column in which to open the tab viewer, if treating it as a custom editor.",
-          "enum": [
-            "Active",
-            "Beside",
-            "One",
-            "Two",
-            "Three"
-          ],
-          "enumDescriptions": [
-            "Use the currently active editor group",
-            "Use the column next to the current editor",
-            "Use the first editor column",
-            "Use the second editor column",
-            "Use the third editor column"
-          ]
-        },
         "latex-workshop.view.pdf.tab.openDelay": {
           "scope": "window",
-          "type": "number",
-          "default": 1000,
-          "markdownDescription": "Defines the delay in milliseconds to wait for a tab opening. Please increase the value if you encounter a focus issue after opening a tab.",
-          "markdownDeprecationMessage": "Deprecated, does not have any effect."
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {},
+          "deprecationMessage": "Deprecated: This config has been removed.",
+          "markdownDeprecationMessage": "**Deprecated**: This config has been removed."
         },
         "latex-workshop.view.pdf.ref.viewer": {
           "type": "string",

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -80,7 +80,7 @@ export function recipes(recipe?: string) {
     })
 }
 
-export async function view(mode?: ViewerMode | 'internal' | vscode.Uri) {
+export async function view(mode?: ViewerMode) {
     if (mode) {
         logger.log(`VIEW command invoked with mode: ${mode}.`)
     } else {

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -80,7 +80,7 @@ export function recipes(recipe?: string) {
     })
 }
 
-export async function view(mode?: ViewerMode) {
+export async function view(mode?: ViewerMode | vscode.Uri) {
     if (mode) {
         logger.log(`VIEW command invoked with mode: ${mode}.`)
     } else {

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -4,6 +4,7 @@ import * as lw from './lw'
 import { getSurroundingCommandRange, stripText } from './utils/utils'
 import { getLogger } from './components/logger'
 import { parser } from './components/parser'
+import { ViewerMode } from './components/viewer'
 
 const logger = getLogger('Commander')
 
@@ -79,7 +80,7 @@ export function recipes(recipe?: string) {
     })
 }
 
-export async function view(mode?: 'tab' | 'browser' | 'external' | vscode.Uri) {
+export async function view(mode?: ViewerMode | 'internal' | vscode.Uri) {
     if (mode) {
         logger.log(`VIEW command invoked with mode: ${mode}.`)
     } else {

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -4,7 +4,6 @@ import * as lw from './lw'
 import { getSurroundingCommandRange, stripText } from './utils/utils'
 import { getLogger } from './components/logger'
 import { parser } from './components/parser'
-import { ViewerMode } from './components/viewer'
 
 const logger = getLogger('Commander')
 
@@ -80,7 +79,7 @@ export function recipes(recipe?: string) {
     })
 }
 
-export async function view(mode?: ViewerMode | vscode.Uri) {
+export async function view(mode?: 'tab' | 'browser' | 'external' | vscode.Uri) {
     if (mode) {
         logger.log(`VIEW command invoked with mode: ${mode}.`)
     } else {

--- a/src/components/viewer.ts
+++ b/src/components/viewer.ts
@@ -99,6 +99,7 @@ export class Viewer {
     async open(pdfFile: string, mode?: ViewerMode): Promise<void> {
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         const tabEditorGroup = configuration.get('view.pdf.tab.editorGroup') as string
+        mode = mode ?? configuration.get<ViewerMode>('view.pdf.viewer', 'tab')
         if (mode === 'browser') {
             return lw.viewer.openBrowser(pdfFile)
         } else if (mode === 'customEditor') {

--- a/src/components/viewer.ts
+++ b/src/components/viewer.ts
@@ -96,17 +96,20 @@ export class Viewer {
         return (await lw.server.getViewerUrl(pdfUri)).url
     }
 
-    async open(pdfFile: string, mode?: ViewerMode): Promise<void> {
+    async open(pdfFile: string, mode?: 'tab' | 'browser' | 'external'): Promise<void> {
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         const tabEditorGroup = configuration.get('view.pdf.tab.editorGroup') as string
-        mode = mode ?? configuration.get<ViewerMode>('view.pdf.viewer', 'tab')
-        if (mode === 'browser') {
+        let viewerMode: ViewerMode = mode ?? configuration.get<ViewerMode>('view.pdf.viewer', 'tab')
+        if (mode === 'tab' && configuration.get<ViewerMode>('view.pdf.viewer', 'tab') === 'customEditor') {
+            viewerMode = 'customEditor'
+        }
+        if (viewerMode === 'browser') {
             return lw.viewer.openBrowser(pdfFile)
-        } else if (mode === 'customEditor') {
+        } else if (viewerMode === 'customEditor') {
             return lw.viewer.openCustomEditor(pdfFile)
-        } else if (mode === 'tab' || mode === 'singleton') {
+        } else if (viewerMode === 'tab' || viewerMode === 'singleton') {
             return lw.viewer.openTab(pdfFile, tabEditorGroup, true)
-        } else if (mode === 'external') {
+        } else if (viewerMode === 'external') {
             return lw.viewer.openExternal(pdfFile)
         }
     }

--- a/src/components/viewer.ts
+++ b/src/components/viewer.ts
@@ -96,15 +96,14 @@ export class Viewer {
         return (await lw.server.getViewerUrl(pdfUri)).url
     }
 
-    async open(pdfFile: string, mode: ViewerMode | 'internal' = 'internal'): Promise<void> {
+    async open(pdfFile: string, mode?: ViewerMode): Promise<void> {
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         const tabEditorGroup = configuration.get('view.pdf.tab.editorGroup') as string
-        const configuredViewerMode = configuration.get<ViewerMode>('view.pdf.viewer', 'tab')
         if (mode === 'browser') {
             return lw.viewer.openBrowser(pdfFile)
-        } else if (mode === 'internal' && configuredViewerMode === 'customEditor') {
+        } else if (mode === 'customEditor') {
             return lw.viewer.openCustomEditor(pdfFile)
-        } else if (mode === 'internal' || mode === 'tab' || mode === 'singleton') {
+        } else if (mode === 'tab' || mode === 'singleton') {
             return lw.viewer.openTab(pdfFile, tabEditorGroup, true)
         } else if (mode === 'external') {
             return lw.viewer.openExternal(pdfFile)

--- a/src/components/viewerlib/pdfviewerhook.ts
+++ b/src/components/viewerlib/pdfviewerhook.ts
@@ -16,7 +16,6 @@ class PdfViewerHookProvider implements vscode.CustomReadonlyEditorProvider {
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
         const viewerLocation = configuration.get<ViewerLocation>('view.pdf.viewer', 'tab')
         if(viewerLocation === 'customEditor'){
-            // todo
             webviewPanel.webview.options = {
                 ...webviewPanel.webview.options,
                 enableScripts: true

--- a/src/components/viewerlib/pdfviewerhook.ts
+++ b/src/components/viewerlib/pdfviewerhook.ts
@@ -1,5 +1,8 @@
-import type * as vscode from 'vscode'
+import * as vscode from 'vscode'
 import * as lw from '../../lw'
+import { ViewerLocation } from '../viewer'
+import { viewerManager } from './pdfviewermanager'
+import { populatePdfViewerPanel } from './pdfviewerpanel'
 
 class PdfViewerHookProvider implements vscode.CustomReadonlyEditorProvider {
     openCustomDocument(uri: vscode.Uri) {
@@ -9,12 +12,24 @@ class PdfViewerHookProvider implements vscode.CustomReadonlyEditorProvider {
         }
     }
 
-    resolveCustomEditor(document: vscode.CustomDocument, webviewPanel: vscode.WebviewPanel) {
-        webviewPanel.onDidChangeViewState(e => { e.webviewPanel.dispose() })
-        if (document.uri === undefined || !document.uri.fsPath.toLocaleLowerCase().endsWith('.pdf')) {
-            return
+    async resolveCustomEditor(document: vscode.CustomDocument, webviewPanel: vscode.WebviewPanel) {
+        const configuration = vscode.workspace.getConfiguration('latex-workshop')
+        const viewerLocation = configuration.get<ViewerLocation>('view.pdf.viewer', 'tab')
+        if(viewerLocation === 'customEditor'){
+            // todo
+            webviewPanel.webview.options = {
+                ...webviewPanel.webview.options,
+                enableScripts: true
+            }
+            const pdfPanel = await populatePdfViewerPanel(document.uri, webviewPanel)
+            void viewerManager.initiatePdfViewerPanel(pdfPanel)
+        } else{
+            webviewPanel.onDidChangeViewState(e => { e.webviewPanel.dispose() })
+            if (document.uri === undefined || !document.uri.fsPath.toLocaleLowerCase().endsWith('.pdf')) {
+                return
+            }
+            void lw.viewer.openPdfInTab(document.uri, 'current', false)
         }
-        void lw.viewer.openPdfInTab(document.uri, 'current', false)
     }
 }
 

--- a/src/components/viewerlib/pdfviewerhook.ts
+++ b/src/components/viewerlib/pdfviewerhook.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode'
 import * as lw from '../../lw'
-import { ViewerLocation } from '../viewer'
+import { ViewerMode } from '../viewer'
 import { viewerManager } from './pdfviewermanager'
 import { populatePdfViewerPanel } from './pdfviewerpanel'
 
@@ -14,15 +14,15 @@ class PdfViewerHookProvider implements vscode.CustomReadonlyEditorProvider {
 
     async resolveCustomEditor(document: vscode.CustomDocument, webviewPanel: vscode.WebviewPanel) {
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
-        const viewerLocation = configuration.get<ViewerLocation>('view.pdf.viewer', 'tab')
-        if(viewerLocation === 'customEditor'){
+        const viewerLocation = configuration.get<ViewerMode>('view.pdf.viewer', 'tab')
+        if (viewerLocation === 'customEditor') {
             webviewPanel.webview.options = {
                 ...webviewPanel.webview.options,
                 enableScripts: true
             }
             const pdfPanel = await populatePdfViewerPanel(document.uri, webviewPanel)
             void viewerManager.initiatePdfViewerPanel(pdfPanel)
-        } else{
+        } else {
             webviewPanel.onDidChangeViewState(e => { e.webviewPanel.dispose() })
             if (document.uri === undefined || !document.uri.fsPath.toLocaleLowerCase().endsWith('.pdf')) {
                 return

--- a/src/components/viewerlib/pdfviewerpanel.ts
+++ b/src/components/viewerlib/pdfviewerpanel.ts
@@ -94,8 +94,7 @@ export async function createPdfViewerPanel(pdfUri: vscode.Uri, preserveFocus: bo
         enableScripts: true,
         retainContextWhenHidden: true
     })
-    const pdfPanel = await populatePdfViewerPanel(pdfUri, panel)
-    return pdfPanel
+    return populatePdfViewerPanel(pdfUri, panel)
 }
 
 // Create a PdfViewerPanel inside an existing vscode.WebviewPanel

--- a/src/components/viewerlib/pdfviewerpanel.ts
+++ b/src/components/viewerlib/pdfviewerpanel.ts
@@ -85,9 +85,8 @@ async function patchCodespaces(url: vscode.Uri) {
     codespacesPatched = true
 }
 
+// Create a new vscode.WebviewPanel and in it a PdfViewerPanel
 export async function createPdfViewerPanel(pdfUri: vscode.Uri, preserveFocus: boolean): Promise<PdfViewerPanel> {
-    await lw.server.serverStarted
-    const htmlContent = await getPDFViewerContent(pdfUri)
     const panel = vscode.window.createWebviewPanel('latex-workshop-pdf', path.basename(pdfUri.path), {
         viewColumn: vscode.ViewColumn.Active,
         preserveFocus
@@ -95,6 +94,14 @@ export async function createPdfViewerPanel(pdfUri: vscode.Uri, preserveFocus: bo
         enableScripts: true,
         retainContextWhenHidden: true
     })
+    const pdfPanel = await populatePdfViewerPanel(pdfUri, panel)
+    return pdfPanel
+}
+
+// Create a PdfViewerPanel inside an existing vscode.WebviewPanel
+export async function populatePdfViewerPanel(pdfUri: vscode.Uri, panel: vscode.WebviewPanel): Promise<PdfViewerPanel>{
+    await lw.server.serverStarted
+    const htmlContent = await getPDFViewerContent(pdfUri)
     panel.webview.html = htmlContent
     const pdfPanel = new PdfViewerPanel(pdfUri, panel)
     return pdfPanel

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode'
 import * as lw from './lw'
-import { type ViewerMode, pdfViewerHookProvider, pdfViewerPanelSerializer } from './components/viewer'
+import { pdfViewerHookProvider, pdfViewerPanelSerializer } from './components/viewer'
 import { MathPreviewPanelSerializer } from './components/mathpreviewpanel'
 import { BibtexCompleter } from './providers/bibtexcompletion'
 import { HoverProvider } from './providers/hover'
@@ -119,7 +119,7 @@ function registerLatexWorkshopCommands() {
         vscode.commands.registerCommand('latex-workshop.saveWithoutBuilding', () => lw.commander.saveActive()),
         vscode.commands.registerCommand('latex-workshop.build', () => lw.commander.build()),
         vscode.commands.registerCommand('latex-workshop.recipes', (recipe: string | undefined) => lw.commander.recipes(recipe)),
-        vscode.commands.registerCommand('latex-workshop.view', (mode?: ViewerMode) => lw.commander.view(mode)),
+        vscode.commands.registerCommand('latex-workshop.view', (uri: vscode.Uri) => lw.commander.view(uri)),
         vscode.commands.registerCommand('latex-workshop.refresh-viewer', () => lw.commander.refresh()),
         vscode.commands.registerCommand('latex-workshop.tab', () => lw.commander.view('tab')),
         vscode.commands.registerCommand('latex-workshop.viewInBrowser', () => lw.commander.view('browser')),

--- a/src/main.ts
+++ b/src/main.ts
@@ -121,7 +121,7 @@ function registerLatexWorkshopCommands() {
         vscode.commands.registerCommand('latex-workshop.recipes', (recipe: string | undefined) => lw.commander.recipes(recipe)),
         vscode.commands.registerCommand('latex-workshop.view', (mode: 'tab' | 'browser' | 'external' | vscode.Uri | undefined) => lw.commander.view(mode)),
         vscode.commands.registerCommand('latex-workshop.refresh-viewer', () => lw.commander.refresh()),
-        vscode.commands.registerCommand('latex-workshop.tab', () => lw.commander.view('tab')),
+        vscode.commands.registerCommand('latex-workshop.tab', () => lw.commander.view('internal')),
         vscode.commands.registerCommand('latex-workshop.viewInBrowser', () => lw.commander.view('browser')),
         vscode.commands.registerCommand('latex-workshop.viewExternal', () => lw.commander.view('external')),
         vscode.commands.registerCommand('latex-workshop.kill', () => lw.commander.kill()),

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode'
 import * as lw from './lw'
-import { pdfViewerHookProvider, pdfViewerPanelSerializer } from './components/viewer'
+import { type ViewerMode, pdfViewerHookProvider, pdfViewerPanelSerializer } from './components/viewer'
 import { MathPreviewPanelSerializer } from './components/mathpreviewpanel'
 import { BibtexCompleter } from './providers/bibtexcompletion'
 import { HoverProvider } from './providers/hover'
@@ -119,9 +119,9 @@ function registerLatexWorkshopCommands() {
         vscode.commands.registerCommand('latex-workshop.saveWithoutBuilding', () => lw.commander.saveActive()),
         vscode.commands.registerCommand('latex-workshop.build', () => lw.commander.build()),
         vscode.commands.registerCommand('latex-workshop.recipes', (recipe: string | undefined) => lw.commander.recipes(recipe)),
-        vscode.commands.registerCommand('latex-workshop.view', (mode: 'tab' | 'browser' | 'external' | vscode.Uri | undefined) => lw.commander.view(mode)),
+        vscode.commands.registerCommand('latex-workshop.view', (mode?: ViewerMode) => lw.commander.view(mode)),
         vscode.commands.registerCommand('latex-workshop.refresh-viewer', () => lw.commander.refresh()),
-        vscode.commands.registerCommand('latex-workshop.tab', () => lw.commander.view('internal')),
+        vscode.commands.registerCommand('latex-workshop.tab', () => lw.commander.view('tab')),
         vscode.commands.registerCommand('latex-workshop.viewInBrowser', () => lw.commander.view('browser')),
         vscode.commands.registerCommand('latex-workshop.viewExternal', () => lw.commander.view('external')),
         vscode.commands.registerCommand('latex-workshop.kill', () => lw.commander.kill()),

--- a/test/suites/05_viewer.test.ts
+++ b/test/suites/05_viewer.test.ts
@@ -52,6 +52,30 @@ suite('PDF viewer test suite', () => {
         assert.strictEqual(statuses.length, 2)
     }, ['linux', 'darwin'])
 
+    test.run('view in custom editor tab', async (fixture: string) => {
+        await vscode.workspace.getConfiguration('latex-workshop').update('view.pdf.viewer', 'customEditor')
+        await test.load(fixture, [
+            {src: 'base.tex', dst: 'main.tex'}
+        ], {skipCache: true})
+
+        await test.build(fixture, 'main.tex')
+        await test.view(fixture, 'main.pdf')
+        await test.sleep(250)
+        await lw.commander.view()
+        let statuses = lw.viewer.getViewerState(vscode.Uri.file(path.resolve(fixture, 'main.pdf')))
+        assert.strictEqual(statuses.length, 1) // Make sure a custom editor was opened
+        await test.sleep(250)
+        await lw.commander.view()
+        await test.sleep(250)
+        statuses = lw.viewer.getViewerState(vscode.Uri.file(path.resolve(fixture, 'main.pdf')))
+        assert.strictEqual(statuses.length, 1) // Make sure the custom editor got reused
+        await vscode.workspace.getConfiguration('latex-workshop').update('view.pdf.viewer', 'tab')
+        await lw.commander.view()
+        await test.sleep(250)
+        statuses = lw.viewer.getViewerState(vscode.Uri.file(path.resolve(fixture, 'main.pdf')))
+        assert.strictEqual(statuses.length, 2) // Make sure a non-customEditor viewer was opened
+    }, ['linux', 'darwin'])
+
     test.run('build main.tex and view it', async (fixture: string) => {
         await vscode.workspace.getConfiguration().update('latex-workshop.latex.rootFile.doNotPrompt', true)
         await vscode.workspace.getConfiguration().update('latex-workshop.latex.rootFile.useSubFile', false)

--- a/test/suites/05_viewer.test.ts
+++ b/test/suites/05_viewer.test.ts
@@ -74,7 +74,7 @@ suite('PDF viewer test suite', () => {
         await test.sleep(250)
         statuses = lw.viewer.getViewerState(vscode.Uri.file(path.resolve(fixture, 'main.pdf')))
         assert.strictEqual(statuses.length, 2) // Make sure a non-customEditor viewer was opened
-    }, ['linux', 'darwin'])
+    })
 
     test.run('build main.tex and view it', async (fixture: string) => {
         await vscode.workspace.getConfiguration().update('latex-workshop.latex.rootFile.doNotPrompt', true)


### PR DESCRIPTION
Implements the changes discussed in #3951

I added a new viewmode instead of replacing the "singleton" mode, in case some users want to preserve the specific behavior of that mode, but of course that can be changed easily.

I had to add the option `"latex-workshop.view.pdf.tab.viewColumn"`, since the current option `"latex-workshop.view.pdf.tab.editorGroup"` is not compatible with the editor-open API of vscode, and merging the two felt rather confusing.

