### PR TITLE
fix link highlighting in \ref and \input for non-word characters

### DIFF
--- a/src/language/definition.ts
+++ b/src/language/definition.ts
@@ -40,52 +40,89 @@ export class DefinitionProvider implements vscode.DefinitionProvider {
         return
     }
 
-    async provideDefinition(document: vscode.TextDocument, position: vscode.Position): Promise<vscode.Location | undefined> {
+    /**
+     * VSCode hook to provide definitions of the symbol at `position`.
+     * In LW these can be custom commands, labels, citations, glossary entries, and file names.
+     *
+     * Also provides the exact range of the found symbol (`originSelectionRange`),
+     * as different symbol types support different characters in LaTeX (esp. regarding `[:-]`)
+     *
+     * @param document The document to be scanned.
+     * @param position The position to be scanned at.
+     *
+     * @returns {DefinitionLink[]} linking `originSelectionRange` to `targetUri`/`targetRange`
+     */
+    async provideDefinition(document: vscode.TextDocument, position: vscode.Position): Promise<vscode.DefinitionLink[]> {
         if (document.uri.scheme !== 'file') {
-            return
+            return []
         }
-        const token = tokenizer(document, position)
-        if (token === undefined) {
-            return
+        const tokenRange = tokenizer(document, position)
+        if (tokenRange === undefined) {
+            return []
         }
+        const token = document.getText(tokenRange)
 
         if (token.startsWith('\\')) {
             const macro = lw.completion.macro.getData().definedCmds.get(token.slice(1))
             if (macro) {
-                return macro.location
+                return [{
+                    targetUri: macro.location.uri,
+                    targetRange: macro.location.range,
+                    originSelectionRange: tokenRange
+                }]
             }
-            return
+            return []
         }
         const ref = lw.completion.reference.getItem(token)
         if (ref) {
-            return new vscode.Location(vscode.Uri.file(ref.file), ref.position)
+            return [{
+                targetUri: vscode.Uri.file(ref.file),
+                targetRange: new vscode.Range(ref.position, ref.position),
+                originSelectionRange: tokenRange
+            }]
         }
         const cite = lw.completion.citation.getItem(token)
         if (cite) {
-            return new vscode.Location(vscode.Uri.file(cite.file), cite.position)
+            return [{
+                targetUri: vscode.Uri.file(cite.file),
+                targetRange: new vscode.Range(cite.position, cite.position),
+                originSelectionRange: tokenRange
+            }]
         }
         const glossary = lw.completion.glossary.getItem(token)
         if (glossary) {
-            return new vscode.Location(vscode.Uri.file(glossary.filePath), glossary.position)
+            return [{
+                targetUri: vscode.Uri.file(glossary.filePath),
+                targetRange: new vscode.Range(glossary.position, glossary.position),
+                originSelectionRange: tokenRange
+            }]
         }
         if (vscode.window.activeTextEditor && token.includes('.')) {
             // We skip graphics files
             const graphicsExtensions = ['.pdf', '.eps', '.jpg', '.jpeg', '.JPG', '.JPEG', '.gif', '.png']
             const ext = path.extname(token)
             if (graphicsExtensions.includes(ext)) {
-                return
+                return []
             }
             const absolutePath = path.resolve(path.dirname(vscode.window.activeTextEditor.document.fileName), token)
             if (fs.existsSync(absolutePath)) {
-                return new vscode.Location( vscode.Uri.file(absolutePath), new vscode.Position(0, 0) )
+                return [{
+                    targetUri: vscode.Uri.file(absolutePath),
+                    targetRange: new vscode.Range(0, 0, 0, 0),
+                    originSelectionRange: tokenRange
+                }]
             }
         }
 
         const filename = await this.onAFilename(document, position, token)
         if (filename) {
-            return new vscode.Location( vscode.Uri.file(filename), new vscode.Position(0, 0) )
+            return [{
+                targetUri: vscode.Uri.file(filename),
+                targetRange: new vscode.Range(0, 0, 0, 0),
+                originSelectionRange: tokenRange
+            }]
         }
-        return
+        return []
     }
 
 }

--- a/src/preview/hover.ts
+++ b/src/preview/hover.ts
@@ -33,7 +33,7 @@ class HoverProvider implements vscode.HoverProvider {
                 return graphicsHover
             }
         }
-        const token = tokenizer(document, position)
+        const token = document.getText(tokenizer(document, position))
         if (!token) {
             return
         }


### PR DESCRIPTION
code version 1.26 (2018) added [support for custom symbol selection range through DefinitionLink](https://code.visualstudio.com/updates/v1_26#_definitionlink) when providing definitions. The feature was missed in the previous discussion.

Making use of the interface we don't get unexpected splits of symbols in words anymore.

Fixes #4446 and #3312 .

## Before

![Word-chunked Link Decoration](https://github.com/user-attachments/assets/c7b4c145-c560-473c-b336-5bfa2df08354)

## After

![Correct Link Decoration](https://github.com/user-attachments/assets/1781aa2d-175c-4f24-b95e-3403d0370677)