### PR TITLE
Fix overlapping ranges when combining LaTeX formatter with quote/math fixers

### DIFF
--- a/src/extras/math-fixer.ts
+++ b/src/extras/math-fixer.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode'
 import { stripCommentsAndVerbatim } from '../utils/utils'
+import { applyEditsToString } from './quote-fixer'
 
 /**
  * Represent the type of math environment we are currently in.
@@ -123,4 +124,23 @@ export function fixMath(document: vscode.TextDocument, range: vscode.Range | und
     const targetRange = range ?? new vscode.Range(0, 0, Number.MAX_VALUE, Number.MAX_VALUE)
     const text = document.getText() // Get full text to ensure correct line numbers
     return mathFixer.getEdits(text).filter(e => targetRange.contains(e.range))
+}
+
+/**
+ * Apply LaTeX math delimiter normalization to a piece of text and return the result.
+ *
+ * Used by the formatter to fold math fixes into the formatter's output text
+ * instead of producing additional `TextEdit`s that would overlap with the
+ * formatter's full-range edit.
+ *
+ * @param document The document used to look up the relevant configuration.
+ * @param text The text to normalize.
+ * @returns The normalized text, or the original text if math fixing is disabled.
+ */
+export function applyMathFixer(document: vscode.TextDocument, text: string): string {
+    const config = vscode.workspace.getConfiguration('latex-workshop', document.uri)
+    if (!config.get('format.fixMath.enabled', false)) {
+        return text
+    }
+    return applyEditsToString(text, new MathFixer().getEdits(text))
 }

--- a/src/extras/quote-fixer.ts
+++ b/src/extras/quote-fixer.ts
@@ -90,3 +90,54 @@ export function fixQuotes(document: vscode.TextDocument, range: vscode.Range | u
     const text = document.getText() // Get full text to ensure correct line numbers
     return quoteFixer.getEdits(text).filter(e => targetRange.contains(e.range))
 }
+
+/**
+ * Apply LaTeX quote normalization to a piece of text and return the result.
+ *
+ * Used by the formatter to fold quote fixes into the formatter's output text
+ * instead of producing additional `TextEdit`s that would overlap with the
+ * formatter's full-range edit.
+ *
+ * @param document The document used to look up the relevant configuration.
+ * @param text The text to normalize.
+ * @returns The normalized text, or the original text if quote fixing is disabled.
+ */
+export function applyQuoteFixer(document: vscode.TextDocument, text: string): string {
+    const config = vscode.workspace.getConfiguration('latex-workshop', document.uri)
+    if (!config.get('format.fixQuotes.enabled', false)) {
+        return text
+    }
+    return applyEditsToString(text, new QuoteFixer().getEdits(text))
+}
+
+/**
+ * Apply a list of `TextEdit`s to a plain string. The fixers report edits with
+ * line/character positions relative to the input text, so we convert each
+ * range to a character offset and splice from the end backwards to keep
+ * earlier offsets stable.
+ */
+export function applyEditsToString(text: string, edits: vscode.TextEdit[]): string {
+    if (edits.length === 0) {
+        return text
+    }
+    const lineOffsets: number[] = [0]
+    for (let i = 0; i < text.length; i++) {
+        if (text[i] === '\n') {
+            lineOffsets.push(i + 1)
+        }
+    }
+    const offsetOf = (line: number, character: number): number => {
+        const base = line < lineOffsets.length ? lineOffsets[line] : text.length
+        return Math.min(base + character, text.length)
+    }
+    const sorted = edits.map(e => ({
+        start: offsetOf(e.range.start.line, e.range.start.character),
+        end: offsetOf(e.range.end.line, e.range.end.character),
+        newText: e.newText,
+    })).sort((a, b) => b.start - a.start)
+    let result = text
+    for (const e of sorted) {
+        result = result.slice(0, e.start) + e.newText + result.slice(e.end)
+    }
+    return result
+}

--- a/src/lint/latex-formatter.ts
+++ b/src/lint/latex-formatter.ts
@@ -3,8 +3,8 @@ import { lw } from '../lw'
 import { LaTeXFormatter } from '../types'
 import { latexindent } from './latex-formatter/latexindent'
 import { texfmt } from './latex-formatter/tex-fmt'
-import { fixQuotes } from '../extras/quote-fixer'
-import { fixMath } from '../extras/math-fixer'
+import { fixQuotes, applyQuoteFixer } from '../extras/quote-fixer'
+import { fixMath, applyMathFixer } from '../extras/math-fixer'
 
 const logger = lw.log('Format', 'LaTeX')
 
@@ -35,12 +35,13 @@ class FormattingProvider implements vscode.DocumentFormattingEditProvider, vscod
         const edits: vscode.TextEdit[] = []
         const formatEdit = await this.formatter?.formatDocument(document)
         if (formatEdit) {
+            // Apply fixers to the formatter output to avoid overlapping ranges.
+            formatEdit.newText = applyMathFixer(document, applyQuoteFixer(document, formatEdit.newText))
             edits.push(formatEdit)
+        } else {
+            edits.push(...fixQuotes(document, undefined))
+            edits.push(...fixMath(document, undefined))
         }
-        const quoteEdits = fixQuotes(document, undefined)
-        edits.push(...quoteEdits)
-        const mathEdits = fixMath(document, undefined)
-        edits.push(...mathEdits)
         return edits
     }
 
@@ -58,13 +59,13 @@ class FormattingProvider implements vscode.DocumentFormattingEditProvider, vscod
                 // In this case, the first line need some leading whitespaces.
                 formatEdit.newText = ' '.repeat(firstLine.firstNonWhitespaceCharacterIndex - range.start.character) + formatEdit.newText
             }
