### PR TITLE
4856 add option to specify a custom source directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -1302,11 +1302,18 @@
           "default": true,
           "markdownDescription": "Enable magic comments if present."
         },
+        "latex-workshop.latex.build.fromFolder": {
+          "scope": "resource",
+          "type": "boolean",
+          "default": "",
+          "markdownDescription": "Run the recipe from the given folder relative to the root workspace. The default empty value will run the recipe from the directory containing the root file. You can also set this value to a relative folder from the root workspace. The setting has no effect on external commands `#latex-workshop.latex.external.build.command`."
+        },
         "latex-workshop.latex.build.fromWorkspaceFolder": {
           "scope": "resource",
           "type": "boolean",
           "default": false,
-          "markdownDescription": "Run the recipe from the workspace folder. If false, the recipe is run from the directory containing the root file. The setting has no effect on external commands `#latex-workshop.latex.external.build.command`."
+          "markdownDescription": "Run the recipe from the workspace folder. If false, the recipe is run from the directory containing the root file. The setting has no effect on external commands `#latex-workshop.latex.external.build.command`.",
+          "deprecationMessage": "Use `#latex-workshop.latex.build.fromFolder` instead."
         },
         "latex-workshop.latex.outDir": {
           "scope": "resource",

--- a/package.json
+++ b/package.json
@@ -1304,9 +1304,9 @@
         },
         "latex-workshop.latex.build.fromFolder": {
           "scope": "resource",
-          "type": "boolean",
+          "type": "string",
           "default": "",
-          "markdownDescription": "Run the recipe from the given folder relative to the root workspace. The default empty value will run the recipe from the directory containing the root file. You can also set this value to a relative folder from the root workspace. The setting has no effect on external commands `#latex-workshop.latex.external.build.command`."
+          "markdownDescription": "Run the recipe from the given folder. The default empty value runs the recipe from the directory containing the root file. Relative paths are resolved from the workspace folder containing the root file; if no workspace folder contains the root file, they are resolved from the root file's directory. The setting has no effect on external commands `#latex-workshop.latex.external.build.command`."
         },
         "latex-workshop.latex.build.fromWorkspaceFolder": {
           "scope": "resource",

--- a/src/compile/recipe.ts
+++ b/src/compile/recipe.ts
@@ -1,6 +1,6 @@
 import vscode from 'vscode'
 import path from 'path'
-import { replaceArgumentPlaceholders } from '../utils/utils'
+import { getWorkingFolder, replaceArgumentPlaceholders } from '../utils/utils'
 
 import { lw } from '../lw'
 import type { Recipe, Tool } from '../types'
@@ -53,14 +53,7 @@ function setDockerPath() {
  */
 export async function build(rootFile: string, langId: string, buildLoop: () => Promise<void>, recipeName?: string) {
     logger.log(`Build root file ${rootFile}`)
-    const rootDir = path.dirname(lw.file.toUri(rootFile).fsPath)
-    let cwd: string = rootDir
-    const configuration = vscode.workspace.getConfiguration('latex-workshop')
-    const buildFromFolder = configuration.get('latex.build.fromFolder', '')
-    if (buildFromFolder) {
-        const workspaceFolder = vscode.workspace.getWorkspaceFolder(lw.file.toUri(rootFile))
-        cwd = workspaceFolder ? path.resolve(workspaceFolder.uri.fsPath, buildFromFolder) : path.resolve(rootDir, buildFromFolder)
-    }
+    const cwd = getWorkingFolder(rootFile)
 
     // Save all open files in the workspace
     await vscode.workspace.saveAll()

--- a/src/compile/recipe.ts
+++ b/src/compile/recipe.ts
@@ -53,13 +53,13 @@ function setDockerPath() {
  */
 export async function build(rootFile: string, langId: string, buildLoop: () => Promise<void>, recipeName?: string) {
     logger.log(`Build root file ${rootFile}`)
-    let cwd: string = path.dirname(lw.file.toUri(rootFile).fsPath)
+    const rootDir = path.dirname(lw.file.toUri(rootFile).fsPath)
+    let cwd: string = rootDir
     const configuration = vscode.workspace.getConfiguration('latex-workshop')
-    if (configuration.get('latex.build.fromWorkspaceFolder')) {
+    const buildFromFolder = configuration.get('latex.build.fromFolder', '')
+    if (buildFromFolder) {
         const workspaceFolder = vscode.workspace.getWorkspaceFolder(lw.file.toUri(rootFile))
-        if (workspaceFolder) {
-            cwd = workspaceFolder.uri.fsPath
-        }
+        cwd = workspaceFolder ? path.resolve(workspaceFolder.uri.fsPath, buildFromFolder) : path.resolve(rootDir, buildFromFolder)
     }
 
     // Save all open files in the workspace

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -267,6 +267,18 @@ export function resolveFileGlob(dirs: string[], inputGlob: string, suffix: strin
     return []
 }
 
+export function getWorkingFolder(rootFile: string): string {
+    const rootDir = path.dirname(lw.file.toUri(rootFile).fsPath)
+    let workingFolder: string = rootDir
+    const configuration = vscode.workspace.getConfiguration('latex-workshop')
+    const buildFromFolder = configuration.get('latex.build.fromFolder', '')
+    if (buildFromFolder) {
+        const workspaceFolder = vscode.workspace.getWorkspaceFolder(lw.file.toUri(rootFile))
+        workingFolder = workspaceFolder ? path.resolve(workspaceFolder.uri.fsPath, buildFromFolder) : path.resolve(rootDir, buildFromFolder)
+    }
+    return workingFolder
+}
+
 /**
  * Return a function replacing placeholders of LaTeX recipes.
  *
@@ -290,8 +302,11 @@ export function replaceArgumentPlaceholders(rootFile: string, tmpDir: string): (
         const doc = docW32.split(path.sep).join('/')
         const docExtW32 = path.join(dirW32, docfileExt)
         const docExt = docExtW32.split(path.sep).join('/')
-        const relativeDir = path.relative(workspaceDir, dir).split(path.sep).join('/')
-        const relativeDoc = path.relative(workspaceDir, doc).split(path.sep).join('/')
+        const relativeWorkspaceDir = path.relative(workspaceDir, dir).split(path.sep).join('/')
+        const relativeWorkspaceDoc = path.relative(workspaceDir, doc).split(path.sep).join('/')
+        const workingFolder = getWorkingFolder(rootFile)
+        const relativeWorkingDir = path.relative(workingFolder, dir).split(path.sep).join('/')
+        const relativeWorkingDoc = path.relative(workingFolder, doc).split(path.sep).join('/')
 
         const expandPlaceHolders = (a: string): string => {
             return a.replace(/%DOC%/g, docker ? docfile : doc)
@@ -304,14 +319,16 @@ export function replaceArgumentPlaceholders(rootFile: string, tmpDir: string): (
                     .replace(/%DIR_W32%/g, docker ? './' : dirW32)
                     .replace(/%TMPDIR%/g, tmpDir)
                     .replace(/%WORKSPACE_FOLDER%/g, docker ? './' : workspaceDir)
-                    .replace(/%RELATIVE_DIR%/, docker ? './' : relativeDir)
-                    .replace(/%RELATIVE_DOC%/, docker ? docfile : relativeDoc)
+                    .replace(/%RELATIVE_DIR%/, docker ? './' : relativeWorkspaceDir)
+                    .replace(/%RELATIVE_DOC%/, docker ? docfile : relativeWorkspaceDoc)
+                    .replace(/%RELATIVE_CWD_DIR%/, docker ? './' : relativeWorkingDir)
+                    .replace(/%RELATIVE_CWD_DOC%/, docker ? docfile : relativeWorkingDoc)
 
         }
         const outDirW32 = path.normalize(expandPlaceHolders(configuration.get('latex.outDir') as string))
         const outDir = outDirW32.split(path.sep).join('/')
         const auxDir = path.normalize(expandPlaceHolders(configuration.get('latex.auxDir') as string)).split(path.sep).join('/')
-        // Replace %AUXDIR% first as its defaut value is %OUTDIR%
+        // Replace %AUXDIR% first as its default value is %OUTDIR%
         return expandPlaceHolders(arg).replace(/%AUXDIR%/g, auxDir).replace(/%OUTDIR%/g, outDir).replace(/%OUTDIR_W32%/g, outDirW32)
     }
 }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -268,12 +268,13 @@ export function resolveFileGlob(dirs: string[], inputGlob: string, suffix: strin
 }
 
 export function getWorkingFolder(rootFile: string): string {
-    const rootDir = path.dirname(lw.file.toUri(rootFile).fsPath)
+    const rootFileUri = lw.file.toUri(rootFile)
+    const rootDir = path.dirname(rootFileUri.fsPath)
     let workingFolder: string = rootDir
-    const configuration = vscode.workspace.getConfiguration('latex-workshop')
+    const configuration = vscode.workspace.getConfiguration('latex-workshop', rootFileUri)
     const buildFromFolder = configuration.get('latex.build.fromFolder', '')
     if (buildFromFolder) {
-        const workspaceFolder = vscode.workspace.getWorkspaceFolder(lw.file.toUri(rootFile))
+        const workspaceFolder = vscode.workspace.getWorkspaceFolder(rootFileUri)
         workingFolder = workspaceFolder ? path.resolve(workspaceFolder.uri.fsPath, buildFromFolder) : path.resolve(rootDir, buildFromFolder)
     }
     return workingFolder

--- a/test/units/01_core/utils.test.ts
+++ b/test/units/01_core/utils.test.ts
@@ -1,0 +1,217 @@
+import * as vscode from 'vscode'
+import * as path from 'path'
+import * as sinon from 'sinon'
+import { assert, get, mock, set } from '../utils'
+import { lw } from '../../../src/lw'
+import { getWorkingFolder, replaceArgumentPlaceholders } from '../../../src/utils/utils'
+
+describe(path.basename(__filename).split('.')[0] + ':', () => {
+    const fixture = get.fixture(__filename)
+
+	before(() => {
+		mock.init(lw)
+	})
+
+	after(() => {
+		sinon.restore()
+	})
+
+	describe('lw.utils->getWorkingFolder', () => {
+		let rootFile: string
+		let workspaceDir: string
+		let getWorkspaceFolderStub: sinon.SinonStub | undefined
+
+		beforeEach(() => {
+			workspaceDir = get.path()
+			rootFile = get.path(fixture, 'main.tex')
+			getWorkspaceFolderStub = undefined
+		})
+
+		afterEach(() => {
+			getWorkspaceFolderStub?.restore()
+		})
+
+		it('should return the root directory when `latex.build.fromFolder` is empty', () => {
+			set.config('latex.build.fromFolder', '')
+
+			const workingFolder = getWorkingFolder(rootFile)
+
+			assert.pathStrictEqual(workingFolder, path.dirname(rootFile))
+		})
+
+		it('should resolve `latex.build.fromFolder` from workspace directory', () => {
+			const workspaceFolder: vscode.WorkspaceFolder = {
+				uri: vscode.Uri.file(workspaceDir),
+				name: path.basename(workspaceDir),
+				index: 0
+			}
+			getWorkspaceFolderStub = sinon.stub(vscode.workspace, 'getWorkspaceFolder').returns(workspaceFolder)
+			set.config('latex.build.fromFolder', 'test/units')
+
+			const workingFolder = getWorkingFolder(rootFile)
+
+			assert.pathStrictEqual(workingFolder, path.resolve(workspaceDir, 'test', 'units'))
+		})
+
+		it('should resolve `latex.build.fromFolder` from root directory when no workspace is found', () => {
+			getWorkspaceFolderStub = sinon.stub(vscode.workspace, 'getWorkspaceFolder').returns(undefined)
+			set.config('latex.build.fromFolder', 'build')
+
+			const workingFolder = getWorkingFolder(rootFile)
+
+			assert.pathStrictEqual(workingFolder, path.resolve(path.dirname(rootFile), 'build'))
+		})
+	})
+
+	describe('lw.utils->replaceArgumentPlaceholders', () => {
+		let workspaceDir: string
+		let rootFile: string
+		let tmpDir: string
+		let workspaceFoldersStub: sinon.SinonStub
+		let getWorkspaceFolderStub: sinon.SinonStub
+
+		const placeholdersReplacedOnce = new Set([
+			'%RELATIVE_DIR%',
+			'%RELATIVE_DOC%',
+			'%RELATIVE_CWD_DIR%',
+			'%RELATIVE_CWD_DOC%'
+		])
+
+		function toPosix(filePath: string): string {
+			return filePath.split(path.sep).join('/')
+		}
+
+		function buildExpectedValues(inputRootFile: string, inputWorkspaceDir: string, inputTmpDir: string, docker: boolean): Record<string, string> {
+			const rootFileParsed = path.parse(inputRootFile)
+			const docfile = rootFileParsed.name
+			const docfileExt = rootFileParsed.base
+			const dirW32 = path.normalize(rootFileParsed.dir)
+			const dir = toPosix(dirW32)
+			const docW32 = path.join(dirW32, docfile)
+			const doc = toPosix(docW32)
+			const docExtW32 = path.join(dirW32, docfileExt)
+			const docExt = toPosix(docExtW32)
+			const relativeWorkspaceDir = toPosix(path.relative(inputWorkspaceDir, dir))
+			const relativeWorkspaceDoc = toPosix(path.relative(inputWorkspaceDir, doc))
+			const workingFolder = path.resolve(inputWorkspaceDir, 'test', 'units')
+			const relativeWorkingDir = toPosix(path.relative(workingFolder, dir))
+			const relativeWorkingDoc = toPosix(path.relative(workingFolder, doc))
+
+			const outDirW32 = path.normalize(docker ? './out' : `${dir}/out`)
+			const outDir = toPosix(outDirW32)
+
+			return {
+				'%DOC%': docker ? docfile : doc,
+				'%DOC_W32%': docker ? docfile : docW32,
+				'%DOC_EXT%': docker ? docfileExt : docExt,
+				'%DOC_EXT_W32%': docker ? docfileExt : docExtW32,
+				'%DOCFILE_EXT%': docfileExt,
+				'%DOCFILE%': docfile,
+				'%DIR%': docker ? './' : dir,
+				'%DIR_W32%': docker ? './' : dirW32,
+				'%TMPDIR%': inputTmpDir,
+				'%WORKSPACE_FOLDER%': docker ? './' : toPosix(inputWorkspaceDir),
+				'%RELATIVE_DIR%': docker ? './' : relativeWorkspaceDir,
+				'%RELATIVE_DOC%': docker ? docfile : relativeWorkspaceDoc,
+				'%RELATIVE_CWD_DIR%': docker ? './' : relativeWorkingDir,
+				'%RELATIVE_CWD_DOC%': docker ? docfile : relativeWorkingDoc,
+				'%OUTDIR%': outDir,
+				'%OUTDIR_W32%': outDirW32,
+				'%AUXDIR%': `${outDir}/aux`
+			}
+		}
+
+		function assertOccurrenceKinds(replacer: (arg: string) => string, placeholder: string, expectedValue: string) {
+			assert.strictEqual(replacer(`${placeholder}-tail`), `${expectedValue}-tail`)
+			assert.strictEqual(replacer(`head-${placeholder}-tail`), `head-${expectedValue}-tail`)
+			assert.strictEqual(replacer(`head-${placeholder}`), `head-${expectedValue}`)
+
+			const repeatedInput = `${placeholder}|${placeholder}|${placeholder}`
+			const repeatedExpected = placeholdersReplacedOnce.has(placeholder)
+				? `${expectedValue}|${placeholder}|${placeholder}`
+				: `${expectedValue}|${expectedValue}|${expectedValue}`
+			assert.strictEqual(replacer(repeatedInput), repeatedExpected)
+		}
+
+		function setupWorkspaceStubs(inputWorkspaceDir: string) {
+			const workspaceFolder: vscode.WorkspaceFolder = {
+				uri: vscode.Uri.file(inputWorkspaceDir),
+				name: path.basename(inputWorkspaceDir),
+				index: 0
+			}
+			const workspaceFoldersStubLocal = sinon.stub(vscode.workspace, 'workspaceFolders').value([workspaceFolder])
+			const getWorkspaceFolderStubLocal = sinon.stub(vscode.workspace, 'getWorkspaceFolder').returns(workspaceFolder)
+
+			return { workspaceFoldersStub: workspaceFoldersStubLocal, getWorkspaceFolderStub: getWorkspaceFolderStubLocal }
+		}
+
+		beforeEach(() => {
+			workspaceDir = get.path()
+			rootFile = get.path(fixture, 'main.tex')
+			tmpDir = path.resolve(workspaceDir, 'tmp')
+			;({ workspaceFoldersStub, getWorkspaceFolderStub } = setupWorkspaceStubs(workspaceDir))
+
+			set.config('latex.build.fromFolder', 'test/units')
+			set.config('latex.outDir', '%DIR%/out')
+			set.config('latex.auxDir', '%OUTDIR%/aux')
+		})
+
+		afterEach(() => {
+			workspaceFoldersStub.restore()
+			getWorkspaceFolderStub.restore()
+		})
+
+		it('should replace each placeholder individually in non-docker mode for all occurrence kinds', () => {
+			set.config('docker.enabled', false)
+
+			const replacer = replaceArgumentPlaceholders(rootFile, tmpDir)
+			const expectedValues = buildExpectedValues(rootFile, workspaceDir, tmpDir, false)
+
+			for (const [placeholder, expected] of Object.entries(expectedValues)) {
+				assertOccurrenceKinds(replacer, placeholder, expected)
+			}
+		})
+
+		it('should replace each placeholder individually in docker mode for all occurrence kinds', () => {
+			set.config('docker.enabled', true)
+
+			const replacer = replaceArgumentPlaceholders(rootFile, tmpDir)
+			const expectedValues = buildExpectedValues(rootFile, workspaceDir, tmpDir, true)
+
+			for (const [placeholder, expected] of Object.entries(expectedValues)) {
+				assertOccurrenceKinds(replacer, placeholder, expected)
+			}
+		})
+
+		it('should replace mixed placeholders in one argument', () => {
+			set.config('docker.enabled', false)
+
+			const replacer = replaceArgumentPlaceholders(rootFile, tmpDir)
+			const expectedValues = buildExpectedValues(rootFile, workspaceDir, tmpDir, false)
+			const argument = [
+				'ROOT=%DOCFILE_EXT%',
+				'PATH=%DOC%',
+				'OUT=%OUTDIR%',
+				'AUX=%AUXDIR%',
+				'REL=%RELATIVE_DOC%',
+				'CWD=%RELATIVE_CWD_DOC%',
+				'TMP=%TMPDIR%'
+			].join(';')
+
+			const replaced = replacer(argument)
+
+			assert.strictEqual(
+				replaced,
+				[
+					`ROOT=${expectedValues['%DOCFILE_EXT%']}`,
+					`PATH=${expectedValues['%DOC%']}`,
+					`OUT=${expectedValues['%OUTDIR%']}`,
+					`AUX=${expectedValues['%AUXDIR%']}`,
+					`REL=${expectedValues['%RELATIVE_DOC%']}`,
+					`CWD=${expectedValues['%RELATIVE_CWD_DOC%']}`,
+					`TMP=${expectedValues['%TMPDIR%']}`
+				].join(';')
+			)
+		})
+	})
+})

--- a/test/units/01_core/utils.test.ts
+++ b/test/units/01_core/utils.test.ts
@@ -8,62 +8,62 @@ import { getWorkingFolder, replaceArgumentPlaceholders } from '../../../src/util
 describe(path.basename(__filename).split('.')[0] + ':', () => {
     const fixture = get.fixture(__filename)
 
-	before(() => {
-		mock.init(lw)
-	})
+    before(() => {
+        mock.init(lw)
+    })
 
-	after(() => {
-		sinon.restore()
-	})
+    after(() => {
+        sinon.restore()
+    })
 
-	describe('lw.utils->getWorkingFolder', () => {
-		let rootFile: string
-		let workspaceDir: string
-		let getWorkspaceFolderStub: sinon.SinonStub | undefined
+    describe('lw.utils->getWorkingFolder', () => {
+        let rootFile: string
+        let workspaceDir: string
+        let getWorkspaceFolderStub: sinon.SinonStub | undefined
 
-		beforeEach(() => {
-			workspaceDir = get.path()
-			rootFile = get.path(fixture, 'main.tex')
-			getWorkspaceFolderStub = undefined
-		})
+        beforeEach(() => {
+            workspaceDir = get.path()
+            rootFile = get.path(fixture, 'main.tex')
+            getWorkspaceFolderStub = undefined
+        })
 
-		afterEach(() => {
-			getWorkspaceFolderStub?.restore()
-		})
+        afterEach(() => {
+            getWorkspaceFolderStub?.restore()
+        })
 
-		it('should return the root directory when `latex.build.fromFolder` is empty', () => {
-			set.config('latex.build.fromFolder', '')
+        it('should return the root directory when `latex.build.fromFolder` is empty', () => {
+            set.config('latex.build.fromFolder', '')
 
-			const workingFolder = getWorkingFolder(rootFile)
+            const workingFolder = getWorkingFolder(rootFile)
 
-			assert.pathStrictEqual(workingFolder, path.dirname(rootFile))
-		})
+            assert.pathStrictEqual(workingFolder, path.dirname(rootFile))
+        })
 
-		it('should resolve `latex.build.fromFolder` from workspace directory', () => {
-			const workspaceFolder: vscode.WorkspaceFolder = {
-				uri: vscode.Uri.file(workspaceDir),
-				name: path.basename(workspaceDir),
-				index: 0
-			}
-			getWorkspaceFolderStub = sinon.stub(vscode.workspace, 'getWorkspaceFolder').returns(workspaceFolder)
-			set.config('latex.build.fromFolder', 'test/units')
+        it('should resolve `latex.build.fromFolder` from workspace directory', () => {
+            const workspaceFolder: vscode.WorkspaceFolder = {
+                uri: vscode.Uri.file(workspaceDir),
+                name: path.basename(workspaceDir),
+                index: 0
+            }
+            getWorkspaceFolderStub = sinon.stub(vscode.workspace, 'getWorkspaceFolder').returns(workspaceFolder)
+            set.config('latex.build.fromFolder', 'test/units')
 
-			const workingFolder = getWorkingFolder(rootFile)
+            const workingFolder = getWorkingFolder(rootFile)
 
-			assert.pathStrictEqual(workingFolder, path.resolve(workspaceDir, 'test', 'units'))
-		})
+            assert.pathStrictEqual(workingFolder, path.resolve(workspaceDir, 'test', 'units'))
+        })
 
-		it('should resolve `latex.build.fromFolder` from root directory when no workspace is found', () => {
-			getWorkspaceFolderStub = sinon.stub(vscode.workspace, 'getWorkspaceFolder').returns(undefined)
-			set.config('latex.build.fromFolder', 'build')
+        it('should resolve `latex.build.fromFolder` from root directory when no workspace is found', () => {
+            getWorkspaceFolderStub = sinon.stub(vscode.workspace, 'getWorkspaceFolder').returns(undefined)
+            set.config('latex.build.fromFolder', 'build')
 
-			const workingFolder = getWorkingFolder(rootFile)
+            const workingFolder = getWorkingFolder(rootFile)
 
-			assert.pathStrictEqual(workingFolder, path.resolve(path.dirname(rootFile), 'build'))
-		})
-	})
+            assert.pathStrictEqual(workingFolder, path.resolve(path.dirname(rootFile), 'build'))
+        })
+    })
 
-	describe('lw.utils->replaceArgumentPlaceholders', () => {
+    describe('lw.utils->replaceArgumentPlaceholders', () => {
 		let workspaceDir: string
 		let rootFile: string
 		let tmpDir: string

--- a/test/units/01_core/utils/main.tex
+++ b/test/units/01_core/utils/main.tex
@@ -1,0 +1,4 @@
+\documentclass{article}
+\begin{document}
+abc
+\end{document}

--- a/test/units/02_compile/recipe.test.ts
+++ b/test/units/02_compile/recipe.test.ts
@@ -6,7 +6,7 @@ import { lw } from '../../../src/lw'
 import { build, initialize } from '../../../src/compile/recipe'
 import { queue } from '../../../src/compile/queue'
 
-describe(path.basename(__filename).split('.')[0] + ':', () => {
+describe.only(path.basename(__filename).split('.')[0] + ':', () => {
     let getAuxDirStub: sinon.SinonStub
     let getIncludedTeXStub: sinon.SinonStub
     let mkdirStub: sinon.SinonStub
@@ -66,6 +66,47 @@ describe(path.basename(__filename).split('.')[0] + ':', () => {
             stub.restore()
 
             assert.ok(stub.calledOnce)
+        })
+
+        it('should run recipe from folder relative to workspace root', async () => {
+            const rootFile = set.root(path.join('tex', 'main.tex'))
+            set.config('latex.tools', [{ name: 'latexmk', command: 'latexmk' }])
+            set.config('latex.recipes', [{ name: 'Recipe1', tools: ['latexmk'] }])
+            set.config('latex.build.fromFolder', 'build')
+
+            await build(rootFile, 'latex', async () => {})
+
+            const step = queue.getStep()
+            assert.ok(step)
+            assert.pathStrictEqual(step.cwd, get.path('build'))
+        })
+
+        it('should run recipe from root file directory when fromFolder is empty', async () => {
+            const rootFile = set.root(path.join('tex', 'main.tex'))
+            set.config('latex.tools', [{ name: 'latexmk', command: 'latexmk' }])
+            set.config('latex.recipes', [{ name: 'Recipe1', tools: ['latexmk'] }])
+            set.config('latex.build.fromFolder', '')
+
+            await build(rootFile, 'latex', async () => {})
+
+            const step = queue.getStep()
+            assert.ok(step)
+            assert.pathStrictEqual(step.cwd, path.dirname(rootFile))
+        })
+
+        it('should fallback to root file directory when no workspace folder is found', async () => {
+            const rootFile = set.root(path.join('tex', 'main.tex'))
+            set.config('latex.tools', [{ name: 'latexmk', command: 'latexmk' }])
+            set.config('latex.recipes', [{ name: 'Recipe1', tools: ['latexmk'] }])
+            set.config('latex.build.fromFolder', 'build')
+            const stub = sinon.stub(vscode.workspace, 'getWorkspaceFolder').returns(undefined)
+
+            await build(rootFile, 'latex', async () => {})
+            stub.restore()
+
+            const step = queue.getStep()
+            assert.ok(step)
+            assert.pathStrictEqual(step.cwd, path.resolve(path.dirname(rootFile), 'build'))
         })
 
         it('should call `createAuxSubFolders` with correct args', async () => {

--- a/test/units/02_compile/recipe.test.ts
+++ b/test/units/02_compile/recipe.test.ts
@@ -6,7 +6,7 @@ import { lw } from '../../../src/lw'
 import { build, initialize } from '../../../src/compile/recipe'
 import { queue } from '../../../src/compile/queue'
 
-describe.only(path.basename(__filename).split('.')[0] + ':', () => {
+describe(path.basename(__filename).split('.')[0] + ':', () => {
     let getAuxDirStub: sinon.SinonStub
     let getIncludedTeXStub: sinon.SinonStub
     let mkdirStub: sinon.SinonStub

--- a/test/units/02_compile/recipe.test.ts
+++ b/test/units/02_compile/recipe.test.ts
@@ -68,47 +68,6 @@ describe.only(path.basename(__filename).split('.')[0] + ':', () => {
             assert.ok(stub.calledOnce)
         })
 
-        it('should run recipe from folder relative to workspace root', async () => {
-            const rootFile = set.root(path.join('tex', 'main.tex'))
-            set.config('latex.tools', [{ name: 'latexmk', command: 'latexmk' }])
-            set.config('latex.recipes', [{ name: 'Recipe1', tools: ['latexmk'] }])
-            set.config('latex.build.fromFolder', 'build')
-
-            await build(rootFile, 'latex', async () => {})
-
-            const step = queue.getStep()
-            assert.ok(step)
-            assert.pathStrictEqual(step.cwd, get.path('build'))
-        })
-
-        it('should run recipe from root file directory when fromFolder is empty', async () => {
-            const rootFile = set.root(path.join('tex', 'main.tex'))
-            set.config('latex.tools', [{ name: 'latexmk', command: 'latexmk' }])
-            set.config('latex.recipes', [{ name: 'Recipe1', tools: ['latexmk'] }])
-            set.config('latex.build.fromFolder', '')
-
-            await build(rootFile, 'latex', async () => {})
-
-            const step = queue.getStep()
-            assert.ok(step)
-            assert.pathStrictEqual(step.cwd, path.dirname(rootFile))
-        })
-
-        it('should fallback to root file directory when no workspace folder is found', async () => {
-            const rootFile = set.root(path.join('tex', 'main.tex'))
-            set.config('latex.tools', [{ name: 'latexmk', command: 'latexmk' }])
-            set.config('latex.recipes', [{ name: 'Recipe1', tools: ['latexmk'] }])
-            set.config('latex.build.fromFolder', 'build')
-            const stub = sinon.stub(vscode.workspace, 'getWorkspaceFolder').returns(undefined)
-
-            await build(rootFile, 'latex', async () => {})
-            stub.restore()
-
-            const step = queue.getStep()
-            assert.ok(step)
-            assert.pathStrictEqual(step.cwd, path.resolve(path.dirname(rootFile), 'build'))
-        })
-
         it('should call `createAuxSubFolders` with correct args', async () => {
             const rootFile = set.root('main.tex')
             const subPath = get.path('sub', 'main.tex')


### PR DESCRIPTION
See discussions in #4856 

This PR introduced a new config item of string type `latex.build.fromFolder` to replace the original boolean `latex.build.fromWorkspaceFolder` for more general usage. Further, two new tool placeholders `%RELATIVE_CWD_DIR%` and `%RELATIVE_CWD_DOC%` are added to provide relative paths from this new building folder.