### PR TITLE
Added extra tabs and new lines to snippets for table

### DIFF
--- a/data/latex-snippet.json
+++ b/data/latex-snippet.json
@@ -91,12 +91,12 @@
 	},
 	"table (caption after tabular)": {
 		"prefix": "BTA",
-		"body": "\\begin{table}[${1:htbp}]\n\t\\centering\\begin{tabular}{${4:<columns>}}\n\t\t${0:${TM_SELECTED_TEXT}}\n\t\\end{tabular}\n\t\\caption{${2:<caption>}}\n\t\\label{${3:<label>}}\n\\end{table}",
+		"body": "\\begin{table}[${1:htbp}]\n\t\\centering\n\t\\begin{tabular}{${4:<columns>}}\n\t\t${0:${TM_SELECTED_TEXT}}\n\t\\end{tabular}\n\t\\caption{${2:<caption>}}\n\t\\label{${3:<label>}}\n\\end{table}",
 		"description": "table"
 	},
 	"table (caption before tabular)": {
 		"prefix": "BTB",
-		"body": "\\begin{table}[${1:htbp}]\n\t\\centering\t\\caption{${2:<caption>}}\n\t\\label{${3:<label>}}\n\\begin{tabular}{${4:<columns>}}\n\t\t${0:${TM_SELECTED_TEXT}}\n\t\\end{tabular}\n\\end{table}",
+		"body": "\\begin{table}[${1:htbp}]\n\t\\centering\n\t\\caption{${2:<caption>}}\n\t\\label{${3:<label>}}\n\t\\begin{tabular}{${4:<columns>}}\n\t\t${0:${TM_SELECTED_TEXT}}\n\t\\end{tabular}\n\\end{table}",
 		"description": "table"
 	},
 	"tikzpicture": {


### PR DESCRIPTION
First of all, thank you for a great extension. I've been using it for a couple of years now.

In my humble opinion, `BTA` and `BTB` snippets look a bit clumsy. Adding extra `\n` and `\t` helps.

## BTA

Current version:
``` latex
\begin{table}[htbp]
    \centering\begin{tabular}{<columns>}
        
    \end{tabular}
    \caption{<caption>}
    \label{<label>}
\end{table}
```
Pull request:
``` latex
\begin{table}[htbp]
    \centering
    \begin{tabular}{<columns>}
        
    \end{tabular}
    \caption{<caption>}
    \label{<label>}
\end{table}
```

## BTB
Current version:
``` latex
\begin{table}[htbp]
    \centering	\caption{<caption>}
    \label{<label>}
\begin{tabular}{<columns>}
        
    \end{tabular}
\end{table}
```
Pull request:
``` latex
\begin{table}[htbp]
    \centering
    \caption{<caption>}
    \label{<label>}
    \begin{tabular}{<columns>}
        
    \end{tabular}
\end{table}
```