### PR TITLE
Fix `querySelector` and SyncTeX keybindings

### DIFF
--- a/test/units/03_viewer/pdf-viewer.test.ts
+++ b/test/units/03_viewer/pdf-viewer.test.ts
@@ -290,6 +290,22 @@ describe(path.basename(__filename).split('.')[0] + ':', () => {
             assert.strictEqual(execSpy.callCount, 1)
             assert.strictEqual(execSpy.firstCall.args[0], 'workbench.action.moveEditorToLeftGroup')
         })
+
+        it('should not log internal viewer DOM errors while applying params', async () => {
+            set.config('view.pdf.invertMode.enabled', 'always')
+
+            const promise = waitMessage('loaded')
+            await viewInWebviewPanel(pdfUri, 'current', true)
+            await promise
+
+            const internalErrorMessages = handlerSpy.getCalls()
+                .map(call => JSON.parse((call.args?.[1] as Uint8Array)?.toString()) as ClientRequest)
+                .filter((message): message is Extract<ClientRequest, { type: 'add_log' }> => message.type === 'add_log')
+                .map(message => message.message)
+                .filter(message => message.startsWith('Internal error:'))
+
+            assert.deepStrictEqual(internalErrorMessages, [])
+        })
     })
 
     describe('lw.viewer->viewer.viewInTab', () => {

--- a/viewer/components/state.ts
+++ b/viewer/components/state.ts
@@ -4,7 +4,7 @@ import type { PanelManagerResponse, PdfViewerState } from '../../types/latex-wor
 import { getTrimValue } from './trimming.js'
 import { isSyncTeXEnabled, registerSyncTeX, setSyncTeXKey } from './synctex.js'
 import { IsAutoRefreshEnabled } from './refresh.js'
-import { sendPanel } from './connection.js'
+import { sendLog, sendPanel } from './connection.js'
 
 declare const PDFViewerApplication: PDFViewerApplicationType
 
@@ -55,9 +55,19 @@ export function uploadState() {
 export async function setParams() {
     const params = await utils.getParams()
 
-    const viewerContainer = document.querySelector('#viewerContainer') as HTMLHtmlElement
-    const thumbnailView = document.querySelector('#thumbnailView') as HTMLHtmlElement
-    const sidebarContent = document.querySelector('#sidebarContent') as HTMLHtmlElement
+    const viewerContainer = document.querySelector('#viewerContainer') as HTMLHtmlElement | null
+    const thumbnailView = document.querySelector('#thumbnailsView') as HTMLHtmlElement | null
+    const viewsManagerContent = document.querySelector('#viewsManagerContent') as HTMLHtmlElement | null
+
+    if (!viewerContainer) {
+        sendLog('Internal error: #viewerContainer is missing.')
+    }
+    if (!thumbnailView) {
+        sendLog('Internal error: #thumbnailsView is missing.')
+    }
+    if (!viewsManagerContent) {
+        sendLog('Internal error: #viewsManagerContent is missing.')
+    }
 
     if (params.sidebar.open === 'on' || params.sidebar.open === 'persist' && localStorage.getItem('lw-pdf-sidebar-open') === 'true') {
         PDFViewerApplication.viewsManager.open()
@@ -81,13 +91,13 @@ export async function setParams() {
     if (params.invertMode.enabled) {
         const { brightness, grayscale, hueRotate, invert, sepia } = params.invertMode
         const filter = `invert(${invert * 100}%) hue-rotate(${hueRotate}deg) grayscale(${grayscale}) sepia(${sepia}) brightness(${brightness})`
-        viewerContainer.style.filter = filter
-        thumbnailView.style.filter = filter
-        sidebarContent.style.background = 'var(--body-bg-color)'
+        if (viewerContainer) viewerContainer.style.filter = filter
+        if (thumbnailView) thumbnailView.style.filter = filter
+        if (viewsManagerContent) viewsManagerContent.style.background = 'var(--body-bg-color)'
     }
 
     const backgroundColor = utils.isPrefersColorSchemeDark(params.codeColorTheme) ? params.color.dark.backgroundColor : params.color.light.backgroundColor
-    viewerContainer.style.background = backgroundColor
+    if (viewerContainer) viewerContainer.style.background = backgroundColor
 
     const css = document.styleSheets[document.styleSheets.length - 1]
     const pageBorderColor = utils.isPrefersColorSchemeDark(params.codeColorTheme) ? params.color.dark.pageBorderColor : params.color.light.pageBorderColor

--- a/viewer/components/state.ts
+++ b/viewer/components/state.ts
@@ -91,13 +91,21 @@ export async function setParams() {
     if (params.invertMode.enabled) {
         const { brightness, grayscale, hueRotate, invert, sepia } = params.invertMode
         const filter = `invert(${invert * 100}%) hue-rotate(${hueRotate}deg) grayscale(${grayscale}) sepia(${sepia}) brightness(${brightness})`
-        if (viewerContainer) viewerContainer.style.filter = filter
-        if (thumbnailView) thumbnailView.style.filter = filter
-        if (viewsManagerContent) viewsManagerContent.style.background = 'var(--body-bg-color)'
+        if (viewerContainer) {
+            viewerContainer.style.filter = filter
+        }
+        if (thumbnailView) {
+            thumbnailView.style.filter = filter
+        }
+        if (viewsManagerContent) {
+            viewsManagerContent.style.background = 'var(--body-bg-color)'
+        }
     }
 
     const backgroundColor = utils.isPrefersColorSchemeDark(params.codeColorTheme) ? params.color.dark.backgroundColor : params.color.light.backgroundColor
-    if (viewerContainer) viewerContainer.style.background = backgroundColor
+    if (viewerContainer) {
+        viewerContainer.style.background = backgroundColor
+    }
 
     const css = document.styleSheets[document.styleSheets.length - 1]
     const pageBorderColor = utils.isPrefersColorSchemeDark(params.codeColorTheme) ? params.color.dark.pageBorderColor : params.color.light.pageBorderColor

--- a/viewer/components/synctex.ts
+++ b/viewer/components/synctex.ts
@@ -49,7 +49,8 @@ export function registerSyncTeX() {
     for (const pageDom of pageDomList as NodeListOf<HTMLElement> | HTMLElement[]) {
         const page = Number(pageDom.dataset.pageNumber)
         const viewerContainer = document.getElementById('viewerContainer')!
-        // Clear both handlers so switching keybindings fully replaces the previous listener.
+        // `registerSyncTeX()` runs before and after `setParams()`,
+        // so clear stale handlers in case configured keybinding changed.
         pageDom.onclick = null
         pageDom.ondblclick = null
         switch (reverseSynctexKeybinding) {

--- a/viewer/components/synctex.ts
+++ b/viewer/components/synctex.ts
@@ -49,6 +49,9 @@ export function registerSyncTeX() {
     for (const pageDom of pageDomList as NodeListOf<HTMLElement> | HTMLElement[]) {
         const page = Number(pageDom.dataset.pageNumber)
         const viewerContainer = document.getElementById('viewerContainer')!
+        // Clear both handlers so switching keybindings fully replaces the previous listener.
+        pageDom.onclick = null
+        pageDom.ondblclick = null
         switch (reverseSynctexKeybinding) {
             case 'ctrl-click': {
                 pageDom.onclick = (e) => {


### PR DESCRIPTION
The root issue I was seeing is that my `latex-workshop.view.pdf.internal.synctex.keybinding` setting was no longer respected. (Ctrl-click worked but double-click did not, despite `"double-click"` setting.) This was caused by `setParams` crashing when `invert` is set.

1. Update viewer DOM selectors to match the current PDF.js markup (`#thumbnailView` → `#thumbnailsView`, `#sidebarContent` → `#viewsManagerContent`)
   * Apparently caused by 9b92b704 Update to PDF.js v5.6.205
2. Add internal-error logs when expected viewer DOM elements are missing, to hopefully prevent this in the future (or at least make it easier to debug).
   * If `throw`ing or something would be better for automated testing purposes, let me know.
   * But note that I wasn't seeing the existing thrown error in logs, so it was difficult to debug. Perhaps both log and throw?
3. Protect access to the queried elements in case they don't exist.
   * This fixes SyncTeX not registering the correct keybinding from config.
   * Could be avoided if we change 2 into a `throw` or something.
4. Deregister click handlers so that reverse SyncTeX handler re-registration always has up-to-date click handlers on page elements
   * Not sure this is important when config changes. Shouldn't hurt, but I can remove it if desired.
