### PR TITLE
Improve citation browser labels and multi-selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -2202,11 +2202,11 @@
             "authors"
           ],
           "default": "bibtex key",
-          "markdownDescription": "Defines what to show as suggestion labels when intellisense provides citation suggestions in inline mode.",
+          "markdownDescription": "Defines what to show as suggestion labels when intellisense provides citation suggestions.",
           "enumDescriptions": [
-            "Show bibtex keys in the inline mode.",
-            "Show publication titles in the inline mode.",
-            "Show publication authors in the inline mode."
+            "Show bibtex keys.",
+            "Show publication titles.",
+            "Show publication authors."
           ]
         },
         "latex-workshop.intellisense.citation.filterText": {

--- a/src/completion/completer/citation.ts
+++ b/src/completion/completer/citation.ts
@@ -94,6 +94,16 @@ function from(_result: RegExpMatchArray, args: CompletionArgs) {
     return provide(args.uri, args.line, args.position)
 }
 
+function getCitationLabel(item: CitationItem, label: string): string {
+    if (label === 'title' && item.fields.title) {
+        return item.fields.title
+    }
+    if (label === 'authors' && item.fields.author) {
+        return item.fields.author
+    }
+    return item.key
+}
+
 function provide(uri: vscode.Uri, line: string, position: vscode.Position): CompletionItem[] {
     // Compile the suggestion array to vscode completion array
     const configuration = vscode.workspace.getConfiguration('latex-workshop', uri)
@@ -136,23 +146,7 @@ function provide(uri: vscode.Uri, line: string, position: vscode.Position): Comp
         return filterText
     }
     return [...items, ...alts].map(item => {
-        // Compile the completion item label
-        switch(label) {
-            case 'bibtex key':
-            default:
-                item.label = item.key
-                break
-            case 'title':
-                if (item.fields.title) {
-                    item.label = item.fields.title
-                }
-                break
-            case 'authors':
-                if (item.fields.author) {
-                    item.label = item.fields.author
-                }
-                break
-        }
+        item.label = getCitationLabel(item, label)
         item.filterText = getFilterText(item)
         item.insertText = item.key
         item.range = range
@@ -166,19 +160,23 @@ function browser(args?: CompletionArgs) {
     const configuration = vscode.workspace.getConfiguration('latex-workshop', args?.uri)
     const label = configuration.get('intellisense.citation.label') as string
     const fields = readCitationFormat(configuration, label)
-    void vscode.window.showQuickPick(updateAll(lw.cache.getIncludedBib(lw.root.file.path)).map(item => {
+    const items = updateAll(lw.cache.getIncludedBib(lw.root.file.path)).map(item => {
+        const itemLabel = getCitationLabel(item, label)
         return {
-            label: item.fields.title ? trimMultiLineString(item.fields.title) : '',
-            description: item.key,
-            detail: item.fields.join(fields, true, ', ')
+            label: itemLabel,
+            description: itemLabel === item.key ? (item.fields.title ? trimMultiLineString(item.fields.title) : '') : item.key,
+            detail: item.fields.join(fields, true, ', '),
+            key: item.key
         }
-    }), {
-        placeHolder: 'Press ENTER to insert citation key at cursor',
+    }).sort((a, b) => a.label.localeCompare(b.label))
+    void vscode.window.showQuickPick(items, {
+        placeHolder: 'Select citation keys, then press ENTER',
+        canPickMany: true,
         matchOnDetail: true,
         matchOnDescription: true,
         ignoreFocusOut: true
     }).then(selected => {
-        if (!selected) {
+        if (!selected || selected.length === 0) {
             return
         }
         if (vscode.window.activeTextEditor) {
@@ -190,7 +188,7 @@ function browser(args?: CompletionArgs) {
                 const commaStart = content.lastIndexOf(',') + 1
                 start = editor.document.positionAt(curlyStart > commaStart ? curlyStart : commaStart)
             }
-            void editor.edit(edit => edit.replace(new vscode.Range(start, editor.selection.end), selected.description || ''))
+            void editor.edit(edit => edit.replace(new vscode.Range(start, editor.selection.end), selected.map(item => item.key).join(',')))
                         .then(() => editor.selection = new vscode.Selection(editor.selection.end, editor.selection.end))
         }
     })

--- a/test/units/05_completion/citation.test.ts
+++ b/test/units/05_completion/citation.test.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode'
 import * as path from 'path'
 import * as sinon from 'sinon'
 import { lw } from '../../../src/lw'
-import { assert, get, mock, set } from '../utils'
+import { assert, deferred, get, mock, set } from '../utils'
 import { citation, provider } from '../../../src/completion/completer/citation'
 import type { CitationItem, FileCache } from '../../../src/types'
 
@@ -140,6 +140,51 @@ describe(path.basename(__filename).split('.')[0] + ':', () => {
             suggestion = suggestions.find(s => s.label === 'Jane Miller and Robert Smith')
             assert.ok(suggestion)
             assert.strictEqual(suggestion.label, suggestion.fields.author)
+        })
+
+        it('should configure citation browser labels and multiple selection', () => {
+            set.config('intellisense.citation.label', 'bibtex key')
+            const quickPickStub = sinon.stub(vscode.window, 'showQuickPick').resolves(undefined)
+
+            citation.browser({ uri: vscode.Uri.file(texPath), langId: 'latex', line: '', position: new vscode.Position(0, 0) })
+
+            const items = quickPickStub.firstCall.args[0] as readonly vscode.QuickPickItem[]
+            const options = quickPickStub.firstCall.args[1] as vscode.QuickPickOptions & { canPickMany: boolean }
+            const suggestion = items.find((item: vscode.QuickPickItem) => item.label === 'miller2024')
+            assert.ok(suggestion)
+            assert.strictEqual(suggestion.description, 'An Overview of Quantum Computing: Challenges and Future Directions')
+            assert.strictEqual(options.canPickMany, true)
+            quickPickStub.restore()
+        })
+
+        it('should insert multiple citations', async () => {
+            const selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(0, 0))
+            const replace = sinon.spy()
+            const editCalled = deferred<boolean>()
+            const editor = {
+                document: { getText: sinon.stub().returns('') },
+                selection,
+                edit: sinon.stub().callsFake((callback: (editBuilder: vscode.TextEditorEdit) => void) => {
+                    callback({ replace } as unknown as vscode.TextEditorEdit)
+                    editCalled.resolve(true)
+                    return Promise.resolve(true)
+                })
+            } as unknown as vscode.TextEditor
+            const editorStub = sinon.stub(vscode.window, 'activeTextEditor').value(editor)
+            const quickPickStub = sinon.stub(vscode.window, 'showQuickPick').resolves([
+                { label: 'miller2024', key: 'miller2024' },
+                { label: 'miller2025', key: 'miller2025' }
+            ] as unknown as vscode.QuickPickItem)
+
+            citation.browser()
+            await editCalled.promise
+            editorStub.restore()
+            quickPickStub.restore()
+
+            sinon.assert.calledOnce(replace)
+            const [range, text] = replace.firstCall.args as [vscode.Range, string]
+            assert.ok(range.isEqual(selection))
+            assert.strictEqual(text, 'miller2024,miller2025')
         })
 
         it('should follow `latex-workshop.intellisense.citation.filterText`', () => {


### PR DESCRIPTION
## Summary
- make the citation browser honor `latex-workshop.intellisense.citation.label` and sort by the selected primary label
- allow selecting multiple entries and insert their citation keys as a comma-separated list
- keep citation keys available independently of their display labels

## Tests
- `npm run compile`
- `npm run lint`
- VS Code unit suite: 1224 passing