### PR TITLE
Fix `*.bib` resolving (glossaries and bib2gls)

### DIFF
--- a/src/core/cache.ts
+++ b/src/core/cache.ts
@@ -541,15 +541,17 @@ async function updateGlossaryBibFiles(fileCache: FileCache) {
         const bibs = (result[1] ? result[1] : result[2]).split(',').map(bib => bib.trim())
 
         for (const bib of bibs) {
-            const bibPath = await utils.resolveFile([path.dirname(fileCache.filePath)], bib, '.bib')
-            if (!bibPath || isExcluded(bibPath)) {
-                continue
-            }
-            fileCache.glossarybibfiles.add(bibPath)
-            logger.log(`Glossary bib ${bibPath} from ${fileCache.filePath} .`)
-            const bibUri = lw.file.toUri(bibPath)
-            if (!lw.watcher.glossary.has(bibUri)) {
-                lw.watcher.glossary.add(bibUri)
+            const bibPaths = await lw.file.getBibPath(bib, path.dirname(fileCache.filePath))
+            for (const bibPath of bibPaths) {
+                if (!bibPath || isExcluded(bibPath)) {
+                    continue
+                }
+                fileCache.glossarybibfiles.add(bibPath)
+                logger.log(`Glossary bib ${bibPath} from ${fileCache.filePath} .`)
+                const bibUri = lw.file.toUri(bibPath)
+                if (!lw.watcher.glossary.has(bibUri)) {
+                    lw.watcher.glossary.add(bibUri)
+                }
             }
         }
     }


### PR DESCRIPTION
This PR introduces a minor change to the cache behavior, so that `core.cache.updateGlossaryBibFiles` behaves similarly to `core.cache.updateBibfiles` in the sense of respect `kpsewhich`.

Currently, `core.cache.updateGlossaryBibFiles` is defined as:

https://github.com/James-Yu/LaTeX-Workshop/blob/master/src/core/cache.ts#L536-L549

Which is similar to `core.cache.updateBibfiles`:

https://github.com/James-Yu/LaTeX-Workshop/blob/master/src/core/cache.ts#L499-L513

This PR updates `core.cache.updateGlossaryBibFiles` to use the same mechanism as `core.cache.updateBibfiles` to load `bibPaths`, calling `lw.file.getBibPath`.

This is aligned with `bib2gls`' own mechanism:

https://github.com/nlct/bib2gls/blob/master/src/lib/resources/bib2gls-en.xml#L14-L18