### PR TITLE
Fix #4347 max-print-line should be added to string when magic tex arg is present

### DIFF
--- a/src/compile/recipe.ts
+++ b/src/compile/recipe.ts
@@ -365,14 +365,23 @@ function populateTools(rootFile: string, buildTools: Tool[]): Tool[] {
         })
         if (configuration.get('latex.option.maxPrintLine.enabled')) {
             tool.args = tool.args ?? []
-            const isLuaLatex = tool.args.includes('-lualatex') ||
-                               tool.args.includes('-pdflua') ||
-                               tool.args.includes('-pdflualatex') ||
-                               tool.args.includes('--lualatex') ||
-                               tool.args.includes('--pdflua') ||
-                               tool.args.includes('--pdflualatex')
-            if (((tool.command === 'latexmk' && !isLuaLatex) || tool.command === 'pdflatex') && isMikTeX()) {
-                tool.args.unshift('--max-print-line=' + lw.constant.MAX_PRINT_LINE)
+            const isLaTeXmk =
+                tool.command === 'latexmk' &&
+                !(
+                    tool.args.includes('-lualatex') ||
+                    tool.args.includes('-pdflua') ||
+                    tool.args.includes('-pdflualatex') ||
+                    tool.args.includes('--lualatex') ||
+                    tool.args.includes('--pdflua') ||
+                    tool.args.includes('--pdflualatex')
+                )
+            if ((isLaTeXmk || tool.command === 'pdflatex') && isMikTeX()) {
+                if (tool.name === lw.constant.TEX_MAGIC_PROGRAM_NAME) {
+                    // %!TeX options is present. All args are provided in a string and { shell: true }
+                    tool.args = [ `--max-print-line=${lw.constant.MAX_PRINT_LINE} ${tool.args.join(' ')}` ]
+                } else {
+                    tool.args.unshift('--max-print-line=' + lw.constant.MAX_PRINT_LINE)
+                }
             }
         }
     })

--- a/test/units/06_compile_recipe.test.ts
+++ b/test/units/06_compile_recipe.test.ts
@@ -734,6 +734,22 @@ describe(path.basename(__filename).split('.')[0] + ':', () => {
             assert.ok(step)
             assert.ok(!step.args?.includes('--max-print-line=' + lw.constant.MAX_PRINT_LINE), step.args?.join(' '))
         })
+
+        it('should add --max-print-line argument to the arg string with MikTeX and %!TeX options', async () => {
+            await set.config('latex.option.maxPrintLine.enabled', true)
+            await set.config('latex.tools', [{ name: 'latexmk', command: 'latexmk' }])
+            await set.config('latex.build.forceRecipeUsage', false)
+            syncStub.returns({ stdout: 'pdfTeX 3.14159265-2.6-1.40.21 (MiKTeX 2.9.7350 64-bit)' })
+            readStub.resolves('% !TEX program = latexmk\n% !TEX options = -synctex=1 -interaction=nonstopmode -file-line-error\n')
+            const rootFile = set.root('main.tex')
+            initialize()
+
+            await build(rootFile, 'latex', async () => {})
+
+            const step = queue.getStep()
+            assert.ok(step)
+            assert.strictEqual(step.args?.[0], '--max-print-line=10000 -synctex=1 -interaction=nonstopmode -file-line-error', JSON.stringify(step.args))
+        })
     })
 
     describe('lw.compile->recipe.isMikTeX', () => {


### PR DESCRIPTION
When there is a `%!TeX options` magic comment, all TeX program arguments are provided to `cs.spawn` as one string with `{ shell: true}` option enabled. In such a case, prepending `--max-print-line` arg will supress other arguments. See https://github.com/James-Yu/LaTeX-Workshop/blob/6adc47f2049efa9c79899f5cb6e261d9089bb8bf/src/compile/build.ts#L210

There are two ways to resolve the issue:
1. Instead of unshifting the max-print-line arg, we prepend it to the arg string when creating recipe.
2. Joining arguments with space when spawning process.

Both ones are fine, and I decided to use the first to make internal variables more consistent with behavior.

Further, a unit test is designed.