### PR TITLE
Change dark mode pdf view background color to dark in settings

### DIFF
--- a/src/preview/viewer.ts
+++ b/src/preview/viewer.ts
@@ -353,7 +353,7 @@ function getParams(): PdfViewerParams {
             dark: {
                 pageColorsForeground: configuration.get('view.pdf.color.dark.pageColorsForeground') || '',
                 pageColorsBackground: configuration.get('view.pdf.color.dark.pageColorsBackground') || '',
-                backgroundColor: configuration.get('view.pdf.color.dark.backgroundColor', '#ffffff'),
+                backgroundColor: configuration.get('view.pdf.color.dark.backgroundColor', '#1b1b1b'),
                 pageBorderColor: configuration.get('view.pdf.color.dark.pageBorderColor', 'lightgrey'),
             },
         },


### PR DESCRIPTION
Change dark mode pdf view background color to darker shade #1b1b1b in the settings, taken from Adobe Acrobat pdf background color in dark mode.

Made the following suggestion permanent: https://github.com/James-Yu/LaTeX-Workshop/issues/1825