### PR TITLE
Parse stderr when the build process crashes

### DIFF
--- a/src/compile/build.ts
+++ b/src/compile/build.ts
@@ -349,6 +349,7 @@ function handleExitCodeError(step: Step, env: ProcessEnv, stderr: string, code: 
         logger.log(`Recipe returns with error code ${code}/${signal} on PID ${lw.compile.process?.pid}.`)
         logger.log(`Does the executable exist? $PATH: ${env['PATH']}, $Path: ${env['Path']}, $SHELL: ${process.env.SHELL}`)
         logger.log(`${stderr}`)
+        lw.parser.parse.log(stderr)
     }
 
     const configuration = vscode.workspace.getConfiguration('latex-workshop', step.rootFile ? lw.file.toUri(step.rootFile) : undefined)


### PR DESCRIPTION
Attempt to improve #4713. Somehow a follow-up on https://github.com/James-Yu/LaTeX-Workshop/commit/af72751ee4dc00062ca8a8bbe3e3d4751258af1c
@James-Yu What do you think?