### PR TITLE
Fix trimming CSS rounding at fractional DPI

### DIFF
--- a/viewer/components/trimming.ts
+++ b/viewer/components/trimming.ts
@@ -65,17 +65,17 @@ export function setTrimCSS() {
 function getPageRule(pageNum: number, pageHeight: number, pageWidth: number): string {
     return `
         .page[data-page-number="${pageNum + 1}"] {
-            width: round(down, calc(var(--scale-factor) * ${pageWidth}px * (1 - var(--trim-factor) / 100)), 1px) !important;
-            height: round(down, calc(var(--scale-factor) * ${pageHeight}px * (1 - var(--trim-factor) / 100)), 1px) !important;
+            width: round(down, calc(var(--total-scale-factor) * ${pageWidth}px * (1 - var(--trim-factor) / 100)), var(--scale-round-x)) !important;
+            height: round(down, calc(var(--total-scale-factor) * ${pageHeight}px * (1 - var(--trim-factor) / 100)), var(--scale-round-y)) !important;
         }`
 }
 
 function getCanvasRule(className: string, pageNum: number, pageHeight: number, pageWidth: number): string {
     return `
         .page[data-page-number="${pageNum + 1}"] .${className} {
-            width: round(down, calc(var(--scale-factor) * ${pageWidth}px), 1px) !important;
-            height: round(down, calc(var(--scale-factor) * ${pageHeight}px), 1px) !important;
-            margin-left: round(down, calc(var(--scale-factor) * ${pageWidth}px * var(--trim-factor) / -200), 1px) !important;
-            margin-top: round(down, calc(var(--scale-factor) * ${pageHeight}px * var(--trim-factor) / -200), 1px) !important;
+            width: round(down, calc(var(--total-scale-factor) * ${pageWidth}px), var(--scale-round-x)) !important;
+            height: round(down, calc(var(--total-scale-factor) * ${pageHeight}px), var(--scale-round-y)) !important;
+            margin-left: round(down, calc(var(--total-scale-factor) * ${pageWidth}px * var(--trim-factor) / -200), var(--scale-round-x)) !important;
+            margin-top: round(down, calc(var(--total-scale-factor) * ${pageHeight}px * var(--trim-factor) / -200), var(--scale-round-y)) !important;
         }`
 }


### PR DESCRIPTION
This patch fixes blurry PDF rendering at fractional device pixel ratios, such as Windows 125% display scaling, when LaTeX Workshop's PDF trimming rules are active.

The fix is in LaTeX Workshop's `viewer/components/trimming.ts`, not in PDF.js.

### Root Cause

PDF.js renders a page using two parallel size calculations:

1. the canvas backing size, which determines the actual rendered pixels;
2. the CSS display size, which determines how large that canvas appears on the page.

Those two sizes must stay aligned. At fractional device pixel ratios, PDF.js does this by computing a rounding denominator and exposing it through CSS variables such as `--scale-round-x` and `--scale-round-y`.

For example, at 125% DPI:

```text
devicePixelRatio = 1.25
approximateFraction(1.25) = [5, 4]
sfx[1] = 4

pageWidth   = floorToDivide(viewport width, 4)        -> 792px
canvasWidth = floorToDivide(viewport width * 1.25, 5) -> 990px
outputScale = 990 / 792 = 1.25
```

PDF.js then sets:

```text
--scale-round-x: 4px
```

and its page dimensions are calculated like this:

```css
width: round(down,
  var(--total-scale-factor) * 612px,
  var(--scale-round-x)
);
```

At 125% DPI this becomes:

```text
round(down, 793.7px, 4px) = 792px
```

That matches the `pageWidth` used for the canvas backing calculation, so the 990px canvas backing store maps to 792 CSS pixels at exactly 1.25.

However, LaTeX Workshop's trimming CSS overrides PDF.js' dimensions with `!important` rules generated in `viewer/components/trimming.ts`. Before this patch those rules used a fixed `1px` rounding granularity:

```css
width: round(down,
  var(--scale-factor) * 612px,
  1px
) !important;
```

At 125% DPI this becomes:

```text
round(down, 793.7px, 1px) = 793px
```

That no longer matches PDF.js' canvas-aligned `pageWidth` of 792px. The browser must scale a 990px canvas into a 793px CSS box:

```text
990 / 793 = 1.2484...
```

instead of the exact intended ratio:

```text
990 / 792 = 1.25
```

This mismatch causes browser interpolation and visible blur.

Integer DPI values do not show the same problem because the PDF.js rounding denominator is `1px`, so the old trimming rule and PDF.js' own sizing happen to agree.

### Fix

The trimming CSS now uses the same variables as PDF.js:

- `--total-scale-factor` instead of `--scale-factor`
- `--scale-round-x` / `--scale-round-y` instead of a hard-coded `1px`

This preserves PDF.js' canvas/CSS alignment while still allowing LaTeX Workshop's trimming rules to crop the visible page area.

### Validation

Tested with:

- `npm run compile`
- `npm run lint`

