### PR TITLE
feat(outline): sanitize LaTeX labels

### DIFF
--- a/src/outline/structure/latex.ts
+++ b/src/outline/structure/latex.ts
@@ -7,7 +7,7 @@ import { resolveFile } from '../../utils/utils'
 import { InputFileRegExp, sanitizeInputFilePath } from '../../utils/inputfilepath'
 
 
-import { argContentToStr } from '../../utils/parser'
+import { argContentToStr, sanitizeLabel } from '../../utils/parser'
 
 const logger = lw.log('Structure', 'LaTeX')
 
@@ -87,7 +87,7 @@ async function constructFile(filePath: string, config: StructureConfig, structs:
 function chooseCaption(...args: (Ast.Argument | undefined)[]): string {
     for (const arg of args) {
         if ((arg?.content?.length ?? 0) > 0) {
-            return argContentToStr(arg?.content ?? [])
+            return sanitizeLabel(arg?.content ?? [])
         }
     }
     return ''
@@ -135,7 +135,7 @@ async function parseNode(
             }
         }
     } else if (node.type === 'macro' && config.macros.cmds.includes(node.content)) {
-        const argStr = argContentToStr(node.args?.[2]?.content || [])
+        const argStr = sanitizeLabel(node.args?.[2]?.content || [])
         element = {
             type: TeXElementType.Macro,
             name: node.content,

--- a/src/utils/parser.ts
+++ b/src/utils/parser.ts
@@ -1,3 +1,5 @@
+import * as fs from 'fs'
+import * as path from 'path'
 import type * as Ast from '@unified-latex/unified-latex-types'
 
 function macroToStr(macro: Ast.Macro): string {
@@ -39,4 +41,75 @@ export function argContentToStr(argContent: Ast.Node[], preserveCurlyBrace: bool
                 return ''
         }
     }).join('')
+}
+
+type UnicodeMathSymbol = { command: string, detail: string }
+
+let unicodeMathSymbols: Map<string, string> | undefined
+
+function getUnicodeMathSymbols(): Map<string, string> {
+    if (unicodeMathSymbols === undefined) {
+        const data = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../../../data/unimathsymbols.json'), { encoding: 'utf8' })) as Record<string, UnicodeMathSymbol>
+        unicodeMathSymbols = new Map(Object.values(data)
+            .filter(symbol => !symbol.detail.startsWith('\\'))
+            .map(symbol => [symbol.command, symbol.detail.split(' (')[0]]))
+    }
+    return unicodeMathSymbols
+}
+
+function getUnicodeMathSymbol(command: string): string | undefined {
+    const symbols = getUnicodeMathSymbols()
+    return symbols.get(command) ?? symbols.get(`up${command}`)
+}
+
+const formattingMacros = ['textbf', 'textit', 'text', 'emph', 'textrm', 'textsf', 'texttt', 'textsl', 'textsc', 'textup', 'textnormal']
+
+function macroContentToLabel(macro: Ast.Macro, inMath: boolean): string {
+    if (macro.content === 'texorpdfstring') {
+        return labelContentToStr(macro.args?.[1]?.content ?? [], inMath)
+    }
+    if (formattingMacros.includes(macro.content)) {
+        return labelContentToStr(macro.args?.[0]?.content ?? [], inMath)
+    }
+    if (macro.content.startsWith('cite')) {
+        return ''
+    }
+    if (inMath && ['left', 'right', 'middle'].includes(macro.content)) {
+        return ''
+    }
+    if (inMath) {
+        const symbol = getUnicodeMathSymbol(macro.content)
+        if (symbol !== undefined) {
+            return symbol
+        }
+    }
+    return `\\${macro.content}` + (macro.args?.map(arg => `${arg.openMark}${labelContentToStr(arg.content, inMath)}${arg.closeMark}`).join('') ?? '')
+}
+
+function labelContentToStr(content: Ast.Node[], inMath: boolean = false): string {
+    return content.map(node => {
+        switch (node.type) {
+            case 'string':
+                return node.content
+            case 'whitespace':
+            case 'parbreak':
+            case 'comment':
+                return ' '
+            case 'macro':
+                return macroContentToLabel(node, inMath)
+            case 'inlinemath':
+            case 'displaymath':
+                return labelContentToStr(node.content, true)
+            case 'group':
+                return labelContentToStr(node.content, inMath)
+            case 'verb':
+                return node.content
+            default:
+                return argContentToStr([node])
+        }
+    }).join('')
+}
+
+export function sanitizeLabel(content: Ast.Node[]): string {
+    return labelContentToStr(content).replace(/\s+/g, ' ').trim()
 }

--- a/test/units/07_outline/latex.test.ts
+++ b/test/units/07_outline/latex.test.ts
@@ -450,8 +450,32 @@ describe(path.basename(__filename).split('.')[0] + ':', () => {
 
 			assert.strictEqual(result[0].label, '1 Title with line break')
 			assert.strictEqual(result[1].label, '2 Title with pdf switch')
-			assert.strictEqual(result[2].label, '3 Title with \\textit{macros}')
+			assert.strictEqual(result[2].label, '3 Title with macros')
 			assert.strictEqual(result[3].label, '4 Short')
+		})
+
+		it('should sanitise formatting, citations, and common math symbols in labels', async () => {
+			set.config('view.outline.numbers.enabled', false)
+			set.config('view.outline.floats.enabled', true)
+			set.config('view.outline.floats.caption.enabled', true)
+			set.config('view.outline.floats.number.enabled', false)
+			const main = set.root('main.tex')
+			await cacheAst(main, [
+				'\\documentclass{article}',
+				'\\begin{document}',
+				'\\section{\\textbf{Important:} \\textit{Physics} Overview}',
+				'\\subsection{$\\alpha, \\beta, \\text{and }\\gamma$ Radiation \\cite{sampleKey}}',
+				'\\begin{figure}',
+				'\\caption{\\textit{Flux} $\\pm$ \\cite{plotKey}}',
+				'\\end{figure}',
+				'\\end{document}'
+			].join('\n'))
+
+			const result = await construct(main, true)
+
+			assert.strictEqual(result[0].label, 'Important: Physics Overview')
+			assert.strictEqual(result[0].children[0].label, 'α, β, and γ Radiation')
+			assert.strictEqual(result[0].children[0].children[0].label, 'Figure: Flux ±')
 		})
 
 		it('should respect custom sections from view.outline.sections', async () => {
@@ -517,13 +541,13 @@ describe(path.basename(__filename).split('.')[0] + ':', () => {
 				'\\begin{document}',
 				'\\section{Section 1}',
 				'\\label{no-show}',
-				'\\note{A note}',
+				'\\note{\\textbf{A note} $\\times$ \\cite{sampleKey}}',
 				'\\end{document}'
 			].join('\n'))
 
 			const result = await construct(main, true)
 
-			assert.strictEqual(result[0].children[0].label, '#note: A note')
+			assert.strictEqual(result[0].children[0].label, '#note: A note ×')
 		})
 
 		it('should build frame environments and respect float numbering toggle', async () => {


### PR DESCRIPTION
Improve LaTeX outline labels by removing presentation-only markup and converting common math commands to Unicode.

This PR resolves #4962.

The outline now:

- Removes formatting macros such as `\textbf`, `\textit`, `\emph`, and `\text`.
- Removes citation commands from section titles and captions.
- Converts supported math commands using `data/unimathsymbols.json`.
- Normalizes whitespace in generated labels.

The generic AST-to-label conversion logic is implemented in `src/utils/parser.ts`, while the outline parser only invokes `sanitizeLabel` for captions and custom outline commands.