### PR TITLE
Support `\boldsymbol`, `\bm` and other `'mathtools'` commands in equations preview

### DIFF
--- a/src/preview/math/mathjax.ts
+++ b/src/preview/math/mathjax.ts
@@ -18,6 +18,7 @@ RegisterHTMLHandler(adaptor)
 const baseExtensions: SupportedExtension[] = ['ams', 'base', 'boldsymbol', 'color', 'configmacros', 'mathtools', 'newcommand', 'noerrors', 'noundefined']
 
 function createHtmlConverter(extensions: SupportedExtension[]) {
+    // https://github.com/mathjax/MathJax/issues/1219
     const macrosOption: MacrosOption = {
         bm: ['\\boldsymbol{#1}', 1],
     }

--- a/src/preview/math/mathjax.ts
+++ b/src/preview/math/mathjax.ts
@@ -1,5 +1,5 @@
 import * as workerpool from 'workerpool'
-import type {ConvertOption, SupportedExtension, SvgOption, TexOption} from 'mathjax-full'
+import type {ConvertOption, MacrosOption, SupportedExtension, SvgOption, TexOption} from 'mathjax-full'
 import { mathjax } from 'mathjax-full/js/mathjax.js'
 import { TeX } from 'mathjax-full/js/input/tex.js'
 import { SVG } from 'mathjax-full/js/output/svg.js'
@@ -15,11 +15,15 @@ import 'mathjax-full/js/input/tex/AllPackages.js'
 const adaptor = liteAdaptor()
 RegisterHTMLHandler(adaptor)
 
-const baseExtensions: SupportedExtension[] = ['ams', 'base', 'color', 'newcommand', 'noerrors', 'noundefined']
+const baseExtensions: SupportedExtension[] = ['ams', 'base', 'boldsymbol', 'color', 'configmacros', 'mathtools', 'newcommand', 'noerrors', 'noundefined']
 
 function createHtmlConverter(extensions: SupportedExtension[]) {
+    const macrosOption: MacrosOption = {
+        bm: ['\\boldsymbol{#1}', 1],
+    }
     const baseTexOption: TexOption = {
         packages: extensions,
+        macros: macrosOption,
         formatError: (_jax, error) => { throw new Error(error.message) }
     }
     const texInput = new TeX<LiteElement, LiteText, LiteDocument>(baseTexOption)

--- a/types/mathjax-full/index.d.ts
+++ b/types/mathjax-full/index.d.ts
@@ -41,6 +41,10 @@ export type SupportedExtension =
     'upgreek' |
     'verb'
 
+export type MacrosOption = {
+    [name: string]: object;
+}
+
 export type TexOption = {
     packages?: readonly SupportedExtension[],
     inlineMath?: readonly [string, string][],
@@ -56,6 +60,7 @@ export type TexOption = {
     maxMacros?: number,
     maxBuffer?: number,
     baseURL?: string,
+    macros?: MacrosOption,
     formatError?: (jax: TeX<LiteElement, LiteText, LiteDocument>, message: TexError) => unknown
 }
 


### PR DESCRIPTION
Support `\boldsymbol` and other commands from `'mathtools'` package in equations preview, and add a tweak to support `\bm` command to bold symbols.

Ref: https://github.com/mathjax/MathJax/issues/1219#issuecomment-341059843