### PR TITLE
Fix forward SyncTex accuracy in internal browser by providing a range location indication alternative

### DIFF
--- a/package.json
+++ b/package.json
@@ -1686,7 +1686,7 @@
             "Indicates a possible range with a rectangular SyncTeX indicator.",
             "Indicates a single specific spot with a red circle SyncTeX indicator"
           ],
-          "default": "Range",
+          "default": "Spot",
           "markdownDescription": "Define the behavior of SyncTex indicator after a forward SyncTeX in the PDF viewer (tab or browser). Valid when use SyncTex binary (latex-workshop.synctex.synctexjs.enabled = false)."
         },
         "latex-workshop.synctex.afterBuild.enabled": {

--- a/package.json
+++ b/package.json
@@ -1672,16 +1672,16 @@
           "scope": "window",
           "type": "string",
           "enum": [
-            "disabled",
-            "spot",
-            "range"
+            "none",
+            "circle",
+            "rectangle"
           ],
           "enumDescriptions": [
-            "Disable indicator.",
-            "Indicates a single specific spot with a red circle SyncTeX indicator.",
-            "Indicates a possible range with a blue rectangular SyncTeX indicator. (Valid when not using synctex.js)"
+            "Hide the indicator.",
+            "Indicates a possible location with a red circular SyncTeX indicator.",
+            "Indicates the whole line selected in the Tex file with a red rectangular SyncTeX indicator. (Valid when not using synctex.js)"
           ],
-          "default": "spot",
+          "default": "circle",
           "markdownDescription": "Define the visibility and style of SyncTeX indicator after a forward SyncTeX in the PDF viewer."
         },
         "latex-workshop.synctex.afterBuild.enabled": {

--- a/package.json
+++ b/package.json
@@ -1672,7 +1672,22 @@
           "scope": "window",
           "type": "boolean",
           "default": true,
-          "markdownDescription": "Define the visibility of SyncTeX indicator (a red highlighting circle) after a forward SyncTeX in the PDF viewer."
+          "markdownDescription": "Define the visibility of SyncTeX indicator after a forward SyncTeX in the PDF viewer."
+        },
+        "latex-workshop.synctex.indicator.type": {
+          "scope": "window",
+          "type": "string",
+          "when": "!latex-workshop.synctex.synctexjs.enabled",
+          "enum": [
+            "Range",
+            "Spot"
+          ],
+          "enumDescriptions": [
+            "Indicates a possible range with a rectangular SyncTeX indicator.",
+            "Indicates a single specific spot with a red circle SyncTeX indicator"
+          ],
+          "default": "Range",
+          "markdownDescription": "Define the behavior of SyncTex indicator after a forward SyncTeX in the PDF viewer (tab or browser). Valid when use SyncTex binary (latex-workshop.synctex.synctexjs.enabled = false)."
         },
         "latex-workshop.synctex.afterBuild.enabled": {
           "scope": "window",

--- a/package.json
+++ b/package.json
@@ -1670,24 +1670,19 @@
         },
         "latex-workshop.synctex.indicator.enabled": {
           "scope": "window",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Define the visibility of SyncTeX indicator after a forward SyncTeX in the PDF viewer."
-        },
-        "latex-workshop.synctex.indicator.type": {
-          "scope": "window",
           "type": "string",
-          "when": "!latex-workshop.synctex.synctexjs.enabled",
           "enum": [
-            "Range",
-            "Spot"
+            "disabled",
+            "spot",
+            "range"
           ],
           "enumDescriptions": [
-            "Indicates a possible range with a rectangular SyncTeX indicator.",
-            "Indicates a single specific spot with a red circle SyncTeX indicator"
+            "Disable indicator.",
+            "Indicates a single specific spot with a red circle SyncTeX indicator.",
+            "Indicates a possible range with a blue rectangular SyncTeX indicator. (Valid when not using synctex.js)"
           ],
-          "default": "Spot",
-          "markdownDescription": "Define the behavior of SyncTex indicator after a forward SyncTeX in the PDF viewer (tab or browser). Valid when use SyncTex binary (latex-workshop.synctex.synctexjs.enabled = false)."
+          "default": "spot",
+          "markdownDescription": "Define the visibility and style of SyncTeX indicator after a forward SyncTeX in the PDF viewer."
         },
         "latex-workshop.synctex.afterBuild.enabled": {
           "scope": "window",

--- a/src/locate/synctex.ts
+++ b/src/locate/synctex.ts
@@ -242,7 +242,7 @@ function toPDF(args?: {line: number, filePath: string}, forcedViewer: 'auto' | '
             if (!record) {
                 return
             }
-            void lw.viewer.locate(pdfFile, record, 'spot')
+            void lw.viewer.locate(pdfFile, record)
         } catch (e) {
             logger.logError('Forward SyncTeX failed.', e)
         }
@@ -267,7 +267,7 @@ function toPDF(args?: {line: number, filePath: string}, forcedViewer: 'auto' | '
 
         void callSyncTeXToPDF(line, character, filePath, pdfFile, indicatorType).then( (record) => {
             if (pdfFile) {
-                    void lw.viewer.locate(pdfFile, record, indicatorType)
+                    void lw.viewer.locate(pdfFile, record)
             }
         })
 

--- a/src/locate/synctex.ts
+++ b/src/locate/synctex.ts
@@ -246,7 +246,7 @@ function toPDF(args?: {line: number, filePath: string}, forcedViewer: 'auto' | '
         const indicatorType = configuration.get('synctex.indicator.type')
 
         if (indicatorType === 'Range') {
-            void callSyncTeXToPDFRange(line, character, filePath, pdfFile).then( (recordList) => {
+            void callSyncTeXToPDFRange(line, filePath, pdfFile).then( (recordList) => {
                 if (pdfFile) {
                     void lw.viewer.locateRange(pdfFile, recordList)
                 }
@@ -327,12 +327,11 @@ function callSyncTeXToPDF(line: number, col: number, filePath: string, pdfFile: 
  * resolving to a SyncTeXRecordToPDFAllList object.
  *
  * @param line - The line number in the TeX file.
- * @param _col - The character position (column) in the line. (not used)
  * @param filePath - The path of the TeX file.
  * @param pdfFile - The path of the PDF file.
  * @returns A promise resolving to a SyncTeXRecordToPDFAllList object.
  */
-function callSyncTeXToPDFRange(line: number, _col: number, filePath: string, pdfFile: string): Thenable<SyncTeXRecordToPDFAllList> {
+function callSyncTeXToPDFRange(line: number, filePath: string, pdfFile: string): Thenable<SyncTeXRecordToPDFAllList> {
     const configuration = vscode.workspace.getConfiguration('latex-workshop')
     const docker = configuration.get('docker.enabled')
     // Pass column parameter with 0 to make SyncTex Cmd ignore specific character, returning whole range of location with respect to the line.

--- a/src/locate/synctex.ts
+++ b/src/locate/synctex.ts
@@ -267,7 +267,7 @@ function toPDF(args?: {line: number, filePath: string}, forcedViewer: 'auto' | '
 
         void callSyncTeXToPDF(line, character, filePath, pdfFile, indicatorType).then( (record) => {
             if (pdfFile) {
-                    void lw.viewer.locate(pdfFile, record)
+                void lw.viewer.locate(pdfFile, record)
             }
         })
 

--- a/src/locate/synctex.ts
+++ b/src/locate/synctex.ts
@@ -65,63 +65,63 @@ function parseToPDF(result: string): SyncTeXRecordToPDF {
  * Parse the result of SyncTeX forward to PDF with a list.
  *
  * This function takes the result of SyncTeX forward to PDF as a string and
- * parses it to extract page number, x-coordinate, y-coordinate, box-based 
- * coordinates (h, v, H, W), and whether the red indicator should be shown 
- * in the viewer.
+ * parses it to extract page number, x-coordinate, y-coordinate, box-based
+ * coordinates (h, v, H, W), and whether the red indicator should be shown in
+ * the viewer.
  *
  * @param result - The result string of SyncTeX forward to PDF.
- * @returns A SyncTeXRecordToPDFAllList object containing a list of records, 
- * with each record containing page number, x-coordinate, y-coordinate, 
+ * @returns A SyncTeXRecordToPDFAllList object containing a list of records,
+ * with each record containing page number, x-coordinate, y-coordinate,
  * h-coordinate, v-coordinate, H-coordinate, W-coordinate, and an indicator.
  * @throws Error if there is a parsing error.
  */
 function parseToPDFList(result: string): SyncTeXRecordToPDFAll[] {
-    const records: SyncTeXRecordToPDFAll[] = [];
-    let started = false;
-    let recordIndex = -1;
+    const records: SyncTeXRecordToPDFAll[] = []
+    let started = false
+    let recordIndex = -1
 
     for (const line of result.split('\n')) {
         if (line.includes('SyncTeX result begin')) {
-            started = true;
-            continue;
+            started = true
+            continue
         }
 
         if (line.includes('SyncTeX result end')) {
-            break;
+            break
         }
 
         if (!started) {
-            continue;
+            continue
         }
 
-        const pos = line.indexOf(':');
+        const pos = line.indexOf(':')
         if (pos < 0) {
-            continue;
+            continue
         }
 
-        const key = line.substring(0, pos);
-        const value = line.substring(pos + 1).trim();
+        const key = line.substring(0, pos)
+        const value = line.substring(pos + 1).trim()
 
-        if (key == 'Output') {
-            recordIndex += 1;
-            const record : SyncTeXRecordToPDFAll = { page: 0, x: 0, y: 0, h: 0, v: 0, W: 0, H: 0, indicator: true };
-            records[recordIndex] = record;
+        if (key === 'Output') {
+            recordIndex += 1
+            const record: SyncTeXRecordToPDFAll = { page: 0, x: 0, y: 0, h: 0, v: 0, W: 0, H: 0, indicator: true }
+            records[recordIndex] = record
         }
 
         if (key === 'Page' || key === 'h' || key === 'v' || key === 'W' || key === 'H' || key === 'x' || key === 'y') {
-            const record = records[recordIndex];
+            const record = records[recordIndex]
             if (record) {
                 if (key === 'Page') {
                     record['page'] = Number(value)
                 } else {
-                    record[key] = Number(value);
+                    record[key] = Number(value)
                 }
             }
         }
     }
 
-    if (recordIndex != -1) {
-        return records;
+    if (recordIndex !== -1) {
+        return records
     } else {
         throw(new Error('parse error when parsing the result of synctex forward.'))
     }
@@ -238,15 +238,13 @@ function toPDF(args?: {line: number, filePath: string}, forcedViewer: 'auto' | '
     let indicatorType: string
 
     const indicatorConfig = configuration.get('synctex.indicator.enabled')
-    
-    if (typeof indicatorConfig === "boolean") {
+
+    if (typeof indicatorConfig === 'boolean') {
         // if configuration is boolean in previous version, then use fallback logic.
         indicatorType = indicatorConfig ? 'circle' : 'none'
-    } else if (typeof indicatorConfig === "string") {
-        // if configuration is enum, then use directly.
-        indicatorType = indicatorConfig
     } else {
-        throw new Error("Invalid configuration value for indicator enabled")
+        // if configuration is enum, then use directly.
+        indicatorType = indicatorConfig as string
     }
 
     // guard if indicatorConfig is illegal or equals to 'none', display none.
@@ -286,9 +284,9 @@ function toPDF(args?: {line: number, filePath: string}, forcedViewer: 'auto' | '
  * @param indicatorType - The type of the SyncTex indicator.
  * @returns A promise resolving to a SyncTeXRecordToPDF object or a SyncTeXRecordToPDF[] object.
  */
-function callSyncTeXToPDF(line: number, col: number, filePath: string, pdfFile: string, indicatorType: string): Thenable<SyncTeXRecordToPDF>;
-function callSyncTeXToPDF(line: number, col: number, filePath: string, pdfFile: string, indicatorType: string): Thenable<SyncTeXRecordToPDFAll[]>;
-function callSyncTeXToPDF(line: number, col: number, filePath: string, pdfFile: string, indicatorType: string): Thenable<SyncTeXRecordToPDF> | Thenable<SyncTeXRecordToPDFAll[]>  {
+function callSyncTeXToPDF(line: number, col: number, filePath: string, pdfFile: string, indicatorType: string): Thenable<SyncTeXRecordToPDF>
+function callSyncTeXToPDF(line: number, col: number, filePath: string, pdfFile: string, indicatorType: string): Thenable<SyncTeXRecordToPDFAll[]>
+function callSyncTeXToPDF(line: number, col: number, filePath: string, pdfFile: string, indicatorType: string): Thenable<SyncTeXRecordToPDF> | Thenable<SyncTeXRecordToPDFAll[]> {
     const configuration = vscode.workspace.getConfiguration('latex-workshop')
     const docker = configuration.get('docker.enabled')
 

--- a/src/preview/viewer.ts
+++ b/src/preview/viewer.ts
@@ -392,7 +392,7 @@ function getParams(): PdfViewerParams {
  * @param pdfFile The path of a PDF file.
  * @param record The position to be revealed.
  */
-async function locate(pdfFile: string, record: SyncTeXRecordToPDF | SyncTeXRecordToPDFAll[], indicatorType: string): Promise<void> {
+async function locate(pdfFile: string, record: SyncTeXRecordToPDF | SyncTeXRecordToPDFAll[]): Promise<void> {
     const pdfUri = vscode.Uri.file(pdfFile)
     let clientSet = manager.getClients(pdfUri)
     if (clientSet === undefined || clientSet.size === 0) {
@@ -407,14 +407,7 @@ async function locate(pdfFile: string, record: SyncTeXRecordToPDF | SyncTeXRecor
     const needDelay = showInvisibleWebviewPanel(pdfUri)
     for (const client of clientSet) {
         setTimeout(() => {
-            if (indicatorType === 'range') {
-                const rangeRecord = record as SyncTeXRecordToPDFAll[]
-                client.send({type: 'synctexRange', data: rangeRecord})
-            } else if (indicatorType === 'spot') {
-                const spotRecord = record as SyncTeXRecordToPDF
-                client.send({type: 'synctex', data: spotRecord})
-            }
-
+            client.send({type: 'synctex', data: record})
         }, needDelay ? 200 : 0)
         logger.log(`Try to synctex ${pdfFile}`)
     }

--- a/src/preview/viewer.ts
+++ b/src/preview/viewer.ts
@@ -4,7 +4,7 @@ import * as path from 'path'
 import * as os from 'os'
 import * as cs from 'cross-spawn'
 import { lw } from '../lw'
-import type { SyncTeXRecordToPDF, ViewerMode } from '../types'
+import type { SyncTeXRecordToPDF, SyncTeXRecordToPDFAllList, ViewerMode } from '../types'
 import * as manager from './viewer/pdfviewermanager'
 import { populate } from './viewer/pdfviewerpanel'
 
@@ -21,6 +21,7 @@ export {
     handler,
     isViewing,
     locate,
+    locateRange,
     viewInWebviewPanel,
     refresh,
     view
@@ -411,6 +412,38 @@ async function locate(pdfFile: string, record: SyncTeXRecordToPDF): Promise<void
             client.send({type: 'synctex', data: {...record, indicator}})
         }, needDelay ? 200 : 0)
         logger.log(`Try to synctex ${pdfFile}`)
+    }
+}
+
+/**
+ * Reveals the position range of `records` on the internal PDF viewers with a Rectangle indicator.
+ *
+ * @param pdfFile The path of a PDF file.
+ * @param recordList The list of positions to be revealed.
+ */
+async function locateRange(pdfFile: string, recordList: SyncTeXRecordToPDFAllList): Promise<void> {
+    const pdfUri = vscode.Uri.file(pdfFile);
+    let clientSet = manager.getClients(pdfUri);
+    if (clientSet === undefined || clientSet.size === 0) {
+      logger.log(`PDF is not opened: ${pdfFile}, try opening.`);
+      await view(pdfFile);
+      clientSet = manager.getClients(pdfUri);
+    }
+    if (clientSet === undefined || clientSet.size === 0) {
+      logger.log(`PDF cannot be opened: ${pdfFile}.`);
+      return;
+    }
+    const needDelay = showInvisibleWebviewPanel(pdfUri);
+    for (const client of clientSet) {
+      setTimeout(() => {
+        const indicator = vscode.workspace
+          .getConfiguration('latex-workshop')
+          .get('synctex.indicator.enabled') as boolean;
+
+        client.send({ type: 'synctexRange', data: { records: recordList.records, indicator } });
+
+      }, needDelay ? 200 : 0);
+      logger.log(`Try to synctex ${pdfFile}`);
     }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -108,6 +108,20 @@ export type SyncTeXRecordToTeX = {
     column: number
 }
 
+export type SyncTeXRecordToPDFAll = {
+    Page: number;
+    x: number;
+    y: number;
+    h: number;
+    v: number;
+    W: number;
+    H: number;
+}
+
+export type SyncTeXRecordToPDFAllList = {
+    records: SyncTeXRecordToPDFAll[];
+}
+
 export interface LaTeXLinter {
     readonly linterDiagnostics: vscode.DiagnosticCollection,
     getName(): string,

--- a/src/types.ts
+++ b/src/types.ts
@@ -108,18 +108,11 @@ export type SyncTeXRecordToTeX = {
     column: number
 }
 
-export type SyncTeXRecordToPDFAll = {
-    Page: number;
-    x: number;
-    y: number;
+export type SyncTeXRecordToPDFAll = SyncTeXRecordToPDF & {
     h: number;
     v: number;
     W: number;
     H: number;
-}
-
-export type SyncTeXRecordToPDFAllList = {
-    records: SyncTeXRecordToPDFAll[];
 }
 
 export interface LaTeXLinter {

--- a/src/types.ts
+++ b/src/types.ts
@@ -109,10 +109,10 @@ export type SyncTeXRecordToTeX = {
 }
 
 export type SyncTeXRecordToPDFAll = SyncTeXRecordToPDF & {
-    h: number;
-    v: number;
-    W: number;
-    H: number;
+    h: number,
+    v: number,
+    W: number,
+    H: number
 }
 
 export interface LaTeXLinter {

--- a/types/latex-workshop-protocol-types/index.d.ts
+++ b/types/latex-workshop-protocol-types/index.d.ts
@@ -17,12 +17,9 @@ export type ServerResponse = {
     type: 'refresh'
 } | {
     type: 'synctex',
-    data: SynctexData 
+    data: SynctexData | SynctexRangeData[]
 } | {
     type: 'reload'
-} | {
-    type: 'synctexRange',
-    data: SynctexRangeData[]
 }
 
 export type PdfViewerParams = {

--- a/types/latex-workshop-protocol-types/index.d.ts
+++ b/types/latex-workshop-protocol-types/index.d.ts
@@ -1,8 +1,12 @@
 
-type SyncTeXRecordToPDFAll = {
-    Page: number;
+type SynctexData = {
+    page: number;
     x: number;
     y: number;
+    indicator: boolean;
+}
+
+type SynctexRangeData = SynctexData & {
     h: number;
     v: number;
     W: number;
@@ -13,20 +17,12 @@ export type ServerResponse = {
     type: 'refresh'
 } | {
     type: 'synctex',
-    data: {
-        page: number,
-        x: number,
-        y: number,
-        indicator: boolean
-    }
+    data: SynctexData 
 } | {
     type: 'reload'
 } | {
     type: 'synctexRange',
-    data: {
-        records: SyncTeXRecordToPDFAll[],
-        indicator: boolean
-    }
+    data: SynctexRangeData[]
 }
 
 export type PdfViewerParams = {

--- a/types/latex-workshop-protocol-types/index.d.ts
+++ b/types/latex-workshop-protocol-types/index.d.ts
@@ -1,3 +1,14 @@
+
+type SyncTeXRecordToPDFAll = {
+    Page: number;
+    x: number;
+    y: number;
+    h: number;
+    v: number;
+    W: number;
+    H: number;
+}
+
 export type ServerResponse = {
     type: 'refresh'
 } | {
@@ -10,6 +21,12 @@ export type ServerResponse = {
     }
 } | {
     type: 'reload'
+} | {
+    type: 'synctexRange',
+    data: {
+        records: SyncTeXRecordToPDFAll[],
+        indicator: boolean
+    }
 }
 
 export type PdfViewerParams = {

--- a/viewer/latexworkshop.css
+++ b/viewer/latexworkshop.css
@@ -56,19 +56,22 @@ html[dir='rtl'] .findbar {
 
 @keyframes synctex-indicator-fadeOut {
     0% {
-      background-color: rgba(255, 0, 0, 0.4);
+        background-color: rgba(255, 0, 0, 0.4);
+    }
+    25% {
+        background-color: rgba(255, 0, 0, 0.4);
     }
     100% {
-      background-color: rgba(0, 0, 0, 0);
+        background-color: rgba(0, 0, 0, 0);
     }
 }
 
 .synctex-indicator-rect {
-  position: absolute;
-  z-index: 100000;
-  background-color: rgba(0, 0, 255, 0.5);
-  pointer-events: none;
-  animation: synctex-indicator-fadeOut 2s forwards;
+    position: absolute;
+    z-index: 100000;
+    background-color: rgba(0, 0, 255, 0.5);
+    pointer-events: none;
+    animation: synctex-indicator-fadeOut 1s forwards;
 }
 
 #synctex-indicator.show {

--- a/viewer/latexworkshop.css
+++ b/viewer/latexworkshop.css
@@ -56,10 +56,10 @@ html[dir='rtl'] .findbar {
 
 @keyframes synctex-indicator-fadeOut {
     0% {
-      background-color: rgba(0, 0, 255, 0.4);
+      background-color: rgba(255, 0, 0, 0.4);
     }
     100% {
-      background-color: rgba(0, 0, 255, 0);
+      background-color: rgba(0, 0, 0, 0);
     }
 }
 

--- a/viewer/latexworkshop.css
+++ b/viewer/latexworkshop.css
@@ -54,6 +54,23 @@ html[dir='rtl'] .findbar {
     transform: translate(-50%, -50%);
 }
 
+@keyframes synctex-indicator-fadeOut {
+    0% {
+      background-color: rgba(0, 0, 255, 0.4);
+    }
+    100% {
+      background-color: rgba(0, 0, 255, 0);
+    }
+}
+
+.synctex-indicator-rect {
+  position: absolute;
+  z-index: 100000;
+  background-color: rgba(0, 0, 255, 0.5);
+  pointer-events: none;
+  animation: synctex-indicator-fadeOut 2s forwards;
+}
+
 #synctex-indicator.show {
     transition: none;
     opacity: 0.8;

--- a/viewer/latexworkshop.ts
+++ b/viewer/latexworkshop.ts
@@ -312,10 +312,12 @@ class LateXWorkshopPdfViewer implements ILatexWorkshopPdfViewer {
         
         const container = document.getElementById('viewerContainer') as HTMLElement
 
+        // if the type of data is SynctexRangeData[], parse as a rectangular indicator.
         if (Array.isArray(data)){
             const indicatorTemplate = document.getElementById('synctex-indicator') as HTMLElement
             const indicatorParent = indicatorTemplate.parentNode as HTMLElement
 
+            // for each record in the array, create a rectangle respectively.
             for (const record of data) {
                 const pos_left_top = PDFViewerApplication.pdfViewer._pages[record.page - 1].viewport.convertToViewportPoint(record.h, record.v - record.H)
                 const pos_right_down = PDFViewerApplication.pdfViewer._pages[record.page - 1].viewport.convertToViewportPoint(record.h + record.W, record.v)

--- a/viewer/latexworkshop.ts
+++ b/viewer/latexworkshop.ts
@@ -7,7 +7,7 @@ import {ExternalPromise} from './components/externalpromise.js'
 import {ViewerHistory} from './components/viewerhistory.js'
 
 import type {PdfjsEventName, IDisposable, ILatexWorkshopPdfViewer, IPDFViewerApplication, IPDFViewerApplicationOptions} from './components/interface.js'
-import type {ClientRequest, ServerResponse, PanelManagerResponse, PanelRequest, PdfViewerParams, PdfViewerState, SyncTeXRecordToPDFAll} from '../types/latex-workshop-protocol-types/index'
+import type {ClientRequest, ServerResponse, PanelManagerResponse, PanelRequest, PdfViewerParams, PdfViewerState, SynctexRangeData} from '../types/latex-workshop-protocol-types/index'
 
 declare const PDFViewerApplication: IPDFViewerApplication
 declare const PDFViewerApplicationOptions: IPDFViewerApplicationOptions
@@ -346,7 +346,7 @@ class LateXWorkshopPdfViewer implements ILatexWorkshopPdfViewer {
         // }, 1000)
     }
 
-    private forwardSynctexRange(position: { records: SyncTeXRecordToPDFAll[], indicator: boolean }) {
+    private forwardSynctexRange(records: SynctexRangeData[]) {
         if (!this.synctexEnabled) {
             this.addLogMessage('SyncTeX temporarily disabled.')
             return
@@ -355,16 +355,16 @@ class LateXWorkshopPdfViewer implements ILatexWorkshopPdfViewer {
         const indicatorTemplate = document.getElementById('synctex-indicator') as HTMLElement
         const indicatorParent = indicatorTemplate.parentNode as HTMLElement
 
-        for (const record of position.records) {
+        for (const record of records) {
             const container = document.getElementById('viewerContainer') as HTMLElement
 
-            const pos_left_top = PDFViewerApplication.pdfViewer._pages[record.Page - 1].viewport.convertToViewportPoint(record.h, record.v - record.H)
-            const pos_right_down = PDFViewerApplication.pdfViewer._pages[record.Page - 1].viewport.convertToViewportPoint(record.h + record.W, record.v)
+            const pos_left_top = PDFViewerApplication.pdfViewer._pages[record.page - 1].viewport.convertToViewportPoint(record.h, record.v - record.H)
+            const pos_right_down = PDFViewerApplication.pdfViewer._pages[record.page - 1].viewport.convertToViewportPoint(record.h + record.W, record.v)
 
             const width_px = pos_right_down[0] - pos_left_top[0]
             const height_px = pos_left_top[1] - pos_right_down[1]
 
-            const page = document.getElementsByClassName('page')[record.Page - 1] as HTMLElement
+            const page = document.getElementsByClassName('page')[record.page - 1] as HTMLElement
 
             const maxScrollX = window.innerWidth
             const minScrollX = 0
@@ -384,7 +384,7 @@ class LateXWorkshopPdfViewer implements ILatexWorkshopPdfViewer {
             }
             this.viewerHistory.set(container.scrollTop)
     
-            if (!position.indicator) {
+            if (!record.indicator) {
                 return
             }
 


### PR DESCRIPTION
This proposed solution for issue #4168  involves implementing a range indicator in the PDF viewer based on the line position in the editor. The solution includes several major modifications:

- Adding a configuration option to choose the indicator type between indicating a single location or a range.
- Ignoring the column parameter when invoking the SyncTex binary when indicating a range.
- Parsing all the SyncTex binary records and extracting the box (rectangle) coordinates.
- Handling the list of records in the viewer, calculating the rectangular coordinates, and displaying them.
- Adding CSS animation to show the corresponding area in the PDF.

To use this solution, follow these steps:
- Uncheck the configuration option `latex-workshop.synctex.synctexjs.enabled`.
- Choose the `Range` option in the `latex-workshop.synctex.indicator.type` configuration.

By implementing these changes, the PDF viewer will display a range rectangular indicator that corresponds to the selected line in the editor.