### PR TITLE
Bugfix: Synctex does not work while using vscode in browser

### DIFF
--- a/viewer/latexworkshop.ts
+++ b/viewer/latexworkshop.ts
@@ -33,7 +33,7 @@ class LateXWorkshopPdfViewer implements ILatexWorkshopPdfViewer {
     private readonly webViewerLoaded: Promise<void> = new Promise((resolve) => {
         document.addEventListener('webviewerloaded', () => resolve() )
 
-        // Bugfix when using LaTeXWorkshop with web based version of vscode
+        // https://github.com/James-Yu/LaTeX-Workshop/pull/4220#issuecomment-2034520751
         try {
           parent.document.addEventListener('webviewerloaded', () => resolve() )
         } catch(err) { /* do nothing */ }

--- a/viewer/latexworkshop.ts
+++ b/viewer/latexworkshop.ts
@@ -35,7 +35,7 @@ class LateXWorkshopPdfViewer implements ILatexWorkshopPdfViewer {
 
         // Bugfix when using LaTeXWorkshop with web based version of vscode
         try {
-          parent.document.addEventListener('webviewerloaded', () => resolve() );
+          parent.document.addEventListener('webviewerloaded', () => resolve() )
         } catch(err) { /* do nothing */ }
     })
     private synctexEnabled = true

--- a/viewer/latexworkshop.ts
+++ b/viewer/latexworkshop.ts
@@ -32,6 +32,11 @@ class LateXWorkshopPdfViewer implements ILatexWorkshopPdfViewer {
     // - https://github.com/mozilla/pdf.js/pull/10318
     private readonly webViewerLoaded: Promise<void> = new Promise((resolve) => {
         document.addEventListener('webviewerloaded', () => resolve() )
+
+        // Bugfix when using LaTeXWorkshop with web based version of vscode
+        try {
+          parent.document.addEventListener('webviewerloaded', () => resolve() );
+        } catch(err) { /* do nothing */ }
     })
     private synctexEnabled = true
     private autoReloadEnabled = true


### PR DESCRIPTION
Although [code-server](https://github.com/coder/code-server) is not officially supported, hereby a bugfix making (ctrl) + click work in the browser.

Namely, before synctex is enabled, it waits before PDF.js is loaded. PDF.js signals this by sending a custom "webviewloaded" event. It first tries to send it to the parent window and if this fails, it send it to its own window.
in code-server, this parent _exists_ as a iframe, hence this event is where there are no listeners. Issue is fixed by added a listener to the parent window if possible.
