### PR TITLE
Use a dedicated watcher for glossary bib files

### DIFF
--- a/src/completion/completer/glossary.ts
+++ b/src/completion/completer/glossary.ts
@@ -24,9 +24,9 @@ const data = {
     bibEntries: new Map<string, GlossaryItem[]>()
 }
 
-lw.watcher.bib.onCreate(uri => parseBibFile(uri.fsPath))
-lw.watcher.bib.onChange(uri => parseBibFile(uri.fsPath))
-lw.watcher.bib.onDelete(uri => removeEntriesInFile(uri.fsPath))
+lw.watcher.glossary.onCreate(uri => parseBibFile(uri.fsPath))
+lw.watcher.glossary.onChange(uri => parseBibFile(uri.fsPath))
+lw.watcher.glossary.onDelete(uri => removeEntriesInFile(uri.fsPath))
 
 function from(result: RegExpMatchArray): vscode.CompletionItem[] {
     updateAll(lw.cache.getIncludedGlossaryBib(lw.root.file.path))

--- a/src/core/cache.ts
+++ b/src/core/cache.ts
@@ -196,6 +196,7 @@ async function wait(filePath: string, seconds: number = 2): Promise<Promise<void
 function reset() {
     lw.watcher.src.reset()
     lw.watcher.bib.reset()
+    lw.watcher.glossary.reset()
     // lw.watcher.pdf.reset()
     paths().forEach(filePath => caches.delete(filePath))
 }
@@ -547,8 +548,8 @@ async function updateGlossaryBibFiles(fileCache: FileCache) {
             fileCache.glossarybibfiles.add(bibPath)
             logger.log(`Glossary bib ${bibPath} from ${fileCache.filePath} .`)
             const bibUri = lw.file.toUri(bibPath)
-            if (!lw.watcher.bib.has(bibUri)) {
-                lw.watcher.bib.add(bibUri)
+            if (!lw.watcher.glossary.has(bibUri)) {
+                lw.watcher.glossary.add(bibUri)
             }
         }
     }

--- a/src/core/watcher.ts
+++ b/src/core/watcher.ts
@@ -307,5 +307,6 @@ class Watcher {
 export const watcher = {
     src: new Watcher(),
     pdf: new Watcher('.pdf'),
-    bib: new Watcher('.bib')
+    bib: new Watcher('.bib'),
+    glossary: new Watcher('.bib')
 }


### PR DESCRIPTION
From the logs in https://github.com/James-Yu/LaTeX-Workshop/issues/4578, we can see that every bib file is parsed twice.

```
[17:05:23.616][Intelli][Glossary] Parse BibTeX AST from c:\Users\edanan\texmf\bibtex\bib\library.bib .
[17:05:23.616][Intelli][Citation] Parse BibTeX AST from c:\Users\edanan\texmf\bibtex\bib\library.bib .
```

This PR introduces a dedicated watcher for glossary bib files to avoid parsing every bib file twice.