### PR TITLE
Parse glossary bib files to populate intellisense

### DIFF
--- a/src/completion/completer/citation.ts
+++ b/src/completion/completer/citation.ts
@@ -44,7 +44,10 @@ export const bibTools = {
     parseAbbrevations
 }
 
-function expandField(abbreviations: {[key: string]: string}, value: bibtexParser.FieldValue): string {
+function expandField(abbreviations: {[key: string]: string}, value: bibtexParser.FieldValue | undefined): string {
+    if (value === undefined) {
+        return ''
+    }
     if (value.kind === 'concat') {
         const args = value.content as bibtexParser.FieldValue[]
         return args.map(arg => expandField(abbreviations, arg)).join(' ')

--- a/src/completion/completer/citation.ts
+++ b/src/completion/completer/citation.ts
@@ -100,7 +100,7 @@ function provide(uri: vscode.Uri, line: string, position: vscode.Position): Comp
     const label = configuration.get('intellisense.citation.label') as string
     const fields = readCitationFormat(configuration)
     const range: vscode.Range | undefined = computeFilteringRange(line, position)
-    return updateAll(getIncludedBibs(lw.root.file.path)).map(item => {
+    return updateAll(lw.cache.getIncludedBib(lw.root.file.path)).map(item => {
         // Compile the completion item label
         switch(label) {
             case 'bibtex key':
@@ -131,7 +131,7 @@ function browser(args?: CompletionArgs) {
     const configuration = vscode.workspace.getConfiguration('latex-workshop', args?.uri)
     const label = configuration.get('intellisense.citation.label') as string
     const fields = readCitationFormat(configuration, label)
-    void vscode.window.showQuickPick(updateAll(getIncludedBibs(lw.root.file.path)).map(item => {
+    void vscode.window.showQuickPick(updateAll(lw.cache.getIncludedBib(lw.root.file.path)).map(item => {
         return {
             label: item.fields.title ? trimMultiLineString(item.fields.title) : '',
             description: item.key,
@@ -176,33 +176,6 @@ function getItem(key: string, configurationScope?: vscode.ConfigurationScope): C
         entry.documentation = new vscode.MarkdownString( '\n' + entry.fields.join(fields, true, '  \n') + '\n\n')
     }
     return entry
-}
-
-/**
- * Returns the array of the paths of `.bib` files referenced from `file`.
- *
- * @param file The path of a LaTeX file. If `undefined`, the keys of `bibEntries` are used.
- * @param visitedTeX Internal use only.
- */
-function getIncludedBibs(file?: string, visitedTeX: string[] = []): string[] {
-    if (file === undefined) {
-        // Only happens when rootFile is undefined
-        return Array.from(data.bibEntries.keys())
-    }
-    const cache = lw.cache.get(file)
-    if (cache === undefined) {
-        return []
-    }
-    let bibs = Array.from(cache.bibfiles)
-    visitedTeX.push(file)
-    for (const child of cache.children) {
-        if (visitedTeX.includes(child.filePath)) {
-            // Already included
-            continue
-        }
-        bibs = Array.from(new Set(bibs.concat(getIncludedBibs(child.filePath, visitedTeX))))
-    }
-    return bibs
 }
 
 /**

--- a/src/completion/completer/glossary.ts
+++ b/src/completion/completer/glossary.ts
@@ -12,7 +12,8 @@ const logger = lw.log('Intelli', 'Glossary')
 export const provider: CompletionProvider = { from }
 export const glossary = {
     parse,
-    getItem
+    getItem,
+    parseBibFile
 }
 
 const data = {

--- a/src/completion/completer/glossary.ts
+++ b/src/completion/completer/glossary.ts
@@ -29,7 +29,7 @@ lw.watcher.bib.onChange(uri => parseBibFile(uri.fsPath))
 lw.watcher.bib.onDelete(uri => removeEntriesInFile(uri.fsPath))
 
 function from(result: RegExpMatchArray): vscode.CompletionItem[] {
-    updateAll(getIncludedBibs(lw.root.file.path))
+    updateAll(lw.cache.getIncludedGlossaryBib(lw.root.file.path))
     let suggestions: Map<string, GlossaryItem>
 
     if (result[1] && result[1].match(/^ac/i)) {
@@ -44,35 +44,10 @@ function from(result: RegExpMatchArray): vscode.CompletionItem[] {
 }
 
 function getItem(token: string): GlossaryItem | undefined {
-    updateAll(getIncludedBibs(lw.root.file.path))
+    updateAll(lw.cache.getIncludedGlossaryBib(lw.root.file.path))
     return data.glossaries.get(token) || data.acronyms.get(token)
 }
 
-/**
- * Returns the array of the paths of glossary `.bib` files referenced from `file`.
- *
- * @param file The path of a LaTeX file.
- * @param visitedTeX Internal use only.
- */
-function getIncludedBibs(file?: string, visitedTeX: string[] = []): string[] {
-    if (file === undefined) {
-        return []
-    }
-    const cache = lw.cache.get(file)
-    if (cache === undefined) {
-        return []
-    }
-    let bibs = Array.from(cache.glossarybibfiles)
-    visitedTeX.push(file)
-    for (const child of cache.children) {
-        if (visitedTeX.includes(child.filePath)) {
-            // Already included
-            continue
-        }
-        bibs = Array.from(new Set(bibs.concat(getIncludedBibs(child.filePath, visitedTeX))))
-    }
-    return bibs
-}
 
 /**
  * Returns aggregated glossary entries from `.bib` files and glossary items defined on LaTeX files included in the root file.

--- a/src/completion/completer/glossary.ts
+++ b/src/completion/completer/glossary.ts
@@ -21,7 +21,7 @@ const data = {
     glossaries: new Map<string, GlossaryItem>(),
     acronyms: new Map<string, GlossaryItem>(),
     // The keys are the paths of the `.bib` files.
-    bibEntries: new Map<string, GlossaryItem[]>(),
+    bibEntries: new Map<string, GlossaryItem[]>()
 }
 
 lw.watcher.bib.onCreate(uri => parseBibFile(uri.fsPath))

--- a/src/completion/completer/glossary.ts
+++ b/src/completion/completer/glossary.ts
@@ -1,11 +1,14 @@
 import * as vscode from 'vscode'
 import type * as Ast from '@unified-latex/unified-latex-types'
+import { bibtexParser } from 'latex-utensils'
 import { lw } from '../../lw'
 import { GlossaryType } from '../../types'
 import type { CompletionProvider, FileCache, GlossaryItem } from '../../types'
 import { argContentToStr } from '../../utils/parser'
 import { getLongestBalancedString } from '../../utils/utils'
+import { bibTools } from './citation'
 
+const logger = lw.log('Intelli', 'Glossary')
 export const provider: CompletionProvider = { from }
 export const glossary = {
     parse,
@@ -13,17 +16,19 @@ export const glossary = {
 }
 
 const data = {
+    // The keys are the labels of the glossary items.
     glossaries: new Map<string, GlossaryItem>(),
-    acronyms: new Map<string, GlossaryItem>()
+    acronyms: new Map<string, GlossaryItem>(),
+    // The keys are the paths of the `.bib` files.
+    bibEntries: new Map<string, GlossaryItem[]>(),
 }
 
-interface GlossaryEntry {
-    label: string | undefined,
-    description: string | undefined
-}
+lw.watcher.bib.onCreate(uri => parseBibFile(uri.fsPath))
+lw.watcher.bib.onChange(uri => parseBibFile(uri.fsPath))
+lw.watcher.bib.onDelete(uri => removeEntriesInFile(uri.fsPath))
 
 function from(result: RegExpMatchArray): vscode.CompletionItem[] {
-    updateAll()
+    updateAll(getIncludedBibs(lw.root.file.path))
     let suggestions: Map<string, GlossaryItem>
 
     if (result[1] && result[1].match(/^ac/i)) {
@@ -38,13 +43,57 @@ function from(result: RegExpMatchArray): vscode.CompletionItem[] {
 }
 
 function getItem(token: string): GlossaryItem | undefined {
-    updateAll()
+    updateAll(getIncludedBibs(lw.root.file.path))
     return data.glossaries.get(token) || data.acronyms.get(token)
 }
 
-function updateAll() {
+/**
+ * Returns the array of the paths of glossary `.bib` files referenced from `file`.
+ *
+ * @param file The path of a LaTeX file.
+ * @param visitedTeX Internal use only.
+ */
+function getIncludedBibs(file?: string, visitedTeX: string[] = []): string[] {
+    if (file === undefined) {
+        return []
+    }
+    const cache = lw.cache.get(file)
+    if (cache === undefined) {
+        return []
+    }
+    let bibs = Array.from(cache.glossarybibfiles)
+    visitedTeX.push(file)
+    for (const child of cache.children) {
+        if (visitedTeX.includes(child.filePath)) {
+            // Already included
+            continue
+        }
+        bibs = Array.from(new Set(bibs.concat(getIncludedBibs(child.filePath, visitedTeX))))
+    }
+    return bibs
+}
+
+/**
+ * Returns aggregated glossary entries from `.bib` files and glossary items defined on LaTeX files included in the root file.
+ *
+ * @param bibFiles The array of the paths of `.bib` files. If `undefined`, the keys of `bibEntries` are used.
+ */
+function updateAll(bibFiles: string[]) {
     // Extract cached references
     const glossaryList: string[] = []
+
+    // From bib files
+    bibFiles.forEach(file => {
+        const entries = data.bibEntries.get(file)
+        entries?.forEach(entry => {
+            if (entry.type === GlossaryType.glossary) {
+                data.glossaries.set(entry.label, entry)
+            } else {
+                data.acronyms.set(entry.label, entry)
+            }
+            glossaryList.push(entry.label)
+        })
+    })
 
     lw.cache.getIncludedTeX().forEach(cachedFile => {
         const cachedGlossaries = lw.cache.get(cachedFile)?.elements.glossary
@@ -61,7 +110,7 @@ function updateAll() {
         })
     })
 
-    // Remove references that has been deleted
+    // Remove references that have been deleted
     data.glossaries.forEach((_, key) => {
         if (!glossaryList.includes(key)) {
             data.glossaries.delete(key)
@@ -74,6 +123,64 @@ function updateAll() {
     })
 }
 
+/**
+ * Parse a glossary `.bib` file. The results are stored in this instance.
+ *
+ * @param fileName The path of `.bib` file.
+ */
+async function parseBibFile(fileName: string) {
+    logger.log(`Parsing glossary .bib entries from ${fileName}`)
+    const configuration = vscode.workspace.getConfiguration('latex-workshop', vscode.Uri.file(fileName))
+    if ((await lw.external.stat(vscode.Uri.file(fileName))).size >= (configuration.get('bibtex.maxFileSize') as number) * 1024 * 1024) {
+        logger.log(`Bib file is too large, ignoring it: ${fileName}`)
+        data.bibEntries.delete(fileName)
+        return
+    }
+    const newEntry: GlossaryItem[] = []
+    const bibtex = await lw.file.read(fileName)
+    logger.log(`Parse BibTeX AST from ${fileName} .`)
+    const ast = await lw.parser.parse.bib(vscode.Uri.file(fileName), bibtex ?? '')
+    if (ast === undefined) {
+        logger.log(`Parsed 0 bib entries from ${fileName}.`)
+        lw.event.fire(lw.event.FileParsed, fileName)
+        return
+    }
+    const abbreviations = bibTools.parseAbbrevations(ast)
+    ast.content
+        .filter(bibtexParser.isEntry)
+        .forEach((entry: bibtexParser.Entry) => {
+            if (entry.internalKey === undefined) {
+                return
+            }
+            let type: GlossaryType
+            if ( ['entry'].includes(entry.entryType) ) {
+                type = GlossaryType.glossary
+            } else {
+                type = GlossaryType.acronym
+            }
+            const name = bibTools.expandField(abbreviations, entry.content.find(field => field.name === 'name')?.value)
+            const description = bibTools.expandField(abbreviations, entry.content.find(field => field.name === 'description')?.value)
+            const item: GlossaryItem = {
+                type,
+                label: entry.internalKey,
+                filePath: fileName,
+                position: new vscode.Position(entry.location.start.line - 1, entry.location.start.column - 1),
+                kind: vscode.CompletionItemKind.Reference,
+                detail: name + ': ' + description
+            }
+            newEntry.push(item)
+        })
+    data.bibEntries.set(fileName, newEntry)
+    logger.log(`Parsed ${newEntry.length} glossary bib entries from ${fileName} .`)
+    void lw.outline.reconstruct()
+    lw.event.fire(lw.event.FileParsed, fileName)
+}
+
+function removeEntriesInFile(file: string) {
+    logger.log(`Remove parsed bib entries for ${file}`)
+    data.bibEntries.delete(file)
+}
+
 function parse(cache: FileCache) {
     if (cache.ast !== undefined) {
         cache.elements.glossary = parseAst(cache.ast, cache.filePath)
@@ -84,12 +191,13 @@ function parse(cache: FileCache) {
 
 function parseAst(node: Ast.Node, filePath: string): GlossaryItem[] {
     let glos: GlossaryItem[] = []
-    let entry: GlossaryEntry = { label: '', description: '' }
+    let label: string = ''
+    let description: string = ''
     let type: GlossaryType | undefined
 
     if (node.type === 'macro' && ['newglossaryentry', 'provideglossaryentry'].includes(node.content)) {
         type = GlossaryType.glossary
-        let description = argContentToStr(node.args?.[1]?.content || [], true)
+        description = argContentToStr(node.args?.[1]?.content || [], true)
         const index = description.indexOf('description=')
         if (index >= 0) {
             description = description.slice(index + 12)
@@ -101,28 +209,23 @@ function parseAst(node: Ast.Node, filePath: string): GlossaryItem[] {
         } else {
             description = ''
         }
-        entry = {
-            label: argContentToStr(node.args?.[0]?.content || []),
-            description
-        }
+        label = argContentToStr(node.args?.[0]?.content || [])
     } else if (node.type === 'macro' && ['longnewglossaryentry', 'longprovideglossaryentry', 'newacronym', 'newabbreviation', 'newabbr'].includes(node.content)) {
         if (['longnewglossaryentry', 'longprovideglossaryentry'].includes(node.content)) {
             type = GlossaryType.glossary
         } else {
             type = GlossaryType.acronym
         }
-        entry = {
-            label: argContentToStr(node.args?.[1]?.content || []),
-            description: argContentToStr(node.args?.[3]?.content || []),
-        }
+        label = argContentToStr(node.args?.[1]?.content || [])
+        description = argContentToStr(node.args?.[3]?.content || [])
     }
-    if (type !== undefined && entry.label && entry.description && node.position !== undefined) {
+    if (type !== undefined && label && description && node.position !== undefined) {
         glos.push({
             type,
             filePath,
             position: new vscode.Position(node.position.start.line - 1, node.position.start.column - 1),
-            label: entry.label,
-            detail: entry.description,
+            label,
+            detail: description,
             kind: vscode.CompletionItemKind.Reference
         })
     }

--- a/src/outline/structure/bibtex.ts
+++ b/src/outline/structure/bibtex.ts
@@ -11,7 +11,7 @@ const logger = lw.log('Structure', 'BibTeX')
 * Convert a bibtexParser.FieldValue to a string
 * @param field the bibtexParser.FieldValue to parse
 */
-function fieldValueToString(field: bibtexParser.FieldValue, abbreviations: {[abbr: string]: string}): string {
+export function fieldValueToString(field: bibtexParser.FieldValue, abbreviations: {[abbr: string]: string}): string {
     if (field.kind === 'concat') {
         return field.content.map(value => fieldValueToString(value, abbreviations)).reduce((acc, cur) => {return acc + ' # ' + cur})
     } else if (field.kind === 'abbreviation') {

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,8 @@ export type FileCache = {
     }[],
     /** The array of the paths of `.bib` files referenced from the LaTeX file */
     bibfiles: Set<string>,
+    /** The array of the paths of `.bib` files listed by `\GlsXtrLoadResources` to provide glossary entries */
+    glossarybibfiles: Set<string>,
     /** A dictionary of external documents provided by `\externaldocument` of
      * `xr` package. The value is its prefix `\externaldocument[prefix]{*}` */
     external: {[filePath: string]: string},

--- a/test/fixtures/armory/intellisense/glossary.bib
+++ b/test/fixtures/armory/intellisense/glossary.bib
@@ -1,0 +1,35 @@
+@symbol{fs,
+  name        = {\ensuremath{f_s}},
+  description = {sample rate}
+}
+
+@symbol{theta,
+  name        = {\ensuremath{\theta}},
+  description = {horizontal angle}
+}
+
+@entry{caesar,
+  name={\sortname{Gaius Julius}{Caesar}},
+  first={\sortname{Julius}{Caesar}},
+  text={Caesar},
+  description={Roman politician and general},
+  born={13~July 100 BC},
+  died={15~March 44 BC},
+  identifier={person}
+}
+
+@entry{wellesley,
+  name={\sortname{Arthur}{Wellesley}},
+  text={Wellington},
+  description={Anglo-Irish soldier and statesman},
+  born={1~May 1769 AD},
+  died={14~September 1852 AD},
+  othername={1st Duke of Wellington},
+  identifier={person}
+}
+
+@index{wellington,
+  name={Wellington},
+  alias={wellesley},
+  identifier={person}
+}

--- a/test/fixtures/armory/intellisense/glossary_bib.tex
+++ b/test/fixtures/armory/intellisense/glossary_bib.tex
@@ -1,0 +1,9 @@
+\documentclass{article}
+\usepackage{glossaries-extra}
+\GlsXtrLoadResources[
+  src={glos.bib},
+]
+
+\begin{document}
+abc\gls{}
+\end{document}

--- a/test/fixtures/unittest/22_completion_glossary/glossary.bib
+++ b/test/fixtures/unittest/22_completion_glossary/glossary.bib
@@ -1,0 +1,35 @@
+@symbol{fs,
+  name        = {\ensuremath{f_s}},
+  description = {sample rate}
+}
+
+@symbol{theta,
+  name        = {\ensuremath{\theta}},
+  description = {horizontal angle}
+}
+
+@entry{caesar,
+  name={\sortname{Gaius Julius}{Caesar}},
+  first={\sortname{Julius}{Caesar}},
+  text={Caesar},
+  description={Roman politician and general},
+  born={13~July 100 BC},
+  died={15~March 44 BC},
+  identifier={person}
+}
+
+@entry{wellesley,
+  name={\sortname{Arthur}{Wellesley}},
+  text={Wellington},
+  description={Anglo-Irish soldier and statesman},
+  born={1~May 1769 AD},
+  died={14~September 1852 AD},
+  othername={1st Duke of Wellington},
+  identifier={person}
+}
+
+@index{wellington,
+  name={Wellington},
+  alias={wellesley},
+  identifier={person}
+}

--- a/test/suites/04_intellisense.test.ts
+++ b/test/suites/04_intellisense.test.ts
@@ -6,7 +6,7 @@ import * as test from './utils'
 import { EnvSnippetType } from '../../src/types'
 import { isTriggerSuggestNeeded } from '../../src/completion/completer/macro'
 
-suite('Intellisense test suite', () => {
+suite.skip('Intellisense test suite', () => {
     test.suite.name = path.basename(__filename).replace('.test.js', '')
     test.suite.fixture = 'testground'
 

--- a/test/suites/04_intellisense.test.ts
+++ b/test/suites/04_intellisense.test.ts
@@ -6,7 +6,7 @@ import * as test from './utils'
 import { EnvSnippetType } from '../../src/types'
 import { isTriggerSuggestNeeded } from '../../src/completion/completer/macro'
 
-suite.skip('Intellisense test suite', () => {
+suite('Intellisense test suite', () => {
     test.suite.name = path.basename(__filename).replace('.test.js', '')
     test.suite.fixture = 'testground'
 
@@ -418,6 +418,20 @@ suite.skip('Intellisense test suite', () => {
         assert.ok(suggestions.items.find(item => item.label === 'vs_code' && item.detail === 'Editor'))
         assert.ok(suggestions.items.find(item => item.label === 'abbr_y' && item.detail === 'A second abbreviation'))
         assert.ok(suggestions.items.find(item => item.label === 'abbr_x' && item.detail === 'A first abbreviation'))
+    })
+
+    test.run('glossary intellisense from .bib files', async (fixture: string) => {
+        await test.load(fixture, [
+            {src: 'intellisense/glossary_bib.tex', dst: 'main.tex'},
+            {src: 'intellisense/glossary.bib', dst: 'glos.bib'}
+        ])
+        const suggestions = test.suggest(7, 8)
+        assert.strictEqual(suggestions.items.length, 5)
+        assert.ok(suggestions.items.find(item => item.label === 'fs' && item.detail?.includes('\\ensuremath{f_s}')))
+        assert.ok(suggestions.items.find(item => item.label === 'theta' && item.detail?.includes('\\ensuremath{\theta}')))
+        assert.ok(suggestions.items.find(item => item.label === 'caesar' && item.detail?.includes('\\sortname{Gaius Julius}{Caesar}')))
+        assert.ok(suggestions.items.find(item => item.label === 'wellesley' && item.detail?.includes('\\sortname{Arthur}{Wellesley}')))
+        assert.ok(suggestions.items.find(item => item.label === 'wellington' && item.detail?.includes('Wellington')))
     })
 
     test.run('@-snippet intellisense and configs intellisense.atSuggestion*', async (fixture: string) => {


### PR DESCRIPTION
Close #4472

This PR implements the use of glossary `.bib` to populate intellisense.
As glossary intellisense treats glossary and acronym entries differently, we do the same when parsing `.bib` files. Currently only `@entry` entries are considered as glossary entries. Everything else is considered as an acronym entry.

Hopefully I will manage to add some automatic tests but some more intensive testing from people who actually use `bib2gls` is more than welcome. @LeoJhonSong Could we count on your feedback?

@James-Yu A lot of the newly added code looks very similar to the one used in `completion/completer/citation.ts`. Yet, factorizing both is not so obvious and would require to extract sub functions. I will think of it but feel free to share your thoughts if any. 

Btw Merry Christmas @James-Yu 