### PR TITLE
Override pdf.js to enable VIM-like scrolling by j, k, J, K, H, L

### DIFF
--- a/viewer/latexworkshop.ts
+++ b/viewer/latexworkshop.ts
@@ -611,13 +611,6 @@ class LateXWorkshopPdfViewer implements ILatexWorkshopPdfViewer {
 
         // keyboard bindings
         window.addEventListener('keydown', (evt: KeyboardEvent) => {
-            // F opens find bar, cause Ctrl-F is handled by vscode
-            // const target = evt.target as HTMLElement
-            // if(evt.keyCode === 70 && target.nodeName !== 'INPUT') { // ignore F typed in the search box
-            //     this.showToolbar(false)
-            //     PDFViewerApplication.findBar.open()
-            //     evt.preventDefault()
-            // }
             if (this.embedded && evt.key === 'c' && (evt.ctrlKey || evt.metaKey)) {
                 const selection = window.getSelection()
                 if (selection !== null && selection.toString().length > 0) {
@@ -627,25 +620,29 @@ class LateXWorkshopPdfViewer implements ILatexWorkshopPdfViewer {
 
             // Chrome's usual Alt-Left/Right (Command-Left/Right on OSX) for history
             // Back/Forward don't work in the embedded viewer, so we simulate them.
-            if (this.embedded && (
-                (evt.altKey && !navigator.userAgent.includes('Mac OS')) ||
-                (evt.metaKey && navigator.userAgent.includes('Mac OS'))
-            )) {
+            if (this.embedded && (navigator.userAgent.includes('Mac OS') ? evt.metaKey : evt.altKey)) {
                 if (evt.key === 'ArrowLeft') {
                     this.viewerHistory.back()
                 } else if(evt.key === 'ArrowRight') {
                     this.viewerHistory.forward()
                 }
             }
-            if (evt.key === 'Backspace' && (evt.target as HTMLElement).nodeName !== 'INPUT') {
+
+            // Following are shortcuts when focus is not in inputs, e.g., search
+            // box or page input
+            if ((evt.target as HTMLElement).nodeName === 'INPUT') {
+                return
+            }
+
+            if (evt.key === 'Backspace') {
                 this.viewerHistory.back()
             }
-            if (evt.key === 'Backspace' && evt.shiftKey && (evt.target as HTMLElement).nodeName !== 'INPUT') {
+            if (evt.key === 'Backspace' && evt.shiftKey) {
                 this.viewerHistory.forward()
             }
 
             // Configure VIM-like shortcut keys
-            if (this.embedded && !evt.altKey && !evt.ctrlKey && !evt.metaKey && ['J', 'K', 'H', 'L'].includes(evt.key)) {
+            if (!evt.altKey && !evt.ctrlKey && !evt.metaKey && ['J', 'K', 'H', 'L'].includes(evt.key)) {
                 evt.stopImmediatePropagation()
                 const container = document.getElementById('viewerContainer') as HTMLElement
 

--- a/viewer/latexworkshop.ts
+++ b/viewer/latexworkshop.ts
@@ -649,11 +649,19 @@ class LateXWorkshopPdfViewer implements ILatexWorkshopPdfViewer {
                 if (evt.key === 'j') {
                     evt.stopImmediatePropagation()
                     const container = document.getElementById('viewerContainer') as HTMLElement
-                    container.scrollBy({top: 40, behavior: 'auto'})
+                    if (evt.repeat) {
+                        container.scrollBy({top: 25, behavior: 'auto'})
+                    } else {
+                        container.scrollBy({top: 40, behavior: 'smooth'})
+                    }
                 } else if (evt.key === 'k') {
                     evt.stopImmediatePropagation()
                     const container = document.getElementById('viewerContainer') as HTMLElement
-                    container.scrollBy({top: -40, behavior: 'auto'})
+                    if (evt.repeat) {
+                        container.scrollBy({top: -25, behavior: 'auto'})
+                    } else {
+                        container.scrollBy({top: -40, behavior: 'smooth'})
+                    }
                 }
             }
         })

--- a/viewer/latexworkshop.ts
+++ b/viewer/latexworkshop.ts
@@ -644,7 +644,7 @@ class LateXWorkshopPdfViewer implements ILatexWorkshopPdfViewer {
                 this.viewerHistory.forward()
             }
 
-            // Configure keys `j, k, H, L` for scrolling like arrow keys
+            // Configure VIM-like shortcut keys
             if (this.embedded && !evt.altKey && !evt.ctrlKey && !evt.metaKey) {
                 if (evt.key === 'j') {
                     evt.stopImmediatePropagation()
@@ -661,6 +661,22 @@ class LateXWorkshopPdfViewer implements ILatexWorkshopPdfViewer {
                         container.scrollBy({top: -20, behavior: 'instant'})
                     } else {
                         container.scrollBy({top: -40, behavior: 'smooth'})
+                    }
+                } else if (evt.key === 'J') {
+                    evt.stopImmediatePropagation()
+                    const container = document.getElementById('viewerContainer') as HTMLElement
+                    if (evt.repeat) {
+                        container.scrollBy({top: container.offsetHeight/5, behavior: 'instant'})
+                    } else {
+                        container.scrollBy({top: container.offsetHeight, behavior: 'smooth'})
+                    }
+                } else if (evt.key === 'K') {
+                    evt.stopImmediatePropagation()
+                    const container = document.getElementById('viewerContainer') as HTMLElement
+                    if (evt.repeat) {
+                        container.scrollBy({top: -container.offsetHeight/5, behavior: 'instant'})
+                    } else {
+                        container.scrollBy({top: -container.offsetHeight, behavior: 'smooth'})
                     }
                 } else if (evt.key === 'H') {
                     evt.stopImmediatePropagation()

--- a/viewer/latexworkshop.ts
+++ b/viewer/latexworkshop.ts
@@ -644,13 +644,13 @@ class LateXWorkshopPdfViewer implements ILatexWorkshopPdfViewer {
                 this.viewerHistory.forward()
             }
 
-            // Configure keys `j`, `k` for scrolling like up/down arrows
-            if (this.embedded && !evt.altKey && !evt.ctrlKey && !evt.shiftKey && !evt.metaKey) {
+            // Configure keys `j, k, H, L` for scrolling like arrow keys
+            if (this.embedded && !evt.altKey && !evt.ctrlKey && !evt.metaKey) {
                 if (evt.key === 'j') {
                     evt.stopImmediatePropagation()
                     const container = document.getElementById('viewerContainer') as HTMLElement
                     if (evt.repeat) {
-                        container.scrollBy({top: 25, behavior: 'auto'})
+                        container.scrollBy({top: 20, behavior: 'instant'})
                     } else {
                         container.scrollBy({top: 40, behavior: 'smooth'})
                     }
@@ -658,9 +658,25 @@ class LateXWorkshopPdfViewer implements ILatexWorkshopPdfViewer {
                     evt.stopImmediatePropagation()
                     const container = document.getElementById('viewerContainer') as HTMLElement
                     if (evt.repeat) {
-                        container.scrollBy({top: -25, behavior: 'auto'})
+                        container.scrollBy({top: -20, behavior: 'instant'})
                     } else {
                         container.scrollBy({top: -40, behavior: 'smooth'})
+                    }
+                } else if (evt.key === 'H') {
+                    evt.stopImmediatePropagation()
+                    const container = document.getElementById('viewerContainer') as HTMLElement
+                    if (evt.repeat) {
+                        container.scrollBy({left: -20, behavior: 'instant'})
+                    } else {
+                        container.scrollBy({left: -40, behavior: 'smooth'})
+                    }
+                } else if (evt.key === 'L') {
+                    evt.stopImmediatePropagation()
+                    const container = document.getElementById('viewerContainer') as HTMLElement
+                    if (evt.repeat) {
+                        container.scrollBy({left: 20, behavior: 'instant'})
+                    } else {
+                        container.scrollBy({left: 40, behavior: 'smooth'})
                     }
                 }
             }

--- a/viewer/latexworkshop.ts
+++ b/viewer/latexworkshop.ts
@@ -645,47 +645,19 @@ class LateXWorkshopPdfViewer implements ILatexWorkshopPdfViewer {
             }
 
             // Configure VIM-like shortcut keys
-            if (this.embedded && !evt.altKey && !evt.ctrlKey && !evt.metaKey) {
-                if (evt.key === 'j') {
-                    evt.stopImmediatePropagation()
-                    const container = document.getElementById('viewerContainer') as HTMLElement
-                    container.scrollBy({top: 40, behavior: evt.repeat ? 'instant' : 'smooth'})
-                } else if (evt.key === 'k') {
-                    evt.stopImmediatePropagation()
-                    const container = document.getElementById('viewerContainer') as HTMLElement
-                    container.scrollBy({top: -40, behavior: evt.repeat ? 'instant' : 'smooth'})
-                } else if (evt.key === 'J') {
-                    evt.stopImmediatePropagation()
-                    const container = document.getElementById('viewerContainer') as HTMLElement
-                    if (evt.repeat) {
-                        container.scrollBy({top: container.offsetHeight/5, behavior: 'instant'})
-                    } else {
-                        container.scrollBy({top: container.offsetHeight, behavior: 'smooth'})
-                    }
-                } else if (evt.key === 'K') {
-                    evt.stopImmediatePropagation()
-                    const container = document.getElementById('viewerContainer') as HTMLElement
-                    if (evt.repeat) {
-                        container.scrollBy({top: -container.offsetHeight/5, behavior: 'instant'})
-                    } else {
-                        container.scrollBy({top: -container.offsetHeight, behavior: 'smooth'})
-                    }
-                } else if (evt.key === 'H') {
-                    evt.stopImmediatePropagation()
-                    const container = document.getElementById('viewerContainer') as HTMLElement
-                    if (evt.repeat) {
-                        container.scrollBy({left: -20, behavior: 'instant'})
-                    } else {
-                        container.scrollBy({left: -40, behavior: 'smooth'})
-                    }
-                } else if (evt.key === 'L') {
-                    evt.stopImmediatePropagation()
-                    const container = document.getElementById('viewerContainer') as HTMLElement
-                    if (evt.repeat) {
-                        container.scrollBy({left: 20, behavior: 'instant'})
-                    } else {
-                        container.scrollBy({left: 40, behavior: 'smooth'})
-                    }
+            if (this.embedded && !evt.altKey && !evt.ctrlKey && !evt.metaKey && ['J', 'K', 'H', 'L'].includes(evt.key)) {
+                evt.stopImmediatePropagation()
+                const container = document.getElementById('viewerContainer') as HTMLElement
+
+                const configMap: {[key: string]: ScrollToOptions} = {
+                    'J': { top: evt.repeat ? 20 : 40 },
+                    'K': { top: evt.repeat ? -20 : -40 },
+                    'H': { left: evt.repeat ? -20 : -40 },
+                    'L': { left: evt.repeat ? 20 : 40 },
+                }
+
+                if (configMap[evt.key]) {
+                    container.scrollBy({ ...configMap[evt.key], behavior: 'smooth' })
                 }
             }
         })

--- a/viewer/latexworkshop.ts
+++ b/viewer/latexworkshop.ts
@@ -649,19 +649,11 @@ class LateXWorkshopPdfViewer implements ILatexWorkshopPdfViewer {
                 if (evt.key === 'j') {
                     evt.stopImmediatePropagation()
                     const container = document.getElementById('viewerContainer') as HTMLElement
-                    if (evt.repeat) {
-                        container.scrollBy({top: 20, behavior: 'instant'})
-                    } else {
-                        container.scrollBy({top: 40, behavior: 'smooth'})
-                    }
+                    container.scrollBy({top: 40, behavior: evt.repeat ? 'instant' : 'smooth'})
                 } else if (evt.key === 'k') {
                     evt.stopImmediatePropagation()
                     const container = document.getElementById('viewerContainer') as HTMLElement
-                    if (evt.repeat) {
-                        container.scrollBy({top: -20, behavior: 'instant'})
-                    } else {
-                        container.scrollBy({top: -40, behavior: 'smooth'})
-                    }
+                    container.scrollBy({top: -40, behavior: evt.repeat ? 'instant' : 'smooth'})
                 } else if (evt.key === 'J') {
                     evt.stopImmediatePropagation()
                     const container = document.getElementById('viewerContainer') as HTMLElement

--- a/viewer/latexworkshop.ts
+++ b/viewer/latexworkshop.ts
@@ -643,6 +643,19 @@ class LateXWorkshopPdfViewer implements ILatexWorkshopPdfViewer {
             if (evt.key === 'Backspace' && evt.shiftKey && (evt.target as HTMLElement).nodeName !== 'INPUT') {
                 this.viewerHistory.forward()
             }
+
+            // Configure keys `j`, `k` for scrolling like up/down arrows
+            if (this.embedded && !evt.altKey && !evt.ctrlKey && !evt.shiftKey && !evt.metaKey) {
+                if (evt.key === 'j') {
+                    evt.stopImmediatePropagation()
+                    const container = document.getElementById('viewerContainer') as HTMLElement
+                    container.scrollBy({top: 40, behavior: 'auto'})
+                } else if (evt.key === 'k') {
+                    evt.stopImmediatePropagation()
+                    const container = document.getElementById('viewerContainer') as HTMLElement
+                    container.scrollBy({top: -40, behavior: 'auto'})
+                }
+            }
         })
 
         ;(document.getElementById('outerContainer') as HTMLElement).onmousemove = (e) => {


### PR DESCRIPTION
Hi,

I override some default keys of pdf.js to enable a VIM-like scrolling experience:
- `j, k` for a small vertical scrolls like VIM (by default in pdf.js, `j, k` will scroll pages)
- `J, K` now scroll pages
- `H, L` for small horizontal scrolls (I didn't assign to `h` since it is used by pdf.js to select the hand tool).

Can you consider merging this PR?

Thanks!