### PR TITLE
Improve magic comments logic

### DIFF
--- a/src/compile/recipe.ts
+++ b/src/compile/recipe.ts
@@ -153,10 +153,13 @@ async function createBuildTools(rootFile: string, langId: string, recipeName?: s
     const configuration = vscode.workspace.getConfiguration('latex-workshop', lw.file.toUri(rootFile))
     const magic = await findMagicComments(rootFile)
 
-    if (configuration.get('latex.build.enableMagicComments') && magic.tex ) {
+    if (configuration.get('latex.build.enableMagicComments') && !recipeName && magic.tex) {
         buildTools = createBuildMagic(rootFile, magic.tex, magic.bib)
     } else {
-        const recipe = findRecipe(rootFile, langId, recipeName || magic.recipe)
+        if (configuration.get('latex.build.enableMagicComments') && !recipeName && magic.recipe) {
+            recipeName = magic.recipe
+        }
+        const recipe = findRecipe(rootFile, langId, recipeName)
         if (recipe === undefined) {
             return
         }

--- a/src/core/commands.ts
+++ b/src/core/commands.ts
@@ -16,7 +16,11 @@ export async function hostPort() {
 }
 
 export async function build(skipSelection: boolean = false, rootFile: string | undefined = undefined, languageId: string | undefined = undefined, recipe: string | undefined = undefined) {
-    logger.log('BUILD command invoked.')
+    let recipeStr = ''
+    if (recipe) {
+        recipeStr = ` with recipe ${recipe}`
+    }
+    logger.log(`BUILD command invoked${recipeStr}.`)
     await lw.compile.build(skipSelection, rootFile, languageId, recipe)
 }
 

--- a/test/units/06_compile_recipe.test.ts
+++ b/test/units/06_compile_recipe.test.ts
@@ -163,7 +163,6 @@ describe(path.basename(__filename).split('.')[0] + ':', () => {
 
         it('should skip undefined tools in the recipe and log an error', async () => {
             const rootFile = set.root('main.tex')
-            // set.config('latex.build.enableMagicComments', false)
             set.config('latex.tools', [{ name: 'existingTool', command: 'pdflatex' }])
             set.config('latex.recipes', [{ name: 'Recipe1', tools: ['nonexistentTool', 'existingTool'] }])
 
@@ -179,7 +178,6 @@ describe(path.basename(__filename).split('.')[0] + ':', () => {
 
         it('should do nothing but log an error if no tools are prepared', async () => {
             const rootFile = set.root('main.tex')
-            // set.config('latex.build.enableMagicComments', false)
             set.config('latex.tools', [])
             set.config('latex.recipes', [{ name: 'Recipe1', tools: ['nonexistentTool'] }])
 
@@ -347,6 +345,20 @@ describe(path.basename(__filename).split('.')[0] + ':', () => {
             assert.ok(step)
             assert.strictEqual(step.name, 'Tool2')
             assert.strictEqual(step.command, 'xelatex')
+        })
+
+            it('should ignore LW recipe comment when calling a given recipe', async () => {
+            set.config('latex.tools', [{ name: 'Tool1', command: 'pdflatex' }, { name: 'Tool2', command: 'xelatex' }])
+            set.config('latex.recipes', [{ name: 'Recipe1', tools: ['Tool1'] }, { name: 'Recipe2', tools: ['Tool2'] }])
+
+            readStub.resolves('% !LW recipe = Recipe2\n')
+
+            await build('dummy.tex', 'latex', async () => {}, 'Recipe1')
+
+            const step = queue.getStep()
+            assert.ok(step)
+            assert.strictEqual(step.name, 'Tool1')
+            assert.strictEqual(step.command, 'pdflatex')
         })
 
         it('should detect all magic comments', async () => {


### PR DESCRIPTION
Related to 

- #4818 
- #4816
- #4813

This PR improves the logic of magic comments handling

1. Calling a recipe from the TeX badge overrides any magic comments
1. If build is called without any recipe name (ie with `ctrl-alt-b` or using the build icon) and magic comments are enabled
   1. If a `% !LW recipe` comment is present, use the recipe given by the magic comment.
   1. If a `% !TEX program` comment is present, use it as a tool to build the file instead of calling a defined recipe.

If we are not in any of the above cases, infer the recipe name as before `10.13.0`.

@James-Yu What do you think of this logic?