### PR TITLE
Providing a Log Parser for `xdvipdfmx`

### DIFF
--- a/src/parse/parser.ts
+++ b/src/parse/parser.ts
@@ -88,8 +88,8 @@ const texifyPattern = /^running\s(pdf|lua|xe)?latex/gm
 const texifyLog = /^running\s((pdf|lua|xe)?latex|miktex-bibtex)/
 const texifyLogLatex = /^running\s(pdf|lua|xe)?latex/
 
-const dvipdfmxPattern = /^(.*)\.dvi -> (.*)\.pdf/m
-const dvipdfmxPatternAlt = /^dvipdfmx: ((Missing argument|Unexpected argument in).*|Multiple dvi filenames\?)/
+const dvipdfmxPattern = /^(.*)(\.dvi|\.xdv|stdin) -> (.*)\.pdf/
+const dvipdfmxPatternAlt = /^x?dvipdfmx: ((Missing argument|Unexpected argument in).*|Multiple dvi filenames\?)/
 const dvipdfmxConfigOption = /^config_special: Unknown option .*?/
 
 const bibtexPattern = /^This is BibTeX, Version.*$/m

--- a/src/parse/parser/dvipdfmxlog.ts
+++ b/src/parse/parser/dvipdfmxlog.ts
@@ -6,10 +6,10 @@ import { l3backend } from '../../compile/build'
 
 const logger = lw.log('Parser', 'DvipdfmxLog')
 
-const divpdfmxWarn = /^dvipdfmx:warning: (.+)$/
-const dvipdfmxContinuedWarn = /^dvipdfmx:warning: >> (.*)$/
-const divpdfmxFatal = /^dvipdfmx:fatal: (.+)$/
-const dvipdfmxArgsError = /^dvipdfmx: ((Missing argument|Unexpected argument in) .+?|Multiple dvi filenames\?)/
+const divpdfmxWarn = /^x?dvipdfmx:warning: (.+)$/
+const dvipdfmxContinuedWarn = /^x?dvipdfmx:warning: >> (.*)$/
+const divpdfmxFatal = /^x?dvipdfmx:fatal: (.+)$/
+const dvipdfmxArgsError = /^x?dvipdfmx: ((Missing argument|Unexpected argument in) .+?|Multiple dvi filenames\?)/
 const dvipdfmxConfigError = /^config_special: (Unknown option .+)/
 const additionalMessage = /^\s*(CMap name|input str|Font|CMap):/
 const noOutputPDF = 'No output PDF file written.'
@@ -64,11 +64,11 @@ function parse(log: string, rootFile?: string) {
         dvipdfmxBuffer: []
     }
 
-    if (l3backend !== 'dvipdfmx' && l3backend !== 'unknown') {
+    if (l3backend !== 'dvipdfmx' && l3backend !== 'xetex' && l3backend !== 'unknown') {
         pushLog(
             'warning',
             rootFile,
-            `${latexWorkshopMesg} Detected backend: \`${l3backend}'.\nThis document appears to require the dvipdfmx backend.\nPlease specify \`dvipdfmx' in your global options within \\documentclass.`,
+            `${latexWorkshopMesg} Detected l3backend: \`${l3backend}'.\nThe recipe uses dvipdfmx, but the l3backend used in the DVI file generated this time\ndoes not support it. You should add \`dvipdfmx' to option list of  \\documentclass.\n\t\\documentclass[dvipdfmx, ...]{...}`,
             1,
             excludeRegexp
         )


### PR DESCRIPTION

## Summary

`xdvipdfmx` is a tool that converts XDV files to PDF and is used with XeLaTeX.

If you use only XeLaTeX, no log messages regarding `xdvipdfmx` will be output; however, if you use latexmk, a XDV file is generated and `xdvipdfmx` is explicitly used, so log messages will be output.

Since `xdvipdfmx` uses the same log format as `dvipdfmx`, you can handle it by extending an existing `dvipdfmx` log parser.

## Changes

* Support for `xdvipdfmx` due to changes in regular expressions (parse.ts, dvipdfmxlog.ts)

In this PR, the following configuration will not be changed. Therefore, this exclusion setting will be shared between `dvipdfmx` and `xdvipdfmx`.

* `latex-workshop.message.dvipdfmxlog.exclude`

----------

Thank you as always.
