### PR TITLE
Fix warning when running docker sample

### DIFF
--- a/samples/docker/.devcontainer/devcontainer.json
+++ b/samples/docker/.devcontainer/devcontainer.json
@@ -1,5 +1,9 @@
 {
 	"name": "TeX Live base",
 	"dockerFile": "Dockerfile",
-	"extensions": ["james-yu.latex-workshop"]
+  "customizations": {
+        "vscode": {
+            "extensions": ["james-yu.latex-workshop"]
+        }
+    }
 }

--- a/samples/docker/.devcontainer/devcontainer.json
+++ b/samples/docker/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
-	"name": "TeX Live base",
-	"dockerFile": "Dockerfile",
-  "customizations": {
+    "name": "TeX Live base",
+    "dockerFile": "Dockerfile",
+    "customizations": {
         "vscode": {
             "extensions": ["james-yu.latex-workshop"]
         }


### PR DESCRIPTION
I got the following warning when I tried to run the docker sample:

```
Property extensions is not allowed.
Use 'customizations/vscode/extensions' instead
```

From [vscode documentation](https://code.visualstudio.com/docs/devcontainers/containers#_create-a-devcontainerjson-file). The extensions should be inside customizations/vscode/extensions. The issue describing this change in devcontainers can be found [here](https://github.com/devcontainers/spec/issues/1).