### PR TITLE
Enable mouse buttons 3, 4 in pdf viewer

### DIFF
--- a/viewer/components/viewerhistory.ts
+++ b/viewer/components/viewerhistory.ts
@@ -31,6 +31,15 @@ export class ViewerHistory {
         (document.getElementById('historyForward') as HTMLElement).addEventListener('click', () => {
             this.lwApp.viewerHistory.forward()
         })
+
+        document.addEventListener('mousedown', (ev) => {
+            if(ev.button === 3) {
+                this.lwApp.viewerHistory.back()
+            }
+            if(ev.button === 4) {
+                this.lwApp.viewerHistory.forward()
+            }
+        })
     }
 
     private last() {


### PR DESCRIPTION
As the title says, this PR enables mouse buttons 3 and 4 in the pdf viewer.
In most applications, these are by default back (3) and forward (4). They have a similar behavior in vscode itself.

So far these buttons don't do anything inside the viewer and this change only has an effect if the user actively clicks them.
