### PR TITLE
Handle LaTeX files with non `.tex` extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -1100,6 +1100,15 @@
           "default": "%DIR%",
           "markdownDescription": "The directory where the extension tries to find project files (e.g., PDF and SyncTeX files) are located. Both relative and absolute paths are supported. Relative path start from the root file location, so beware if it is located in sub-directory. The path must not contain a trailing slash. The LaTeX toolchain should output files to this path. For a list of supported placeholders, please visit https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#placeholders. Note that if this config is set to %DIR% (default value) or %DIR_W32%, the extension will try to parse the last LaTeX tools used and look for `-out-directory=` and `-outdir=`, and automatically determine the output directory. This means that you can safely ignore this config if you use `latexmk` and do not manually `mv` the output files in your recipe."
         },
+        "latex-workshop.latex.extraExts": {
+          "scope": "resource",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "markdownDescription": "The list of extra file extensions to be considered as LaTeX files. The extension will parse these files for references and to provide intellisense."
+        },
         "latex-workshop.latex.jobname": {
           "scope": "resource",
           "type": "string",

--- a/src/core/file.ts
+++ b/src/core/file.ts
@@ -276,7 +276,7 @@ function getOutDir(texPath?: string): string {
  */
 function getLangId(filename: string): string | undefined {
     const ext = path.extname(filename).toLocaleLowerCase()
-    if (ext === '.tex') {
+    if (ext === '.tex' || extraTeXExts.includes(ext)) {
         return 'latex'
     } else if (lw.constant.PWEAVE_EXT.includes(ext)) {
         return 'pweave'

--- a/src/core/file.ts
+++ b/src/core/file.ts
@@ -98,6 +98,7 @@ function handleTmpDirError(error: Error) {
 function hasTeXExt(extname: string): boolean {
     return [
         ...lw.constant.TEX_EXT,
+        ...lw.constant.EXTRA_TEX_EXT,
         ...lw.constant.RSWEAVE_EXT,
         ...lw.constant.JLWEAVE_EXT,
         ...lw.constant.PWEAVE_EXT
@@ -123,6 +124,7 @@ function hasTeXExt(extname: string): boolean {
 function hasBinaryExt(extname: string): boolean {
     return ![
         ...lw.constant.TEX_EXT,
+        ...lw.constant.EXTRA_TEX_EXT,
         ...lw.constant.TEX_NOCACHE_EXT,
         ...lw.constant.RSWEAVE_EXT,
         ...lw.constant.JLWEAVE_EXT,

--- a/src/core/file.ts
+++ b/src/core/file.ts
@@ -7,6 +7,7 @@ import { lw } from '../lw'
 
 const logger = lw.log('File')
 
+let extraTeXExts: string[]
 export const file = {
     tmpDirPath: '',
     getOutDir,
@@ -29,6 +30,12 @@ export const file = {
 initialize()
 export function initialize() {
     file.tmpDirPath = createTmpDir()
+}
+
+setExtraTeXExts()
+lw.onConfigChange('latex.extraExts', setExtraTeXExts)
+function setExtraTeXExts() {
+    extraTeXExts = vscode.workspace.getConfiguration('latex-workshop').get('latex.extraExts', []) as string[]
 }
 
 /**
@@ -87,8 +94,9 @@ function handleTmpDirError(error: Error) {
  * This function verifies whether a provided file extension string matches any
  * of the TeX-related extensions defined in several constant arrays. It
  * consolidates these arrays into a single collection and checks if the given
- * extension exists within this collection. The arrays include TeX extensions, R
- * Sweave extensions, Julia Weave extensions, and Python Weave extensions.
+ * extension exists within this collection. The arrays include TeX extensions
+ * (including those defined by the user ), R Sweave extensions, Julia Weave extensions,
+ * and Python Weave extensions.
  *
  * @param {string} extname - The file extension to be checked including the dot
  * (e.g., '.tex').
@@ -97,8 +105,8 @@ function handleTmpDirError(error: Error) {
  */
 function hasTeXExt(extname: string): boolean {
     return [
+        ...extraTeXExts,
         ...lw.constant.TEX_EXT,
-        ...lw.constant.EXTRA_TEX_EXT,
         ...lw.constant.RSWEAVE_EXT,
         ...lw.constant.JLWEAVE_EXT,
         ...lw.constant.PWEAVE_EXT
@@ -112,9 +120,10 @@ function hasTeXExt(extname: string): boolean {
  * This function evaluates the given file extension and checks it against a
  * predefined list of TeX source extensions such as `.tex`, `.ltx`, `.sty`,
  * `.cls`, `.fd`, `.aux`, `.bbl`, `.blg`, `.brf`, `.log`, `.out`, and R Sweave
- * extensions, Julia Weave extensions, and Python Weave extensions. It returns
- * `true` if the extension is not found in this list, and `false` otherwise.
- * This is useful for filtering out non-TeX files from a collection of files.
+ * extensions, Julia Weave extensions, Python Weave extensions and user defined
+ * tex extensions. It returns `true` if the extension is not found in this list,
+ * and `false` otherwise. This is useful for filtering out non-TeX files from a
+ * collection of files.
  *
  * @param {string} extname - The file extension to be checked including the dot
  * (e.g., '.tex').
@@ -123,8 +132,8 @@ function hasTeXExt(extname: string): boolean {
  */
 function hasBinaryExt(extname: string): boolean {
     return ![
+        ...extraTeXExts,
         ...lw.constant.TEX_EXT,
-        ...lw.constant.EXTRA_TEX_EXT,
         ...lw.constant.TEX_NOCACHE_EXT,
         ...lw.constant.RSWEAVE_EXT,
         ...lw.constant.JLWEAVE_EXT,

--- a/src/lw.ts
+++ b/src/lw.ts
@@ -60,6 +60,7 @@ export const lw = {
 
 const constant = {
     TEX_EXT: ['.tex', '.bib'],
+    EXTRA_TEX_EXT: vscode.workspace.getConfiguration('latex-workshop').get('latex.extraExts', []) as string[],
     TEX_NOCACHE_EXT: ['.cls', '.sty', '.bst', '.bbx', '.cbx', '.def', '.cfg'],
     RSWEAVE_EXT: ['.rnw', '.Rnw', '.rtex', '.Rtex', '.snw', '.Snw'],
     JLWEAVE_EXT: ['.jnw', '.jtexw'],
@@ -69,7 +70,7 @@ const constant = {
     MAGIC_PROGRAM_ARGS_SUFFIX: '_WITH_ARGS',
     MAX_PRINT_LINE: '10000',
     /**
-     * Prefix that server.ts uses to distiguish requests on pdf files from
+     * Prefix that server.ts uses to distinguish requests on pdf files from
      * others. We use '.' because it is not converted by encodeURIComponent and
      * other functions.
      * See https://stackoverflow.com/questions/695438/safe-characters-for-friendly-url

--- a/src/lw.ts
+++ b/src/lw.ts
@@ -60,7 +60,6 @@ export const lw = {
 
 const constant = {
     TEX_EXT: ['.tex', '.bib'],
-    EXTRA_TEX_EXT: vscode.workspace.getConfiguration('latex-workshop').get('latex.extraExts', []) as string[],
     TEX_NOCACHE_EXT: ['.cls', '.sty', '.bst', '.bbx', '.cbx', '.def', '.cfg'],
     RSWEAVE_EXT: ['.rnw', '.Rnw', '.rtex', '.Rtex', '.snw', '.Snw'],
     JLWEAVE_EXT: ['.jnw', '.jtexw'],

--- a/test/units/01_core_file.test.ts
+++ b/test/units/01_core_file.test.ts
@@ -395,6 +395,28 @@ describe(path.basename(__filename).split('.')[0] + ':', () => {
             assert.ok(!lw.file.hasTeXExt('.sty'))
             assert.ok(!lw.file.hasTeXExt('.txt'))
         })
+
+        it('should return true for extensions defined in `latex.extraExts`', async () => {
+            await set.codeConfig('latex.extraExts', ['.txt'])
+            assert.ok(lw.file.hasTeXExt('.txt'))
+        })
+
+        it('should respond to changes to `latex.extraExts` on-the-fly', async () => {
+            assert.ok(!lw.file.hasTeXExt('.txt'))
+            assert.ok(!lw.file.hasTeXExt('.md'))
+
+            await set.codeConfig('latex.extraExts', ['.txt'])
+            assert.ok(lw.file.hasTeXExt('.txt'))
+            assert.ok(!lw.file.hasTeXExt('.md'))
+
+            await set.codeConfig('latex.extraExts', ['.txt', '.md'])
+            assert.ok(lw.file.hasTeXExt('.txt'))
+            assert.ok(lw.file.hasTeXExt('.md'))
+
+            await set.codeConfig('latex.extraExts', [])
+            assert.ok(!lw.file.hasTeXExt('.txt'))
+            assert.ok(!lw.file.hasTeXExt('.md'))
+        })
     })
 
     describe('lw.file.hasBinaryExt', () => {
@@ -410,6 +432,28 @@ describe(path.basename(__filename).split('.')[0] + ':', () => {
             assert.ok(!lw.file.hasBinaryExt('.rnw'))
             assert.ok(!lw.file.hasBinaryExt('.jnw'))
             assert.ok(!lw.file.hasBinaryExt('.pnw'))
+        })
+
+        it('should return false for extensions defined in `latex.extraExts`', async () => {
+            await set.codeConfig('latex.extraExts', ['.txt'])
+            assert.ok(!lw.file.hasBinaryExt('.txt'))
+        })
+
+        it('should respond to changes to `latex.extraExts` on-the-fly', async () => {
+            assert.ok(lw.file.hasBinaryExt('.txt'))
+            assert.ok(lw.file.hasBinaryExt('.md'))
+
+            await set.codeConfig('latex.extraExts', ['.txt'])
+            assert.ok(!lw.file.hasBinaryExt('.txt'))
+            assert.ok(lw.file.hasBinaryExt('.md'))
+
+            await set.codeConfig('latex.extraExts', ['.txt', '.md'])
+            assert.ok(!lw.file.hasBinaryExt('.txt'))
+            assert.ok(!lw.file.hasBinaryExt('.md'))
+
+            await set.codeConfig('latex.extraExts', [])
+            assert.ok(lw.file.hasBinaryExt('.txt'))
+            assert.ok(lw.file.hasBinaryExt('.md'))
         })
     })
 


### PR DESCRIPTION
Related to #4457 

This PR adds a new configuration variable to let the user specify file extensions to be treated as LaTeX files similarly to `.tex` files.

@James-Yu What do you think of this very little intrusive approach?

