### PR TITLE
Providing a Log Parser for `dvipdfmx`

### DIFF
--- a/package.json
+++ b/package.json
@@ -2403,6 +2403,15 @@
           "default": [],
           "markdownDescription": "Exclude bibtex log messages matching the given regexp from the problems panel."
         },
+        "latex-workshop.message.dvipdfmxlog.exclude": {
+          "scope": "window",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "markdownDescription": "Exclude dvipdfmx log messages matching the given regexp from the problems panel."
+        },
         "latex-workshop.message.latexlog.exclude": {
           "scope": "window",
           "type": "array",

--- a/src/compile/build.ts
+++ b/src/compile/build.ts
@@ -319,7 +319,15 @@ async function monitorProcess(step: Step, env: ProcessEnv): Promise<boolean> {
         })
 
         lw.compile.process.on('exit', (code, signal) => {
-            const isSkipped = lw.parser.parse.log(stdout, step.rootFile)
+            let isSkipped = false
+
+            if (stderr.trim().length > 0) {
+                isSkipped = lw.parser.parse.log(stderr, step.rootFile) || isSkipped
+            }
+            if (stdout.trim().length > 0) {
+                isSkipped = lw.parser.parse.log(stdout, step.rootFile) || isSkipped
+            }
+
             if (!step.isExternal) {
                 step.isSkipped = isSkipped
             }
@@ -337,7 +345,7 @@ async function monitorProcess(step: Step, env: ProcessEnv): Promise<boolean> {
                 return
             }
 
-            handleExitCodeError(step, env, stderr, code, signal)
+            handleExitCodeError(step, env, stdout, stderr, code, signal)
             resolve(false)
         })
     })
