### PR TITLE
Actionable error message when MiKTeX cannot run latexmk without Perl

### DIFF
--- a/src/compile/executor.ts
+++ b/src/compile/executor.ts
@@ -388,6 +388,16 @@ export class Executor {
                 logger.logError('Failed to clean auxiliary files after build failure.', error)
             }
         }
+        // MiKTeX ships latexmk (and other Perl-based tools) as wrappers that need
+        // an external Perl, which Windows does not provide out of the box. The
+        // resulting failure ("MiKTeX could not find the script engine 'perl'") is
+        // a setup problem, not a document problem, so point at the remedy instead
+        // of the generic message.
+        const output = result.result.stdout + result.result.stderr
+        if (output.includes('could not find the script engine')) {
+            void logger.showErrorMessageWithCompilerLogButton(`Recipe terminated with error: MiKTeX could not run "${result.step.command}" because it needs a Perl installation, and none was found. Install Perl (e.g. Strawberry Perl) and restart VS Code, or switch to a recipe that does not need Perl, such as "pdflatex ➞ bibtex ➞ pdflatex × 2".`)
+            return
+        }
         void logger.showErrorMessageWithCompilerLogButton('Recipe terminated with error.')
     }
 

--- a/src/compile/executor.ts
+++ b/src/compile/executor.ts
@@ -390,11 +390,12 @@ export class Executor {
         }
         // MiKTeX ships latexmk (and other Perl-based tools) as wrappers that need
         // an external Perl, which Windows does not provide out of the box. The
-        // resulting failure ("MiKTeX could not find the script engine 'perl'") is
-        // a setup problem, not a document problem, so point at the remedy instead
-        // of the generic message.
+        // resulting failure is a setup problem, not a document problem, so point
+        // at the remedy instead of the generic message. Only the Perl diagnostic
+        // is matched: MiKTeX uses the same wording for other missing script
+        // engines (e.g. Python), whose remedy is different.
         const output = result.result.stdout + result.result.stderr
-        if (output.includes('could not find the script engine')) {
+        if (output.includes('MiKTeX could not find the script engine \'perl\'')) {
             void logger.showErrorMessageWithCompilerLogButton(`Recipe terminated with error: MiKTeX could not run "${result.step.command}" because it needs a Perl installation, and none was found. Install Perl (e.g. Strawberry Perl), then quit and relaunch VS Code so it picks up the new PATH (reloading the window is not enough) — or switch to a recipe that does not need Perl, such as "pdflatex ➞ bibtex ➞ pdflatex × 2".`)
             return
         }

--- a/src/compile/executor.ts
+++ b/src/compile/executor.ts
@@ -395,7 +395,7 @@ export class Executor {
         // of the generic message.
         const output = result.result.stdout + result.result.stderr
         if (output.includes('could not find the script engine')) {
-            void logger.showErrorMessageWithCompilerLogButton(`Recipe terminated with error: MiKTeX could not run "${result.step.command}" because it needs a Perl installation, and none was found. Install Perl (e.g. Strawberry Perl) and restart VS Code, or switch to a recipe that does not need Perl, such as "pdflatex ➞ bibtex ➞ pdflatex × 2".`)
+            void logger.showErrorMessageWithCompilerLogButton(`Recipe terminated with error: MiKTeX could not run "${result.step.command}" because it needs a Perl installation, and none was found. Install Perl (e.g. Strawberry Perl), then quit and relaunch VS Code so it picks up the new PATH (reloading the window is not enough) — or switch to a recipe that does not need Perl, such as "pdflatex ➞ bibtex ➞ pdflatex × 2".`)
             return
         }
         void logger.showErrorMessageWithCompilerLogButton('Recipe terminated with error.')

--- a/test/units/02_compile/executor.test.ts
+++ b/test/units/02_compile/executor.test.ts
@@ -610,6 +610,51 @@ describe(path.basename(__filename).split('.')[0] + ':', () => {
             }
             assert.ok((lw.extra.clean as sinon.SinonStub).notCalled)
         })
+
+        it('points at Perl when MiKTeX cannot find the Perl script engine', async () => {
+            const showError = sinon.stub(vscode.window, 'showErrorMessage')
+            createPlanStub.callsFake(() => {
+                const plan = createPlan('latexmk', {tools: [{name: 'latexmk', command: 'latexmk'}]})
+                sinon.stub(plan, 'run').resolves(planResult(plan, {
+                    status: 'failed',
+                    result: stepResult({
+                        status: 'failed',
+                        code: 1,
+                        stderr: 'Sorry, but latexmk did not succeed for the following reason:\n\n' +
+                            '  MiKTeX could not find the script engine \'perl\' which is required to execute \'latexmk\'.\n'
+                    })
+                }))
+                return plan
+            })
+            await executor.run({isAuto: false, isBibChanged: false})
+            assert.ok(showError.calledOnce)
+            const message = showError.firstCall.args[0] as string
+            assert.ok(message.includes('MiKTeX could not run "latexmk"'), message)
+            assert.ok(message.includes('Install Perl'), message)
+            assert.notStrictEqual(message, 'Recipe terminated with error.')
+            showError.restore()
+        })
+
+        it('keeps the generic message for other failures and other missing script engines', async () => {
+            for (const stderr of [
+                '! Undefined control sequence.',
+                'MiKTeX could not find the script engine \'python\' which is required to execute \'pythontex\'.'
+            ]) {
+                const showError = sinon.stub(vscode.window, 'showErrorMessage')
+                createPlanStub.callsFake(() => {
+                    const plan = createPlan()
+                    sinon.stub(plan, 'run').resolves(planResult(plan, {
+                        status: 'failed',
+                        result: stepResult({status: 'failed', code: 1, stderr})
+                    }))
+                    return plan
+                })
+                await executor.run({isAuto: false, isBibChanged: false})
+                assert.ok(showError.calledOnce, stderr)
+                assert.strictEqual(showError.firstCall.args[0], 'Recipe terminated with error.', stderr)
+                showError.restore()
+            }
+        })
     })
 
     describe('Executor pending and drain state', () => {


### PR DESCRIPTION
## Problem

A fresh Windows + MiKTeX install fails on LaTeX Workshop's default recipe: MiKTeX ships `latexmk` as a wrapper that requires an external Perl, and Windows provides none (unlike TeX Live, which bundles one). The user sees only the generic

> Recipe terminated with error.

while the actual cause sits in the compiler log:

> MiKTeX could not find the script engine 'perl' which is required to execute 'latexmk'.

Since this is the out-of-the-box path for one of the two major Windows distributions, first-run users hit it as their very first build result, and the fix (install Perl, or pick a Perl-free recipe) is not discoverable from the message.

## Change

In `handleFailedPlan`, when the collected build output contains MiKTeX's script-engine failure, show a targeted message naming the failing tool and both remedies (install Perl, e.g. Strawberry Perl, and restart VS Code — or switch to a recipe that does not need Perl, such as "pdflatex ➞ bibtex ➞ pdflatex × 2"). The generic message is unchanged for every other failure, and — per CONTRIBUTING — no default settings or recipes are touched.

## Verification

- Reproduced the failure on Windows 11 + MiKTeX 26.5 (no Perl): default recipe fails with the message above in the log.
- After installing Strawberry Perl, the same setup builds a real 51-page document with the untouched default recipe — confirming the remedy the new message gives is the right one.
- `npm run lint` and `npm run compile` pass.