### PR TITLE
Enable preview for empheq env

### DIFF
--- a/src/parse/find.ts
+++ b/src/parse/find.ts
@@ -3,7 +3,7 @@ import { escapeRegExp, stripCommentsAndVerbatim } from '../utils/utils'
 import type { TeXMathEnv } from '../types'
 
 const ENV_NAMES = [
-    'align', 'align\\*', 'alignat', 'alignat\\*', 'aligned', 'alignedat', 'array', 'Bmatrix', 'bmatrix', 'cases', 'CD', 'eqnarray', 'eqnarray\\*', 'equation', 'equation\\*', 'flalign', 'flalign\\*', 'gather', 'gather\\*', 'gathered', 'matrix', 'multline', 'multline\\*', 'pmatrix', 'smallmatrix', 'split', 'subarray', 'Vmatrix', 'vmatrix'
+    'align', 'align\\*', 'alignat', 'alignat\\*', 'aligned', 'alignedat', 'array', 'Bmatrix', 'bmatrix', 'cases', 'CD', 'eqnarray', 'eqnarray\\*', 'equation', 'equation\\*', 'flalign', 'flalign\\*', 'gather', 'gather\\*', 'gathered', 'matrix', 'multline', 'multline\\*', 'pmatrix', 'smallmatrix', 'split', 'subarray', 'Vmatrix', 'vmatrix', 'empheq'
 ]
 
 export function findTeX(document: vscode.TextDocument, position: vscode.Position): TeXMathEnv | undefined {
@@ -106,7 +106,7 @@ function getFirstRememberedSubstring(s: string, pat: RegExp): string {
 }
 
 const MATH_ENV_NAMES = [
-    'align', 'align\\*', 'alignat', 'alignat\\*', 'eqnarray', 'eqnarray\\*', 'equation', 'equation\\*', 'flalign', 'flalign\\*', 'gather', 'gather\\*', 'multline', 'multline\\*'
+    'align', 'align\\*', 'alignat', 'alignat\\*', 'eqnarray', 'eqnarray\\*', 'equation', 'equation\\*', 'flalign', 'flalign\\*', 'gather', 'gather\\*', 'multline', 'multline\\*', 'empheq'
 ]
 
 export function findMath(document: vscode.TextDocument, position: vscode.Position): TeXMathEnv | undefined {

--- a/src/preview/hover/utils.ts
+++ b/src/preview/hover/utils.ts
@@ -15,6 +15,10 @@ export function mathjaxify(tex: string, envname: string, opt = { stripLabel: tru
     if (envname.match(/^(aligned|alignedat|array|Bmatrix|bmatrix|cases|CD|gathered|matrix|pmatrix|smallmatrix|split|subarray|Vmatrix|vmatrix)$/)) {
         s = '\\begin{equation}' + s + '\\end{equation}'
     }
+    if (envname == 'empheq') {
+        const empheqPat = /\\begin\{empheq\}\[.*?\]\{(\w+)\}/g;
+        s = s.replace(empheqPat, '\\begin{empheq}[]{$1}');
+    }
     return s
 }
 


### PR DESCRIPTION
Related to #4349 .

From https://docs.mathjax.org/en/v3.2-latest/input/tex/extensions/empheq.html :

> Note that the current implementation of the empheq environment supports only the left and right options.

MathJax fails when the `box` option is used, i.e. when doing

```
\begin{empheq}[box=\fbox]{align}
    A & = B \\
    C &= D
\end{empheq}
```

but not 

```
\begin{empheq}[]{align}
    A & = B \\
    C &= D
\end{empheq}
```

 It's not clear from the MathJax docs whether it would be possible to just ignore the option rather than fail to generate a preview. 
