### PR TITLE
Add source to warning messages

### DIFF
--- a/src/parse/parser/latexlog.ts
+++ b/src/parse/parser/latexlog.ts
@@ -191,7 +191,7 @@ function parseLine(line: string, state: ParserState) {
             type: 'warning',
             file: filename,
             line: result[4] ? parseInt(result[4], 10) : 1,
-            text: result[3] + result[5]
+            text: result[1] + ': ' + result[3] + result[5]
         }
         state.searchEmptyLine = true
         return

--- a/src/parse/parser/parserutils.ts
+++ b/src/parse/parser/parserutils.ts
@@ -56,7 +56,7 @@ export function showCompilerDiagnostics(diagnostics: vscode.DiagnosticCollection
         }
 
         const range = new vscode.Range(new vscode.Position(item.line - 1, startChar), new vscode.Position(item.line - 1, endChar))
-        const diag = new vscode.Diagnostic(range, item.text, DIAGNOSTIC_SEVERITY[item.type])
+        const diag = new vscode.Diagnostic(range, item.text.trimEnd(), DIAGNOSTIC_SEVERITY[item.type])
         diag.source = diagnostics.name
         if (diagsCollection[item.file] === undefined) {
             diagsCollection[item.file] = []


### PR DESCRIPTION
I noticed Latex-Workshop shows the package name when there is a PackageError, but not when there is a PackageWarning.

I would like to have the package name printed, so I can get a better understanding of the warning messages without having to look into the LaTeX compiler log.

I searched for 'Warning' in the codebase, and found about `latexlog.ts`. I guess the regex in there are for parsing the compiler log. I found a line that used the `latexWarn` regex, changed the message generated to include the package name, followed by a colon and a space to get a readable message.

I tested it by changing `latexlog.js` in my vscode extensions directory; this is a very small change and shouldn't introduce any bugs.

Would you consider merging this little change ?