### PR TITLE
Improve doctex folding

### DIFF
--- a/src/language/folding.ts
+++ b/src/language/folding.ts
@@ -180,15 +180,21 @@ export class DoctexFoldingProvider extends FoldingProvider {
                 keyword,
                 index: match.index
             }
-            const lastItem = opStack[opStack.length - 1]
 
-            if ((match[4] || match[6] || match[8] || match[10] || match[12]) && lastItem && lastItem.keyword === item.keyword) { // match 'end' with its 'begin'
-                const lastLineTune: number = match[10] || match[12] ? 0 : -1
-                opStack.pop()
-                ranges.push(new vscode.FoldingRange(
-                    document.positionAt(lastItem.index).line,
-                    document.positionAt(item.index).line + lastLineTune
-                ))
+            if (match[4] || match[6] || match[8] || match[10] || match[12]) {
+                // We have found a closing item
+                for (let openingIndex = opStack.length - 1; openingIndex >= 0; openingIndex--) {
+                    const openingItem = opStack[openingIndex]
+                    if (openingItem && openingItem.keyword === item.keyword) { // match 'end' with its 'begin'
+                        const lastLineTune: number = match[10] || match[12] ? 0 : -1
+                        ranges.push(new vscode.FoldingRange(
+                            document.positionAt(openingItem.index).line,
+                            document.positionAt(item.index).line + lastLineTune
+                        ))
+                        opStack.splice(openingIndex, 1)
+                        break
+                    }
+                }
             } else {
                 opStack.push(item)
             }


### PR DESCRIPTION
Related to #4527 

First, we must keep in mind from the documentation of `registerFoldingRangeProvider` (see https://code.visualstudio.com/api/references/vscode-api)

> If a folding range overlaps with an other range that has a smaller position, it is also ignored.

This PR improves things by properly computing overlapping ranges. This improves folding for the case of #4527 even though not all driver regions will be properly folded because of VS Code's limitation. Yet, the implementation will become fully effective when VS Code removes the overlapping limitation.