### PR TITLE
Fix recurrence of scrollbar color inconsistency in dark mode

### DIFF
--- a/viewer/latexworkshop.css
+++ b/viewer/latexworkshop.css
@@ -157,6 +157,7 @@ html[dir='rtl'] .findbar {
 
 #viewerContainer {
     top: 0;
+    color-scheme: light !important;
 }
 
 #pageNumber {


### PR DESCRIPTION
Re-apply the patch from PR #4763 to `viewer/latexworkshop.css` to avoid `viewer.css` being overwritten by future PDF.js update like the recent [commit a241a5a](https://github.com/James-Yu/LaTeX-Workshop/commit/a241a5a038ae8c4a9694ff0173c2143e8eb182b3).