### PR TITLE
Mouse wheel-driven page turning in viewer when Page Scrolling is enabled

### DIFF
--- a/viewer/viewer.mjs
+++ b/viewer/viewer.mjs
@@ -14845,6 +14845,42 @@ function onWheel(evt) {
       }
       this.updateZoom(ticks, null, origin);
     }
+    return;
+  }
+
+  // Minimal page-turn-on-wheel behavior: 
+  // If there is remaining content to scroll in the wheel direction, let native scrolling occur, otherwise turn page.
+  if (pdfViewer.scrollMode === ScrollMode.PAGE) {
+    const container = pdfViewer.container;
+    if (!container) {
+      return;
+    }
+
+    const absX = Math.abs(evt.deltaX || 0);
+    const absY = Math.abs(evt.deltaY || 0);
+    const useHorizontal = absX > absY || (evt.shiftKey && absY > 0);
+
+    let goNext = false;
+    if (useHorizontal) {
+      const goingRight = (evt.deltaX || (evt.shiftKey ? evt.deltaY : 0)) > 0;
+      if (container.scrollWidth > container.clientWidth + 1) {
+        return; // allow native horizontal scrolling
+      }
+      goNext = goingRight; // right => next, left => previous
+    } else {
+      const goingDown = (evt.deltaY || 0) > 0;
+      if (container.scrollHeight > container.clientHeight + 1) {
+        return; // allow native vertical scrolling
+      }
+      goNext = goingDown; // down => next, up => previous
+    }
+
+    evt.preventDefault();
+    if (goNext) {
+      pdfViewer.nextPage();
+    } else {
+      pdfViewer.previousPage();
+    }
   }
 }
 function closeSecondaryToolbar(evt) {


### PR DESCRIPTION
## Overview
This PR adds a very small change to viewer.mjs (`onWheel`) so the mouse wheel (vertical or horizontal) will turn the page when there is no content to scroll in that wheel direction.

## Motivation
Users expect the wheel to behave similar to PgDn/PgUp for single-page viewing: if there is nowhere to scroll on the page, the mouse wheel should advance/rewind the document.

## Behavior changes
- New: In Page Scrolling mode (`scrollMode=3`), when a wheel event has no scrollable content in its dominant axis:
  - Scrolling down/right → next page
  - Scrolling up/left → previous page
- Native behavior preserved:
  - If there is content to scroll in the wheel direction, the event is not intercepted and the browser handles scrolling.
  - Ctrl/Meta/pinch zoom handling is unchanged and still takes precedence.
  - "Presentation mode" (whatever that is) is unaffected.

## Implementation
- File: [viewer.mjs](viewer.mjs)
- Function: `onWheel(evt)`
  - Keep the existing zoom branch intact and return early after handling zoom.
  - Detect dominant axis (horizontal vs vertical; support Shift+wheel).
  - If the axis is scrollable, return to allow native scrolling; otherwise do nothing (conservative: no flip when zoomed in).

## Backward compatibility
- Minimal, low-risk change:
  - No new settings or flags.
  - Existing zoom and scrolling semantics preserved except for the added wheel→page action when there is no scrollable content.
  - Presentation mode and other keyboard shortcuts remain unchanged.

## How to test
1. Choose zoom mode "Page Fit" or smaller:
   - Wheel down/right → next page immediately.
   - Wheel up/left → previous page immediately.
2. Zoomed in (page larger than viewport):
   - Wheel scrolls within the page normally; no page flip while there is content to scroll.

## Follow-ups:
I have also developed a more comprehensive, "edge-aware" Page Scrolling mode, which might be preferrable, let me know what you think. If so, I can move that content onto this branch:
- When fully zoomed out, let the user change pages with the mouse wheel—just like this PR.
- When zoomed in, flipping to the previous/next page is triggered when the viewport is at the top/bottom (or left/right) edge and the user keeps “pushing” in that direction.
- Additionally, Up/Down/Space and PageUp/PageDown keys perform a similar behavior, allowing for flipping pages when reaching the end of the scroll bar.