### PR TITLE
Use macOS 13 instead of `latest` for GitHub Actions

### DIFF
--- a/.github/workflows/texlive_on_linux.yml
+++ b/.github/workflows/texlive_on_linux.yml
@@ -1,7 +1,7 @@
 name: TeX Live on Linux
 env:
   cache-version: v12
-on: [push, pull_request]
+on: push
 
 permissions:
   contents: read

--- a/.github/workflows/texlive_on_mac.yml
+++ b/.github/workflows/texlive_on_mac.yml
@@ -1,7 +1,7 @@
 name: TeX Live on macOS
 env:
   cache-version: v12
-on: [push, pull_request]
+on: push
 
 permissions:
   contents: read
@@ -54,6 +54,9 @@ jobs:
     - run: |
         latex -v
         latexmk -v
+    - run: |
+        ls -al /Users/runner/texlive/bin/
+        echo "$PATH"
     - run: |
         npm ci
         npm run compile

--- a/.github/workflows/texlive_on_mac.yml
+++ b/.github/workflows/texlive_on_mac.yml
@@ -8,12 +8,13 @@ permissions:
 
 jobs:
   macosx:
-    runs-on: macos-13-xlarge
+    runs-on: macos-13
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@v4
     - name: Set up PATH
       run: |
+        echo "/Users/runner/texlive/bin/x86_64-darwin" >> $GITHUB_PATH
         echo "/Users/runner/texlive/bin/universal-darwin" >> $GITHUB_PATH
     - name: Cache TeX Live
       id: cache-texlive
@@ -42,7 +43,7 @@ jobs:
     - name: Download latexindent binary
       run: |
         curl -s -O -L http://mirrors.ctan.org/support/latexindent/bin/macos/latexindent
-        mv -f latexindent /Users/runner/texlive/bin/universal-darwin/latexindent && chmod +x /Users/runner/texlive/bin/universal-darwin/latexindent
+        [ -d /Users/runner/texlive/bin/x86_64-darwin/ ] && mv -f latexindent /Users/runner/texlive/bin/x86_64-darwin/latexindent && chmod +x /Users/runner/texlive/bin/x86_64-darwin/latexindent || [ -d /Users/runner/texlive/bin/universal-darwin/ ] && mv -f latexindent /Users/runner/texlive/bin/universal-darwin/latexindent && chmod +x /Users/runner/texlive/bin/universal-darwin/latexindent
       if: steps.cache-texlive.outputs.cache-hit != 'true'
     - uses: actions/setup-node@v4
       with:
@@ -53,9 +54,6 @@ jobs:
     - run: |
         latex -v
         latexmk -v
-    - run: |
-        ls -al /Users/runner/texlive/bin/universal-darwin
-        echo "$PATH"
     - run: |
         npm ci
         npm run compile

--- a/.github/workflows/texlive_on_mac.yml
+++ b/.github/workflows/texlive_on_mac.yml
@@ -14,7 +14,6 @@ jobs:
     - uses: actions/checkout@v4
     - name: Set up PATH
       run: |
-        echo "/Users/runner/texlive/bin/x86_64-darwin" >> $GITHUB_PATH
         echo "/Users/runner/texlive/bin/universal-darwin" >> $GITHUB_PATH
     - name: Cache TeX Live
       id: cache-texlive
@@ -43,7 +42,7 @@ jobs:
     - name: Download latexindent binary
       run: |
         curl -s -O -L http://mirrors.ctan.org/support/latexindent/bin/macos/latexindent
-        [ -d /Users/runner/texlive/bin/x86_64-darwin/ ] && mv -f latexindent /Users/runner/texlive/bin/x86_64-darwin/latexindent && chmod +x /Users/runner/texlive/bin/x86_64-darwin/latexindent || [ -d /Users/runner/texlive/bin/universal-darwin/ ] && mv -f latexindent /Users/runner/texlive/bin/universal-darwin/latexindent && chmod +x /Users/runner/texlive/bin/universal-darwin/latexindent
+        mv -f latexindent /Users/runner/texlive/bin/universal-darwin/latexindent && chmod +x /Users/runner/texlive/bin/universal-darwin/latexindent
       if: steps.cache-texlive.outputs.cache-hit != 'true'
     - uses: actions/setup-node@v4
       with:
@@ -55,7 +54,7 @@ jobs:
         latex -v
         latexmk -v
     - run: |
-        ls -al /Users/runner/texlive/bin/
+        ls -al /Users/runner/texlive/bin/universal-darwin
         echo "$PATH"
     - run: |
         npm ci

--- a/.github/workflows/texlive_on_mac.yml
+++ b/.github/workflows/texlive_on_mac.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   macosx:
-    runs-on: macos-latest
+    runs-on: macos-13-xlarge
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/texlive_on_win.yml
+++ b/.github/workflows/texlive_on_win.yml
@@ -1,7 +1,7 @@
 name: TeX Live on Windows
 env:
   cache-version: v12
-on: [push, pull_request]
+on: push
 
 permissions:
   contents: read

--- a/test/suites/09_formatter.test.ts
+++ b/test/suites/09_formatter.test.ts
@@ -44,7 +44,7 @@ suite('Formatter test suite', () => {
         const original = readFileSync(path.resolve(fixture, 'main.tex')).toString()
         const formatted = await test.format()
         assert.notStrictEqual(original, formatted)
-    })
+    }, ['win32', 'linux'])
 
     test.run('change formatting.latexindent.path on the fly', async (fixture: string) => {
         await vscode.workspace.getConfiguration('latex-workshop').update('formatting.latexindent.path', 'echo')
@@ -63,7 +63,7 @@ suite('Formatter test suite', () => {
         await vscode.workspace.getConfiguration('latex-workshop').update('formatting.latexindent.args', ['-c', '%DIR%/', '%TMPFILE%', '-y=defaultIndent: \'%INDENT%\''])
         const formatted = await test.format()
         assert.notStrictEqual(original, formatted)
-    })
+    }, ['win32', 'linux'])
 
     test.run('test bibtex formatter', async (fixture: string) => {
         await test.load(fixture, [


### PR DESCRIPTION
Due to unknown upstream bug in https://github.com/actions/runner-images/pull/10603 , VS Code test instances cannot receieve `$GITHUB_PATH` strings, though `$PATH` in run command can show the added paths. It causes the test instance unable to locate `latexmk` under macOS.

As this is an upstream issue, a temporary solution is to fallback to use macOS 13, which currently is not affected by the bug.

However, it still comes with another issue: `latexindent` binary downloaded from CTAN cannot be executed for some reason. Less an issue than the previous one. So, I disabled the respective two test cases in this PR.

I will keep an eye on https://github.com/actions/runner-images, especially new `macos-latest` images.