### PR TITLE
fix #4474

### DIFF
--- a/src/lint/latex-formatter/tex-fmt.ts
+++ b/src/lint/latex-formatter/tex-fmt.ts
@@ -43,9 +43,13 @@ async function formatDocument(document: vscode.TextDocument, range?: vscode.Rang
         })
     })
 
-    process.stdin?.write(document.getText(range))
+    // write the document to the process, and add a newline at the end
+    process.stdin?.write(document.getText(range)+'\n')
     process.stdin?.end()
     const edits = await promise
-
+    // remove extra newline at the end
+    if (edits) {
+        edits.newText = edits.newText.replace(/\n$/, '')
+    }
     return edits
 }


### PR DESCRIPTION
By adding an extra "\n" at the end of the input text and remove it after using `tex-fmt`, the problem is solved.

![iShot_2024-12-02_10 36 07](https://github.com/user-attachments/assets/083ab30e-cc8b-4015-8bc7-2287169dec57)
