### PR TITLE
Add intellisense for macros defined by \NewDocumentCommand

### DIFF
--- a/src/completion/completer/macro.ts
+++ b/src/completion/completer/macro.ts
@@ -251,6 +251,21 @@ function parseAst(node: Ast.Node, filePath: string, defined?: Set<string>): CmdE
             parseInt(node.args?.[2].content?.[0].content) > 0) {
             args = (node.args?.[3].openMark === '[' ? '[]' : '{}') + '{}'.repeat(parseInt(node.args?.[2].content?.[0].content) - 1)
         }
+    } else if (node.type === 'macro' &&
+        ['ReNewDocumentCommand', 'NewDocumentCommand', 'ProvideDocumentCommand', 'DeclareDocumentCommand'].includes(node.content) &&
+        node.args?.length === 3 && node.args[0]?.content?.[0]?.type === 'macro') {
+        found = true
+        name = node.args[0].content[0].content
+        node.args[1].content.forEach((entry: Ast.Node) => {
+            if (entry.type === 'string') {
+                if (entry.content === 'm') {
+                    args += '{}'
+                }
+                if (entry.content === 'o' || entry.content === 'O') {
+                    args += '[]'
+                }
+            }
+        })
     }
 
     if (found && !defined.has(`${name}${args}`)) {

--- a/src/completion/completer/macro.ts
+++ b/src/completion/completer/macro.ts
@@ -260,8 +260,7 @@ function parseAst(node: Ast.Node, filePath: string, defined?: Set<string>): CmdE
             if (entry.type === 'string') {
                 if (entry.content === 'm') {
                     args += '{}'
-                }
-                if (entry.content === 'o' || entry.content === 'O') {
+                } else if (entry.content === 'o' || entry.content === 'O') {
                     args += '[]'
                 }
             }

--- a/test/fixtures/armory/intellisense/newdocumentcommand.tex
+++ b/test/fixtures/armory/intellisense/newdocumentcommand.tex
@@ -1,0 +1,9 @@
+\documentclass[10pt]{article}
+\usepackage{xparse}
+\NewDocumentCommand\testNoArg{}{ABC}
+\DeclareDocumentCommand\testA{m}{ABC #1}
+\NewDocumentCommand{\testB}{O{}m}{ABC #2 #1}
+\ProvideDocumentCommand{\testC}{m o O{} m r() m}{ABC}
+\begin{document}
+
+\end{document}

--- a/test/suites/04_intellisense.test.ts
+++ b/test/suites/04_intellisense.test.ts
@@ -156,6 +156,17 @@ suite('Intellisense test suite', () => {
         assert.ok(suggestions.labels.includes('\\fix[]{}{}'))
     })
 
+    test.run('command intellisense with cmds defined by \\NewDocumentCommand', async (fixture: string) => {
+        await test.load(fixture, [
+            {src: 'intellisense/newdocumentcommand.tex', dst: 'main.tex'}
+        ])
+        const suggestions = test.suggest(0, 1)
+        assert.ok(suggestions.labels.includes('\\testNoArg'))
+        assert.ok(suggestions.labels.includes('\\testA{}'))
+        assert.ok(suggestions.labels.includes('\\testB[]{}'))
+        assert.ok(suggestions.labels.includes('\\testC{}[][]{}{}'))
+    })
+
     test.run('command intellisense with config `intellisense.argumentHint.enabled`', async (fixture: string) => {
         await vscode.workspace.getConfiguration('latex-workshop').update('intellisense.argumentHint.enabled', true)
         await test.load(fixture, [


### PR DESCRIPTION
This PR closes #3995 and adds (partial) intellisense support for macros defined by `\ReNewDocumentCommand`, `\NewDocumentCommand`, `\ProvideDocumentCommand`, `\DeclareDocumentCommand` from the `xparse` package.

These commands expect three arguments: `{macro_name}`, `{args_list)`, `{definition}`. The argument list allows to define argument that have their own delimiters such as `(...)`, `<...>`, or the same token used for opening and closing as in the `\verb` command. This is not supported for now as our `CmdSignature` interface only handles compulsory arguments `{}` or optional ones `[]`. The current implementation only supports the following types in the argument list 

- `m`: a mandatory argument
- `o` or `O`: an optional argument

Anything else is simply ignored.

