### PR TITLE
When formatting a selection of latex, consider the leading spaces

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -124,7 +124,7 @@ export interface LaTeXLinter {
 }
 
 export interface LaTeXFormatter {
-    formatDocument(document: vscode.TextDocument, range?: vscode.Range): Promise<vscode.TextEdit[]>
+    formatDocument(document: vscode.TextDocument, range?: vscode.Range): Promise<vscode.TextEdit | undefined>
 }
 
 export enum TeXElementType { Environment, Macro, Section, SectionAst, SubFile, BibItem, BibField }


### PR DESCRIPTION
This PR resolves #4394.

Previous formatting logic will do a text replacement after invoking `latexindent` or `tex-fmt`, without looking at the possible leading spaces/tabs before the selection.

This PR adds a preliminary logic to prepend spaces using the context.