### PR TITLE
Provides a feature to detect whether L3backend for dvipdfmx is in use

### DIFF
--- a/src/compile/build.ts
+++ b/src/compile/build.ts
@@ -15,7 +15,7 @@ export {
     autoBuild,
     build,
     isFileExcludedFromBuildOnSave,
-    getL3Backend
+    l3backend
 }
 
 lw.watcher.src.onChange(filePath => autoBuild(filePath.fsPath, 'onFileChange'))
@@ -280,12 +280,8 @@ function spawnProcess(step: Step): ProcessEnv {
     return env
 }
 
-let backend: string = 'unknown'
-// backend expected: pdftex | luatex | xetex | dvips | dvipdfmx | dvisvgm
-const setL3Backend = (l3b: string) => {
-    backend = l3b
-}
-const getL3Backend = () => backend
+let l3backend: string = 'unknown'
+// l3backend expected: pdftex | luatex | xetex | dvips | dvipdfmx | dvisvgm
 
 /**
  * Monitors the output and termination of the tool process. This function
@@ -329,8 +325,8 @@ async function monitorProcess(step: Step, env: ProcessEnv): Promise<boolean> {
         lw.compile.process.on('exit', (code, signal) => {
             let isSkipped = false
 
-            const l3backend = stdout.match(/l3backend-(.*?)\.def/)?.[1] ?? 'unknown'
-            setL3Backend(l3backend)
+            const backend = stdout.match(/l3backend-(.*?)\.def/)?.[1] ?? 'unknown'
+            l3backend = backend
 
             // #4838 LaTeX writes messages to stdout, while dvipdfmx writes
             // messages to stderr, so both output streams need to be parsed.

--- a/src/compile/build.ts
+++ b/src/compile/build.ts
@@ -14,7 +14,8 @@ const logger = lw.log('Build')
 export {
     autoBuild,
     build,
-    isFileExcludedFromBuildOnSave
+    isFileExcludedFromBuildOnSave,
+    getL3Backend
 }
 
 lw.watcher.src.onChange(filePath => autoBuild(filePath.fsPath, 'onFileChange'))
@@ -279,13 +280,12 @@ function spawnProcess(step: Step): ProcessEnv {
     return env
 }
 
-export type L3Backend = string
-// L3Backend expected: pdftex | luatex | xetex | dvips | dvipdfmx | dvisvgm
-let backend: L3Backend = 'unknown'
-export const setL3Backend = (l3b: L3Backend) => {
+let backend: string = 'unknown'
+// backend expected: pdftex | luatex | xetex | dvips | dvipdfmx | dvisvgm
+const setL3Backend = (l3b: string) => {
     backend = l3b
 }
-export const getL3Backend = () => backend
+const getL3Backend = () => backend
 
 /**
  * Monitors the output and termination of the tool process. This function

--- a/src/compile/build.ts
+++ b/src/compile/build.ts
@@ -279,6 +279,14 @@ function spawnProcess(step: Step): ProcessEnv {
     return env
 }
 
+export type L3Backend = string;
+// L3Backend expected: pdftex | luatex | xetex | dvips | dvipdfmx | dvisvgm
+let backend: L3Backend = "unknown";
+export const setL3Backend = (l3b: L3Backend) => {
+    backend = l3b;
+};
+export const getL3Backend = () => backend;
+
 /**
  * Monitors the output and termination of the tool process. This function
  * monitors the stdout and stderr channels to log and parse the output messages.
@@ -320,6 +328,9 @@ async function monitorProcess(step: Step, env: ProcessEnv): Promise<boolean> {
 
         lw.compile.process.on('exit', (code, signal) => {
             let isSkipped = false
+
+            const l3backend = stdout.match(/l3backend-(.*?)\.def/)?.[1] ?? "unknown"
+            setL3Backend(l3backend)
 
             // #4838 LaTeX writes messages to stdout, while dvipdfmx writes
             // messages to stderr, so both output streams need to be parsed.

--- a/src/compile/build.ts
+++ b/src/compile/build.ts
@@ -279,7 +279,7 @@ function spawnProcess(step: Step): ProcessEnv {
     return env
 }
 
-export type L3Backend = string;
+export type L3Backend = string
 // L3Backend expected: pdftex | luatex | xetex | dvips | dvipdfmx | dvisvgm
 let backend: L3Backend = 'unknown'
 export const setL3Backend = (l3b: L3Backend) => {

--- a/src/compile/build.ts
+++ b/src/compile/build.ts
@@ -281,11 +281,11 @@ function spawnProcess(step: Step): ProcessEnv {
 
 export type L3Backend = string;
 // L3Backend expected: pdftex | luatex | xetex | dvips | dvipdfmx | dvisvgm
-let backend: L3Backend = "unknown";
+let backend: L3Backend = 'unknown'
 export const setL3Backend = (l3b: L3Backend) => {
-    backend = l3b;
-};
-export const getL3Backend = () => backend;
+    backend = l3b
+}
+export const getL3Backend = () => backend
 
 /**
  * Monitors the output and termination of the tool process. This function
@@ -329,7 +329,7 @@ async function monitorProcess(step: Step, env: ProcessEnv): Promise<boolean> {
         lw.compile.process.on('exit', (code, signal) => {
             let isSkipped = false
 
-            const l3backend = stdout.match(/l3backend-(.*?)\.def/)?.[1] ?? "unknown"
+            const l3backend = stdout.match(/l3backend-(.*?)\.def/)?.[1] ?? 'unknown'
             setL3Backend(l3backend)
 
             // #4838 LaTeX writes messages to stdout, while dvipdfmx writes

--- a/src/parse/parser/dvipdfmxlog.ts
+++ b/src/parse/parser/dvipdfmxlog.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode'
 import { lw } from '../../lw'
 import { type IParser, type LogEntry, showCompilerDiagnostics } from './parserutils'
+import { getL3Backend } from '../../compile/build'
 
 
 const logger = lw.log('Parser', 'DvipdfmxLog')
@@ -12,6 +13,8 @@ const dvipdfmxArgsError = /^dvipdfmx: ((Missing argument|Unexpected argument in)
 const dvipdfmxConfigError = /^config_special: (Unknown option .+)/
 const additionalMessage = /^\s*(CMap name|input str|Font|CMap):/
 const noOutputPDF = 'No output PDF file written.'
+
+const latexWorkshopMesg = "Message from LaTeX Workshop:"
 
 const dvipdfmxDiagnostics = vscode.languages.createDiagnosticCollection('Dvipdfmx')
 
@@ -59,6 +62,16 @@ function parse(log: string, rootFile?: string) {
     const state: ParserState = {
         currentType: undefined,
         dvipdfmxBuffer: []
+    }
+
+    if (getL3Backend() !== "dvipdfmx") {
+        pushLog(
+            'warning',
+            rootFile,
+            `${latexWorkshopMesg} Detected backend: \`${getL3Backend()}'.\nThis document appears to require the dvipdfmx backend.\nPlease specify \`dvipdfmx' in your global options within \\documentclass.`,
+            1,
+            excludeRegexp
+        )
     }
 
     for (const line of lines) {

--- a/src/parse/parser/dvipdfmxlog.ts
+++ b/src/parse/parser/dvipdfmxlog.ts
@@ -14,7 +14,7 @@ const dvipdfmxConfigError = /^config_special: (Unknown option .+)/
 const additionalMessage = /^\s*(CMap name|input str|Font|CMap):/
 const noOutputPDF = 'No output PDF file written.'
 
-const latexWorkshopMesg = "Message from LaTeX Workshop:"
+const latexWorkshopMesg = 'Message from LaTeX Workshop:'
 
 const dvipdfmxDiagnostics = vscode.languages.createDiagnosticCollection('Dvipdfmx')
 
@@ -64,7 +64,7 @@ function parse(log: string, rootFile?: string) {
         dvipdfmxBuffer: []
     }
 
-    if (getL3Backend() !== "dvipdfmx") {
+    if (getL3Backend() !== 'dvipdfmx') {
         pushLog(
             'warning',
             rootFile,

--- a/src/parse/parser/dvipdfmxlog.ts
+++ b/src/parse/parser/dvipdfmxlog.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode'
 import { lw } from '../../lw'
 import { type IParser, type LogEntry, showCompilerDiagnostics } from './parserutils'
-import { getL3Backend } from '../../compile/build'
+import { l3backend } from '../../compile/build'
 
 
 const logger = lw.log('Parser', 'DvipdfmxLog')
@@ -64,11 +64,11 @@ function parse(log: string, rootFile?: string) {
         dvipdfmxBuffer: []
     }
 
-    if (getL3Backend() !== 'dvipdfmx') {
+    if (l3backend !== 'dvipdfmx') {
         pushLog(
             'warning',
             rootFile,
-            `${latexWorkshopMesg} Detected backend: \`${getL3Backend()}'.\nThis document appears to require the dvipdfmx backend.\nPlease specify \`dvipdfmx' in your global options within \\documentclass.`,
+            `${latexWorkshopMesg} Detected backend: \`${l3backend}'.\nThis document appears to require the dvipdfmx backend.\nPlease specify \`dvipdfmx' in your global options within \\documentclass.`,
             1,
             excludeRegexp
         )


### PR DESCRIPTION

## Summary

In LaTeX versions released in 2020 and later, `expl3` is always loaded, and the backend is automatically selected depending on the engine (e.g., pdfTeX, LuaTeX, XeTeX). However, when using a DVI-based workflow, LaTeX cannot detect which tool will be used to DVI convert (e.g., `dvipdfmx` or `dvips`).

As a result, users who intend to use dvipdfmx must explicitly specify it as a global option in their TeX files. This requirement is frequently overlooked, leading to DVI files being generated with the default `dvips` backend, which can cause incorrect output or compilation issues.

## PR

This proposal introduces a warning mechanism in LaTeX Workshop to help users detect such misconfigurations early.

The feature analyzes the LaTeX log to determine which backend is being used and issues a warning if the detected backend is incompatible with dvipdfmx.

### Purpose

In LaTeX + dvipdfmx workflow, failing to specify `dvipdfmx` in the following global options will result in the creation of incorrect DVI files.

```latex
\documentclass{article}
\begin{document} Hello World \end{document}
```

The purpose is to have the following changes made based on the message added by this PR.

```latex
\documentclass[dvipdfmx]{article}
\begin{document} Hello World \end{document}
```

## Implementation Details

The backend is identified by inspecting the `l3backend-*.def` file referenced in the LaTeX log (where `*` may be `pdftex`, `luatex`, `xetex`, `dvipdfmx`, or `dvips`).

The implementation proceeds as follows:

* compile/build.ts
  * Within `monitorProcess`, scan `stdout` using the regex `/l3backend-(.*?)\.def/`.
  * Store the detected backend in a variable (`getL3Backend()`).
* parse/parser/dvipdfmxlog.ts
  * If `getL3Backend() !== 'dvipdfmx'`, emit a warning message from LW.

This implementation does not affect other LaTeX workflows.

### Warning Message displayed

The warning is generated by LaTeX Workshop (not by LaTeX or external tools):

```
Message from LaTeX workshop: Detected backend: `${getL3Backend()}'.
This document appears to require the dvipdfmx backend.
Please specify `dvipdfmx' in your global options within \documentclass.
```

Until now, LaTeX Workshop did not have any post-build messages generated from extension. For this reason, we explicitly state that the message was generated by LaTeX Workshop. However, in implementation, it is generated by dvipdfmxlog.
