### PR TITLE
Fix/Repair the Lock Threads workflow

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -2,7 +2,8 @@ name: 'Lock Threads'
 
 on:
   schedule:
-    - cron: '0 0 * * *'
+    # avoid rate limit at 00:00 everyday
+    - cron: '37 2 * * *'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -21,4 +21,5 @@ jobs:
         with:
           issue-inactive-days: '30'
           pr-inactive-days: '30'
+          process-only: 'issues, prs'
           log-output: true


### PR DESCRIPTION
This PR fixes two problems in running the `lock.yml` workflow.

1. Cron schedule `0 0 * * *` (00:00 everyday) may easily reach rate limit, so shift the schedule a bit.
   - First encountered in https://github.com/muzimuzhi/LaTeX-Workshop/actions/runs/10534419477
   - https://github.com/dessant/lock-threads/issues/48#issuecomment-2089318436
1. `dessant/lock-threads@v5` gained the ability to lock discussions by default, thus without discussion permission it would fail with "Resource not accessible by integration" error.
   - Recent runs of `lock.yml` in this repo failed because of this, see https://github.com/James-Yu/LaTeX-Workshop/actions/workflows/lock.yml.
   - This breaking change is documented in the changelog of `dessant/lock-threads` action, see https://github.com/dessant/lock-threads/blob/main/CHANGELOG.md#-breaking-changes.
   - Current proposed change disables discussion locking. If you want the other way, I can adapt it by adding `discussions: write` permission and setting the `discussion-inactive-days` input.