### PR TITLE
Refactor build on save

### DIFF
--- a/package.json
+++ b/package.json
@@ -1365,7 +1365,7 @@
             "**/Library/Application Support/MiKTeX/texmfs/**",
             "/dev/null"
           ],
-          "markdownDescription": "Files to ignore from the watching mechanism, i.e., no intellisense or build-on-file-change. However, document structure/outline and build-on-save won't be affected. This property must be an array of glob patterns. The patterns are matched against the absolute file path. To ignore everything inside the `texmf` tree, `**/texmf/**` can be used."
+          "markdownDescription": "Files to ignore from the watching mechanism, i.e., no intellisense or build-on-file-change. However, document structure/outline and build-on-save won't be affected (For build-on-save configuration, see #latex-workshop.autoBuild.onSave.files.ignore#). This property must be an array of glob patterns. The patterns are matched against the absolute file path. To ignore everything inside the `texmf` tree, `**/texmf/**` can be used. "
         },
         "latex-workshop.latex.autoBuild.run": {
           "scope": "resource",
@@ -1394,6 +1394,18 @@
           "type": "boolean",
           "default": true,
           "markdownDescription": "Delete LaTeX auxiliary files when errors occur during build and retry. This property defines whether LaTeX Workshop will try to clean and build the project once again after errors happen in the build toolchain."
+        },
+        "latex-workshop.latex.autoBuild.onSave.files.ignore": {
+          "scope": "window",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "**/*.sty",
+            "**/*.cls"
+          ],
+          "markdownDescription": "Files to ignore from the auto-build on save mechanism, This property must be an array of glob patterns. The patterns are matched against the absolute file path."
         },
         "latex-workshop.latex.build.clearLog.everyRecipeStep.enabled": {
           "scope": "resource",

--- a/src/compile/index.ts
+++ b/src/compile/index.ts
@@ -1,10 +1,11 @@
 import type { ChildProcess } from 'child_process'
-import { build, autoBuild } from './build'
+import { build, autoBuild, isFileExcludedFromBuildOnSave } from './build'
 import { terminate } from './terminate'
 
 export const compile = {
     build,
     autoBuild,
+    isFileExcludedFromBuildOnSave,
     terminate,
     lastAutoBuildTime: 0,
     compiledPDFPath: '',

--- a/src/core/commands.ts
+++ b/src/core/commands.ts
@@ -99,7 +99,7 @@ export function kill() {
 export function synctex() {
     logger.log('SYNCTEX command invoked.')
     if (!vscode.window.activeTextEditor || !lw.file.hasLaTeXLangId(vscode.window.activeTextEditor.document.languageId)) {
-        logger.log('Cannot start SyncTeX. The active editor is undefined, or the document is not a TeX document.')
+        logger.log('Cannot start SyncTeX. The active editor is undefined, or the document is not a LaTeX document.')
         return
     }
     const configuration = vscode.workspace.getConfiguration('latex-workshop', lw.root.getWorkspace())
@@ -119,7 +119,7 @@ export function synctex() {
 export function synctexonref(line: number, filePath: string) {
     logger.log('SYNCTEX command invoked on a reference.')
     if (!vscode.window.activeTextEditor || !lw.file.hasLaTeXLangId(vscode.window.activeTextEditor.document.languageId)) {
-        logger.log('Cannot start SyncTeX. The active editor is undefined, or the document is not a TeX document.')
+        logger.log('Cannot start SyncTeX. The active editor is undefined, or the document is not a LaTeX document.')
         return
     }
     lw.locate.synctex.toPDFFromRef({line, filePath})
@@ -147,6 +147,7 @@ export async function clean(): Promise<void> {
 export function addTexRoot() {
     logger.log('ADDTEXROOT command invoked.')
     if (!vscode.window.activeTextEditor || !lw.file.hasLaTeXLangId(vscode.window.activeTextEditor.document.languageId)) {
+        logger.log('Cannot add tex root. The active editor is undefined, or the document is not a LaTeX document.')
         return
     }
     lw.extra.texroot()
@@ -198,6 +199,7 @@ export async function gotoSection(filePath: string, lineNumber: number) {
 export function navigateToEnvPair() {
     logger.log('JumpToEnvPair command invoked.')
     if (!vscode.window.activeTextEditor || !lw.file.hasLaTeXLangId(vscode.window.activeTextEditor.document.languageId)) {
+        logger.log('Cannot run navigateToEnvPair. The active editor is undefined, or the document is not a LaTeX document.')
         return
     }
     void lw.locate.pair.goto()
@@ -206,6 +208,7 @@ export function navigateToEnvPair() {
 export function selectEnvContent(mode: 'content' | 'whole') {
     logger.log('SelectEnv command invoked.')
     if (!vscode.window.activeTextEditor || !lw.file.hasLaTeXLangId(vscode.window.activeTextEditor.document.languageId)) {
+        logger.log('Cannot run selectEnvContent. The active editor is undefined, or the document is not a LaTeX document.')
         return
     }
     void lw.locate.pair.select(mode)
@@ -214,6 +217,7 @@ export function selectEnvContent(mode: 'content' | 'whole') {
 export function selectEnvName() {
     logger.log('SelectEnvName command invoked.')
     if (!vscode.window.activeTextEditor || !lw.file.hasLaTeXLangId(vscode.window.activeTextEditor.document.languageId)) {
+        logger.log('Cannot run selectEnvName. The active editor is undefined, or the document is not a LaTeX document.')
         return
     }
     void lw.locate.pair.name('selection')
@@ -222,6 +226,7 @@ export function selectEnvName() {
 export function multiCursorEnvName() {
     logger.log('MutliCursorEnvName command invoked.')
     if (!vscode.window.activeTextEditor || !lw.file.hasLaTeXLangId(vscode.window.activeTextEditor.document.languageId)) {
+        logger.log('Cannot run multiCursorEnvName. The active editor is undefined, or the document is not a LaTeX document.')
         return
     }
     void lw.locate.pair.name('cursor')
@@ -230,6 +235,7 @@ export function multiCursorEnvName() {
 export function toggleEquationEnv() {
     logger.log('toggleEquationEnv command invoked.')
     if (!vscode.window.activeTextEditor || !lw.file.hasLaTeXLangId(vscode.window.activeTextEditor.document.languageId)) {
+        logger.log('Cannot run toggleEquationEnv. The active editor is undefined, or the document is not a LaTeX document.')
         return
     }
     void lw.locate.pair.name('equationToggle')
@@ -238,6 +244,7 @@ export function toggleEquationEnv() {
 export function closeEnv() {
     logger.log('CloseEnv command invoked.')
     if (!vscode.window.activeTextEditor || !lw.file.hasLaTeXLangId(vscode.window.activeTextEditor.document.languageId)) {
+        logger.log('Cannot run closeEnv. The active editor is undefined, or the document is not a LaTeX document.')
         return
     }
     void lw.locate.pair.close()

--- a/src/core/commands.ts
+++ b/src/core/commands.ts
@@ -146,8 +146,8 @@ export async function clean(): Promise<void> {
 
 export function addTexRoot() {
     logger.log('ADDTEXROOT command invoked.')
-    if (!vscode.window.activeTextEditor || !lw.file.hasLaTeXLangId(vscode.window.activeTextEditor.document.languageId)) {
-        logger.log('Cannot add tex root. The active editor is undefined, or the document is not a LaTeX document.')
+    if (!vscode.window.activeTextEditor || !lw.file.hasLaTeXLangId(vscode.window.activeTextEditor.document.languageId) || !lw.file.hasLaTeXClassPackageLangId(vscode.window.activeTextEditor.document.languageId)) {
+        logger.log('Cannot add tex root. The active editor is undefined, or the document is not related to a LaTeX document.')
         return
     }
     lw.extra.texroot()

--- a/src/core/file.ts
+++ b/src/core/file.ts
@@ -19,6 +19,7 @@ export const file = {
     hasBinaryExt,
     hasTeXExt,
     hasLaTeXLangId,
+    hasLaTeXClassPackageLangId,
     hasTeXLangId,
     hasBibLangId,
     hasDtxLangId,
@@ -152,7 +153,18 @@ function hasBinaryExt(extname: string): boolean {
  * language identifiers, otherwise `false`.
  */
 function hasLaTeXLangId(langId: string): boolean {
-    return ['latex', 'context', 'latex-expl3', 'doctex', 'pweave', 'jlweave', 'rsweave'].includes(langId)
+    return ['latex', 'context', 'latex-expl3', 'pweave', 'jlweave', 'rsweave'].includes(langId)
+}
+
+/**
+ * Determines if the given language ID corresponds to a LaTeX class or package.
+ *
+ * @param {string} langId - The language identifier to check.
+ * @returns {boolean} Returns `true` if `langId` is one of the LaTeX class or package
+ * language identifiers, otherwise `false`.
+ */
+function hasLaTeXClassPackageLangId(langId: string): boolean {
+    return ['latex-class', 'latex-package'].includes(langId)
 }
 
 /**
@@ -163,11 +175,11 @@ function hasLaTeXLangId(langId: string): boolean {
  * language identifiers, otherwise `false`.
  */
 function hasTeXLangId(langId: string): boolean {
-    return ['tex', 'latex-class', 'latex-package', 'doctex-installer'].includes(langId)
+    return ['tex', 'doctex-installer'].includes(langId)
 }
 
 /**
- * Returns `true` if the language id is 'bibtex'.
+ * Returns `true` if the language ID is 'bibtex'.
  *
  * @param {string} langId - The language identifier.
  * @returns {boolean} - Indicates whether the language is BibTeX.
@@ -177,7 +189,7 @@ function hasBibLangId(langId: string): boolean {
 }
 
 /**
- * Returns `true` if the language id is 'doctex'.
+ * Returns `true` if the language ID is 'doctex'.
  *
  * @param {string} langId - The language identifier.
  * @returns {boolean} - Indicates whether the language is Doctex.
@@ -187,7 +199,7 @@ function hasDtxLangId(langId: string): boolean {
 }
 
 function hasLaTeXWorkshopLangId(langId: string): boolean {
-    return hasLaTeXLangId(langId) || hasTeXLangId(langId) || hasBibLangId(langId) || hasDtxLangId(langId)
+    return hasLaTeXLangId(langId) || hasLaTeXClassPackageLangId(langId) || hasTeXLangId(langId) || hasBibLangId(langId) || hasDtxLangId(langId)
 }
 /**
  * An object that stores the output and auxiliary directories for TeX files.

--- a/src/core/root.ts
+++ b/src/core/root.ts
@@ -206,7 +206,10 @@ function findFromRoot(): string | undefined {
         return
     }
     logger.log('Try finding root from current root.')
-    if (lw.cache.getIncludedTeX().has(vscode.window.activeTextEditor.document.fileName)) {
+    const langId = vscode.window.activeTextEditor.document.languageId
+    if (langId && (lw.file.hasLaTeXLangId(langId) || lw.file.hasLaTeXClassPackageLangId(langId))
+        && lw.cache.getIncludedTeX().has(vscode.window.activeTextEditor.document.fileName)) {
+        logger.log(`Current root file is still valid: ${root.file.path}`)
         return root.file.path
     }
     return

--- a/src/main.ts
+++ b/src/main.ts
@@ -77,10 +77,11 @@ export function activate(extensionContext: vscode.ExtensionContext) {
             lw.lint.latex.root()
             if (lw.compile.isFileExcludedFromBuildOnSave(e.fileName)) {
                 logger.log(`File ${file} is excluded from build-on-save due to configuration.`)
-                return
             } else {
                 void lw.compile.autoBuild(e.fileName, 'onSave')
             }
+        }
+        if (lw.file.hasLaTeXLangId(e.languageId)) {
             lw.extra.count(e.fileName)
         }
         // We don't check LaTeX ID as the reconstruct is handled by the Cacher.
@@ -248,7 +249,7 @@ function registerProviders(extensionContext: vscode.ExtensionContext) {
 
     // According to cmhughes/latexindent.pl, it aims to beautify .tex, .sty and .cls files.
     const latexindentSelector = selectDocumentsWithId(['tex', 'latex', 'latex-expl3', 'latex-class', 'latex-package'])
-    const latexSelector = selectDocumentsWithId(['latex', 'latex-expl3', 'pweave', 'jlweave', 'rsweave', 'latex-class', 'latex-package', 'biblatex', 'context'])
+    const latexSymbolSelector = selectDocumentsWithId(['latex', 'latex-expl3', 'pweave', 'jlweave', 'rsweave', 'context'])
     const weaveSelector = selectDocumentsWithId(['pweave', 'jlweave', 'rsweave'])
     const latexDoctexSelector = selectDocumentsWithId(['latex', 'latex-expl3', 'pweave', 'jlweave', 'rsweave', 'latex-class', 'latex-package', 'biblatex', 'context', 'doctex', 'doctex-installer'])
     const bibtexSelector = selectDocumentsWithId(['bibtex'])
@@ -267,9 +268,9 @@ function registerProviders(extensionContext: vscode.ExtensionContext) {
     )
 
     extensionContext.subscriptions.push(
-        vscode.languages.registerHoverProvider(latexSelector, lw.preview.provider),
-        vscode.languages.registerDefinitionProvider(latexSelector, lw.language.definition),
-        vscode.languages.registerDocumentSymbolProvider(latexSelector, lw.language.docSymbol),
+        vscode.languages.registerHoverProvider(latexSymbolSelector, lw.preview.provider),
+        vscode.languages.registerDefinitionProvider(latexSymbolSelector, lw.language.definition),
+        vscode.languages.registerDocumentSymbolProvider(latexSymbolSelector, lw.language.docSymbol),
         vscode.languages.registerDocumentSymbolProvider(bibtexSelector, lw.language.docSymbol),
         vscode.languages.registerDocumentSymbolProvider(selectDocumentsWithId(['doctex']), lw.language.docSymbol),
         vscode.languages.registerWorkspaceSymbolProvider(lw.language.projectSymbol)
@@ -318,8 +319,8 @@ function registerProviders(extensionContext: vscode.ExtensionContext) {
     })
 
     extensionContext.subscriptions.push(
-        vscode.languages.registerCodeActionsProvider(latexSelector, lw.lint.latex.actionprovider),
-        vscode.languages.registerFoldingRangeProvider(latexSelector, lw.language.folding),
+        vscode.languages.registerCodeActionsProvider(latexSymbolSelector, lw.lint.latex.actionprovider),
+        vscode.languages.registerFoldingRangeProvider(latexSymbolSelector, lw.language.folding),
         vscode.languages.registerFoldingRangeProvider(weaveSelector, lw.language.weaveFolding),
         vscode.languages.registerFoldingRangeProvider(latexDoctexSelector, lw.language.doctexFolding)
     )

--- a/src/main.ts
+++ b/src/main.ts
@@ -76,7 +76,7 @@ export function activate(extensionContext: vscode.ExtensionContext) {
             logger.log(`onDidSaveTextDocument triggered: ${e.uri.toString(true)}`)
             lw.lint.latex.root()
             if (lw.compile.isFileExcludedFromBuildOnSave(e.fileName)) {
-                logger.log(`File ${file} is excluded from build-on-save due to configuration.`)
+                logger.log(`File ${e.fileName} is excluded from build-on-save due to configuration.`)
             } else {
                 void lw.compile.autoBuild(e.fileName, 'onSave')
             }

--- a/src/main.ts
+++ b/src/main.ts
@@ -70,7 +70,7 @@ export function activate(extensionContext: vscode.ExtensionContext) {
         if (!lw.constant.FILE_URI_SCHEMES.includes(e.uri.scheme)){
             return
         }
-        if (lw.file.hasLaTeXLangId(e.languageId) ||
+        if (lw.file.hasLaTeXLangId(e.languageId) || lw.file.hasLaTeXClassPackageLangId(e.languageId) ||
             lw.cache.getIncludedTeX(lw.root.file.path).has(e.fileName) ||
             lw.cache.getIncludedBib().includes(e.fileName)) {
             logger.log(`onDidSaveTextDocument triggered: ${e.uri.toString(true)}`)

--- a/src/main.ts
+++ b/src/main.ts
@@ -122,10 +122,9 @@ export function activate(extensionContext: vscode.ExtensionContext) {
             return
         }
 
-        if (e && (
-            lw.file.hasLaTeXLangId(e.document.languageId)
+        if ( lw.file.hasLaTeXLangId(e.document.languageId)
             || lw.file.hasBibLangId(e.document.languageId)
-            || lw.file.hasDtxLangId(e.document.languageId))) {
+            || lw.file.hasDtxLangId(e.document.languageId)) {
             void lw.outline.refresh()
         }
     }))

--- a/src/main.ts
+++ b/src/main.ts
@@ -75,7 +75,12 @@ export function activate(extensionContext: vscode.ExtensionContext) {
             lw.cache.getIncludedBib().includes(e.fileName)) {
             logger.log(`onDidSaveTextDocument triggered: ${e.uri.toString(true)}`)
             lw.lint.latex.root()
-            void lw.compile.autoBuild(e.fileName, 'onSave')
+            if (lw.compile.isFileExcludedFromBuildOnSave(e.fileName)) {
+                logger.log(`File ${file} is excluded from build-on-save due to configuration.`)
+                return
+            } else {
+                void lw.compile.autoBuild(e.fileName, 'onSave')
+            }
             lw.extra.count(e.fileName)
         }
         // We don't check LaTeX ID as the reconstruct is handled by the Cacher.

--- a/src/main.ts
+++ b/src/main.ts
@@ -103,15 +103,18 @@ export function activate(extensionContext: vscode.ExtensionContext) {
             return
         }
 
-        if (e && lw.file.hasLaTeXLangId(e.document.languageId) && e.document.fileName !== lw.previousActive?.document.fileName) {
-            await lw.root.find()
-            lw.lint.latex.root()
-        } else if (!e || !lw.file.hasBibLangId(e.document.languageId)) {
-            isLaTeXActive = false
-        }
-
-        if (e && lw.file.hasLaTeXLangId(e.document.languageId)) {
+        if (e && (
+            lw.file.hasLaTeXLangId(e.document.languageId)
+            || lw.file.hasBibLangId(e.document.languageId)
+            || lw.file.hasLaTeXClassPackageLangId(e.document.languageId) )) {
+            if (!lw.file.hasBibLangId(e.document.languageId) && (e.document.fileName !== lw.previousActive?.document.fileName)) {
+                await lw.root.find()
+                lw.lint.latex.root()
+            }
             lw.previousActive = e
+        } else {
+            isLaTeXActive = false
+            return
         }
 
         if (e && (

--- a/src/preview/math-preview-panel.ts
+++ b/src/preview/math-preview-panel.ts
@@ -180,7 +180,7 @@ async function update(ev?: UpdateEvent) {
     }
     const editor = vscode.window.activeTextEditor
     const document = editor?.document
-    if (!editor || !document?.languageId || !lw.file.hasLaTeXWorkshopLangId(document.languageId)) {
+    if (!editor || !document?.languageId || !lw.file.hasLaTeXLangId(document.languageId)) {
         clearCache()
         return
     }

--- a/test/units/01_core_file.test.ts
+++ b/test/units/01_core_file.test.ts
@@ -476,8 +476,6 @@ describe(path.basename(__filename).split('.')[0] + ':', () => {
     describe('lw.file.hasTeXLangId', () => {
         it('should return true for supported TeX languages', () => {
             assert.ok(lw.file.hasTeXLangId('tex'))
-            assert.ok(lw.file.hasTeXLangId('latex-class'))
-            assert.ok(lw.file.hasTeXLangId('latex-package'))
             assert.ok(lw.file.hasTeXLangId('doctex-installer'))
         })
     })


### PR DESCRIPTION
This PR aims at solving #4606 and #4602, which contradict each other.

A new configuration variable is added `latex.autoBuild.onSave.files.ignore` to list which file extension should not trigger a build. The default is to ignore `.sty` and `.cls`. Saving a `.tex` with `latex` id or a bib file triggers a build if build on save is set.