### PR TITLE
Support code folding for DocTeX

### DIFF
--- a/src/language/index.ts
+++ b/src/language/index.ts
@@ -10,6 +10,7 @@ export const language = {
     projectSymbol: new ProjectSymbolProvider(),
     definition: new DefinitionProvider(),
     folding: new FoldingProvider(),
+    doctexFolding: new FoldingProvider(true),
     weaveFolding: new WeaveFoldingProvider(),
     selectionRage: new SelectionRangeProvider(),
     getLocaleString

--- a/src/main.ts
+++ b/src/main.ts
@@ -311,7 +311,8 @@ function registerProviders(extensionContext: vscode.ExtensionContext) {
     extensionContext.subscriptions.push(
         vscode.languages.registerCodeActionsProvider(latexSelector, lw.lint.latex.actionprovider),
         vscode.languages.registerFoldingRangeProvider(latexSelector, lw.language.folding),
-        vscode.languages.registerFoldingRangeProvider(weaveSelector, lw.language.weaveFolding)
+        vscode.languages.registerFoldingRangeProvider(weaveSelector, lw.language.weaveFolding),
+        vscode.languages.registerFoldingRangeProvider(latexDoctexSelector, lw.language.doctexFolding)
     )
 
     const selectionLatex = configuration.get('selection.smart.latex.enabled', true)


### PR DESCRIPTION
This pull request enhances the LaTeX-Workshop extension by adding support for VSCode code folding for DocTeX files. The new functionality includes:

1. Sections Folding: Adds support for folding LaTeX section commands in DocTeX, such as `% \section{abc}`.
2. DocStrip Guards Folding: Adds support for folding DocStrip guard ranges with patterns like `%<*abc>` to `%</abc>`, where `abc` can be replaced with characters such as `|, -, _, (, )`.

Showcase for the `l3doc` class:
<img width="983" alt="image" src="https://github.com/user-attachments/assets/490a846c-9b9c-42e4-a0fe-56e99c484c80">
