### PR TITLE
Fix language embedding

### DIFF
--- a/package.json
+++ b/package.json
@@ -239,12 +239,50 @@
       {
         "language": "latex-class",
         "scopeName": "text.tex.latex",
-        "path": "./syntax/LaTeX.tmLanguage.json"
+        "path": "./syntax/LaTeX.tmLanguage.json",
+        "embeddedLanguages": {
+          "source.asymptote": "asymptote",
+          "source.cpp": "cpp_embedded_latex",
+          "source.css": "css",
+          "source.dot": "dot",
+          "source.gnuplot": "gnuplot",
+          "text.html": "html",
+          "source.java": "java",
+          "source.js": "javascript",
+          "source.julia": "julia",
+          "source.lua": "lua",
+          "source.python": "python",
+          "source.ruby": "ruby",
+          "source.scala": "scala",
+          "source.ts": "typescript",
+          "text.xml": "xml",
+          "source.yaml": "yaml",
+          "meta.embedded.markdown_latex_combined": "markdown_latex_combined"
+        }
       },
       {
         "language": "latex-package",
         "scopeName": "text.tex.latex",
-        "path": "./syntax/LaTeX.tmLanguage.json"
+        "path": "./syntax/LaTeX.tmLanguage.json",
+        "embeddedLanguages": {
+          "source.asymptote": "asymptote",
+          "source.cpp": "cpp_embedded_latex",
+          "source.css": "css",
+          "source.dot": "dot",
+          "source.gnuplot": "gnuplot",
+          "text.html": "html",
+          "source.java": "java",
+          "source.js": "javascript",
+          "source.julia": "julia",
+          "source.lua": "lua",
+          "source.python": "python",
+          "source.ruby": "ruby",
+          "source.scala": "scala",
+          "source.ts": "typescript",
+          "text.xml": "xml",
+          "source.yaml": "yaml",
+          "meta.embedded.markdown_latex_combined": "markdown_latex_combined"
+        }
       },
       {
         "language": "latex-expl3",
@@ -302,7 +340,26 @@
       {
         "language": "doctex-installer",
         "scopeName": "text.tex.latex",
-        "path": "./syntax/LaTeX.tmLanguage.json"
+        "path": "./syntax/LaTeX.tmLanguage.json",
+        "embeddedLanguages": {
+          "source.asymptote": "asymptote",
+          "source.cpp": "cpp_embedded_latex",
+          "source.css": "css",
+          "source.dot": "dot",
+          "source.gnuplot": "gnuplot",
+          "text.html": "html",
+          "source.java": "java",
+          "source.js": "javascript",
+          "source.julia": "julia",
+          "source.lua": "lua",
+          "source.python": "python",
+          "source.ruby": "ruby",
+          "source.scala": "scala",
+          "source.ts": "typescript",
+          "text.xml": "xml",
+          "source.yaml": "yaml",
+          "meta.embedded.markdown_latex_combined": "markdown_latex_combined"
+        }
       },
       {
         "language": "bibtex",
@@ -313,11 +370,6 @@
         "language": "bibtex-style",
         "scopeName": "source.bst",
         "path": "./syntax/BibTeX-style.tmLanguage.json"
-      },
-      {
-        "language": "biblatex",
-        "scopeName": "text.tex.latex",
-        "path": "./syntax/LaTeX.tmLanguage.json"
       },
       {
         "language": "pweave",


### PR DESCRIPTION
Related to #4671 

Language embedding is currently broken. From my understanding, the entries in `contributes.grammars` may overwrite. In particular if a grammar is used by two languages, for instance `latex` and `biblatex`, the `embbedLangagues` must be repeated in the `biblatex` entry. It seems to be corroborated by 

https://github.com/microsoft/vscode/blob/6b924c51528e663dda5091a1493229a361676aca/src/vs/workbench/services/textMate/common/TMGrammars.ts#L52-L55

It does not seem to break anything else. I will make a few more tests and hopefully merge it.