### PR TITLE
Refine language, grammar, and snippet contributions

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,6 +109,16 @@
         "configuration": "./syntax/doctex-language-configuration.json"
       },
       {
+        "id": "doctex-installer",
+        "aliases": [
+          "DocTeX installer"
+        ],
+        "extensions": [
+          ".ins"
+        ],
+        "configuration": "./syntax/latex-language-configuration.json"
+      },
+      {
         "id": "bibtex",
         "aliases": [
           "BibTeX"
@@ -288,6 +298,11 @@
         "language": "doctex",
         "scopeName": "text.tex.doctex",
         "path": "./syntax/DocTeX.tmLanguage.json"
+      },
+      {
+        "language": "doctex-installer",
+        "scopeName": "text.tex.latex",
+        "path": "./syntax/LaTeX.tmLanguage.json"
       },
       {
         "language": "bibtex",

--- a/package.json
+++ b/package.json
@@ -46,22 +46,62 @@
       {
         "id": "tex",
         "aliases": [
-          "TeX",
-          "tex"
+          "TeX"
+        ],
+        "configuration": "./syntax/latex-language-configuration.json"
+      },
+      {
+        "id": "latex",
+        "aliases": [
+          "LaTeX"
         ],
         "extensions": [
-          ".sty",
-          ".cls",
-          ".bbx",
-          ".cbx"
+          ".tex",
+          ".ltx"
+        ],
+        "configuration": "./syntax/latex-language-configuration.json"
+      },
+      {
+        "id": "latex-class",
+        "aliases": [
+          "LaTeX class"
+        ],
+        "extensions": [
+          ".cls"
+        ],
+        "configuration": "./syntax/latex-language-configuration.json"
+      },
+      {
+        "id": "latex-package",
+        "aliases": [
+          "LaTeX package"
+        ],
+        "extensions": [
+          ".sty"
+        ],
+        "configuration": "./syntax/latex-language-configuration.json"
+      },
+      {
+        "id": "latex-expl3",
+        "aliases": [
+          "LaTeX expl3"
+        ],
+        "configuration": "./syntax/latex3-language-configuration.json"
+      },
+      {
+        "id": "context",
+        "aliases": [
+          "ConTeXt"
+        ],
+        "extensions": [
+          ".ctx"
         ],
         "configuration": "./syntax/latex-language-configuration.json"
       },
       {
         "id": "doctex",
         "aliases": [
-          "DocTeX",
-          "doctex"
+          "DocTeX"
         ],
         "extensions": [
           ".dtx"
@@ -69,23 +109,9 @@
         "configuration": "./syntax/doctex-language-configuration.json"
       },
       {
-        "id": "latex",
-        "aliases": [
-          "LaTeX",
-          "latex"
-        ],
-        "extensions": [
-          ".tex",
-          ".ltx",
-          ".ctx"
-        ],
-        "configuration": "./syntax/latex-language-configuration.json"
-      },
-      {
         "id": "bibtex",
         "aliases": [
-          "BibTeX",
-          "bibtex"
+          "BibTeX"
         ],
         "extensions": [
           ".bib"
@@ -103,11 +129,16 @@
         "configuration": "./syntax/bibtex-style-language-configuration.json"
       },
       {
-        "id": "latex-expl3",
+        "id": "biblatex",
         "aliases": [
-          "LaTeX-Expl3"
+          "BibLaTeX"
         ],
-        "configuration": "./syntax/latex3-language-configuration.json"
+        "extensions": [
+          ".bbx",
+          ".cbx",
+          ".lbx"
+        ],
+        "configuration": "./syntax/latex-language-configuration.json"
       },
       {
         "id": "pweave",
@@ -134,31 +165,34 @@
       {
         "id": "rsweave",
         "aliases": [
-          "R Sweave"
+          "Sweave"
         ],
         "extensions": [
           ".rnw",
-          ".Rnw",
-          ".Rtex",
           ".rtex",
-          ".snw",
-          ".Snw"
+          ".snw"
         ],
         "configuration": "./syntax/latex-language-configuration.json"
       },
       {
         "id": "cpp_embedded_latex",
-        "configuration": "./syntax/latex-cpp-embedded-language-configuration.json",
-        "aliases": []
+        "aliases": [
+          "C++ embedded in LaTeX"
+        ],
+        "configuration": "./syntax/latex-cpp-embedded-language-configuration.json"
       },
       {
         "id": "markdown_latex_combined",
-        "configuration": "./syntax/markdown-latex-combined-language-configuration.json",
-        "aliases": []
+        "aliases": [
+          "Combined Markdown/LaTeX"
+        ],
+        "configuration": "./syntax/markdown-latex-combined-language-configuration.json"
       },
       {
         "id": "latex_workshop_log",
-        "aliases": [],
+        "aliases": [
+          "LaTeX Workshop log"
+        ],
         "configuration": "./syntax/latex-workshop-log-language-configuration.json"
       }
     ],
@@ -167,11 +201,6 @@
         "language": "tex",
         "scopeName": "text.tex",
         "path": "./syntax/TeX.tmLanguage.json"
-      },
-      {
-        "language": "doctex",
-        "scopeName": "text.tex.doctex",
-        "path": "./syntax/DocTeX.tmLanguage.json"
       },
       {
         "language": "latex",
@@ -198,14 +227,14 @@
         }
       },
       {
-        "language": "bibtex",
-        "scopeName": "text.bibtex",
-        "path": "./syntax/Bibtex.tmLanguage.json"
+        "language": "latex-class",
+        "scopeName": "text.tex.latex",
+        "path": "./syntax/LaTeX.tmLanguage.json"
       },
       {
-        "language": "bibtex-style",
-        "scopeName": "source.bst",
-        "path": "./syntax/BibTeX-style.tmLanguage.json"
+        "language": "latex-package",
+        "scopeName": "text.tex.latex",
+        "path": "./syntax/LaTeX.tmLanguage.json"
       },
       {
         "language": "latex-expl3",
@@ -232,17 +261,48 @@
         }
       },
       {
-        "language": "markdown_latex_combined",
-        "scopeName": "text.tex.markdown_latex_combined",
-        "path": "./syntax/markdown-latex-combined.tmLanguage.json"
+        "language": "context",
+        "scopeName": "text.tex.latex",
+        "path": "./syntax/LaTeX.tmLanguage.json",
+        "embeddedLanguages": {
+          "source.asymptote": "asymptote",
+          "source.cpp": "cpp_embedded_latex",
+          "source.css": "css",
+          "source.dot": "dot",
+          "source.gnuplot": "gnuplot",
+          "text.html": "html",
+          "source.java": "java",
+          "source.js": "javascript",
+          "source.julia": "julia",
+          "source.lua": "lua",
+          "source.python": "python",
+          "source.ruby": "ruby",
+          "source.scala": "scala",
+          "source.ts": "typescript",
+          "text.xml": "xml",
+          "source.yaml": "yaml",
+          "meta.embedded.markdown_latex_combined": "markdown_latex_combined"
+        }
       },
       {
-        "language": "cpp_embedded_latex",
-        "scopeName": "source.cpp.embedded.latex",
-        "path": "./syntax/cpp-grammar-bailout.tmLanguage.json",
-        "embeddedLanguages": {
-          "meta.embedded.assembly.cpp": "asm"
-        }
+        "language": "doctex",
+        "scopeName": "text.tex.doctex",
+        "path": "./syntax/DocTeX.tmLanguage.json"
+      },
+      {
+        "language": "bibtex",
+        "scopeName": "text.bibtex",
+        "path": "./syntax/Bibtex.tmLanguage.json"
+      },
+      {
+        "language": "bibtex-style",
+        "scopeName": "source.bst",
+        "path": "./syntax/BibTeX-style.tmLanguage.json"
+      },
+      {
+        "language": "biblatex",
+        "scopeName": "text.tex.latex",
+        "path": "./syntax/LaTeX.tmLanguage.json"
       },
       {
         "language": "pweave",
@@ -269,6 +329,19 @@
         }
       },
       {
+        "language": "cpp_embedded_latex",
+        "scopeName": "source.cpp.embedded.latex",
+        "path": "./syntax/cpp-grammar-bailout.tmLanguage.json",
+        "embeddedLanguages": {
+          "meta.embedded.assembly.cpp": "asm"
+        }
+      },
+      {
+        "language": "markdown_latex_combined",
+        "scopeName": "text.tex.markdown_latex_combined",
+        "path": "./syntax/markdown-latex-combined.tmLanguage.json"
+      },
+      {
         "language": "latex_workshop_log",
         "scopeName": "text.latex_workshop.log",
         "path": "./syntax/LaTeX-Workshop-Log.tmLanguage.json"
@@ -276,7 +349,19 @@
     ],
     "snippets": [
       {
+        "language": "tex",
+        "path": "./data/latex-snippet.json"
+      },
+      {
         "language": "latex",
+        "path": "./data/latex-snippet.json"
+      },
+      {
+        "language": "latex-expl3",
+        "path": "./data/latex-snippet.json"
+      },
+      {
+        "language": "context",
         "path": "./data/latex-snippet.json"
       },
       {
@@ -289,10 +374,6 @@
       },
       {
         "language": "rsweave",
-        "path": "./data/latex-snippet.json"
-      },
-      {
-        "language": "latex-expl3",
         "path": "./data/latex-snippet.json"
       }
     ],

