### PR TITLE
Allow compiler log to preserve editor focus

### DIFF
--- a/src/core/commands.ts
+++ b/src/core/commands.ts
@@ -176,10 +176,10 @@ export function wordcount() {
     }
 }
 
-export function showLog(compiler?: string) {
+export function showLog(compiler?: string, preserveFocus = false) {
     logger.log(`SHOWLOG command invoked: ${compiler || 'default'}`)
     if (compiler) {
-        logger.showCompilerLog()
+        logger.showCompilerLog(preserveFocus)
     } else {
         logger.showLog()
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -187,7 +187,7 @@ function registerLatexWorkshopCommands(extensionContext: vscode.ExtensionContext
         vscode.commands.registerCommand('latex-workshop.addtexroot', () => lw.commands.addTexRoot()),
         vscode.commands.registerCommand('latex-workshop.wordcount', () => lw.commands.wordcount()),
         vscode.commands.registerCommand('latex-workshop.log', () => lw.commands.showLog()),
-        vscode.commands.registerCommand('latex-workshop.compilerlog', () => lw.commands.showLog('compiler')),
+        vscode.commands.registerCommand('latex-workshop.compilerlog', (preserveFocus?: boolean) => lw.commands.showLog('compiler', preserveFocus)),
         vscode.commands.registerCommand('latex-workshop.code-action', (d: vscode.TextDocument, r: vscode.Range, c: number, m: string) => lw.lint.latex.action(d, r, c, m)),
         vscode.commands.registerCommand('latex-workshop.goto-section', (filePath: string, lineNumber: number) => lw.commands.gotoSection(filePath, lineNumber)),
         vscode.commands.registerCommand('latex-workshop.navigate-envpair', () => lw.commands.navigateToEnvPair()),

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -134,8 +134,8 @@ function showLog() {
     LOG_PANEL.show()
 }
 
-function showCompilerLog() {
-    COMPILER_PANEL.show()
+function showCompilerLog(preserveFocus = false) {
+    COMPILER_PANEL.show(preserveFocus)
 }
 
 function showStatus() {


### PR DESCRIPTION
`latex-workshop.compilerlog` currently always focuses the compiler output because it calls `OutputChannel.show()` without exposing VS Code's `preserveFocus` argument.

This makes the command harder to compose with other commands. For example, when using VS Code's `runCommands` to:

1. show the compiler log,
2. start a LaTeX Workshop recipe,
3. open the generated PDF,

the focus change caused by `latex-workshop.compilerlog` can interfere with subsequent commands.

This PR adds an optional `preserveFocus` argument to `latex-workshop.compilerlog` and passes it through to `OutputChannel.show(preserveFocus)`.

Existing behavior is unchanged because `preserveFocus` defaults to `false`.

For example:

```json
{
    "command": "latex-workshop.compilerlog",
    "args": [true]
}
```

This shows the LaTeX Compiler output while preserving editor focus, which allows it to be used before commands such as `latex-workshop.recipes` in a `runCommands` sequence.

I verified the change in an Extension Development Host and confirmed that the compiler output is shown before the build starts, the build proceeds normally, and the compiler log is updated in real time.

`npm run lint`, `npm run compile`, and `npm run test` all pass.