### PR TITLE
Improve DocTeX onEnterRules in documentation texts

### DIFF
--- a/syntax/doctex-language-configuration.json
+++ b/syntax/doctex-language-configuration.json
@@ -53,5 +53,21 @@
 			"start": "^\\s*%\\s*#?region\\b.*",
 			"end": "^\\s*%\\s*#?endregion\\b.*"
 		}
-	}
+	},
+	"onEnterRules": [
+		{
+			"beforeText": "^%    .*",
+			"action": {
+				"indent": "none",
+				"appendText": "%    "
+			}
+		},
+		{
+			"beforeText": "^%.*",
+			"action": {
+				"indent": "none",
+				"appendText": "% "
+			}
+		}
+	]
 }


### PR DESCRIPTION
When writing DocTeX, the major parts of documentation lines are lead by `%`. It would be really helpful if the user press enter within a documentation line, the new line is also lead by `%`.

This PR add this feature to the language configuration file of DocTeX using `onEnterRules`. 

Two rules are added:
1. if the current line starts with `%` plus four or more whitespaces, the newline would starts with `%    ` (four whitespaces).
2. if the current line starts with `%` plus three or less whitespaces, the newline would starts with `% ` (one whitespace).