### PR TITLE
Support \setcounter in Structure numbering

### DIFF
--- a/src/outline/structure/doctex.ts
+++ b/src/outline/structure/doctex.ts
@@ -62,6 +62,7 @@ async function getToC(document: vscode.TextDocument, docContent: string) {
         }
     }
     let struct = root.children
+    struct = outline.applySectionCounters(struct, config)
     struct = outline.nestNonSection(struct)
     struct = outline.nestSection(struct, config)
     const configuration = vscode.workspace.getConfiguration('latex-workshop')

--- a/src/outline/structure/latex.ts
+++ b/src/outline/structure/latex.ts
@@ -39,6 +39,7 @@ export async function construct(filePath: string | undefined = undefined, subFil
     // In rare cases, the following struct may be undefined. Typically in tests
     // where roots are changed rapidly.
     let struct = subFile ? insertSubFile(structs) : structs[filePath] ?? []
+    struct = applySectionCounters(struct, config)
     struct = nestNonSection(struct)
     struct = nestSection(struct, config)
     fixSectionToLine(struct, config, Number.MAX_SAFE_INTEGER)
@@ -117,6 +118,21 @@ async function parseNode(
             label: chooseCaption(node.args?.[1], node.args?.[2]),
             appendix: inAppendix,
             ...attributes
+        }
+    } else if (node.type === 'macro' && node.content === 'setcounter') {
+        const counterName = argContentToStr(node.args?.[0]?.content ?? []).trim()
+        const counterValueString = argContentToStr(node.args?.[1]?.content ?? []).trim()
+        const counterValue = Number(counterValueString)
+        if (config.secIndex[counterName] !== undefined
+            && /^[+-]?\d+$/.test(counterValueString)
+            && Number.isSafeInteger(counterValue)) {
+            element = {
+                type: TeXElementType.SetCounter,
+                name: counterName,
+                label: '',
+                counterValue,
+                ...attributes
+            }
         }
     } else if (node.type === 'macro' && config.macros.cmds.includes(node.content)) {
         const argStr = argContentToStr(node.args?.[2]?.content || [])
@@ -285,6 +301,37 @@ function nestNonSection(struct: TeXElement[]): TeXElement[] {
     return elements
 }
 
+/**
+ * Applies each parsed \setcounter value to the next matching numbered section
+ * and removes the internal counter elements. This runs after subfiles are
+ * expanded to preserve document order, but before structure elements are
+ * nested, which would attach counter elements to the preceding section.
+ */
+function applySectionCounters(
+        struct: TeXElement[],
+        config: StructureConfig,
+        pending: {[counter: string]: number} = {}): TeXElement[] {
+    const elements: TeXElement[] = []
+    for (const element of struct) {
+        const level = config.secIndex[element.name]
+        if (element.type === TeXElementType.SetCounter) {
+            if (level !== undefined && element.counterValue !== undefined) {
+                pending[element.name] = element.counterValue
+            }
+            continue
+        }
+        if (element.type === TeXElementType.Section && level !== undefined && pending[element.name] !== undefined) {
+            element.counterValue = pending[element.name]
+            delete pending[element.name]
+        }
+        if (element.children.length > 0) {
+            element.children = applySectionCounters(element.children, config, pending)
+        }
+        elements.push(element)
+    }
+    return elements
+}
+
 function nestSection(struct: TeXElement[], config: StructureConfig): TeXElement[] {
     const stack: TeXElement[] = []
     const elements: TeXElement[] = []
@@ -364,7 +411,8 @@ function addSectionNumber(struct: TeXElement[], config: StructureConfig, tag?: s
             continue
         }
         if (element.type === TeXElementType.Section) {
-            counter[config.secIndex[element.name]] = (counter[config.secIndex[element.name]] ?? 0) + 1
+            const level = config.secIndex[element.name]
+            counter[level] = (element.counterValue ?? counter[level] ?? 0) + 1
         }
         let sectionNumber = tag +
             '0.'.repeat(config.secIndex[element.name] - lowest) +
@@ -426,6 +474,7 @@ function refreshLaTeXModelConfig(subFile: boolean = true, defaultFloats = ['fram
 export const outline = {
     refreshLaTeXModelConfig,
     parseNode,
+    applySectionCounters,
     nestNonSection,
     nestSection,
     addFloatNumber,

--- a/src/outline/structure/latex.ts
+++ b/src/outline/structure/latex.ts
@@ -306,6 +306,8 @@ function nestNonSection(struct: TeXElement[]): TeXElement[] {
  * and removes the internal counter elements. This runs after subfiles are
  * expanded to preserve document order, but before structure elements are
  * nested, which would attach counter elements to the preceding section.
+ *
+ * @see https://github.com/James-Yu/LaTeX-Workshop/issues/4955
  */
 function applySectionCounters(
         struct: TeXElement[],
@@ -318,6 +320,7 @@ function applySectionCounters(
             if (level !== undefined && element.counterValue !== undefined) {
                 pending[element.name] = element.counterValue
             }
+            // Consume the internal marker without adding it to the visible structure.
             continue
         }
         if (element.type === TeXElementType.Section && level !== undefined && pending[element.name] !== undefined) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -131,7 +131,7 @@ export interface LaTeXFormatter {
     formatDocument(document: vscode.TextDocument, range?: vscode.Range): Promise<vscode.TextEdit | undefined>
 }
 
-export enum TeXElementType { Environment, Macro, Section, SectionAst, SubFile, BibItem, BibField }
+export enum TeXElementType { Environment, Macro, Section, SectionAst, SubFile, BibItem, BibField, SetCounter }
 
 export type TeXElement = {
     readonly type: TeXElementType,
@@ -142,7 +142,8 @@ export type TeXElement = {
     readonly filePath: string,
     children: TeXElement[],
     parent?: TeXElement,
-    appendix?: boolean
+    appendix?: boolean,
+    counterValue?: number
 }
 
 export type TeXMathEnv = {

--- a/test/units/07_outline/latex.test.ts
+++ b/test/units/07_outline/latex.test.ts
@@ -118,6 +118,19 @@ describe(path.basename(__filename).split('.')[0] + ':', () => {
 			assert.strictEqual(root.children.length, 0)
 		})
 
+		it('should parse literal section counter assignments as internal elements', async () => {
+			const node = await firstNode('\\setcounter{chapter}{-1}')
+			const root = { children: [] as TeXElement[] }
+			const config = outline.refreshLaTeXModelConfig()
+
+			await outline.parseNode(node, [], root, get.path('main.tex'), config, {}, false)
+
+			assert.strictEqual(root.children.length, 1)
+			assert.strictEqual(root.children[0].type, TeXElementType.SetCounter)
+			assert.strictEqual(root.children[0].name, 'chapter')
+			assert.strictEqual(root.children[0].counterValue, -1)
+		})
+
 		it('should resolve and parse input subfiles when enabled', async () => {
 			const node = await firstNode('\\input{sub}')
 			const root = { children: [] as TeXElement[] }
@@ -338,6 +351,35 @@ describe(path.basename(__filename).split('.')[0] + ':', () => {
 			assert.strictEqual(result.length, 1)
 			assert.strictEqual(result[0].children[0].label, '1.1 Section 1.1')
 			assert.strictEqual(result[0].children[0].children[0].label, '1.1.1 Section 1.1.1')
+		})
+
+		it('should apply setcounter values without exposing internal elements', async () => {
+			const main = set.root('main.tex')
+			await cacheAst(main, [
+				'\\documentclass{report}',
+				'\\begin{document}',
+				'\\setcounter{chapter}{-1}',
+				'\\chapter{Introduction}',
+				'\\chapter{Next}',
+				'\\setcounter{chapter}{4}',
+				'\\chapter{Fifth}',
+				'\\end{document}'
+			].join('\n'))
+
+			const numbered = await construct(main, true)
+			set.config('view.outline.numbers.enabled', false)
+			const unnumbered = await construct(main, true)
+
+			assert.deepStrictEqual(numbered.map(element => element.label), [
+				'0 Introduction',
+				'1 Next',
+				'5 Fifth'
+			])
+			assert.deepStrictEqual(unnumbered.map(element => element.label), [
+				'Introduction',
+				'Next',
+				'Fifth'
+			])
 		})
 
 		it('should preserve numbering gaps for skipped section levels', async () => {
@@ -609,6 +651,20 @@ describe(path.basename(__filename).split('.')[0] + ':', () => {
 			assert.strictEqual((lw.cache.wait as sinon.SinonStub).withArgs(sub).callCount, 1)
 			assert.strictEqual(result.length, 2)
 			assert.strictEqual(result[0].label, '1 From sub')
+		})
+
+		it('should apply setcounter values before expanded subfile sections', async () => {
+			const main = set.root('main.tex')
+			const sub = get.path('sections/sub.tex')
+			const resolveFileStub = sinon.stub(utils, 'resolveFile').resolves(sub)
+			await cacheAst(main, '\\setcounter{chapter}{-1}\n\\input{sub}')
+			await cacheAst(sub, '\\chapter{From sub}')
+
+			const result = await construct(main, true)
+			resolveFileStub.restore()
+
+			assert.strictEqual(result.length, 1)
+			assert.strictEqual(result[0].label, '0 From sub')
 		})
 
 		it('should inline nested input, import and subimport subfiles', async () => {


### PR DESCRIPTION
## Summary

This PR adds support for literal `\setcounter` assignments when generating section numbers in the Structure view.

Previously, commands such as:

```latex
\setcounter{chapter}{-1}
\chapter{Introduction}
```

were ignored by the outline parser, causing the Structure view to display `1 Introduction` while the compiled document displayed Chapter 0.

## Changes

- Parse signed integer `\setcounter` assignments for configured section counters.
- Preserve counter assignments until subfiles have been expanded, so they are applied in document order.
- Apply each assignment to the next matching numbered section before incrementing its counter.
- Remove internal counter elements before constructing the visible Structure tree.
- Keep counter elements hidden when outline numbering is disabled.
- Add regression tests for:
  - the example from the issue;
  - counter assignments between chapters;
  - disabled outline numbering;
  - counter assignments preceding sections from an included subfile.

Only literal signed integers are handled. TeX expressions and counters unrelated to configured section commands remain unchanged.

Fixes #4955