### PR TITLE
add handling for 'unknown' backend

### DIFF
--- a/src/parse/parser/dvipdfmxlog.ts
+++ b/src/parse/parser/dvipdfmxlog.ts
@@ -64,7 +64,7 @@ function parse(log: string, rootFile?: string) {
         dvipdfmxBuffer: []
     }
 
-    if (l3backend !== 'dvipdfmx') {
+    if (l3backend !== 'dvipdfmx' && l3backend !== 'unknown') {
         pushLog(
             'warning',
             rootFile,


### PR DESCRIPTION
I apologize for contacting you repeatedly regarding this matter.

I have modified the code so that a warning message no longer appears when l3backend is set to “`unknown`”.

The `unknown` status for l3backend occurs when dvipdfmx is run independently, rather than in conjunction with LaTeX as in latexmk. Previously, even if a DVI file was created using the `dvipdfmx` backend, a warning message stating `unknown` would still appear when dvipdfmx was run independently. 
I have implemented a fix to prevent this from happening.
