### PR TITLE
fix: tex-fmt subprocess halting when pipe buffer for stderr is full

### DIFF
--- a/src/lint/latex-formatter/tex-fmt.ts
+++ b/src/lint/latex-formatter/tex-fmt.ts
@@ -25,6 +25,11 @@ async function formatDocument(document: vscode.TextDocument, range?: vscode.Rang
         stdout = Buffer.concat([stdout, Buffer.isBuffer(msg) ? msg : Buffer.from(msg)])
     })
 
+    let stderr: Buffer = Buffer.alloc(0)
+    process.stderr?.on('data', (msg: Buffer | string) => {
+        stderr = Buffer.concat([stderr, Buffer.isBuffer(msg) ? msg : Buffer.from(msg)])
+    })
+
     const promise = new Promise<vscode.TextEdit | undefined>(resolve => {
         process.on('error', err => {
             logger.logError(`Failed to run ${program}`, err)


### PR DESCRIPTION
### Description of the issue
LaTeX-Workshop spawns a ChildProcess of tex-fmt in `--stdin`-mode and adds a listener-function to the stdout stream that writes the data in the stream into a Buffer as tex-fmt outputs the result of formatting to stdout.
Warnings while formatting are written to stderr which has no listener attached to it. This wouldn't be a problem normally but with too many warnings the maximum buffer size for stderr is reached.
More information on this can be found [here](https://nodejs.org/docs/latest-v18.x/api/child_process.html#child-process)

Quote:
> By default, pipes for stdin, stdout, and stderr are established between the parent Node.js process and the spawned subprocess. These pipes have limited (and platform-specific) capacity. If the subprocess writes to stdout in excess of that limit without the output being captured, the subprocess blocks waiting for the pipe buffer to accept more data. This is identical to the behavior of pipes in the shell. Use the { stdio: 'ignore' } option if the output will not be consumed.

So the ChildProcess blocks execution until the stderr-buffer is read. This leads to infinite waiting for the stderr-Buffer to be read and the fomatting not working.

https://github.com/user-attachments/assets/c3330a10-9327-4d01-999c-b4027fbb442b

### Proposed solution
Just read the process-stderr into another buffer and discard it. This way the execution does not block when the buffer is full.

### Quick fix until this is merged
Just configure the `--quiet` command-line option to be used. This way warnings aren't emitted by tex-fmt in the first place

### Future considerations
The warnings and errors emitted by tex-fmt (or even latexindent) cloud be emitted to the user in some way. I have created an issue to discuss this:
https://github.com/James-Yu/LaTeX-Workshop/issues/4744