### PR TITLE
ci: retry CTAN downloads in the TeX Live workflows

### DIFF
--- a/.github/workflows/texlive_on_linux.yml
+++ b/.github/workflows/texlive_on_linux.yml
@@ -25,7 +25,7 @@ jobs:
           ${{ env.cache-version }}-${{ runner.os }}-texlive-essential
     - name: Download install-tl.zip
       run: |
-        curl -s -O -L http://mirror.ctan.org/systems/texlive/tlnet/install-tl.zip
+        curl -fsSL --retry 5 --retry-all-errors -O http://mirror.ctan.org/systems/texlive/tlnet/install-tl.zip
         unzip -q install-tl.zip
         mv install-tl-2* install-tl-dir
       if: steps.cache-texlive.outputs.cache-hit != 'true'
@@ -42,7 +42,7 @@ jobs:
       if: steps.cache-texlive.outputs.cache-hit != 'true'
     - name: Download latexindent binary
       run: |
-        curl -s -O -L http://mirrors.ctan.org/support/latexindent/bin/linux/latexindent
+        curl -fsSL --retry 5 --retry-all-errors -O http://mirrors.ctan.org/support/latexindent/bin/linux/latexindent
         mv -f latexindent /tmp/texlive/bin/x86_64-linux/latexindent
         chmod +x /tmp/texlive/bin/x86_64-linux/latexindent
       if: steps.cache-texlive.outputs.cache-hit != 'true'

--- a/.github/workflows/texlive_on_mac.yml
+++ b/.github/workflows/texlive_on_mac.yml
@@ -26,7 +26,7 @@ jobs:
           ${{ env.cache-version }}-${{ runner.os }}-texlive-essential
     - name: Download install-tl.zip
       run: |
-        curl -s -O -L http://mirror.ctan.org/systems/texlive/tlnet/install-tl.zip
+        curl -fsSL --retry 5 --retry-all-errors -O http://mirror.ctan.org/systems/texlive/tlnet/install-tl.zip
         unzip -q install-tl.zip
         mv install-tl-2* install-tl-dir
       if: steps.cache-texlive.outputs.cache-hit != 'true'
@@ -42,7 +42,7 @@ jobs:
       if: steps.cache-texlive.outputs.cache-hit != 'true'
     - name: Download latexindent binary
       run: |
-        curl -s -O -L http://mirrors.ctan.org/support/latexindent/bin/macos/latexindent
+        curl -fsSL --retry 5 --retry-all-errors -O http://mirrors.ctan.org/support/latexindent/bin/macos/latexindent
         [ -d /Users/runner/texlive/bin/x86_64-darwin/ ] && mv -f latexindent /Users/runner/texlive/bin/x86_64-darwin/latexindent && chmod +x /Users/runner/texlive/bin/x86_64-darwin/latexindent || [ -d /Users/runner/texlive/bin/universal-darwin/ ] && mv -f latexindent /Users/runner/texlive/bin/universal-darwin/latexindent && chmod +x /Users/runner/texlive/bin/universal-darwin/latexindent
       if: steps.cache-texlive.outputs.cache-hit != 'true'
     - uses: actions/setup-node@v7

--- a/.github/workflows/texlive_on_win.yml
+++ b/.github/workflows/texlive_on_win.yml
@@ -29,7 +29,7 @@ jobs:
           ${{ env.cache-version }}-${{ runner.os }}-texlive-essential
     - name: Download install-tl.zip
       run: |
-        curl -s -O -L http://mirror.ctan.org/systems/texlive/tlnet/install-tl.zip
+        curl -fsSL --retry 5 --retry-all-errors -O http://mirror.ctan.org/systems/texlive/tlnet/install-tl.zip
         unzip -q install-tl.zip
         mv install-tl-2* install-tl-dir
       if: steps.cache-texlive.outputs.cache-hit != 'true'
@@ -46,7 +46,7 @@ jobs:
       if: steps.cache-texlive.outputs.cache-hit != 'true'
     - name: Download latexindent binary
       run: |
-        curl -s -O -L http://mirrors.ctan.org/support/latexindent/bin/windows/latexindent.exe
+        curl -fsSL --retry 5 --retry-all-errors -O http://mirrors.ctan.org/support/latexindent/bin/windows/latexindent.exe
         mv -Force "latexindent.exe" "D:\texlive\bin\windows\latexindent-binary.exe"
       if: steps.cache-texlive.outputs.cache-hit != 'true'
     - uses: actions/setup-node@v7


### PR DESCRIPTION
On a TeX Live cache miss, `texlive_on_{linux,mac,win}.yml` download `install-tl.zip` and the `latexindent` binary from the CTAN mirror network with `curl -s -O -L`. A transient mirror problem then fails the whole job before anything is compiled or tested, and the log gives no reason because `-s` also hides curl's error message. This PR changes those six lines to

```
curl -fsSL --retry 5 --retry-all-errors -O <url>
```

- `--retry 5 --retry-all-errors`: retry the transfer on any error (connection, TLS, HTTP) with curl's default backoff. Each retry re-enters the CTAN redirector, which usually hands out a different mirror.
- `-f`: fail on HTTP 4xx/5xx instead of saving an error page under the binary's name, where it would only surface later as an unrelated failure.
- `-S`: keep curl's error message visible under `-s`.

### Motivation

The "TeX Live on Linux" run for #4970 failed in **Download latexindent binary** with `Process completed with exit code 60` (curl: TLS certificate problem on the mirror the redirect landed on) and passed unchanged when re-run: https://github.com/James-Yu/LaTeX-Workshop/actions/runs/33592926988/attempts/2

For scale: in the last 60 runs of each of the three workflows (mid-August onward), the download steps executed only in the four job attempts for #4970, where the TeX Live cache had expired after a quiet week; one of those four failed. All 19 other job failures in that window were in "Run tests". So the steps are rarely exercised, but after any week without pushes every run goes through them, and a single bad mirror currently fails the job.

### Notes

- No change to the extension or its tests. Runs with a warm TeX Live cache skip these steps entirely.
- `--retry-all-errors` needs curl 7.71 or newer (2020). The runner images ship curl 8.5.0 (Ubuntu 24.04) and 8.21.0 (macOS 15), and Windows Server 2025 includes curl 8.x.
