### PR TITLE
Customize docker (or podman) path

### DIFF
--- a/package.json
+++ b/package.json
@@ -2105,6 +2105,12 @@
           "default": "",
           "markdownDescription": "Define the image for `latexmk`, `synctex`, `texcount`, and `latexindent`."
         },
+        "latex-workshop.docker.path": {
+          "scope": "window",
+          "type": "string",
+          "default": "docker",
+          "markdownDescription": "Docker (or Podman) executable name or path."
+        },
         "latex-workshop.showContextMenu": {
           "scope": "window",
           "type": "boolean",

--- a/scripts/latexindent
+++ b/scripts/latexindent
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker run -i --rm -w "$(pwd)" -v "$(pwd):$(pwd)" $LATEXWORKSHOP_DOCKER_LATEX latexindent "$@"
+$LATEXWORKSHOP_DOCKER_PATH run -i --rm -w "$(pwd)" -v "$(pwd):$(pwd)" $LATEXWORKSHOP_DOCKER_LATEX latexindent "$@"

--- a/scripts/latexindent.bat
+++ b/scripts/latexindent.bat
@@ -1,1 +1,1 @@
-@docker run -i --rm -w /data -v "%cd%:/data" %LATEXWORKSHOP_DOCKER_LATEX% latexindent %*
+@%LATEXWORKSHOP_DOCKER_PATH% run -i --rm -w /data -v "%cd%:/data" %LATEXWORKSHOP_DOCKER_LATEX% latexindent %*

--- a/scripts/latexmk
+++ b/scripts/latexmk
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker run -i --rm -w "$(pwd)" -v "$(pwd):$(pwd)" $LATEXWORKSHOP_DOCKER_LATEX latexmk "$@"
+$LATEXWORKSHOP_DOCKER_PATH run -i --rm -w "$(pwd)" -v "$(pwd):$(pwd)" $LATEXWORKSHOP_DOCKER_LATEX latexmk "$@"

--- a/scripts/latexmk.bat
+++ b/scripts/latexmk.bat
@@ -1,1 +1,1 @@
-@docker run -i --rm -w /data -v "%cd%:/data" %LATEXWORKSHOP_DOCKER_LATEX% latexmk %*
+@%LATEXWORKSHOP_DOCKER_PATH% run -i --rm -w /data -v "%cd%:/data" %LATEXWORKSHOP_DOCKER_LATEX% latexmk %*

--- a/scripts/synctex
+++ b/scripts/synctex
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker run -i --rm -w "$(pwd)" -v "$(pwd):$(pwd)" $LATEXWORKSHOP_DOCKER_LATEX synctex "$@"
+$LATEXWORKSHOP_DOCKER_PATH run -i --rm -w "$(pwd)" -v "$(pwd):$(pwd)" $LATEXWORKSHOP_DOCKER_LATEX synctex "$@"

--- a/scripts/synctex.bat
+++ b/scripts/synctex.bat
@@ -1,1 +1,1 @@
-@docker run -i --rm -w /data -v "%cd%:/data" %LATEXWORKSHOP_DOCKER_LATEX% synctex %*
+@%LATEXWORKSHOP_DOCKER_PATH% run -i --rm -w /data -v "%cd%:/data" %LATEXWORKSHOP_DOCKER_LATEX% synctex %*

--- a/scripts/texcount
+++ b/scripts/texcount
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker run -i --rm -w "$(pwd)" -v "$(pwd):$(pwd)" $LATEXWORKSHOP_DOCKER_LATEX texcount "$@"
+$LATEXWORKSHOP_DOCKER_PATH run -i --rm -w "$(pwd)" -v "$(pwd):$(pwd)" $LATEXWORKSHOP_DOCKER_LATEX texcount "$@"

--- a/scripts/texcount.bat
+++ b/scripts/texcount.bat
@@ -1,1 +1,1 @@
-@docker run -i --rm -w /data -v "%cd%:/data" %LATEXWORKSHOP_DOCKER_LATEX% texcount %*
+@%LATEXWORKSHOP_DOCKER_PATH% run -i --rm -w /data -v "%cd%:/data" %LATEXWORKSHOP_DOCKER_LATEX% texcount %*

--- a/src/compile/recipe.ts
+++ b/src/compile/recipe.ts
@@ -21,6 +21,14 @@ function setDockerImage() {
     process.env['LATEXWORKSHOP_DOCKER_LATEX'] = dockerImageName
 }
 
+setDockerPath()
+lw.onConfigChange('docker.path', setDockerPath)
+function setDockerPath() {
+    const dockerPath: string = vscode.workspace.getConfiguration('latex-workshop').get('docker.path', '')
+    logger.log(`Set $LATEXWORKSHOP_DOCKER_PATH: ${JSON.stringify(dockerPath)}`)
+    process.env['LATEXWORKSHOP_DOCKER_PATH'] = dockerPath
+}
+
 /**
  * Build LaTeX project using the recipe system. Creates Tools containing the
  * tool info and adds them to the queue. Initiates a buildLoop if there is no


### PR DESCRIPTION
Currently LaTeX Workshop supports only `docker` and it expects to have it in PATH. This small PR addresses this problem by creating a new config `docker.path` allowing the user to customize the location of `docker`.

This config makes also possible to use `podman`, a drop-in replacement of `docker` as explained in #1130, by setting `docker.path` to `podman`.

My commits makes this to work only in GNU/Linux and macOS as I modified only the bash scripts. Modifying the powershell scripts would make this fix available to Windows users as well.