### PR TITLE
Fix link to `latex-workshop.texcount.autorun` setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1837,7 +1837,7 @@
           "scope": "resource",
           "type": "number",
           "default": 1000,
-          "markdownDescription": "The minimal time interval between two consecutive runs of `texcount` in milliseconds when `#latex-workshop.texcount.run#` is set to `onSave`."
+          "markdownDescription": "The minimal time interval between two consecutive runs of `texcount` in milliseconds when `#latex-workshop.texcount.autorun#` is set to `onSave`."
         },
         "latex-workshop.intellisense.update.aggressive.enabled": {
           "scope": "window",


### PR DESCRIPTION
The setting used to be called `texcount.run`, but was renamed in https://github.com/James-Yu/LaTeX-Workshop/pull/3046. During the renaming, the link to the setting wasn't updated.

This change fixes the link so that users of the extension can jump directly to the linked setting. Right now, clicking on it makes the user jump to a random (?) section in the settings view.