### PR TITLE
4374 extra brace in default macros

### DIFF
--- a/data/macros.json
+++ b/data/macros.json
@@ -38,7 +38,7 @@
     "name": "left",
     "arg": {
       "format": "{",
-      "snippet": "left{\\{${1}\\right\\\\}"
+      "snippet": "left\\{${1}\\right\\\\}"
     },
     "detail": "\\left\\{ ... \\right\\}, shortcut @{"
   },
@@ -166,7 +166,7 @@
     "name": "{",
     "arg": {
       "format": "",
-      "snippet": "{${1}\\\\}"
+      "snippet": "\\{${1}\\\\}"
     },
     "detail": "curly brackets \\{ ... \\}"
   },

--- a/data/packages/latex-document.json
+++ b/data/packages/latex-document.json
@@ -1395,17 +1395,6 @@
         "format": "{}{}{}",
         "snippet": "renewenvironment*{${1:envname}}{${2:begdef}}{${3:enddef}}"
       }
-    },
-    {
-      "name": "left"
-    },
-    {
-      "name": "left)",
-      "unusual": true
-    },
-    {
-      "name": "left]",
-      "unusual": true
     }
   ],
   "envs": [

--- a/data/packages/latex-document.json
+++ b/data/packages/latex-document.json
@@ -57,21 +57,21 @@
     {
       "name": "Bigg(",
       "arg": {
-        "format": "()",
+        "format": "",
         "snippet": "Bigg(${1}\\Bigg)"
       }
     },
     {
       "name": "Bigg[",
       "arg": {
-        "format": "[]",
+        "format": "",
         "snippet": "Bigg[${1}\\Bigg]"
       }
     },
     {
       "name": "Bigg|",
       "arg": {
-        "format": "||",
+        "format": "",
         "snippet": "Bigg|${1}\\Bigg|"
       }
     },
@@ -81,21 +81,21 @@
     {
       "name": "bigg(",
       "arg": {
-        "format": "()",
+        "format": "",
         "snippet": "bigg(${1}\\bigg)"
       }
     },
     {
       "name": "bigg[",
       "arg": {
-        "format": "[]",
+        "format": "",
         "snippet": "bigg[${1}\\bigg]"
       }
     },
     {
       "name": "bigg|",
       "arg": {
-        "format": "||",
+        "format": "",
         "snippet": "bigg|${1}\\bigg|"
       }
     },

--- a/data/packages/physics2.json
+++ b/data/packages/physics2.json
@@ -31,30 +31,6 @@
       }
     },
     {
-      "name": "bigg"
-    },
-    {
-      "name": "Bigg"
-    },
-    {
-      "name": "bigg"
-    },
-    {
-      "name": "bigg"
-    },
-    {
-      "name": "bigg"
-    },
-    {
-      "name": "Bigg"
-    },
-    {
-      "name": "Bigg"
-    },
-    {
-      "name": "Bigg"
-    },
-    {
       "name": "pab",
       "arg": {
         "format": "{}",

--- a/data/packages/tex.json
+++ b/data/packages/tex.json
@@ -1425,22 +1425,22 @@
       "name": "Bigg"
     },
     {
-      "name": "bigg"
+      "name": "biggl"
     },
     {
-      "name": "Bigg"
+      "name": "Biggl"
     },
     {
-      "name": "bigg"
+      "name": "biggm"
     },
     {
-      "name": "Bigg"
+      "name": "Biggm"
     },
     {
-      "name": "bigg"
+      "name": "biggr"
     },
     {
-      "name": "Bigg"
+      "name": "Biggr"
     },
     {
       "name": "bigl"
@@ -2911,92 +2911,130 @@
       "doc": "Vertical ellipsis"
     },
     {
-      "name": "big",
+      "name": "big(",
       "arg": {
-        "format": "()",
-        "snippet": "big(${1:%<..%>\\big})"
+        "format": "",
+        "snippet": "big(${1}\\big)"
       }
     },
     {
-      "name": "big",
+      "name": "big[",
       "arg": {
-        "format": "[]",
-        "snippet": "big[${1:..\\big}]"
+        "format": "",
+        "snippet": "big[${1}\\big]"
       }
     },
     {
-      "name": "big",
+      "name": "big|",
       "arg": {
-        "format": "||",
-        "snippet": "big|${1:..\\big}|"
+        "format": "",
+        "snippet": "big|${1}\\big|"
       }
     },
     {
-      "name": "Big",
+      "name": "Big(",
       "arg": {
-        "format": "()",
-        "snippet": "Big(${1:%<..%>\\Big})"
+        "format": "",
+        "snippet": "Big(${1}\\Big)"
       }
     },
     {
-      "name": "Big",
+      "name": "Big[",
       "arg": {
-        "format": "[]",
-        "snippet": "Big[${1:..\\Big}]"
+        "format": "",
+        "snippet": "Big[${1}\\Big]"
       }
     },
     {
-      "name": "Big",
+      "name": "Big|",
       "arg": {
-        "format": "||",
-        "snippet": "Big|${1:..\\Big}|"
+        "format": "",
+        "snippet": "Big|${1}\\Big|"
       }
     },
     {
-      "name": "bigl",
+      "name": "bigl(",
       "arg": {
-        "format": "()",
-        "snippet": "bigl(${1:%<..%>\\bigr})"
+        "format": "",
+        "snippet": "bigl(${1}\\bigr)"
       }
     },
     {
-      "name": "bigl",
+      "name": "bigl[",
       "arg": {
-        "format": "[]",
-        "snippet": "bigl[${1:..\\bigr}]"
+        "format": "",
+        "snippet": "bigl[${1}\\bigr]"
       }
     },
     {
-      "name": "Bigl",
+      "name": "bigl\\{",
       "arg": {
-        "format": "()",
-        "snippet": "Bigl(${1:%<..%>\\Bigr})"
+        "format": "",
+        "snippet": "bigl\\{${1}\\bigr\\\\}"
       }
     },
     {
-      "name": "Bigl",
+      "name": "Bigl(",
       "arg": {
-        "format": "[]",
-        "snippet": "Bigl[${1:..\\Bigr}]"
+        "format": "",
+        "snippet": "Bigl(${1}\\Bigr)"
       }
     },
     {
-      "name": "bigg"
+      "name": "Bigl[",
+      "arg": {
+        "format": "",
+        "snippet": "Bigl[${1}\\Bigr]"
+      }
     },
     {
-      "name": "bigg"
+      "name": "Bigl\\{",
+      "arg": {
+        "format": "",
+        "snippet": "Bigl\\{${1}\\Bigr\\\\}"
+      }
     },
     {
-      "name": "bigg"
+      "name": "biggl(",
+      "arg": {
+        "format": "",
+        "snippet": "biggl(${1}\\biggr)"
+      }
     },
     {
-      "name": "Bigg"
+      "name": "biggl[",
+      "arg": {
+        "format": "",
+        "snippet": "biggl[${1}\\biggr]"
+      }
     },
     {
-      "name": "Bigg"
+      "name": "biggl\\{",
+      "arg": {
+        "format": "",
+        "snippet": "biggl\\{${1}\\biggr\\\\}"
+      }
     },
     {
-      "name": "Bigg"
+      "name": "Biggl(",
+      "arg": {
+        "format": "",
+        "snippet": "Biggl(${1}\\Biggr)"
+      }
+    },
+    {
+      "name": "Biggl[",
+      "arg": {
+        "format": "",
+        "snippet": "Biggl[${1}\\Biggr]"
+      }
+    },
+    {
+      "name": "Biggl\\{",
+      "arg": {
+        "format": "",
+        "snippet": "Biggl\\{${1}\\Biggr\\\\}"
+      }
     },
     {
       "name": "int_",

--- a/dev/packages/latex-document.json
+++ b/dev/packages/latex-document.json
@@ -1395,17 +1395,6 @@
         "format": "{}{}{}",
         "snippet": "renewenvironment*{${1:envname}}{${2:begdef}}{${3:enddef}}"
       }
-    },
-    {
-      "name": "left"
-    },
-    {
-      "name": "left)",
-      "unusual": true
-    },
-    {
-      "name": "left]",
-      "unusual": true
     }
   ],
   "envs": [

--- a/dev/packages/latex-document.json
+++ b/dev/packages/latex-document.json
@@ -57,21 +57,21 @@
     {
       "name": "Bigg(",
       "arg": {
-        "format": "()",
+        "format": "",
         "snippet": "Bigg(${1}\\Bigg)"
       }
     },
     {
       "name": "Bigg[",
       "arg": {
-        "format": "[]",
+        "format": "",
         "snippet": "Bigg[${1}\\Bigg]"
       }
     },
     {
       "name": "Bigg|",
       "arg": {
-        "format": "||",
+        "format": "",
         "snippet": "Bigg|${1}\\Bigg|"
       }
     },
@@ -81,21 +81,21 @@
     {
       "name": "bigg(",
       "arg": {
-        "format": "()",
+        "format": "",
         "snippet": "bigg(${1}\\bigg)"
       }
     },
     {
       "name": "bigg[",
       "arg": {
-        "format": "[]",
+        "format": "",
         "snippet": "bigg[${1}\\bigg]"
       }
     },
     {
       "name": "bigg|",
       "arg": {
-        "format": "||",
+        "format": "",
         "snippet": "bigg|${1}\\bigg|"
       }
     },

--- a/dev/packages/tex.json
+++ b/dev/packages/tex.json
@@ -1425,22 +1425,22 @@
       "name": "Bigg"
     },
     {
-      "name": "bigg"
+      "name": "biggl"
     },
     {
-      "name": "Bigg"
+      "name": "Biggl"
     },
     {
-      "name": "bigg"
+      "name": "biggm"
     },
     {
-      "name": "Bigg"
+      "name": "Biggm"
     },
     {
-      "name": "bigg"
+      "name": "biggr"
     },
     {
-      "name": "Bigg"
+      "name": "Biggr"
     },
     {
       "name": "bigl"
@@ -2911,92 +2911,130 @@
       "doc": "Vertical ellipsis"
     },
     {
-      "name": "big",
+      "name": "big(",
       "arg": {
-        "format": "()",
-        "snippet": "big(${1:%<..%>\\big})"
+        "format": "",
+        "snippet": "big(${1}\\big)"
       }
     },
     {
-      "name": "big",
+      "name": "big[",
       "arg": {
-        "format": "[]",
-        "snippet": "big[${1:..\\big}]"
+        "format": "",
+        "snippet": "big[${1}\\big]"
       }
     },
     {
-      "name": "big",
+      "name": "big|",
       "arg": {
-        "format": "||",
-        "snippet": "big|${1:..\\big}|"
+        "format": "",
+        "snippet": "big|${1}\\big|"
       }
     },
     {
-      "name": "Big",
+      "name": "Big(",
       "arg": {
-        "format": "()",
-        "snippet": "Big(${1:%<..%>\\Big})"
+        "format": "",
+        "snippet": "Big(${1}\\Big)"
       }
     },
     {
-      "name": "Big",
+      "name": "Big[",
       "arg": {
-        "format": "[]",
-        "snippet": "Big[${1:..\\Big}]"
+        "format": "",
+        "snippet": "Big[${1}\\Big]"
       }
     },
     {
-      "name": "Big",
+      "name": "Big|",
       "arg": {
-        "format": "||",
-        "snippet": "Big|${1:..\\Big}|"
+        "format": "",
+        "snippet": "Big|${1}\\Big|"
       }
     },
     {
-      "name": "bigl",
+      "name": "bigl(",
       "arg": {
-        "format": "()",
-        "snippet": "bigl(${1:%<..%>\\bigr})"
+        "format": "",
+        "snippet": "bigl(${1}\\bigr)"
       }
     },
     {
-      "name": "bigl",
+      "name": "bigl[",
       "arg": {
-        "format": "[]",
-        "snippet": "bigl[${1:..\\bigr}]"
+        "format": "",
+        "snippet": "bigl[${1}\\bigr]"
       }
     },
     {
-      "name": "Bigl",
+      "name": "bigl\\{",
       "arg": {
-        "format": "()",
-        "snippet": "Bigl(${1:%<..%>\\Bigr})"
+        "format": "",
+        "snippet": "bigl\\{${1}\\bigr\\}"
       }
     },
     {
-      "name": "Bigl",
+      "name": "Bigl(",
       "arg": {
-        "format": "[]",
-        "snippet": "Bigl[${1:..\\Bigr}]"
+        "format": "",
+        "snippet": "Bigl(${1}\\Bigr)"
       }
     },
     {
-      "name": "bigg"
+      "name": "Bigl[",
+      "arg": {
+        "format": "",
+        "snippet": "Bigl[${1}\\Bigr]"
+      }
     },
     {
-      "name": "bigg"
+      "name": "Bigl\\{",
+      "arg": {
+        "format": "",
+        "snippet": "Bigl\\{${1}\\Bigr\\}"
+      }
     },
     {
-      "name": "bigg"
+      "name": "biggl(",
+      "arg": {
+        "format": "",
+        "snippet": "biggl(${1}\\biggr)"
+      }
     },
     {
-      "name": "Bigg"
+      "name": "biggl[",
+      "arg": {
+        "format": "",
+        "snippet": "biggl[${1}\\biggr]"
+      }
     },
     {
-      "name": "Bigg"
+      "name": "biggl\\{",
+      "arg": {
+        "format": "",
+        "snippet": "biggl\\{${1}\\biggr\\}"
+      }
     },
     {
-      "name": "Bigg"
+      "name": "Biggl(",
+      "arg": {
+        "format": "",
+        "snippet": "Biggl(${1}\\Biggr)"
+      }
+    },
+    {
+      "name": "Biggl[",
+      "arg": {
+        "format": "",
+        "snippet": "Biggl[${1}\\Biggr]"
+      }
+    },
+    {
+      "name": "Biggl\\{",
+      "arg": {
+        "format": "",
+        "snippet": "Biggl\\{${1}\\Biggr\\}"
+      }
     },
     {
       "name": "int_",

--- a/dev/parse-cwl.ts
+++ b/dev/parse-cwl.ts
@@ -278,7 +278,7 @@ function parseEnv(pkg: PackageRaw, line: string, ifCond?: string): void {
  */
 function parseMacro(pkg: PackageRaw, line: string, ifCond?: string): void {
     // Special cases in latex-document
-    if ((/\\left[^a-zA-Z]/.test(line) && line.includes('\\right')) || /\\right[^a-zA-Z]/.test(line)) {
+    if (/(?:\\left|\\right)[^a-zA-Z]/.test(line)) {
         return
     }
     // Special cases in latex-document

--- a/dev/parse-cwl.ts
+++ b/dev/parse-cwl.ts
@@ -290,7 +290,7 @@ function parseMacro(pkg: PackageRaw, line: string, ifCond?: string): void {
         const pairs = { '(': ')', '[': ']', '|': '|' }
         const macro: MacroRaw = { name: match[1] + (match[2] ?? '') }
         if (match[2] === '(' || match[2] === '[' || match[2] === '|') {
-            macro.arg = { format: match[2] + pairs[match[2]], snippet: `${match[1]}${match[2]}$\{1}\\${match[1]}${pairs[match[2]]}` }
+            macro.arg = { format: '', snippet: `${match[1]}${match[2]}$\{1}\\${match[1]}${pairs[match[2]]}` }
         }
         pkg.macros.push(macro)
         return


### PR DESCRIPTION
This PR fixes #4374

When migrating in #4367, the default `\left` macros escaped my transpilation script. This PR resolves the issue by removing the additional left curly brace.

This PR also brings an improvement on `\big` and friend suggestion. Originally, all such macros are skipped in `tex.cwl` and `latex-document.cwl`. Thanks to the new parsing script, adding fine-grained parsing can be implemented with ease, in this PR.