### PR TITLE
Add option to include filename in status bar

### DIFF
--- a/package.json
+++ b/package.json
@@ -1074,6 +1074,12 @@
           "default": "",
           "markdownDescription": "The jobname argument of the compiling tool, which is used by the extension to find project files (e.g., PDF and SyncTeX files). This config should be set identical to the value provided to the `-jobname=` argument, and should not have placeholders. Leave the config empty to ignore jobname and keep the default behavior."
         },
+        "latex-workshop.latex.build.rootfileInStatus": {
+          "scope": "resource",
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Whether to include the name of the root file being built in the status bar."
+        },
         "latex-workshop.latex.texDirs": {
           "scope": "window",
           "type": "array",

--- a/src/components/builder.ts
+++ b/src/components/builder.ts
@@ -764,13 +764,24 @@ class BuildToolQueue {
     }
 
     getStepString(step: Step): string {
+        let stepString: string
         if (step.timestamp !== this.steps[0]?.timestamp && step.index === 0) {
-            return step.recipeName
+            stepString = step.recipeName
         } else if (step.timestamp === this.steps[0]?.timestamp) {
-            return `${step.recipeName}: ${step.index + 1}/${this.steps[this.steps.length - 1].index + 1} (${step.name})`
+            stepString = `${step.recipeName}: ${step.index + 1}/${this.steps[this.steps.length - 1].index + 1} (${step.name})`
         } else {
-            return `${step.recipeName}: ${step.index + 1}/${step.index + 1} (${step.name})`
+            stepString = `${step.recipeName}: ${step.index + 1}/${step.index + 1} (${step.name})`
         }
+        if(step.rootFile) {
+            const rootFileUri = vscode.Uri.file(step.rootFile)
+            const configuration = vscode.workspace.getConfiguration('latex-workshop', rootFileUri)
+            const showFilename = configuration.get<boolean>('latex.build.rootfileInStatus', false)
+            if(showFilename) {
+                const relPath = vscode.workspace.asRelativePath(step.rootFile)
+                stepString = `${relPath}: ${stepString}`
+            }
+        }
+        return stepString
     }
 
     getStep(): Step | undefined {


### PR DESCRIPTION
This PR adds an option to include the name of the root file in the status bar while compiling/building.

I find this very useful when working in directories with multiple latex files that take a long time to compile. Scenarios are e.g.:
- `fileA.tex` is being built/just got done being built, and I save `fileB.tex`. Now I can see whether `fileA.tex` is still being built or `fileB.tex` is already being built.
- `fileA.tex` is included by two root files, e.g. `examQuestions.tex` and `examSolutions.tex`, and I save it. Now I can see which of the two root files was chosen to be built by the root-finding mechanism.

This does not solve the issues raised e.g. in #3614 and #3172, but helps coping with the "blackbox" root-finding mechanism.

I set the option default to `false` to not add noise to the status bar for users who are not interested in this info, but that can of course be changed.

I am already using this modification on my personal fork, so I directly opened a PR. If you prefer, I can also close this PR and open a discussion topic first.

