### PR TITLE
Fix #4724 Add WASM support for PDF.js v5.4.394

### DIFF
--- a/dev/editviewer.py
+++ b/dev/editviewer.py
@@ -39,6 +39,7 @@ with open(args.web + '/viewer.mjs', 'rt', encoding='utf-8') as fin:
                 .replace('''value: "../build/pdf.sandbox.mjs"''', '''value: "./build/pdf.sandbox.mjs"''') \
                 .replace('''value: "../web/standard_fonts/"''', '''value: "../standard_fonts/"''') \
                 .replace('''value: "../web/cmaps/"''', '''value: "../cmaps/"''') \
+                .replace('''value: "../web/wasm/"''', '''value: "../wasm/"''') \
                 .replace('''(this.container.clientWidth - hPadding) / currentPage.width * currentPage.scale / this.#pageWidthScaleFactor;''', '''(this.container.clientWidth - hPadding) / Math.max(...this._pages.map(p => p.width)) * currentPage.scale / this.#pageWidthScaleFactor * (1 / (1 - (viewerTrim ?? 0) / 100));''') \
                 .replace('''(this.container.clientHeight - vPadding) / currentPage.height * currentPage.scale;''', '''(this.container.clientHeight - vPadding) / Math.max(...this._pages.map(p => p.height)) * currentPage.scale * (1 / (1 - (viewerTrim ?? 0) / 100));''') \
                 .replace('''setRotation(this.initialRotation);''', '''// setRotation(this.initialRotation);''') \

--- a/src/preview/server.ts
+++ b/src/preview/server.ts
@@ -228,7 +228,7 @@ async function handler(request: http.IncomingMessage, response: http.ServerRespo
         return
     }
     let root: string
-    if (request.url.startsWith('/build/') || request.url.startsWith('/cmaps/') || request.url.startsWith('/standard_fonts/')) {
+    if (request.url.startsWith('/build/') || request.url.startsWith('/cmaps/') || request.url.startsWith('/standard_fonts/') || request.url.startsWith('/wasm/')) {
         root = path.resolve(lw.extensionRoot, 'node_modules', 'pdfjs-dist')
         console.log('Request URL:', request.url, 'served from', root)
     } else if (request.url.startsWith('/out/viewer/') || request.url.startsWith('/viewer/')) {

--- a/viewer/latexworkshop.ts
+++ b/viewer/latexworkshop.ts
@@ -53,9 +53,10 @@ async function initialization() {
             annotationEditorMode: -1,
             disablePreferences: true,
             enableScripting: false,
-            // The following two paths are requested from ./build/cmaps/ and ./build/standard_fonts/
+            // The following paths are requested from ./build/cmaps/, ./build/standard_fonts/, and ./build/wasm/
             cMapUrl: '../cmaps/',
             standardFontDataUrl: '../standard_fonts/',
+            wasmUrl: '../wasm/',
             sidebarViewOnLoad: 0,
             workerSrc: './build/pdf.worker.mjs',
             forcePageColors: true,


### PR DESCRIPTION
## Problem

PDF.js v5.4.394 introduced WASM modules for JPEG 2000 decoding and color management, but the extension was missing the required configuration and routing. This caused:
- Blank PDFs when viewing scanned documents (JPEG 2000 compression)
- Missing CJK (Chinese, Japanese, Korean) characters in PDFs
- Console errors: `JpxError: OpenJPEG failed to initialize`

Root cause: When PDF.js tried to load WASM files (`openjpeg.wasm`, `qcms_bg.wasm`), the server returned 404 errors because:
1. No `wasmUrl` configuration in viewer options
2. No `/wasm/` route handler in the server

## Solution

This PR adds the missing WASM support in 3 files:

1. **viewer/latexworkshop.ts**: Add `wasmUrl: '../wasm/'` to PDF.js options
2. **src/preview/server.ts**: Add `/wasm/` route to serve files from `pdfjs-dist`
3. **dev/editviewer.py**: Add path replacement for future PDF.js updates

## Testing

Verified the fix resolves the issue:
- ✅ Scanned PDFs (image-based) display correctly
- ✅ CJK characters render properly in all tested documents
- ✅ Console shows successful WASM loading (200 OK)
- ✅ Tested with the sample PDF from issue #4724
- ✅ Tested with Japanese text documents

## Related

- Fixes #4724
- Similar to #4710 (cmaps/standard_fonts path fix)