--- a/src/compile/build.ts
+++ b/src/compile/build.ts
@@ -95,7 +95,7 @@ async function build(skipSelection: boolean = false, rootFile: string | undefine
     const externalBuildCommand = configuration.get('latex.external.build.command') as string
     const externalBuildArgs = configuration.get('latex.external.build.args') as string[]
 
-    if (rootFile === undefined && lw.file.hasTeXLangId(activeEditor.document.languageId)) {
+    if (rootFile === undefined && lw.file.hasLaTeXLangId(activeEditor.document.languageId)) {
         await lw.root.find()
         rootFile = lw.root.file.path
         languageId = lw.root.file.langId

--- a/src/core/commands.ts
+++ b/src/core/commands.ts
@@ -65,7 +65,7 @@ export async function view(mode?: 'tab' | 'browser' | 'external' | vscode.Uri) {
         logger.log('Cannot find active TextEditor.')
         return
     }
-    if (!lw.file.hasTeXLangId(vscode.window.activeTextEditor.document.languageId)) {
+    if (!lw.file.hasLaTeXLangId(vscode.window.activeTextEditor.document.languageId)) {
         logger.log('Active document is not a TeX file.')
         return
     }
@@ -98,7 +98,7 @@ export function kill() {
 
 export function synctex() {
     logger.log('SYNCTEX command invoked.')
-    if (!vscode.window.activeTextEditor || !lw.file.hasTeXLangId(vscode.window.activeTextEditor.document.languageId)) {
+    if (!vscode.window.activeTextEditor || !lw.file.hasLaTeXLangId(vscode.window.activeTextEditor.document.languageId)) {
         logger.log('Cannot start SyncTeX. The active editor is undefined, or the document is not a TeX document.')
         return
     }
@@ -118,7 +118,7 @@ export function synctex() {
 
 export function synctexonref(line: number, filePath: string) {
     logger.log('SYNCTEX command invoked on a reference.')
-    if (!vscode.window.activeTextEditor || !lw.file.hasTeXLangId(vscode.window.activeTextEditor.document.languageId)) {
+    if (!vscode.window.activeTextEditor || !lw.file.hasLaTeXLangId(vscode.window.activeTextEditor.document.languageId)) {
         logger.log('Cannot start SyncTeX. The active editor is undefined, or the document is not a TeX document.')
         return
     }
@@ -146,7 +146,7 @@ export async function clean(): Promise<void> {
 
 export function addTexRoot() {
     logger.log('ADDTEXROOT command invoked.')
-    if (!vscode.window.activeTextEditor || !lw.file.hasTeXLangId(vscode.window.activeTextEditor.document.languageId)) {
+    if (!vscode.window.activeTextEditor || !lw.file.hasLaTeXLangId(vscode.window.activeTextEditor.document.languageId)) {
         return
     }
     lw.extra.texroot()
@@ -159,7 +159,7 @@ export function citation() {
 
 export function wordcount() {
     logger.log('WORDCOUNT command invoked.')
-    if (!vscode.window.activeTextEditor || !lw.file.hasTeXLangId(vscode.window.activeTextEditor.document.languageId) ||
+    if (!vscode.window.activeTextEditor || !lw.file.hasLaTeXLangId(vscode.window.activeTextEditor.document.languageId) ||
         lw.root.file.path === vscode.window.activeTextEditor.document.fileName) {
         if (lw.root.file.path) {
             lw.extra.count(lw.root.file.path, true, true)
@@ -197,7 +197,7 @@ export async function gotoSection(filePath: string, lineNumber: number) {
 
 export function navigateToEnvPair() {
     logger.log('JumpToEnvPair command invoked.')
-    if (!vscode.window.activeTextEditor || !lw.file.hasTeXLangId(vscode.window.activeTextEditor.document.languageId)) {
+    if (!vscode.window.activeTextEditor || !lw.file.hasLaTeXLangId(vscode.window.activeTextEditor.document.languageId)) {
         return
     }
     void lw.locate.pair.goto()
@@ -205,7 +205,7 @@ export function navigateToEnvPair() {
 
 export function selectEnvContent(mode: 'content' | 'whole') {
     logger.log('SelectEnv command invoked.')
-    if (!vscode.window.activeTextEditor || !lw.file.hasTeXLangId(vscode.window.activeTextEditor.document.languageId)) {
+    if (!vscode.window.activeTextEditor || !lw.file.hasLaTeXLangId(vscode.window.activeTextEditor.document.languageId)) {
         return
     }
     void lw.locate.pair.select(mode)
@@ -213,7 +213,7 @@ export function selectEnvContent(mode: 'content' | 'whole') {
 
 export function selectEnvName() {
     logger.log('SelectEnvName command invoked.')
-    if (!vscode.window.activeTextEditor || !lw.file.hasTeXLangId(vscode.window.activeTextEditor.document.languageId)) {
+    if (!vscode.window.activeTextEditor || !lw.file.hasLaTeXLangId(vscode.window.activeTextEditor.document.languageId)) {
         return
     }
     void lw.locate.pair.name('selection')
@@ -221,7 +221,7 @@ export function selectEnvName() {
 
 export function multiCursorEnvName() {
     logger.log('MutliCursorEnvName command invoked.')
-    if (!vscode.window.activeTextEditor || !lw.file.hasTeXLangId(vscode.window.activeTextEditor.document.languageId)) {
+    if (!vscode.window.activeTextEditor || !lw.file.hasLaTeXLangId(vscode.window.activeTextEditor.document.languageId)) {
         return
     }
     void lw.locate.pair.name('cursor')
@@ -229,7 +229,7 @@ export function multiCursorEnvName() {
 
 export function toggleEquationEnv() {
     logger.log('toggleEquationEnv command invoked.')
-    if (!vscode.window.activeTextEditor || !lw.file.hasTeXLangId(vscode.window.activeTextEditor.document.languageId)) {
+    if (!vscode.window.activeTextEditor || !lw.file.hasLaTeXLangId(vscode.window.activeTextEditor.document.languageId)) {
         return
     }
     void lw.locate.pair.name('equationToggle')
@@ -237,7 +237,7 @@ export function toggleEquationEnv() {
 
 export function closeEnv() {
     logger.log('CloseEnv command invoked.')
-    if (!vscode.window.activeTextEditor || !lw.file.hasTeXLangId(vscode.window.activeTextEditor.document.languageId)) {
+    if (!vscode.window.activeTextEditor || !lw.file.hasLaTeXLangId(vscode.window.activeTextEditor.document.languageId)) {
         return
     }
     void lw.locate.pair.close()

--- a/src/core/file.ts
+++ b/src/core/file.ts
@@ -154,7 +154,7 @@ function hasBinaryExt(extname: string): boolean {
  * language identifiers, otherwise `false`.
  */
 function hasTeXLangId(langId: string): boolean {
-    return ['tex', 'latex', 'context', 'latex-class', 'latex-expl3', 'latex-package', 'doctex', 'pweave', 'jlweave', 'rsweave'].includes(langId)
+    return ['tex', 'latex', 'context', 'latex-class', 'latex-expl3', 'latex-package', 'doctex', 'doctex-installer', 'pweave', 'jlweave', 'rsweave'].includes(langId)
 }
 
 /**

--- a/src/core/file.ts
+++ b/src/core/file.ts
@@ -18,9 +18,11 @@ export const file = {
     getFlsPath,
     hasBinaryExt,
     hasTeXExt,
+    hasLaTeXLangId,
     hasTeXLangId,
     hasBibLangId,
     hasDtxLangId,
+    hasLaTeXWorkshopLangId,
     setTeXDirs,
     exists,
     read,
@@ -143,18 +145,25 @@ function hasBinaryExt(extname: string): boolean {
 }
 
 /**
- * Determines if the given language ID corresponds to a TeX-related language.
- *
- * This function checks if the provided `langId` matches any of the known
- * TeX-related language identifiers. These identifiers include 'tex', 'latex',
- * 'latex-expl3', 'doctex', 'pweave', 'jlweave', and 'rsweave'.
+ * Determines if the given language ID corresponds to a LaTeX-related language.
  *
  * @param {string} langId - The language identifier to check.
- * @returns {boolean} Returns `true` if `langId` is one of the TeX-related
+ * @returns {boolean} Returns `true` if `langId` is one of the LaTeX-related
+ * language identifiers, otherwise `false`.
+ */
+function hasLaTeXLangId(langId: string): boolean {
+    return ['latex', 'context', 'latex-expl3', 'pweave', 'jlweave', 'rsweave'].includes(langId)
+}
+
+/**
+ * Determines if the given language ID corresponds to a LaTeX-related language.
+ *
+ * @param {string} langId - The language identifier to check.
+ * @returns {boolean} Returns `true` if `langId` is one of the LaTeX-related
  * language identifiers, otherwise `false`.
  */
 function hasTeXLangId(langId: string): boolean {
-    return ['tex', 'latex', 'context', 'latex-class', 'latex-expl3', 'latex-package', 'doctex', 'doctex-installer', 'pweave', 'jlweave', 'rsweave'].includes(langId)
+    return ['tex', 'latex-class', 'latex-package', 'doctex', 'doctex-installer'].includes(langId)
 }
 
 /**
@@ -177,6 +186,9 @@ function hasDtxLangId(langId: string): boolean {
     return langId === 'doctex'
 }
 
+function hasLaTeXWorkshopLangId(langId: string): boolean {
+    return hasLaTeXLangId(langId) || hasTeXLangId(langId) || hasBibLangId(langId) || hasDtxLangId(langId)
+}
 /**
  * An object that stores the output and auxiliary directories for TeX files.
  *

--- a/src/core/file.ts
+++ b/src/core/file.ts
@@ -154,7 +154,7 @@ function hasBinaryExt(extname: string): boolean {
  * language identifiers, otherwise `false`.
  */
 function hasTeXLangId(langId: string): boolean {
-    return ['tex', 'latex', 'latex-expl3', 'doctex', 'pweave', 'jlweave', 'rsweave'].includes(langId)
+    return ['tex', 'latex', 'context', 'latex-class', 'latex-expl3', 'latex-package', 'doctex', 'pweave', 'jlweave', 'rsweave'].includes(langId)
 }
 
 /**

--- a/src/extras/counter.ts
+++ b/src/extras/counter.ts
@@ -26,7 +26,7 @@ loadConfigs()
 
 lw.onConfigChange(['texcount', 'docker.enabled'], loadConfigs)
 lw.onDispose(vscode.window.onDidChangeActiveTextEditor((e: vscode.TextEditor | undefined) => {
-    if (e && lw.file.hasTeXLangId(e.document.languageId)) {
+    if (e && lw.file.hasLaTeXLangId(e.document.languageId)) {
         loadConfigs(e.document.uri)
     } else {
         state.statusBar.hide()

--- a/src/locate/synctex.ts
+++ b/src/locate/synctex.ts
@@ -191,7 +191,7 @@ function getCurrentEditorCoordinates(): {line: number, column: number, inputFile
     }
 
     const inputFileUri = vscode.window.activeTextEditor.document.uri
-    if (!lw.file.hasTeXLangId(vscode.window.activeTextEditor.document.languageId)) {
+    if (!lw.file.hasLaTeXLangId(vscode.window.activeTextEditor.document.languageId)) {
         logger.log(`${inputFileUri} is not valid LaTeX.`)
         return
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -70,7 +70,7 @@ export function activate(extensionContext: vscode.ExtensionContext) {
         if (!lw.constant.FILE_URI_SCHEMES.includes(e.uri.scheme)){
             return
         }
-        if (lw.file.hasTeXLangId(e.languageId) ||
+        if (lw.file.hasLaTeXLangId(e.languageId) ||
             lw.cache.getIncludedTeX(lw.root.file.path, false).includes(e.fileName) ||
             lw.cache.getIncludedBib().includes(e.fileName)) {
             logger.log(`onDidSaveTextDocument triggered: ${e.uri.toString(true)}`)
@@ -89,7 +89,7 @@ export function activate(extensionContext: vscode.ExtensionContext) {
     extensionContext.subscriptions.push(vscode.window.onDidChangeActiveTextEditor(async (e: vscode.TextEditor | undefined) => {
         const configuration = vscode.workspace.getConfiguration('latex-workshop')
 
-        if (vscode.window.visibleTextEditors.filter(editor => lw.file.hasTeXLangId(editor.document.languageId)).length > 0) {
+        if (vscode.window.visibleTextEditors.filter(editor => lw.file.hasLaTeXWorkshopLangId(editor.document.languageId)).length > 0) {
             logger.showStatus()
             if (configuration.get('view.autoFocus.enabled') && !isLaTeXActive) {
                 void vscode.commands.executeCommand('workbench.view.lw.latex-workshop-activitybar').then(() => vscode.commands.executeCommand('workbench.action.focusActiveEditorGroup'))
@@ -103,19 +103,19 @@ export function activate(extensionContext: vscode.ExtensionContext) {
             return
         }
 
-        if (e && lw.file.hasTeXLangId(e.document.languageId) && e.document.fileName !== lw.previousActive?.document.fileName) {
+        if (e && lw.file.hasLaTeXLangId(e.document.languageId) && e.document.fileName !== lw.previousActive?.document.fileName) {
             await lw.root.find()
             lw.lint.latex.root()
         } else if (!e || !lw.file.hasBibLangId(e.document.languageId)) {
             isLaTeXActive = false
         }
 
-        if (e && lw.file.hasTeXLangId(e.document.languageId)) {
+        if (e && lw.file.hasLaTeXLangId(e.document.languageId)) {
             lw.previousActive = e
         }
 
         if (e && (
-            lw.file.hasTeXLangId(e.document.languageId)
+            lw.file.hasLaTeXLangId(e.document.languageId)
             || lw.file.hasBibLangId(e.document.languageId)
             || lw.file.hasDtxLangId(e.document.languageId))) {
             void lw.outline.refresh()
@@ -126,9 +126,7 @@ export function activate(extensionContext: vscode.ExtensionContext) {
         if (!lw.constant.FILE_URI_SCHEMES.includes(e.document.uri.scheme)){
             return
         }
-        if (!lw.file.hasTeXLangId(e.document.languageId) &&
-            !lw.file.hasBibLangId(e.document.languageId) &&
-            !lw.file.hasDtxLangId(e.document.languageId)) {
+        if (!lw.file.hasLaTeXWorkshopLangId(e.document.languageId)) {
             return
         }
         lw.event.fire(lw.event.DocumentChanged)
@@ -137,7 +135,7 @@ export function activate(extensionContext: vscode.ExtensionContext) {
     }))
 
     extensionContext.subscriptions.push(vscode.window.onDidChangeTextEditorSelection((e: vscode.TextEditorSelectionChangeEvent) => {
-        if (lw.file.hasTeXLangId(e.textEditor.document.languageId) ||
+        if (lw.file.hasLaTeXLangId(e.textEditor.document.languageId) ||
             lw.file.hasBibLangId(e.textEditor.document.languageId) ||
             lw.file.hasDtxLangId(e.textEditor.document.languageId)) {
             return lw.outline.reveal(e)
@@ -149,7 +147,7 @@ export function activate(extensionContext: vscode.ExtensionContext) {
 
     void lw.root.find().then(() => {
         lw.lint.latex.root()
-        if (lw.file.hasTeXLangId(vscode.window.activeTextEditor?.document.languageId ?? '')) {
+        if (lw.file.hasLaTeXLangId(vscode.window.activeTextEditor?.document.languageId ?? '')) {
             lw.previousActive = vscode.window.activeTextEditor
         }
     })

--- a/src/preview/math-preview-panel.ts
+++ b/src/preview/math-preview-panel.ts
@@ -180,7 +180,7 @@ async function update(ev?: UpdateEvent) {
     }
     const editor = vscode.window.activeTextEditor
     const document = editor?.document
-    if (!editor || !document?.languageId || !lw.file.hasTeXLangId(document.languageId)) {
+    if (!editor || !document?.languageId || !lw.file.hasLaTeXWorkshopLangId(document.languageId)) {
         clearCache()
         return
     }

--- a/syntax/TeX.tmLanguage.json
+++ b/syntax/TeX.tmLanguage.json
@@ -48,7 +48,7 @@
             "name": "meta.catcode.tex"
         },
         "iffalse-block": {
-            "begin": "(?<=^\\s*)((\\\\)iffalse)(?!\\s*[{}]\\s*\\\\fi)",
+            "begin": "(?<=^\\s*)((\\\\)iffalse)(?!\\s*[{}]\\s*\\\\fi\\b)",
             "beginCaptures": {
                 "1": {
                     "name": "keyword.control.tex"
@@ -58,7 +58,7 @@
                 }
             },
             "contentName": "comment.line.percentage.tex",
-            "end": "((\\\\)(?:else|fi))",
+            "end": "((\\\\)(?:else|fi)\\b)",
             "endCaptures": {
                 "1": {
                     "name": "keyword.control.tex"

--- a/test/units/01_core_file.test.ts
+++ b/test/units/01_core_file.test.ts
@@ -457,21 +457,28 @@ describe(path.basename(__filename).split('.')[0] + ':', () => {
         })
     })
 
-    describe('lw.file.hasTeXLangId', () => {
-        it('should return true for supported TeX languages', () => {
-            assert.ok(lw.file.hasTeXLangId('tex'))
-            assert.ok(lw.file.hasTeXLangId('latex'))
-            assert.ok(lw.file.hasTeXLangId('latex-expl3'))
-            assert.ok(lw.file.hasTeXLangId('doctex'))
-            assert.ok(lw.file.hasTeXLangId('pweave'))
-            assert.ok(lw.file.hasTeXLangId('jlweave'))
-            assert.ok(lw.file.hasTeXLangId('rsweave'))
+    describe('lw.file.hasLaTeXLangId', () => {
+        it('should return true for supported LaTeX languages', () => {
+            assert.ok(lw.file.hasLaTeXLangId('latex'))
+            assert.ok(lw.file.hasLaTeXLangId('latex-expl3'))
+            assert.ok(lw.file.hasLaTeXLangId('pweave'))
+            assert.ok(lw.file.hasLaTeXLangId('jlweave'))
+            assert.ok(lw.file.hasLaTeXLangId('rsweave'))
         })
 
         it('should return false for unsupported languages', () => {
-            assert.ok(!lw.file.hasTeXLangId('markdown'))
-            assert.ok(!lw.file.hasTeXLangId('python'))
-            assert.ok(!lw.file.hasTeXLangId('html'))
+            assert.ok(!lw.file.hasLaTeXLangId('markdown'))
+            assert.ok(!lw.file.hasLaTeXLangId('python'))
+            assert.ok(!lw.file.hasLaTeXLangId('html'))
+        })
+    })
+
+    describe('lw.file.hasTeXLangId', () => {
+        it('should return true for supported TeX languages', () => {
+            assert.ok(lw.file.hasTeXLangId('tex'))
+            assert.ok(lw.file.hasLaTeXLangId('latex-class'))
+            assert.ok(lw.file.hasLaTeXLangId('latex-package'))
+            assert.ok(lw.file.hasLaTeXLangId('doctex-installer'))
         })
     })
 

--- a/test/units/01_core_file.test.ts
+++ b/test/units/01_core_file.test.ts
@@ -476,9 +476,9 @@ describe(path.basename(__filename).split('.')[0] + ':', () => {
     describe('lw.file.hasTeXLangId', () => {
         it('should return true for supported TeX languages', () => {
             assert.ok(lw.file.hasTeXLangId('tex'))
-            assert.ok(lw.file.hasLaTeXLangId('latex-class'))
-            assert.ok(lw.file.hasLaTeXLangId('latex-package'))
-            assert.ok(lw.file.hasLaTeXLangId('doctex-installer'))
+            assert.ok(lw.file.hasTeXLangId('latex-class'))
+            assert.ok(lw.file.hasTeXLangId('latex-package'))
+            assert.ok(lw.file.hasTeXLangId('doctex-installer'))
         })
     })
 


### PR DESCRIPTION
This pull request proposes a reorganization of the language, grammar, and snippet contributions provided by this extension.

It separates some languages into more specific ones and adjusts their grammars and snippets accordingly. The collapsed sections below show a before-and-after comparison of this change, as seen on the [Marketplace](https://marketplace.visualstudio.com/items?itemName=James-Yu.latex-workshop).

<details>
  <summary>Before</summary>

|ID|Name|File Extensions|Grammar|Snippets|
|---|---|---|---|---|
|bibtex|BibTeX|`.bib`|✔︎|—|
|bibtex-style|BibTeX style|`.bst`|✔︎|—|
|cpp_embedded_latex|cpp_embedded_latex||✔︎|—|
|doctex|DocTeX|`.dtx`|✔︎|—|
|jlweave|Weave.jl|`.jnw` `.jtexw`|✔︎|✔︎|
|latex|LaTeX|`.tex` `.ltx` `.ctx`|✔︎|✔︎|
|latex_workshop_log|latex_workshop_log||✔︎|—|
|latex-expl3|LaTeX-Expl3||✔︎|✔︎|
|markdown_latex_combined|markdown_latex_combined||✔︎|—|
|pweave|Pweave|`.pnw` `.ptexw`|✔︎|✔︎|
|rsweave|R Sweave|`.rnw` `.Rnw` `.Rtex` `.rtex` `.snw` `.Snw`|✔︎|✔︎|
|tex|TeX|`.sty` `.cls` `.bbx` `.cbx`|✔︎|—|
</details>

<details>
  <summary>After</summary>

|ID|Name|File Extensions|Grammar|Snippets|
|---|---|---|---|---|
|biblatex|BibLaTeX|`.bbx` `.cbx` `.lbx`|✔︎|—|
|bibtex|BibTeX|`.bib`|✔︎|—|
|bibtex-style|BibTeX style|`.bst`|✔︎|—|
|context|ConTeXt|`.ctx`|✔︎|✔︎|
|cpp_embedded_latex|C++ embedded in LaTeX||✔︎|—|
|doctex|DocTeX|`.dtx`|✔︎|—|
|jlweave|Weave.jl|`.jnw` `.jtexw`|✔︎|✔︎|
|latex|LaTeX|`.tex` `.ltx`|✔︎|✔︎|
|latex_workshop_log|LaTeX Workshop log||✔︎|—|
|latex-class|LaTeX class|`.cls`|✔︎|—|
|latex-expl3|LaTeX expl3||✔︎|✔︎|
|latex-package|LaTeX package|`.sty`|✔︎|—|
|markdown_latex_combined|Combined Markdown/LaTeX||✔︎|—|
|pweave|Pweave|`.pnw` `.ptexw`|✔︎|✔︎|
|rsweave|Sweave|`.rnw` `.rtex` `.snw`|✔︎|✔︎|
|tex|TeX||✔︎|✔︎|
</details>

My intention with this is to allow the use of specialized icons for classes, packages, and other file types in the TeX/LaTeX ecosystem, so they can be more clearly distinguished throughout the UI. Unfortunately, some file extensions overlap with those used by other technologies — at least `.cls`, as noted in material-extensions/vscode-material-icon-theme#3004 and then in material-extensions/vscode-material-icon-theme#2997 (see [this comment](https://github.com/material-extensions/vscode-material-icon-theme/pull/2997#issuecomment-2868576716)), is also used by the Salesforce API (see [this](https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_classes.htm), under _Declarative Metadata File Suffix and Directory Location_). Defining more specific languages would solve that issue, and I believe it could also pave the way for further improvements, such as more specialized grammars.

I also took the opportunity to adjust the file extensions and aliases associated with some of the languages, which in my opinion improves how the extension appears in the Marketplace.

I’m not sure what the real impact of this change will be, but from what I can tell, it shouldn’t cause any issues.

Either way, I’m happy to make any adjustments if needed. Feedback and suggestions are very welcome!