### PR TITLE
Update leading string for doctex line comments

### DIFF
--- a/syntax/doctex-language-configuration.json
+++ b/syntax/doctex-language-configuration.json
@@ -1,6 +1,6 @@
 {
 	"comments": {
-		"lineComment": "^^A"
+		"lineComment": "%^^A"
 	},
 	"brackets": [
 		["{", "}"],


### PR DESCRIPTION
I changed the leading string for line comments in doctex files to `%^^A`.
This would cause the line to be ignored in all scenarios: DocStrip by `ins` file, TeX, and LaTeX.

https://tex.stackexchange.com/questions/415738/is-it-possible-to-make-comments-in-dtx-file#comment1040003_415744