### PR TITLE
allow more relative pathes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1092,7 +1092,7 @@
           "scope": "resource",
           "type": "boolean",
           "default": false,
-          "markdownDescription": "Whether to include the name of the root file being built in the status bar. You can use only 2 placeholders: `%WORKSPACE_FOLDER%`, `%RELATIVE_DIR%`. Please visit https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#placeholders for a complete list of all placeholders."
+          "markdownDescription": "Whether to include the name of the root file being built in the status bar. You can use only 2 placeholders: `%WORKSPACE_FOLDER%`, `%RELATIVE_DIR%`. Please visit https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#placeholders for their definitions."
         },
         "latex-workshop.latex.texDirs": {
           "scope": "window",
@@ -2039,7 +2039,7 @@
           "scope": "window",
           "type": "boolean",
           "default": true,
-          "markdownDescription": "If true, every environment provided by an included package is available by a snippet `\\envname`. Only applies when `#latex-workshop.intellisense.package.enabled#` is true. You can use only 2 placeholders: `%WORKSPACE_FOLDER%`, `%RELATIVE_DIR%`. Please visit https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#placeholders for a complete list of all placeholders."
+          "markdownDescription": "If true, every environment provided by an included package is available by a snippet `\\envname`. Only applies when `#latex-workshop.intellisense.package.enabled#` is true. You can use only 2 placeholders: `%WORKSPACE_FOLDER%`, `%RELATIVE_DIR%`. Please visit https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#placeholders for their definitions."
         },
         "latex-workshop.intellisense.package.dirs": {
           "scope": "window",

--- a/package.json
+++ b/package.json
@@ -1092,7 +1092,7 @@
           "scope": "resource",
           "type": "boolean",
           "default": false,
-          "markdownDescription": "Whether to include the name of the root file being built in the status bar."
+          "markdownDescription": "Whether to include the name of the root file being built in the status bar. You can use only 2 placeholders: `%WORKSPACE_FOLDER%`, `%RELATIVE_DIR%`. Please visit https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#placeholders for a complete list of all placeholders."
         },
         "latex-workshop.latex.texDirs": {
           "scope": "window",
@@ -2039,7 +2039,7 @@
           "scope": "window",
           "type": "boolean",
           "default": true,
-          "markdownDescription": "If true, every environment provided by an included package is available by a snippet `\\envname`. Only applies when `#latex-workshop.intellisense.package.enabled#` is true. "
+          "markdownDescription": "If true, every environment provided by an included package is available by a snippet `\\envname`. Only applies when `#latex-workshop.intellisense.package.enabled#` is true. You can use only 2 placeholders: `%WORKSPACE_FOLDER%`, `%RELATIVE_DIR%`. Please visit https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#placeholders for a complete list of all placeholders."
         },
         "latex-workshop.intellisense.package.dirs": {
           "scope": "window",

--- a/src/completion/completer/package.ts
+++ b/src/completion/completer/package.ts
@@ -5,6 +5,7 @@ import type * as Ast from '@unified-latex/unified-latex-types'
 import { lw } from '../../lw'
 import type { CompletionProvider, FileCache, Package } from '../../types'
 import { argContentToStr } from '../../utils/parser'
+import { replaceArgumentPlaceholders }  from '../../utils/utils'
 
 const logger = lw.log('Intelli', 'Package')
 
@@ -60,7 +61,9 @@ function load(packageName: string) {
 
 function resolvePackageFile(packageName: string): string | undefined {
     const defaultDir = `${lw.extensionRoot}/data/packages/`
-    const dirs = vscode.workspace.getConfiguration('latex-workshop').get('intellisense.package.dirs') as string[]
+    const dirs_raw = vscode.workspace.getConfiguration('latex-workshop').get('intellisense.package.dirs') as string[]
+    const dirs = dirs_raw.map((dir) => {return replaceArgumentPlaceholders("","")(dir)}) 
+
     dirs.push(defaultDir)
     for (const dir of dirs) {
         const filePath = path.resolve(dir, `${packageName}.json`)

--- a/src/utils/inputfilepath.ts
+++ b/src/utils/inputfilepath.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode'
 import * as path from 'path'
 import { resolveFile } from './utils'
+import { replaceArgumentPlaceholders }  from '../utils/utils'
 
 enum MatchType {
     Input,
@@ -86,7 +87,9 @@ export class InputFileRegExp {
      * @param rootFile
      */
     static parseInputFilePath(match: MatchPath, currentFile: string, rootFile: string): string | undefined {
-        const texDirs = vscode.workspace.getConfiguration('latex-workshop').get('latex.texDirs') as string[]
+
+        const texDirs_raw = vscode.workspace.getConfiguration('latex-workshop').get('latex.texDirs') as string[]
+        const texDirs = texDirs_raw.map((texDir) => {return replaceArgumentPlaceholders("","")(texDir)}) 
         /* match of this.childReg */
         if (match.type === MatchType.Child) {
             return resolveFile([path.dirname(currentFile), path.dirname(rootFile), ...texDirs], match.path)


### PR DESCRIPTION
it allows to set relative path in below
- "latex-workshop.latex.texDirs"
- "latex-workshop.intellisense.package.dirs"

args: rootFile and tmpDir set as "".
so it  allows only WORKSPACE_FOLDER and RELATIVE_DIR

This change is useful to use .sty which user made.

And if setting is below:
"latex-workshop.intellisense.package.dirs" = %WorkspaseFolder%/styles
It also allow completions (.json) which user made.

So, this change will make user's workspace more potable.

