### PR TITLE
Define tex-fmt arguments in `formatting.tex-fmt.args`

### DIFF
--- a/package.json
+++ b/package.json
@@ -2184,7 +2184,18 @@
           "scope": "window",
           "type": "boolean",
           "default": true,
-          "markdownDescription": "Do not wrap the output of `tex-fmt`. This setting adds `--keep` flag to `tex-fmt`. Turning this off may wrap magic comments, and/or has unintended side effects."
+          "markdownDeprecationMessage": "This configuration has been extended to `#latex-workshop.formatting.tex-fmt.args#` and has no effect."
+        },
+        "latex-workshop.formatting.tex-fmt.args": {
+          "scope": "resource",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "--keep"
+          ],
+          "markdownDescription": "Define the command line arguments for tex-fmt. Refer to https://github.com/WGUNDERWOOD/tex-fmt?tab=readme-ov-file#usage for more information about the arguments. Note that `--stdin` is added by the extension, so no need to add it again. For key-value arguments, separate the key and value in two strings, e.g., [\"--tab\", \"4\"]."
         },
         "latex-workshop.docker.enabled": {
           "scope": "window",

--- a/src/lint/latex-formatter/tex-fmt.ts
+++ b/src/lint/latex-formatter/tex-fmt.ts
@@ -12,10 +12,7 @@ export const texfmt: LaTeXFormatter = {
 async function formatDocument(document: vscode.TextDocument, range?: vscode.Range): Promise<vscode.TextEdit | undefined> {
     const config = vscode.workspace.getConfiguration('latex-workshop')
     const program = config.get('formatting.tex-fmt.path') as string
-    const args = ['--stdin']
-    if (config.get('formatting.tex-fmt.doNotWrap') as boolean) {
-        args.push('--keep')
-    }
+    const args = [...(config.get('formatting.tex-fmt.args') as string[]), '--stdin']
     const process = lw.external.spawn(program, args, { cwd: path.dirname(document.uri.fsPath) })
 
     let stdout: string = ''


### PR DESCRIPTION
Resolves #4425 .

This PR adds a new `formatting.tex-fmt.args` config to define the command line arguments of `tex-fmt`.