### PR TITLE
Parse `\providecommand` in math preview properly

### DIFF
--- a/src/preview/math.ts
+++ b/src/preview/math.ts
@@ -53,6 +53,7 @@ async function onTeX(document: vscode.TextDocument, tex: TeXMathEnv, newCommand:
     const scale = configuration.get('hover.preview.scale') as number
     let s = await renderCursor(document, tex)
     s = MathPreviewUtils.mathjaxify(s, tex.envname)
+    newCommand = replaceNewCommand(newCommand)
     const typesetArg = newCommand + MathPreviewUtils.stripTeX(s, newCommand)
     const typesetOpts = { scale, color }
     try {
@@ -153,4 +154,10 @@ async function renderSvgOnRef(tex: TeXMathEnv, refData: Pick<ReferenceEntry, 'la
 
 function findMath(document: ITextDocumentLike, position: vscode.Position): TeXMathEnv | undefined {
     return TeXMathEnvFinder.findMathEnvIncludingPosition(document, position)
+}
+
+function replaceNewCommand(newCommand: string): string {
+    const replacedNewCommand = newCommand.replace(/\\providecommand\{(.*?)\}/g, '\\newcommand{$1}')
+    console.log(replacedNewCommand)
+    return replacedNewCommand
 }

--- a/src/preview/math.ts
+++ b/src/preview/math.ts
@@ -157,7 +157,7 @@ function findMath(document: ITextDocumentLike, position: vscode.Position): TeXMa
 }
 
 function replaceNewCommand(newCommand: string): string {
-    const replacedNewCommand = newCommand.replace(/\\providecommand\{(.*?)\}/g, '\\newcommand{$1}')
+    const replacedNewCommand = newCommand.replaceAll(/\\providecommand\{(.*?)\}/g, '\\newcommand{$1}')
     console.log(replacedNewCommand)
     return replacedNewCommand
 }


### PR DESCRIPTION
Follow the solution for `replaceLabelWithTag` by substituting `\providecommand` with `\newcommand` to ensure proper parsing by MathJax.

If I have misplaced the new function, please inform me or relocate it to the appropriate position directly.

| ![](https://github.com/James-Yu/LaTeX-Workshop/assets/32028289/da33732b-1231-4c41-9a1d-bc50682408ef) | ![](https://github.com/James-Yu/LaTeX-Workshop/assets/32028289/0f2809cf-5e95-4513-bc6f-b5237827f9c1) |
|:--:|:--:|
| *Before* | *After* |

```
\documentclass{minimal}

\providecommand{\newprovidetextcmd}{ABC}
\providecommand{\newprovidemathcmd}{\mathrm{def}}
\newcommand{\newtextcmd}{ghi}
\newcommand{\newmathcmd}{\mathrm{jkl}}
\renewcommand{\renewtextcmd}{mno}
\renewcommand{\renewmathcmd}{\mathrm{pqr}}

\begin{document}

\newtextcmd

\[ \newtextcmd \newprovidetextcmd \newprovidemathcmd f(x) \]

\end{document}
```
