### PR TITLE
Update refresh.ts

### DIFF
--- a/viewer/components/refresh.ts
+++ b/viewer/components/refresh.ts
@@ -76,7 +76,7 @@ export async function refresh() {
     const { encodedPath, docTitle } = utils.parseURL()
     /* eslint-disable */
     const doc = await pdfjsLib.getDocument({
-        url: `/${utils.pdfFilePrefix}${encodedPath}`,
+        url: `${utils.pdfFilePrefix}${encodedPath}`,
         cMapUrl: '../cmaps/'
     }).promise
     PDFViewerApplication.load(doc)


### PR DESCRIPTION
This will fix #4306, and allow LaTeX-Workshop to work with code-server.

I have checked and this update will not break the plugin on the desktop version of vscode.