### PR TITLE
3783 writing end autocomplete with another

### DIFF
--- a/src/completion/completer/environment.ts
+++ b/src/completion/completer/environment.ts
@@ -77,15 +77,15 @@ function getPackageEnvs(type?: EnvSnippetType): Map<string, CmdEnvSuggestion[]> 
 }
 
 function from(result: RegExpMatchArray, args: CompletionArgs) {
-    const suggestions = provide(args.langId, args.line, args.position)
+    const suggestions = provide(args.langId, args.line)
     // Macros starting with a non letter character are not filtered properly because of wordPattern definition.
     return filterNonLetterSuggestions(suggestions, result[1], args.position)
 }
 
-function provide(langId: string, line: string, position: vscode.Position): CompletionItem[] {
-    let snippetType: EnvSnippetType = EnvSnippetType.ForBegin
-    if (vscode.window.activeTextEditor && vscode.window.activeTextEditor.selections.length > 1 || line.slice(position.character).match(/[a-zA-Z*]*}/)) {
-        snippetType = EnvSnippetType.AsName
+function provide(langId: string, line: string): CompletionItem[] {
+    let snippetType: EnvSnippetType = EnvSnippetType.AsName
+    if (vscode.window.activeTextEditor && vscode.window.activeTextEditor.selections.length === 1 && line.indexOf('\\begin') > line.indexOf('\\end')) {
+        snippetType = EnvSnippetType.ForBegin
     }
 
     // Extract cached envs and add to default ones

--- a/test/units/17_completion_environment.test.ts
+++ b/test/units/17_completion_environment.test.ts
@@ -74,6 +74,22 @@ describe(path.basename(__filename).split('.')[0] + ':', () => {
             assert.ok(suggestion.insertText.value.startsWith('itemize}\n'), suggestion.insertText.value)
         })
 
+        it('should provide environment name when the cursor is `\\begin{|}`', () => {
+            const stub = mock.activeTextEditor(texPath, '\\begin{}')
+            const suggestion = provider
+                .from(['\\begin{', ''], {
+                    uri: vscode.Uri.file(texPath),
+                    langId: 'latex',
+                    line: '\\begin{}',
+                    position: new vscode.Position(0, 7),
+                })
+                .find(s => s.label === 'itemize')
+            stub.restore()
+
+            assert.ok(suggestion)
+            assert.strictEqual(suggestion.insertText, undefined)
+        })
+
         it('should provide environment name when the cursor is `\\begin{|}\\end{|}`', () => {
             const editor = new TextEditor(texPath, '\\begin{}\\end{}', {})
             editor.setSelections([

--- a/test/units/17_completion_environment.test.ts
+++ b/test/units/17_completion_environment.test.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode'
 import * as path from 'path'
 import * as sinon from 'sinon'
 import { lw } from '../../src/lw'
-import { assert, get, mock, set } from './utils'
+import { assert, get, mock, set, TextEditor } from './utils'
 import { provider } from '../../src/completion/completer/environment'
 import { provider as macro } from '../../src/completion/completer/macro'
 
@@ -45,7 +45,7 @@ describe(path.basename(__filename).split('.')[0] + ':', () => {
         })
 
         it('should provide environments in the form of macros', () => {
-            const labels = macro
+            const labels = provider
                 .from(['', ''], {
                     uri: vscode.Uri.file(texPath),
                     langId: 'latex',
@@ -55,6 +55,60 @@ describe(path.basename(__filename).split('.')[0] + ':', () => {
                 .map((s) => s.label)
 
             assert.ok(labels.includes('document'))
+        })
+
+        it('should provide environment snippet when the cursor is `\\begin{|`', () => {
+            const stub = mock.activeTextEditor(texPath, '\\begin{')
+            const suggestion = provider
+                .from(['\\begin{', ''], {
+                    uri: vscode.Uri.file(texPath),
+                    langId: 'latex',
+                    line: '\\begin{',
+                    position: new vscode.Position(0, 7),
+                })
+                .find(s => s.label === 'itemize')
+            stub.restore()
+
+            assert.ok(suggestion)
+            assert.ok(suggestion.insertText instanceof vscode.SnippetString)
+            assert.ok(suggestion.insertText.value.startsWith('itemize}\n'), suggestion.insertText.value)
+        })
+
+        it('should provide environment name when the cursor is `\\begin{|}\\end{|}`', () => {
+            const editor = new TextEditor(texPath, '\\begin{}\\end{}', {})
+            editor.setSelections([
+                new vscode.Selection(new vscode.Position(0, 7), new vscode.Position(0, 7)),
+                new vscode.Selection(new vscode.Position(0, 13), new vscode.Position(0, 13))
+            ])
+            const stub = sinon.stub(vscode.window, 'activeTextEditor').value(editor)
+            const suggestion = provider
+                .from(['\\begin{', ''], {
+                    uri: vscode.Uri.file(texPath),
+                    langId: 'latex',
+                    line: '\\begin{',
+                    position: new vscode.Position(0, 7),
+                })
+                .find(s => s.label === 'itemize')
+            stub.restore()
+
+            assert.ok(suggestion)
+            assert.strictEqual(suggestion.insertText, undefined)
+        })
+
+        it('should provide environment name when the cursor is `\\end{|`', () => {
+            const stub = mock.activeTextEditor(texPath, '\\begin{itemize}\\end{')
+            const suggestion = provider
+                .from(['\\end{', ''], {
+                    uri: vscode.Uri.file(texPath),
+                    langId: 'latex',
+                    line: '\\begin{itemize}\\end{',
+                    position: new vscode.Position(0, 20),
+                })
+                .find(s => s.label === 'itemize')
+            stub.restore()
+
+            assert.ok(suggestion)
+            assert.strictEqual(suggestion.insertText, undefined)
         })
 
         it('should provide environments defined in packages', async () => {

--- a/test/units/utils.ts
+++ b/test/units/utils.ts
@@ -266,7 +266,7 @@ export class TextDocument implements vscode.TextDocument {
     validatePosition(_: vscode.Position): vscode.Position { throw new Error('Not implemented.') }
 }
 
-class TextEditor implements vscode.TextEditor {
+export class TextEditor implements vscode.TextEditor {
     document: TextDocument
     selection: vscode.Selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(0, 0))
     selections: vscode.Selection[] = [ this.selection ]
@@ -281,6 +281,10 @@ class TextEditor implements vscode.TextEditor {
         }
     }
 
+    setSelections(selections: vscode.Selection[]) {
+        this.selection = selections[0]
+        this.selections = selections
+    }
     edit(_: (_: vscode.TextEditorEdit) => void): Thenable<boolean> { throw new Error('Not implemented.') }
     insertSnippet(_: vscode.SnippetString): Thenable<boolean> { throw new Error('Not implemented.') }
     setDecorations(_d: vscode.TextEditorDecorationType, _r: vscode.Range[] | vscode.DecorationOptions[]): void { throw new Error('Not implemented.') }


### PR DESCRIPTION
This PR closes #3783 .

After a careful check (and partially thanks to the new unit test system), I finally figured out the root cause to #3783 :

Originally, we consider all env suggestions to have the begin-end snippet, unless within the brace `{}`. This makes `\end{` without the ending `}` to be considered the same as `\begin{`, and a full snippet is inserted.

This PR changed the behavior by making the suggestions default to `AsName`, and insert full snippet of begin-end only when there is one active selection, the nearest macro is \begin (instead of \end), and selection is not in `{}`.

Corresponding unit tests are added.

Note that this PR does not, and cannot, avoid vscode un-indenting `\end`. Anyways it's not a big issue.