### PR TITLE
Latexmk `-cd` flag

### DIFF
--- a/src/compile/build.ts
+++ b/src/compile/build.ts
@@ -241,13 +241,12 @@ function spawnProcess(step: Step): ProcessEnv {
     if (step.index === 0 || configuration.get('latex.build.clearLog.everyRecipeStep.enabled') as boolean) {
         logger.clearCompilerMessage()
     }
-    let cwd = step.cwd
 
     logger.refreshStatus('sync~spin', 'statusBar.foreground', undefined, undefined, ' ' + queue.getStepString(step))
     logger.logCommand(`Recipe step ${step.index + 1}`, step.command, step.args)
     logger.log(`env: ${JSON.stringify(step.env)}`)
     logger.log(`root: ${step.rootFile}`)
-    logger.log(`cwd: ${cwd}`)
+    logger.log(`cwd: ${step.cwd}`)
 
     const env: ProcessEnv = { ...process.env, ...step.env }
     env['max_print_line'] = lw.constant.MAX_PRINT_LINE
@@ -259,21 +258,16 @@ function spawnProcess(step: Step): ProcessEnv {
         const args = step.args
         if (args && !step.name.endsWith(lw.constant.MAGIC_PROGRAM_ARGS_SUFFIX)) {
             // All optional arguments are given as a unique string (% !TeX options) if any, so we use {shell: true}
-            lw.compile.process = lw.external.spawn(`${step.command} ${args[0]}`, [], {cwd, env, shell: true})
+            lw.compile.process = lw.external.spawn(`${step.command} ${args[0]}`, [], {cwd: step.cwd, env, shell: true})
         } else {
-            lw.compile.process = lw.external.spawn(step.command, args ?? [], {cwd, env})
+            lw.compile.process = lw.external.spawn(step.command, args ?? [], {cwd: step.cwd, env})
         }
     } else if (!step.isExternal) {
-        if (step.command === 'latexmk' && step.rootFile === lw.root.subfiles.path && lw.root.dir.path && cwd === path.dirname(step.rootFile)) {
-            cwd = lw.root.dir.path
-        }
         if (step.command === 'bibtex' && step.args && step.args.length > 0) {
-            step.args[step.args.length - 1] = normalizeArgForCwd(step.args[step.args.length - 1], cwd, cwd)
+            step.args[step.args.length - 1] = normalizeArgForCwd(step.args[step.args.length - 1], step.cwd, step.cwd)
         }
-        logger.log(`cwd: ${cwd}`)
-        lw.compile.process = lw.external.spawn(step.command, step.args ?? [], {cwd, env})
+        lw.compile.process = lw.external.spawn(step.command, step.args ?? [], {cwd: step.cwd, env})
     } else {
-        logger.log(`cwd: ${step.cwd}`)
         lw.compile.process = lw.external.spawn(step.command, step.args ?? [], {cwd: step.cwd})
     }
     logger.log(`LaTeX build process spawned with PID ${lw.compile.process.pid}.`)

--- a/src/compile/recipe.ts
+++ b/src/compile/recipe.ts
@@ -1,6 +1,6 @@
 import vscode from 'vscode'
 import path from 'path'
-import { getWorkingFolder, replaceArgumentPlaceholders } from '../utils/utils'
+import { getWorkingFolder, replaceArgumentPlaceholders, resolveFile } from '../utils/utils'
 
 import { lw } from '../lw'
 import type { Recipe, Tool } from '../types'
@@ -183,7 +183,7 @@ async function createBuildTools(rootFile: string, langId: string, recipeName?: s
     // Use JSON.parse and JSON.stringify for a deep copy.
     buildTools = JSON.parse(JSON.stringify(buildTools)) as Tool[]
 
-    populateTools(rootFile, buildTools)
+    await populateTools(rootFile, buildTools)
 
     return buildTools
 }
@@ -341,15 +341,15 @@ function findRecipe(rootFile: string, langId: string, recipeName?: string): Reci
  *
  * @param {string} rootFile - Path to the root LaTeX file.
  * @param {Tool[]} buildTools - An array of Tool objects to be populated.
- * @returns {Tool[]} - An array of Tool objects with expanded values.
+ * @returns {Promise<Tool[]>} - An array of Tool objects with expanded values.
  */
-function populateTools(rootFile: string, buildTools: Tool[]): Tool[] {
+async function populateTools(rootFile: string, buildTools: Tool[]): Promise<Tool[]> {
     const configuration = vscode.workspace.getConfiguration('latex-workshop', lw.file.toUri(rootFile))
     const docker = configuration.get('docker.enabled')
     const defaultCwd = getWorkingFolder(rootFile)
     const replaceFn = replaceArgumentPlaceholders(rootFile, lw.file.tmpDirPath)
 
-    buildTools.forEach(tool => {
+    await Promise.all(buildTools.map(async tool => {
         if (docker) {
             switch (tool.command) {
                 case 'latexmk':
@@ -390,6 +390,10 @@ function populateTools(rootFile: string, buildTools: Tool[]): Tool[] {
         Object.entries(env).forEach(([key, value]) => {
             env[key] = value && replaceArgumentPlaceholders(rootFile, lw.file.tmpDirPath)(value)
         })
+        if (await shouldAddLaTeXmkCD(tool, rootFile)) {
+            tool.args = tool.args ?? []
+            tool.args.push('-cd')
+        }
         if (configuration.get('latex.option.maxPrintLine.enabled')) {
             tool.args = tool.args ?? []
             const isLaTeXmk =
@@ -413,8 +417,48 @@ function populateTools(rootFile: string, buildTools: Tool[]): Tool[] {
                 }
             }
         }
-    })
+    }))
     return buildTools
+}
+
+async function shouldAddLaTeXmkCD(tool: Tool, rootFile: string): Promise<boolean> {
+    // Don't add -cd if the tool is not latexmk
+    if (tool.command !== 'latexmk') {
+        return false
+    }
+    // Don't add -cd if the tool already has a working directory specified by
+    // cwd or defined in args
+    if (tool.cwd || tool.args?.includes('-cd') || tool.args?.includes('--cd')) {
+        return false
+    }
+    // Don't add -cd if the root file is not in the workspace root or its
+    // subdirectories
+    if (rootFile !== lw.root.subfiles.path || lw.root.dir.path === undefined || path.dirname(rootFile) !== lw.root.dir.path) {
+        return false
+    }
+    // Don't add -cd if the root file does not contain
+    // \documentclass[...]{subfiles}
+    const regex = /(?:\\documentclass\[(.*)\]{subfiles})/s
+    const result = (await lw.file.read(lw.root.subfiles.path) ?? '').match(regex)
+    if (!result) {
+        return false
+    }
+    // Now `cwd` does not exist in the tool, check if the file indicated in the
+    // \documentclass macro exist w.r.t cwd
+    let filePath = await resolveFile([getWorkingFolder(rootFile)], result[1])
+    // If the file exist, then it means the root file can be compiled in its own
+    // directory and we don't need to add -cd
+    if (filePath) {
+        return false
+    }
+    // If the file does not exist, try to resolve it w.r.t the directory of the
+    // root file
+    filePath = await resolveFile([path.dirname(lw.root.subfiles.path)], result[1])
+    if (filePath) {
+        return true
+    }
+
+    return false
 }
 
 /**

--- a/src/compile/recipe.ts
+++ b/src/compile/recipe.ts
@@ -431,9 +431,8 @@ async function shouldAddLaTeXmkCD(tool: Tool, rootFile: string): Promise<boolean
     if (tool.cwd || tool.args?.includes('-cd') || tool.args?.includes('--cd')) {
         return false
     }
-    // Don't add -cd if the root file is not in the workspace root or its
-    // subdirectories
-    if (rootFile !== lw.root.subfiles.path || lw.root.dir.path === undefined || path.dirname(rootFile) !== lw.root.dir.path) {
+    // Don't add -cd if the root file is the same as the subfile
+    if (rootFile === lw.root.subfiles.path || lw.root.subfiles.path === undefined) {
         return false
     }
     // Don't add -cd if the root file does not contain

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,7 +83,7 @@ export type RecipeStep = Tool & {
     isExternal: false,
     isRetry: boolean,
     isSkipped: boolean,
-     cwd: string
+    cwd: string
 }
 
 export type ExternalStep = Tool & {

--- a/test/units/02_compile/build.test.ts
+++ b/test/units/02_compile/build.test.ts
@@ -1,6 +1,4 @@
 import * as vscode from 'vscode'
-import type { SpawnOptions } from 'child_process'
-import * as cs from 'cross-spawn'
 import * as path from 'path'
 import * as sinon from 'sinon'
 import { assert, get, log, mock, set, sleep } from '../utils'
@@ -249,28 +247,6 @@ describe(path.basename(__filename).split('.')[0] + ':', () => {
             spawnSpy.restore()
 
             assert.pathStrictEqual(spawnSpy.getCall(0)?.args?.[2].cwd?.toString(), path.dirname(get.path('main.tex')))
-        })
-
-        it('should change current working directory to root when using subfiles to compile sub files', async () => {
-            set.root('main.tex')
-            set.config('latex.tools', [
-                { name: 'tool', command: 'latexmk', args: [] },
-            ])
-            lw.root.subfiles.path = get.path('sub/subfile.tex')
-
-            const spawnStub = sinon.stub(lw.external, 'spawn')
-            let lastSpawnArgs: [command: string, args: readonly string[], options: SpawnOptions] | undefined
-            spawnStub.callsFake((...args) => {
-                lastSpawnArgs = args
-                return cs.spawn('true')
-            })
-
-            await build(true, get.path('sub/subfile.tex'), 'latex')
-            spawnStub.restore()
-
-            lw.root.subfiles.path = undefined
-
-            assert.pathStrictEqual(lastSpawnArgs?.[2].cwd?.toString(), path.dirname(get.path('main.tex')))
         })
 
         it('should set and use `max_print_line` envvar when building', async () => {

--- a/test/units/02_compile/recipe.test.ts
+++ b/test/units/02_compile/recipe.test.ts
@@ -158,6 +158,114 @@ describe(path.basename(__filename).split('.')[0] + ':', () => {
             assert.ok(step)
             assert.pathStrictEqual(step.cwd, get.path('build'))
         })
+
+        const fileStat = { type: vscode.FileType.File, ctime: 0, mtime: 0, size: 0 }
+
+        it('should add -cd for a subfiles build when the main file resolves only from the subfile directory', async () => {
+            const rootFile = set.root('main.tex')
+            lw.root.subfiles.path = get.path('section', 'main.tex')
+            const readStub = sinon.stub(lw.file, 'read').resolves('\\documentclass[../main.tex]{subfiles}\n')
+            const existsStub = sinon.stub(lw.file, 'exists').callsFake((target: string | vscode.Uri) => {
+                return Promise.resolve(target === get.path('main.tex') ? fileStat : false)
+            })
+
+            set.config('latex.tools', [{ name: 'latexmk', command: 'latexmk', args: ['-pdf'] }])
+            set.config('latex.recipes', [{ name: 'Recipe1', tools: ['latexmk'] }])
+
+            await build(rootFile, 'latex', async () => {})
+
+            readStub.restore()
+            existsStub.restore()
+            const step = queue.getStep()
+            assert.ok(step)
+            assert.listStrictEqual(step.args, ['-pdf', '-cd'])
+        })
+
+        it('should not add -cd when no subfiles root is used', async () => {
+            const rootFile = set.root('main.tex')
+            set.config('latex.tools', [{ name: 'latexmk', command: 'latexmk', args: ['-pdf'] }])
+            set.config('latex.recipes', [{ name: 'Recipe1', tools: ['latexmk'] }])
+
+            await build(rootFile, 'latex', async () => {})
+
+            const step = queue.getStep()
+            assert.ok(step)
+            assert.listStrictEqual(step.args, ['-pdf'])
+        })
+
+        it('should not add -cd when the main file already resolves from the working folder', async () => {
+            const rootFile = set.root('main.tex')
+            lw.root.subfiles.path = get.path('section', 'main.tex')
+            const readStub = sinon.stub(lw.file, 'read').resolves('\\documentclass[../main.tex]{subfiles}\n')
+            const existsStub = sinon.stub(lw.file, 'exists').callsFake((target: string | vscode.Uri) => {
+                return Promise.resolve(target === get.path('main.tex') ? fileStat : false)
+            })
+            set.config('latex.build.fromFolder', 'section')
+            set.config('latex.tools', [{ name: 'latexmk', command: 'latexmk', args: ['-pdf'] }])
+            set.config('latex.recipes', [{ name: 'Recipe1', tools: ['latexmk'] }])
+
+            await build(rootFile, 'latex', async () => {})
+
+            readStub.restore()
+            existsStub.restore()
+            const step = queue.getStep()
+            assert.ok(step)
+            assert.listStrictEqual(step.args, ['-pdf'])
+        })
+
+        it('should not add -cd when latexmk already defines a cwd override', async () => {
+            const rootFile = set.root('main.tex')
+            lw.root.subfiles.path = get.path('section', 'main.tex')
+            const readStub = sinon.stub(lw.file, 'read').resolves('\\documentclass[../main.tex]{subfiles}\n')
+            const existsStub = sinon.stub(lw.file, 'exists').resolves(false)
+            set.config('latex.tools', [{ name: 'latexmk', command: 'latexmk', cwd: 'build', args: ['-pdf'] }])
+            set.config('latex.recipes', [{ name: 'Recipe1', tools: ['latexmk'] }])
+
+            await build(rootFile, 'latex', async () => {})
+
+            readStub.restore()
+            existsStub.restore()
+            const step = queue.getStep()
+            assert.ok(step)
+            assert.listStrictEqual(step.args, ['-pdf'])
+        })
+
+        it('should not add -cd when latexmk already includes the switch in its args', async () => {
+            const rootFile = set.root('main.tex')
+            lw.root.subfiles.path = get.path('section', 'main.tex')
+            const readStub = sinon.stub(lw.file, 'read').resolves('\\documentclass[../main.tex]{subfiles}\n')
+            const existsStub = sinon.stub(lw.file, 'exists').resolves(false)
+            set.config('latex.tools', [{ name: 'latexmk', command: 'latexmk', args: ['-pdf', '-cd'] }])
+            set.config('latex.recipes', [{ name: 'Recipe1', tools: ['latexmk'] }])
+
+            await build(rootFile, 'latex', async () => {})
+
+            readStub.restore()
+            existsStub.restore()
+            const step = queue.getStep()
+            assert.ok(step)
+            assert.listStrictEqual(step.args, ['-pdf', '-cd'])
+        })
+
+        it('should not add -cd for non-latexmk tools even in a subfiles build', async () => {
+            const rootFile = set.root('main.tex')
+            lw.root.subfiles.path = get.path('section', 'main.tex')
+            const readStub = sinon.stub(lw.file, 'read').resolves('\\documentclass[../main.tex]{subfiles}\n')
+            const existsStub = sinon.stub(lw.file, 'exists').callsFake((target: string | vscode.Uri) => {
+                return Promise.resolve(target === get.path('main.tex') ? fileStat : false)
+            })
+
+            set.config('latex.tools', [{ name: 'pdflatex', command: 'pdflatex', args: ['-interaction=nonstopmode'] }])
+            set.config('latex.recipes', [{ name: 'Recipe1', tools: ['pdflatex'] }])
+
+            await build(rootFile, 'latex', async () => {})
+
+            readStub.restore()
+            existsStub.restore()
+            const step = queue.getStep()
+            assert.ok(step)
+            assert.listStrictEqual(step.args, ['-interaction=nonstopmode'])
+        })
     })
 
     describe('lw.compile->recipe.createBuildTools', () => {


### PR DESCRIPTION
This PR is a revival of the auto `-cd` flag addition discussed in #1895, #3654, and other issues.

Previously the `-cd` flag is aggressively added based only on tool settings and subfile root definition in `\documentclass`. This new logic is more cautious. Only when compiling from working folder will absolutely not finding the corresponding file, will the `-cd` flag being added.