@@ -377,12 +385,20 @@ function handleProcessError(env: ProcessEnv, stderr: string, err: Error) {
  * @param {number | null} code - The exit code of the process.
  * @param {NodeJS.Signals | null} signal - The exit signal of the process.
  */
-function handleExitCodeError(step: Step, env: ProcessEnv, stderr: string, code: number | null, signal: NodeJS.Signals | null) {
+function handleExitCodeError(step: Step, env: ProcessEnv, stdout: string, stderr: string, code: number | null, signal: NodeJS.Signals | null) {
     if (!step.isExternal) {
         logger.log(`Recipe returns with error code ${code}/${signal} on PID ${lw.compile.process?.pid}.`)
         logger.log(`Does the executable exist? $PATH: ${env['PATH']}, $Path: ${env['Path']}, $SHELL: ${process.env.SHELL}`)
-        logger.log(`${stderr}`)
-        lw.parser.parse.log(stderr)
+
+        if (stdout.trim().length > 0) {
+            logger.log(stdout)
+            lw.parser.parse.log(stdout)
+        }
+
+        if (stderr.trim().length > 0) {
+            logger.log(stderr)
+            lw.parser.parse.log(stderr)
+        }
     }
 
     const configuration = vscode.workspace.getConfiguration('latex-workshop', step.rootFile ? lw.file.toUri(step.rootFile) : undefined)

--- a/src/compile/build.ts
+++ b/src/compile/build.ts
@@ -321,6 +321,10 @@ async function monitorProcess(step: Step, env: ProcessEnv): Promise<boolean> {
         lw.compile.process.on('exit', (code, signal) => {
             let isSkipped = false
 
+            // #4838 LaTeX writes messages to stdout, while dvipdfmx writes
+            // messages to stderr, so both output streams need to be parsed.
+            // Both stdout and stderr are parsed every time, but only when they
+            // contain non-whitespace content.
             if (stderr.trim().length > 0) {
                 isSkipped = lw.parser.parse.log(stderr, step.rootFile) || isSkipped
             }

--- a/src/parse/parser.ts
+++ b/src/parse/parser.ts
@@ -82,15 +82,16 @@ const latexXeNoOutputPattern = /^No pages of output.$/gm
 const latexmkPattern = /^Latexmk:\sapplying\srule/gm
 const latexmkLog = /^Latexmk:\sapplying\srule/
 const latexmkLogLatex = /^Latexmk:\sapplying\srule\s'(pdf|lua|xe)?latex'/
+const latexmkLogDvipdfmx = /^Running 'dvipdfmx/
 const latexmkUpToDate = /^Latexmk: All targets \(.*\) are up-to-date/m
 
 const texifyPattern = /^running\s(pdf|lua|xe)?latex/gm
 const texifyLog = /^running\s((pdf|lua|xe)?latex|miktex-bibtex)/
 const texifyLogLatex = /^running\s(pdf|lua|xe)?latex/
 
-const dvipdfmxPattern = /^(.*)\.dvi -> (.*)\.pdf/
+const dvipdfmxPattern = /^(.*)\.dvi -> (.*)\.pdf/m
 const dvipdfmxPatternAlt = /^dvipdfmx: ((Missing argument|Unexpected argument in).*|Multiple dvi filenames\?)/
-const outputDviFile = /^Output written on (.+)\.dvi \(.*\)\./
+const dvipdfmxConfigOption = /^config_special: Unknown option .*?/
 
 const bibtexPattern = /^This is BibTeX, Version.*$/m
 const biberPattern = /^INFO - This is Biber .*$/m
@@ -117,8 +118,10 @@ function log(msg: string, rootFile?: string): boolean {
         bibtexLogParser.showLog()
     }
 
+    let msgDvipdfmx = msg
     if (msg.match(latexmkPattern)) {
         msg = trimLaTeXmk(msg)
+        msgDvipdfmx = trimLaTeXmkDvipdfmx(msgDvipdfmx)
     } else if (msg.match(texifyPattern)) {
         msg = trimTexify(msg)
     }
@@ -128,10 +131,8 @@ function log(msg: string, rootFile?: string): boolean {
     } else if (latexmkSkipped(msg)) {
         isLaTeXmkSkipped = true
     }
-
-    if (msg.match(dvipdfmxPattern) || msg.match(dvipdfmxPatternAlt) || msg.match(outputDviFile)) {
-        logger.log(`In dvipdfmxPattern`)
-        dvipdfmxLogParser.parse(msg, rootFile)
+    if (msgDvipdfmx.match(dvipdfmxPattern) || msgDvipdfmx.match(dvipdfmxPatternAlt) || msgDvipdfmx.match(dvipdfmxConfigOption)) {
+        dvipdfmxLogParser.parse(msgDvipdfmx, rootFile)
         dvipdfmxLogParser.showLog()
     }
 
@@ -142,9 +143,9 @@ function trimLaTeXmk(msg: string): string {
     return trimPattern(msg, latexmkLogLatex, latexmkLog)
 }
 
-// function trimLaTeXmkDvipdfmx(msg: string): string {
-//     return trimPattern(msg, latexmkLogDvipdfmx, latexmkLog)
-// }
+function trimLaTeXmkDvipdfmx(msg: string): string {
+    return trimPattern(msg, latexmkLogDvipdfmx, latexmkLog)
+}
 
 function trimLaTeXmkBibTeX(msg: string): string {
     return trimPattern(msg, bibtexPattern, latexmkLogLatex)

--- a/src/parse/parser.ts
+++ b/src/parse/parser.ts
@@ -9,6 +9,7 @@ import { getEnvDefs, getMacroDefs } from './parser/unified-defs'
 import { bibtexLogParser } from './parser/bibtexlog'
 import { biberLogParser } from './parser/biberlog'
 import { latexLogParser } from './parser/latexlog'
+import { dvipdfmxLogParser } from './parser/dvipdfmxlog'
 // @ts-expect-error Load unified.js from /out/src/...
 import { toString } from '../../../resources/unified.js'
 
@@ -87,6 +88,10 @@ const texifyPattern = /^running\s(pdf|lua|xe)?latex/gm
 const texifyLog = /^running\s((pdf|lua|xe)?latex|miktex-bibtex)/
 const texifyLogLatex = /^running\s(pdf|lua|xe)?latex/
 
+const dvipdfmxPattern = /^(.*)\.dvi -> (.*)\.pdf/
+const dvipdfmxPatternAlt = /^dvipdfmx: ((Missing argument|Unexpected argument in).*|Multiple dvi filenames\?)/
+const outputDviFile = /^Output written on (.+)\.dvi \(.*\)\./
+
 const bibtexPattern = /^This is BibTeX, Version.*$/m
 const biberPattern = /^INFO - This is Biber .*$/m
 const bibtexPatternAlt = /^The top-level auxiliary file: .*$/m // #4197
@@ -124,12 +129,22 @@ function log(msg: string, rootFile?: string): boolean {
         isLaTeXmkSkipped = true
     }
 
+    if (msg.match(dvipdfmxPattern) || msg.match(dvipdfmxPatternAlt) || msg.match(outputDviFile)) {
+        logger.log(`In dvipdfmxPattern`)
+        dvipdfmxLogParser.parse(msg, rootFile)
+        dvipdfmxLogParser.showLog()
+    }
+
     return isLaTeXmkSkipped
 }
 
 function trimLaTeXmk(msg: string): string {
     return trimPattern(msg, latexmkLogLatex, latexmkLog)
 }
+
+// function trimLaTeXmkDvipdfmx(msg: string): string {
+//     return trimPattern(msg, latexmkLogDvipdfmx, latexmkLog)
+// }
 
 function trimLaTeXmkBibTeX(msg: string): string {
     return trimPattern(msg, bibtexPattern, latexmkLogLatex)
@@ -175,6 +190,7 @@ function trimPattern(msg: string, beginPattern: RegExp, endPattern: RegExp): str
 function latexmkSkipped(msg: string): boolean {
     if (msg.match(latexmkUpToDate) && !msg.match(latexmkPattern)) {
         latexLogParser.showLog()
+        dvipdfmxLogParser.showLog()
         bibtexLogParser.showLog()
         biberLogParser.showLog()
         return true
@@ -186,5 +202,6 @@ function clearLog() {
     // Clear all diagnostics messages
     biberLogParser.clearLog()
     bibtexLogParser.clearLog()
+    dvipdfmxLogParser.clearLog()
     latexLogParser.clearLog()
 }

--- a/src/parse/parser.ts
+++ b/src/parse/parser.ts
@@ -82,7 +82,6 @@ const latexXeNoOutputPattern = /^No pages of output.$/gm
 const latexmkPattern = /^Latexmk:\sapplying\srule/gm
 const latexmkLog = /^Latexmk:\sapplying\srule/
 const latexmkLogLatex = /^Latexmk:\sapplying\srule\s'(pdf|lua|xe)?latex'/
-const latexmkLogDvipdfmx = /^Running 'dvipdfmx/
 const latexmkUpToDate = /^Latexmk: All targets \(.*\) are up-to-date/m
 
 const texifyPattern = /^running\s(pdf|lua|xe)?latex/gm
@@ -118,10 +117,8 @@ function log(msg: string, rootFile?: string): boolean {
         bibtexLogParser.showLog()
     }
 
-    let msgDvipdfmx = msg
     if (msg.match(latexmkPattern)) {
         msg = trimLaTeXmk(msg)
-        msgDvipdfmx = trimLaTeXmkDvipdfmx(msgDvipdfmx)
     } else if (msg.match(texifyPattern)) {
         msg = trimTexify(msg)
     }
@@ -131,8 +128,8 @@ function log(msg: string, rootFile?: string): boolean {
     } else if (latexmkSkipped(msg)) {
         isLaTeXmkSkipped = true
     }
-    if (msgDvipdfmx.match(dvipdfmxPattern) || msgDvipdfmx.match(dvipdfmxPatternAlt) || msgDvipdfmx.match(dvipdfmxConfigOption)) {
-        dvipdfmxLogParser.parse(msgDvipdfmx, rootFile)
+    if (msg.match(dvipdfmxPattern) || msg.match(dvipdfmxPatternAlt) || msg.match(dvipdfmxConfigOption)) {
+        dvipdfmxLogParser.parse(msg, rootFile)
         dvipdfmxLogParser.showLog()
     }
 
@@ -141,10 +138,6 @@ function log(msg: string, rootFile?: string): boolean {
 
 function trimLaTeXmk(msg: string): string {
     return trimPattern(msg, latexmkLogLatex, latexmkLog)
-}
-
-function trimLaTeXmkDvipdfmx(msg: string): string {
-    return trimPattern(msg, latexmkLogDvipdfmx, latexmkLog)
 }
 
 function trimLaTeXmkBibTeX(msg: string): string {

--- a/src/parse/parser/dvipdfmxlog.ts
+++ b/src/parse/parser/dvipdfmxlog.ts
@@ -1,0 +1,139 @@
+import * as vscode from 'vscode'
+import { lw } from '../../lw'
+import { type IParser, type LogEntry, showCompilerDiagnostics } from './parserutils'
+
+
+const logger = lw.log('Parser', 'DvipdfmxLog')
+
+const divpdfmxWarn = /^dvipdfmx:warning: (.+)$/
+const dvipdfmxContinuedWarn = /^dvipdfmx:warning: >> (.*)$/
+const divpdfmxFatal = /^dvipdfmx:fatal: (.+)$/
+const dvipdfmxArgsError = /^dvipdfmx: ((Missing argument|Unexpected argument in) .+?|Multiple dvi filenames\?)/
+const dvipdfmxConfigError = /^config_special: (Unknown option .+)/
+const noOutputPDF = 'No output PDF file written.'
+
+const dvipdfmxDiagnostics = vscode.languages.createDiagnosticCollection('Dvipdfmx')
+
+const buildLog: LogEntry[] = []
+
+export const dvipdfmxLogParser: IParser = {
+    clearLog,
+    showLog,
+    parse
+}
+
+function clearLog() {
+    dvipdfmxDiagnostics.clear()
+}
+
+function showLog() {
+    showCompilerDiagnostics(dvipdfmxDiagnostics, buildLog)
+}
+
+type ParserState = {
+    currentType?: 'warning' | 'error'
+    dvipdfmxBuffer: string[]
+}
+
+function parse(log: string, rootFile?: string) {
+    if (rootFile === undefined) {
+        rootFile = lw.root.file.path
+    }
+    if (rootFile === undefined) {
+        logger.log('How can you reach this point?')
+        return []
+    }
+
+    const configuration = vscode.workspace.getConfiguration('latex-workshop')
+    let excludeRegexp: RegExp[]
+    try {
+        excludeRegexp = (configuration.get('message.dvipdfmxlog.exclude') as string[] || []).map(regexp => RegExp(regexp))
+    } catch (e) {
+        logger.logError('Invalid message.dvipdfmxlog.exclude config.', e)
+        return []
+    }
+    buildLog.length = 0
+    const lines = log.split('\n')
+
+    const state: ParserState = {
+        currentType: undefined,
+        dvipdfmxBuffer: []
+    }
+
+    for (const line of lines) {
+        parseLine(line, state, rootFile, excludeRegexp)
+    }
+    flushLog(state, rootFile, excludeRegexp)
+
+    logger.log(`Logged ${buildLog.length} messages.`)
+    return buildLog
+}
+
+function parseLine(line: string, state: ParserState, rootFile: string, excludeRegexp: RegExp[]) {
+    let result: RegExpMatchArray | null = null
+
+    result = line.match(dvipdfmxContinuedWarn)
+    if (result) {
+        if (state.currentType !== 'warning') {
+            flushLog(state, rootFile, excludeRegexp)
+            state.currentType = 'warning'
+        }
+        state.dvipdfmxBuffer.push(result[1].trim())
+        return
+    }
+
+    result = line.match(divpdfmxWarn)
+    if (result) {
+        flushLog(state, rootFile, excludeRegexp)
+        state.currentType = 'warning'
+        state.dvipdfmxBuffer.push(result[1].trim())
+        return
+    }
+
+    result = line.match(divpdfmxFatal)
+    if (result) {
+        flushLog(state, rootFile, excludeRegexp)
+        state.currentType = 'error'
+        state.dvipdfmxBuffer.push(result[1].trim())
+        return
+    }
+
+    result = line.match(dvipdfmxArgsError)
+    if (result) {
+        flushLog(state, rootFile, excludeRegexp)
+        state.currentType = 'error'
+        state.dvipdfmxBuffer.push(result[1].trim())
+        return
+    }
+
+    result = line.match(dvipdfmxConfigError)
+    if (result) {
+        flushLog(state, rootFile, excludeRegexp)
+        state.currentType = 'error'
+        state.dvipdfmxBuffer.push(result[1].trim())
+        return
+    }
+
+    if (line.includes(noOutputPDF)) {
+        flushLog(state, rootFile, excludeRegexp)
+        pushLog('error', rootFile, noOutputPDF, 1, excludeRegexp)
+        return
+    }
+}
+
+function flushLog(state: ParserState, rootFile: string, excludeRegexp: RegExp[]) {
+    if (state.currentType && state.dvipdfmxBuffer.length > 0) {
+        pushLog(state.currentType, rootFile!, state.dvipdfmxBuffer.join('\n'), 1, excludeRegexp)
+    }
+    state.dvipdfmxBuffer.length = 0
+    state.currentType = undefined
+}
+
+function pushLog(type: string, file: string, message: string, line: number, excludeRegexp: RegExp[]) {
+    for (const regexp of excludeRegexp) {
+        if (message.match(regexp)) {
+            return
+        }
+    }
+    buildLog.push({ type, file, text: message, line })
+}


### PR DESCRIPTION

## Summary

This PR adds a log parser that analyzes `dvipdfmx` logs and extracts the necessary logs for the PROBLEMS Pane.

This issue was raised in #4693, but I decided to create this PR in response to the following comments.

* https://github.com/James-Yu/LaTeX-Workshop/issues/4693#issuecomment-3435496846

## Problem

Currently, LaTeX Workshop does not have a log parser to analyze `dvipdfmx` warnings and error messages.

As a result, users of `dvipdfmx` often find that PDFs fail to generate without any error messages appearing in the PROBLEMS Pane.

## Changes

* Add new configuration (`latex-workshop.message.dvipdfmxlog.exclude`, package.json)
* Add log parser (dvipdfmxlog.ts)
* Change to parse `stdout` stream (build.ts)

## For testing purposes

<details>
<summary>settings.json</summary>

```json
{
    "latex-workshop.latex.recipes": [
        {
            "name": "upLaTeX (latexmk)",
            "tools": ["uplatexmk"]
        },
        {
            "name": "ptex2pdf",
            "tools": ["uptex2pdf"]
        },
    ],
    "latex-workshop.latex.tools": [
        {
            "name": "uplatexmk",
            "command": "latexmk",
            "args": [
                "-interaction=nonstopmode",
                "-file-line-error",
                "-latex=\"uplatex -kanji=utf8\"",
                "-e",
                "\"$dvipdf = 'dvipdfmx %O -o %D %S'; $pdf_mode = 3;\"",
                "-outdir=%OUTDIR%",
                "%DOC%"
            ],
            "env": {}
        },
        {
            "name": "uptex2pdf",
            "command": "ptex2pdf",
            "args": [
                "-u",
                "-l",
                "-ot",
                "--kanji=utf8 -interaction=nonstopmode -file-line-error",
                "%DOC%",
            ]
        },
    ],
}
```

</details>

<details>
<summary>test files</summary>

```latex
\documentclass[uplatex, dvipdfmx, a4paper]{jsarticle}
\usepackage[noalphabet, haranoaji]{pxchfon}
\setminchofont{foo.ttf}
\begin{document}

テスト文書。

\end{document}
```

```latex
\documentclass[uplatex, dvipdfmx, a4paper]{jsarticle}
\begin{document}

\special{dvipdfmx:config -r 600 foo}

テスト文書。

\end{document}
```

```latex
\documentclass[uplatex, dvipdfmx, a4paper]{jsarticle}
\usepackage{hyperref}
\title{タイトル} \author{著者名} \date{\today}
\begin{document}

\pagestyle{empty}
\maketitle \tableofcontents \clearpage

\setcounter{page}{1} \pagestyle{plain}

\section{第1節} \clearpage
\section{第2節} \clearpage
\section{第3節} \clearpage

\end{document}
```


</details>

