### PR TITLE
Added optional capture pattern for `\subfix` in bibliography regex

### DIFF
--- a/src/core/cache.ts
+++ b/src/core/cache.ts
@@ -387,7 +387,7 @@ function updateElements(fileCache: FileCache) {
  * for.
  */
 function updateBibfiles(fileCache: FileCache) {
-    const bibReg = /(?:\\(?:bibliography|addbibresource)(?:\[[^[\]{}]*\])?){([\s\S]+?)}|(?:\\putbib)\[(.+?)\]/gm
+    const bibReg = /(?:\\(?:bibliography|addbibresource)(?:\[[^[\]{}]*\])?){(?:\\subfix{)?([\s\S]+?)(?:\})?}|(?:\\putbib)\[(.+?)\]/gm
     while (true) {
         const result = bibReg.exec(fileCache.contentTrimmed)
         if (!result) {


### PR DESCRIPTION
Fixes #4192.

Simply added optional capture groups `(?:\\subfix{)?` and `(?:\})?` that make the regex match if the bibliography is imported with `\subfix` when using the `subfiles` package.