### PR TITLE
Make langid of doctex LaTeX rather than TeX (so that it can be auto build)

### DIFF
--- a/src/core/file.ts
+++ b/src/core/file.ts
@@ -152,18 +152,18 @@ function hasBinaryExt(extname: string): boolean {
  * language identifiers, otherwise `false`.
  */
 function hasLaTeXLangId(langId: string): boolean {
-    return ['latex', 'context', 'latex-expl3', 'pweave', 'jlweave', 'rsweave'].includes(langId)
+    return ['latex', 'context', 'latex-expl3', 'doctex', 'pweave', 'jlweave', 'rsweave'].includes(langId)
 }
 
 /**
- * Determines if the given language ID corresponds to a LaTeX-related language.
+ * Determines if the given language ID corresponds to a TeX-related language.
  *
  * @param {string} langId - The language identifier to check.
- * @returns {boolean} Returns `true` if `langId` is one of the LaTeX-related
+ * @returns {boolean} Returns `true` if `langId` is one of the TeX-related
  * language identifiers, otherwise `false`.
  */
 function hasTeXLangId(langId: string): boolean {
-    return ['tex', 'latex-class', 'latex-package', 'doctex', 'doctex-installer'].includes(langId)
+    return ['tex', 'latex-class', 'latex-package', 'doctex-installer'].includes(langId)
 }
 
 /**


### PR DESCRIPTION
Before version 10.10.0, after I add `**/*.dtx` to `latex-workshop.latex.search.rootFiles.include`, `dtx` files can auto build on file change. After updating to 10.10.0, it is no longer possible.

In #4592, language configuration has been largely updated. TeX-relatex files (`hasTeXLangId`) and LaTeX-related filed (`hasLaTeXLangId`) are now differentiated, and only the change of **LaTeX**-related will trigger auto building.
DocTeX files are classified as TeX-related rather than LaTeX-related.

Usually, `dtx` files are standable LaTeX files that can be built into the documentation by themselves. It is thus better to classify DocTeX files as LaTeX-related, so that user can choose to autobuild them by modifying `latex-workshop.latex.search.rootFiles.include`.

