### PR TITLE
Add several messages to warning message for dvipdfmx

### DIFF
--- a/src/parse/parser/dvipdfmxlog.ts
+++ b/src/parse/parser/dvipdfmxlog.ts
@@ -10,6 +10,7 @@ const dvipdfmxContinuedWarn = /^dvipdfmx:warning: >> (.*)$/
 const divpdfmxFatal = /^dvipdfmx:fatal: (.+)$/
 const dvipdfmxArgsError = /^dvipdfmx: ((Missing argument|Unexpected argument in) .+?|Multiple dvi filenames\?)/
 const dvipdfmxConfigError = /^config_special: (Unknown option .+)/
+const additionalMessage = /^\s*(CMap name|input str|Font|CMap):/
 const noOutputPDF = 'No output PDF file written.'
 
 const dvipdfmxDiagnostics = vscode.languages.createDiagnosticCollection('Dvipdfmx')
@@ -79,6 +80,17 @@ function parseLine(line: string, state: ParserState, rootFile: string, excludeRe
             state.currentType = 'warning'
         }
         state.dvipdfmxBuffer.push(result[1].trim())
+        return
+    }
+
+    result = line.match(additionalMessage)
+    if (result) {
+        if (state.currentType !== 'warning') {
+            flushLog(state, rootFile, excludeRegexp)
+            state.currentType = 'warning'
+        }
+        line = line.replace(/^\s*/, '\t')
+        state.dvipdfmxBuffer.push(line)
         return
     }
 


### PR DESCRIPTION
I found a small omission in the warning messages of the dvipdfmx log parser.
This PR is to fix this.

More specifically, I've implemented a mechanism to capture and display the second line and subsequent lines of warning messages like the following:

```
dvipdfmx:warning: No character mapping available.
 CMap name: UniJIS2004-UTF16-H
 input str: <e0>
```

```
dvipdfmx:warning: Inconsistent ROS found:
	Font: Adobe-Identity-0
	CMap: Adobe-Japan1-7
```