### PR TITLE
Correctly display Latex 'info' as information instead of warning

### DIFF
--- a/src/parse/parser/latexlog.ts
+++ b/src/parse/parser/latexlog.ts
@@ -13,7 +13,8 @@ const latexOverfullBoxOutput = /^(Overfull \\[vh]box \([^)]*\)) has occurred whi
 const latexUnderfullBox = /^(Underfull \\[vh]box \([^)]*\)) in paragraph at lines (\d+)--(\d+)$/
 const latexUnderfullBoxAlt = /^(Underfull \\[vh]box \([^)]*\)) detected at line (\d+)$/
 const latexUnderfullBoxOutput = /^(Underfull \\[vh]box \([^)]*\)) has occurred while \\output is active(?: \[(\d+)\])?/
-const latexWarn = /^((?:(?:Class|Package|Module) \S*)|LaTeX(?: \S*)?|LaTeX3) (Warning|Info):\s+(.*?)(?: on(?: input)? line (\d+))?(\.|\?|)$/
+const latexInfo = /^((?:(?:Class|Package|Module) \S*)|LaTeX(?: \S*)?|LaTeX3) (Info):\s+(.*?)(?: on(?: input)? line (\d+))?(\.|\?|)$/
+const latexWarn = /^((?:(?:Class|Package|Module) \S*)|LaTeX(?: \S*)?|LaTeX3) (Warning):\s+(.*?)(?: on(?: input)? line (\d+))?(\.|\?|)$/
 const latexPackageWarningExtraLines = /^\((.*)\)\s+(.*?)(?: +on input line (\d+))?(\.)?$/
 const latexMissChar = /^\s*(Missing character:.*?!)/
 const latexNoPageOutput = /^No pages of output\.$/
@@ -180,6 +181,20 @@ function parseLine(line: string, state: ParserState) {
             text: result[1]
         }
         state.searchEmptyLine = false
+        return
+    }
+    result = line.match(latexInfo)
+    if (result) {
+        if (state.currentResult.type !== '') {
+            buildLog.push(state.currentResult)
+        }
+        state.currentResult = {
+            type: 'information',
+            file: filename,
+            line: result[4] ? parseInt(result[4], 10) : 1,
+            text: result[1] + ': ' + result[3] + result[5]
+        }
+        state.searchEmptyLine = true
         return
     }
     result = line.match(latexWarn)

--- a/src/parse/parser/parserutils.ts
+++ b/src/parse/parser/parserutils.ts
@@ -40,6 +40,7 @@ const DIAGNOSTIC_SEVERITY: { [key: string]: vscode.DiagnosticSeverity } = {
     'typesetting': vscode.DiagnosticSeverity.Information,
     'warning': vscode.DiagnosticSeverity.Warning,
     'error': vscode.DiagnosticSeverity.Error,
+    'information': vscode.DiagnosticSeverity.Information
 }
 
 export async function showCompilerDiagnostics(diagnostics: vscode.DiagnosticCollection, buildLog: LogEntry[]) {

--- a/test/units/04_parser/log.test.ts
+++ b/test/units/04_parser/log.test.ts
@@ -182,7 +182,7 @@ TEXIFY LOG
         })
     })
 
-    describe('lw.parser->latex', () => {
+    describe.only('lw.parser->latex', () => {
         beforeEach(() => {
             set.config('message.badbox.show', 'both')
         })
@@ -330,18 +330,25 @@ Test message`
         })
 
         it('should parse class/package/module/LaTeX3 warnings/infos', () => {
-            const logs = [
+            const warningLogs = [
                 'Class MyClass Warning: This is a warning message on input line 42.',
-                'Package MyPackage Info: All systems operational.',
                 'Module MyModule Warning: Something went wrong.',
-                'LaTeX Info: Compilation successful.',
                 'LaTeX3 Warning: Deprecated feature used on line 10.',
+            ]
+            const infoLogs = [
+                'Package MyPackage Info: All systems operational.',
+                'LaTeX Info: Compilation successful.',
                 'LaTeX3 Info: No issues found.',
             ]
 
-            for (const log of logs) {
+            for (const log of warningLogs) {
                 const warning = latexLogParser.parse(log, get.path('main.tex'))?.[0]
                 assert.strictEqual(warning?.type, 'warning')
+            }
+
+            for (const log of infoLogs) {
+                const info = latexLogParser.parse(log, get.path('main.tex'))?.[0]
+                assert.strictEqual(info?.type, 'information')
             }
         })
 


### PR DESCRIPTION
This PR modifies the Latex log parsing to display 'info' messages as information rather than as a warning in the problem panel.

Here is an example, making use of the `\PackageWarning` and `\PackageNote` macros to push messages into the log at compile time. The notes are then displayed as information in VS Code:
<img width="152" height="270" alt="image" src="https://github.com/user-attachments/assets/ba84dd92-ae28-45d4-a8a7-84f92fc40cba" />

This resolves #4639.