### PR TITLE
Support filename conversion for error messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -2091,6 +2091,18 @@
           "default": true,
           "markdownDescription": "Convert the encoding of filenames if necessary when displaying them in the problems panel."
         },
+        "latex-workshop.message.filenameConverter.matcher": {
+          "scope": "window",
+          "type": "string",
+          "default": "",
+          "markdownDescription": "A regular expression to match the filename of an error message. The matched part of the filename is replaced by `#latex-workshop.message.filenameConverter.replacer#` before sending to the log panel. The syntax of regular expressions and replacers is one for `String.replace()` in JavaScript."
+        },
+        "latex-workshop.message.filenameConverter.replacer": {
+          "scope": "window",
+          "type": "string",
+          "default": "",
+          "markdownDescription": "A string specifying the replacement of the filename converting function. See `#latex-workshop.message.filenameConverter.matcher#` for the details."
+        },
         "latex-workshop.latexindent.path": {
           "scope": "window",
           "type": "string",

--- a/src/parse/parser/parserutils.ts
+++ b/src/parse/parser/parserutils.ts
@@ -45,7 +45,14 @@ const DIAGNOSTIC_SEVERITY: { [key: string]: vscode.DiagnosticSeverity } = {
 export function showCompilerDiagnostics(diagnostics: vscode.DiagnosticCollection, buildLog: LogEntry[]) {
     diagnostics.clear()
     const diagsCollection = Object.create(null) as { [key: string]: vscode.Diagnostic[] }
+    const configuration = vscode.workspace.getConfiguration('latex-workshop')
+    const convertFilenameRegexp = new RegExp(configuration.get('message.filenameConverter.matcher') as string)
+    const convertFilenameReplacer = configuration.get('message.filenameConverter.replacer') as string
     for (const item of buildLog) {
+        const srcFile = item.file.replace(convertFilenameRegexp, convertFilenameReplacer)
+        if (fs.existsSync(srcFile)) {
+            item.file = srcFile
+        }
         let startChar = 0
         let endChar = 65535
         // Try to compute a more precise position
@@ -64,7 +71,6 @@ export function showCompilerDiagnostics(diagnostics: vscode.DiagnosticCollection
         diagsCollection[item.file].push(diag)
     }
 
-    const configuration = vscode.workspace.getConfiguration('latex-workshop')
     const convEnc = configuration.get('message.convertFilenameEncoding') as boolean
     for (const file in diagsCollection) {
         let file1 = file


### PR DESCRIPTION
This RP adds a function that can convert the filename of an error message before outputting it to the log panel.

The primary purpose of this extension is to enhance support for TeX writing, especially in cases where TeX files undergo preprocessing before typesetting. In such scenarios, the files compiled by a TeX processor may differ from the ones the author originally worked on. This discrepancy often leads to difficulties in locating error positions when using VSCode support.

It's important to note that this extension may not perform optimally with general preprocessing tasks, such as altering the line positions of text before and after preprocessing. However, it is well-suited for lightweight preprocessing, where line positions remain unchanged. Therefore, this extension is particularly beneficial for authors employing such a workflow.