+            // Apply fixers to the formatter output to avoid overlapping ranges.
+            formatEdit.newText = applyMathFixer(document, applyQuoteFixer(document, formatEdit.newText))
             edits.push(formatEdit)
+        } else {
+            edits.push(...fixQuotes(document, range))
+            edits.push(...fixMath(document, range))
         }
-
-        const quoteEdits = fixQuotes(document, range)
-        edits.push(...quoteEdits)
-        const mathEdits = fixMath(document, range)
-        edits.push(...mathEdits)
         return edits
     }
 }

--- a/test/units/06_linter/latex-formatter.test.ts
+++ b/test/units/06_linter/latex-formatter.test.ts
@@ -147,16 +147,31 @@ describe(path.basename(__filename).split('.')[0] + ':', () => {
                 assert.ok(edits.length > 0, 'Expected fixMath to produce edits')
             })
 
-            it('should combine formatter edits and fixQuotes edits', async () => {
+            it('should apply fixQuotes to formatter output without producing overlapping edits', async () => {
                 set.config('format.fixQuotes.enabled', true)
-                const formatterEdit = vscode.TextEdit.replace(new vscode.Range(0, 0, 0, 5), 'formatted')
+                const formatterEdit = vscode.TextEdit.replace(new vscode.Range(0, 0, 0, 13), '"hello" world')
                 latexindentStub.resolves(formatterEdit)
 
                 const edits = await formatter.provideDocumentFormattingEdits(makeDocument('"hello" world\n'), dummyOptions, dummyToken)
 
+                // A single edit avoids "Overlapping ranges are not allowed!" from VS Code.
+                assert.strictEqual(edits.length, 1)
                 assert.ok(edits.includes(formatterEdit))
-                // fixQuotes edits should also be present
-                assert.ok(edits.length > 1)
+                assert.ok(edits[0].newText.includes("``hello''"))
+            })
+
+            it('should apply fixMath to formatter output without producing overlapping edits', async () => {
+                set.config('format.fixMath.enabled', true)
+                const formatterEdit = vscode.TextEdit.replace(new vscode.Range(0, 0, 0, 5), '$x^2$')
+                latexindentStub.resolves(formatterEdit)
+
+                const edits = await formatter.provideDocumentFormattingEdits(makeDocument('$x^2$\n'), dummyOptions, dummyToken)
+
+                // A single edit avoids "Overlapping ranges are not allowed!" from VS Code.
+                assert.strictEqual(edits.length, 1)
+                assert.ok(edits.includes(formatterEdit))
+                assert.ok(edits[0].newText.includes('\\(x^2\\)'))
+                assert.ok(!edits[0].newText.includes('$'))
             })
         })
     })
@@ -309,16 +324,17 @@ describe(path.basename(__filename).split('.')[0] + ':', () => {
             assert.ok(edits.length > 0, 'Expected fixMath to produce edits')
         })
 
-        it('should combine formatter edit and fixQuotes edits for range formatting', async () => {
+        it('should apply fixQuotes to formatter output for range formatting without overlapping edits', async () => {
             set.config('format.fixQuotes.enabled', true)
             const range = new vscode.Range(0, 0, 0, 13)
-            const formatterEdit = vscode.TextEdit.replace(range, 'formatted')
+            const formatterEdit = vscode.TextEdit.replace(range, '"hello" world')
             latexindentStub.resolves(formatterEdit)
 
             const edits = await formatter.provideDocumentRangeFormattingEdits(makeDocument('"hello" world\n'), range, dummyOptions, dummyToken)
 
+            assert.strictEqual(edits.length, 1)
             assert.ok(edits.includes(formatterEdit))
-            assert.ok(edits.length > 1, 'Expected both formatter and fixQuotes edits')
+            assert.ok(edits[0].newText.includes("``hello''"))
         })
     })
 })


### PR DESCRIPTION
## Summary

- Formatting a document fails with `Overlapping ranges are not allowed!` whenever `formatting.latex` is set to `latexindent` or `tex-fmt` **and** `format.fixQuotes.enabled` or `format.fixMath.enabled` is `true`.
- Root cause: the LaTeX formatter returns a single `TextEdit` covering the full document (or selection), while the quote/math fixers emit small edits inside that same range. VS Code rejects a `TextEdit[]` from a formatter when any ranges overlap.
- Fix: when the LaTeX formatter produces an edit, apply the quote and math fixers to its `newText` and return a single non-overlapping `TextEdit`. When no LaTeX formatter is active, the small fixer edits are returned as before (they don't overlap with each other).

## Reproduction

1. Set `latex-workshop.formatting.latex` to `latexindent` (or `tex-fmt`).
2. Enable `latex-workshop.format.fixQuotes.enabled` and/or `latex-workshop.format.fixMath.enabled`.
3. Open a `.tex` file containing straight quotes or `$...$` math and run `Format Document`.
4. Before the fix: VS Code shows `Command 'Format Document With…' resulted in an error — Overlapping ranges are not allowed!`.
5. After the fix: the document is formatted and quotes/math are normalised in a single pass.

## Test plan

- [x] `npm run compile` succeeds
- [x] Updated unit tests in `test/units/06_linter/latex-formatter.test.ts` reflect the new non-overlapping single-edit behavior
- [x] Manually verified `Format Document` works with latexindent + `fixQuotes` + `fixMath` enabled on a real document
- [x] Reviewer confirms `npm test` passes in CI