### PR TITLE
improve outdir for bibtex

### DIFF
--- a/src/compile/build.ts
+++ b/src/compile/build.ts
@@ -186,6 +186,36 @@ async function buildLoop() {
     isBuilding = false
     setTimeout(() => lw.compile.compiledPDFWriting--, vscode.workspace.getConfiguration('latex-workshop').get('latex.watch.pdf.delay') as number * 2)
 }
+/** Normalizes a command-line argument that represents a file path to be
+ * relative to the current working directory (`cwd`) if it is under the root
+ * directory (`rootDir`). If the argument does not represent a path or is not
+ * under the root directory, it is returned unchanged.
+ *
+ * @param {string} arg - The command-line argument to normalize.
+ * @param {string} cwd - The current working directory.
+ * @param {string} rootDir - The root directory of the LaTeX project.
+ * @returns {string} - The normalized command-line argument.
+ */
+function normalizeArgForCwd(arg: string, cwd: string, rootDir: string): string {
+    if (!arg) { return arg }
+    let abs: string
+    try {
+        abs = path.isAbsolute(arg) ? path.normalize(arg) : path.resolve(cwd, arg)
+    } catch {
+        logger.log(`Cannot resolve path for arg: ${arg} please check if it is a valid path.`)
+        return arg
+    }
+    const relToRoot = path.relative(rootDir, abs)
+    const isUnderRoot = relToRoot === '' || (!relToRoot.startsWith('..') && !path.isAbsolute(relToRoot))
+    if (!isUnderRoot) {
+        logger.log(`Argument path not under root dir, you can wiki how to set openout_any=a if you want to keep as-is: ${arg}`)
+        return arg
+    }
+    const rel = path.relative(cwd, abs).split(path.sep).join('/')
+    logger.log(`Argument path converted to relative: ${arg} -> ${rel}`)
+    return rel
+}
+
 
 /**
  * Spawns a child process for the specified step. The function creates the
@@ -235,6 +265,9 @@ function spawnProcess(step: Step): ProcessEnv {
         let cwd = path.dirname(step.rootFile)
         if (step.command === 'latexmk' && step.rootFile === lw.root.subfiles.path && lw.root.dir.path) {
             cwd = lw.root.dir.path
+        }
+        if (step.command === 'bibtex' && step.args && step.args.length > 0) {
+            step.args[step.args.length - 1] = normalizeArgForCwd(step.args[step.args.length - 1], cwd, cwd)
         }
         logger.log(`cwd: ${cwd}`)
         lw.compile.process = lw.external.spawn(step.command, step.args ?? [], {cwd, env})


### PR DESCRIPTION
Although Even though a solution was [mentioned](https://github.com/gallandarakhneorg/autolatex/issues/83) many years ago , if users configure `outDir` as `%WS1%/build`, the BibTeX parameters must then be configured as `%OUTDIR%/%DOCFILE%`. At this point, the parameters expand to `%WS1%/build/%DOCFILE%`, and `%WS1%` is, in turn, expanded into an absolute path.

Calling the BibTeX recipe at this stage will result in an error. This is because BibTeX, under the default security settings of TeXLive and MacTex (`openout_any = p`), is not allowed to write files (such as .blg/.bbl) to an absolute path outside the working directory. Many users will, sooner or later, encounter this `openout_any = p` problem. https://github.com/James-Yu/LaTeX-Workshop/issues/3045 https://github.com/James-Yu/LaTeX-Workshop/issues/3023 https://github.com/James-Yu/LaTeX-Workshop/issues/2303 https://github.com/James-Yu/LaTeX-Workshop/issues/2042 https://github.com/James-Yu/LaTeX-Workshop/issues/1932 https://github.com/James-Yu/LaTeX-Workshop/issues/384

To address this, I am attempting to solve the issue with a minimal change, which is to add the variable `env['openout_any']='a'
Thanks for your review again.
```
"latex-workshop.latex.outDir": "%DIR%/build",
"latex-workshop.latex.tools": [
  {
    "name": "bibtex",
    "command": "bibtex",
    "args": ["%OUTDIR%/%DOCFILE%"]
  }
]
```

<img width="815" height="115" alt="img" src="https://github.com/user-attachments/assets/506c46fc-60df-49ba-a54e-f8aa068c7455" />
